### PR TITLE
Fix for Panasinic encoding

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -1000,10 +1000,10 @@ long IRrecv::decodeRC6(decode_results *results) {
 long IRrecv::decodePanasonic(decode_results *results) {
     unsigned long long data = 0;
 	int offset = 1;  // Dont skip first space    
-    /*if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
+    if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
         return ERR;
     }
-    offset++;*/		
+    offset++;		
     if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_SPACE)) {
         return ERR;
     }


### PR DESCRIPTION
With this part of code commented I couldn't decode Panasonic codes. After uncommenting it works fine. (It is uncommented in 2.1.0 version of Arduino-IRremote library)
