### PR TITLE
Isr flash fix

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -28,7 +28,7 @@
  ****************************************************/
 
 #include "IRremoteESP8266.h"
-#include "IRremoteInt.h"
+#include "IRremoteInt.h" 
 
 // These versions of MATCH, MATCH_MARK, and MATCH_SPACE are only for debugging.
 // To use them, set DEBUG in IRremoteInt.h
@@ -499,7 +499,7 @@ extern "C" {
 static ETSTimer timer;
 volatile irparams_t irparams;
 
-static void ICACHE_FLASH_ATTR read_timeout(void *arg) {
+static void ICACHE_RAM_ATTR read_timeout(void *arg) {
     os_intr_lock();
     if (irparams.rawlen) {
 		irparams.rcvstate = STATE_STOP;
@@ -507,7 +507,7 @@ static void ICACHE_FLASH_ATTR read_timeout(void *arg) {
 	os_intr_unlock();
 }
 
-static void ICACHE_FLASH_ATTR gpio_intr() {
+static void ICACHE_RAM_ATTR gpio_intr() {
     uint32_t gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
     GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status);
 

--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -28,7 +28,7 @@
  ****************************************************/
 
 #include "IRremoteESP8266.h"
-#include "IRremoteInt.h" 
+#include "IRremoteInt.h"
 
 // These versions of MATCH, MATCH_MARK, and MATCH_SPACE are only for debugging.
 // To use them, set DEBUG in IRremoteInt.h


### PR DESCRIPTION
This fixes the problem where the ESP8266 will crash when using the IR libs as per these comments:

https://github.com/markszabo/IRremoteESP8266/issues/22#issuecomment-234137959
"FYI, a lot of these Exception (0) issues reported here have to do with the fact that GPIO ISR handler is placed into flash. ISR handler should instead be marked with IRAM_ATTR for placement into RAM. Otherwise if the interrupt happens while flash cache is disabled, ISR code will not be accessible, causing exception 0."

https://github.com/markszabo/IRremoteESP8266/issues/22#issuecomment-235092407


