### PR TITLE
Add support for Daikin AC

### DIFF
--- a/IRDaikinESP.cpp
+++ b/IRDaikinESP.cpp
@@ -1,0 +1,153 @@
+/*
+An Arduino sketch to emulate IR Daikin ARC433** remote control unit
+Read more on http://harizanov.com/2012/02/control-daikin-air-conditioner-over-the-internet/
+*/
+
+#include <IRDaikinESP.h>
+
+IRDaikinESP::IRDaikinESP(int pin) : _irsend(pin)
+{
+}
+
+void IRDaikinESP::begin()
+{
+    _irsend.begin();
+}
+
+void IRDaikinESP::send()
+{
+  _irsend.sendDaikin(daikin);
+}
+
+uint8_t IRDaikinESP::checksum()
+{
+    uint8_t sum = 0;
+    uint8_t i;
+
+    for(i = 0; i <= 6; i++){
+        sum += daikin[i];
+    }
+
+    daikin[7] = sum &0xFF;
+    sum=0;
+    for(i = 8; i <= 25; i++){
+        sum += daikin[i];
+    }
+    daikin[26] = sum &0xFF;
+}
+
+void IRDaikinESP::on()
+{
+    //state = ON;
+    daikin[13] |= 0x01;
+    checksum();
+}
+
+void IRDaikinESP::off()
+{
+    //state = OFF;
+    daikin[13] &= 0xFE;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getPower()
+{
+    return (daikin[13])&0x01;
+}
+
+// DAIKIN_SILENT or DAIKIN_POWERFUL
+void IRDaikinESP::setAux(uint8_t aux)
+{
+    daikin[21] = aux;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getAux(){
+    return daikin[21];
+}
+
+
+// Set the temp in deg C
+void IRDaikinESP::setTemp(uint8_t temp)
+{
+    if (temp < 18) 
+        temp = 18;
+    else if (temp > 32)
+        temp = 32;
+    daikin[14] = (temp)*2;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getTemp()
+{
+    return (daikin[14])/2;
+}
+
+// Set the speed of the fan, 0-5, 0 is auto, 1-5 is the speed
+void IRDaikinESP::setFan(uint8_t fan)
+{
+    // Set the fan speed bits, leave low 4 bits alone
+    uint8_t fanset;
+    daikin[16] = daikin[16] & 0x0F;
+    if (fan >= 1 && fan <= 5)
+        fanset = 0x20 + (0x10 * fan);
+    else
+        fanset = 0xA0;
+    daikin[16] = daikin[16] | fanset;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getFan()
+{
+    uint8_t fan = daikin[16] >> 4;
+    fan = fan - 2;
+    if (fan > 5)
+        fan = 0;
+    return fan;
+}
+
+uint8_t IRDaikinESP::getMode()
+{/*
+  DAIKIN_COOL
+  DAIKIN_HEAT
+  DAIKIN_FAN
+  DAIKIN_AUTO
+  DAIKIN_DRY
+  */
+    return (daikin[13])>>4;
+}
+
+void IRDaikinESP::setMode(uint8_t mode)
+{
+    daikin[13]=mode<<4 | getPower();
+    checksum();
+}
+
+void IRDaikinESP::setSwingVertical(uint8_t swing)
+{
+    if (swing)
+        daikin[16] = daikin[16] | 0x0F;
+    else
+        daikin[16] = daikin[16] & 0xF0;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getSwingVertical()
+{
+    return (daikin[16])&0x01;
+}
+
+void IRDaikinESP::setSwingHorizontal(uint8_t swing)
+{
+    if (swing)
+        daikin[17] = daikin[17] | 0x0F;
+    else
+        daikin[17] = daikin[17] & 0xF0;
+    checksum();
+}
+
+uint8_t IRDaikinESP::getSwingHorizontal()
+{
+    return (daikin[17])&0x01;
+}
+

--- a/IRDaikinESP.h
+++ b/IRDaikinESP.h
@@ -1,0 +1,101 @@
+
+#include <IRremoteESP8266.h>
+#include <Arduino.h>
+
+#define DAIKIN_COOL B011
+#define DAIKIN_HEAT B100
+#define DAIKIN_FAN B110
+#define DAIKIN_AUTO B000
+#define DAIKIN_DRY B010
+
+#define DAIKIN_POWERFUL B00000010
+#define DAIKIN_SILENT   B00100000
+
+/*
+	Daikin AC map
+	byte 7= checksum of the first part (and last byte before a 29ms pause)
+	byte 13=mode
+		b7 = 0
+		b6+b5+b4 = Mode
+			Modes: b6+b5+b4
+			011 = Cool
+			100 = Heat (temp 23)
+			110 = FAN (temp not shown, but 25)
+			000 = Fully Automatic (temp 25)
+			010 = DRY (temp 0xc0 = 96 degrees c)
+		b3 = 0
+		b2 = OFF timer set
+		b1 = ON timer set
+		b0 = Air Conditioner ON
+	byte 14=temp*2   (Temp should be between 18 - 32)
+	byte 16=Fan
+		FAN control
+		b7+b6+b5+b4 = Fan speed
+			Fan: b7+b6+b5+b4
+			0×30 = 1 bar
+			0×40 = 2 bar
+			0×50 = 3 bar
+			0×60 = 4 bar
+			0×70 = 5 bar
+			0xa0 = Auto
+			0xb0 = Not auto, moon + tree
+		b3+b2+b1+b0 = Swing control up/down
+			Swing control up/down:
+			0000 = Swing up/down off
+			1111 = Swing up/down on
+	byte 17
+			Swing control left/right:
+			0000 = Swing left/right off
+			1111 = Swing left/right on
+	byte 21=Aux  -> Powerful (bit 1), Silent (bit 5)
+	byte 24=Aux2 -> Intelligent eye on (bit 7)
+	byte 26= checksum of the second part 
+*/
+
+#define DAIKIN_COMMAND_LENGTH 27
+
+class IRDaikinESP
+{
+    public:
+        IRDaikinESP(int pin);
+        //: IRsend(pin){};
+
+        void send();
+
+        void begin();
+        void on();
+        void off();
+        uint8_t getPower();
+
+        void setAux(uint8_t aux);
+        uint8_t getAux();
+
+        void setTemp(uint8_t temp);
+        uint8_t getTemp();
+
+        void setFan(uint8_t fan);
+        uint8_t getFan();
+
+        uint8_t getMode();
+        void setMode(uint8_t mode);
+
+        void setSwingVertical(uint8_t swing);
+        uint8_t getSwingVertical();
+        void setSwingHorizontal(uint8_t swing);
+        uint8_t getSwingHorizontal();
+
+    private:
+        // # of bytes per command
+        unsigned char daikin[DAIKIN_COMMAND_LENGTH] = {
+        0x11,0xDA,0x27,0xF0,0x00,0x00,0x00,0x20,
+        //0    1    2   3    4    5     6   7
+        0x11,0xDA,0x27,0x00,0x00,0x41,0x1E,0x00,
+        //8    9   10   11   12    13   14   15
+        0xB0,0x00,0x00,0x00,0x00,0x00,0x00,0xC0,0x00,0x00,0xE3 };
+        //16  17    18  19   20    21   22  23   24   25   26
+
+        uint8_t checksum();
+
+        IRsend _irsend;
+};
+

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -20,6 +20,9 @@
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for sending IR code on ESP8266
  * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code on ESP8266
  *
+ *  Updated by sillyfrog for Daikin, adopted from
+ * (https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/)
+ *
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -57,6 +60,7 @@ enum decode_type_t {
   DISH,
   SHARP,
   COOLIX,
+  DAIKIN,
 };
 
 // Results returned from the decoder
@@ -88,6 +92,7 @@ public:
 #define LG 12
 #define WHYNTER 13
 #define COOLIX 15
+#define DAIKIN 16
 #define UNKNOWN -1
 
 // Decoded value for NEC when a repeat code is received
@@ -130,6 +135,7 @@ public:
   long decodeHash(decode_results *results);
   // COOLIX decode is not implemented yet
   //  long decodeCOOLIX(decode_results *results);
+  long decodeDaikin(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
 };
 
@@ -176,6 +182,8 @@ public:
   void sendPanasonic(unsigned int address, unsigned long data);
   void sendJVC(unsigned long data, int nbits, int repeat); // *Note instead of sending the REPEAT constant if you want the JVC repeat signal sent, send the original code value and change the repeat argument from 0 to 1. JVC protocol repeats by skipping the header NOT by sending a separate code value like NEC does.
   void sendSAMSUNG(unsigned long data, int nbits);
+  void sendDaikin(unsigned char daikin[]);
+  void sendDaikinChunk(unsigned char buf[], int len, int start);
   void enableIROut(int khz);
   VIRTUAL void mark(int usec);
   VIRTUAL void space(int usec);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -143,6 +143,15 @@
 #define SHARP_BITS 15
 #define DISH_BITS 16
 
+// Dakin, from https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
+#define DAIKIN_HDR_MARK	    3650 //DAIKIN_ZERO_MARK*8
+#define DAIKIN_HDR_SPACE	1623 //DAIKIN_ZERO_MARK*4
+#define DAIKIN_ONE_SPACE	1280 
+#define DAIKIN_ONE_MARK	    428
+#define DAIKIN_ZERO_MARK	428
+#define DAIKIN_ZERO_SPACE 428
+
+
 #define TOLERANCE 25  // percent tolerance in measurements
 #define LTOL (1.0 - TOLERANCE/100.) 
 #define UTOL (1.0 + TOLERANCE/100.) 
@@ -193,5 +202,6 @@ extern volatile irparams_t irparams;
 #define SAMSUNG_BITS 32
 #define WHYNTER_BITS 32
 #define COOLIX_NBYTES 3
+#define DAIKIN_BITS 99
 
 #endif

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -1,5 +1,5 @@
 
-#include <ESPIRDaikinESP.h>
+#include <IRDaikinESP.h>
 
 IRDaikinESP dakinir(D1);
 

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -1,0 +1,20 @@
+
+#include <ESPIRDaikinESP.h>
+
+IRDaikinESP dakinir(D1);
+
+void setup(){
+  dakinir.begin();
+  Serial.begin(115200);
+}
+
+
+void loop(){
+  Serial.println("Sending...");
+  dakinir.setFan(1);
+  dakinir.setMode(DAIKIN_COOL);
+  dakinir.setTemp(25);
+  dakinir.send();
+  delay(5000);
+}
+

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -11,10 +11,17 @@ void setup(){
 
 void loop(){
   Serial.println("Sending...");
+
+  // Set up what we want to send. See IRDaikinESP.cpp for all the options.
+  dakinir.on();
   dakinir.setFan(1);
   dakinir.setMode(DAIKIN_COOL);
   dakinir.setTemp(25);
+  dakinir.setSwingVertical(0);
+  dakinir.setSwingHorizontal(0);
+
+  // Now send the IR signal.
   dakinir.send();
+
   delay(5000);
 }
-


### PR DESCRIPTION
This adds support for sending Daikian IR signals. I have put it into it's own file as the way it's used is a bit different because everything is sent in a single signal (i.e.: the state, temperature, mode etc). The idea is you set up what you want, then `send` the signal in one hit. As it requires an extension to the `IRremoteESP8266` library, I figure it will be better as part of this library rather than a stand alone library.

I have also included an example as to how it should be used.

Thanks!