### PR TITLE
Fix issues with IR send routines with large unsigned longs

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -1,30 +1,37 @@
  /***************************************************
  * IRremote for ESP8266
  *
- * Based on the IRremote library for Arduino by Ken Shirriff 
+ * Based on the IRremote library for Arduino by Ken Shirriff
  * Version 0.11 August, 2009
  * Copyright 2009 Ken Shirriff
- * For details, see http://arcfn.com/2009/08/multi-protocol-infrared-remote-library.html
+ * For details, see
+ *   http://arcfn.com/2009/08/multi-protocol-infrared-remote-library.html
  *
- * Modified by Paul Stoffregen <paul@pjrc.com> to support other boards and timers
- * Modified  by Mitra Ardron <mitra@mitra.biz> 
+ * Modified by Paul Stoffregen <paul@pjrc.com> to support other boards and
+ *   timers
+ * Modified by Mitra Ardron <mitra@mitra.biz>
  * Added Sanyo and Mitsubishi controllers
  * Modified Sony to spot the repeat codes that some Sony's send
  *
  * Interrupt code based on NECIRrcv by Joe Knapp
  * http://www.arduino.cc/cgi-bin/yabb2/YaBB.pl?num=1210243556
- * Also influenced by http://zovirl.com/2008/11/12/building-a-universal-remote-with-an-arduino/
+ * Also influenced by
+ *   http://zovirl.com/2008/11/12/building-a-universal-remote-with-an-arduino/
  *
- * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
+ * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and
+ *   other people at the original blog post)
  * LG added by Darryl Smith (based on the JVC protocol)
  * Whynter A/C ARC-110WD added by Francesco Meschia
- * Global Cache IR format sender added by Hisham Khalifa (http://www.hishamkhalifa.com)
+ * Global Cache IR format sender added by Hisham Khalifa
+ *   (http://www.hishamkhalifa.com)
  * Coolix A/C / heatpump added by bakrus
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
-          (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
+ *   (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  *
- * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for sending IR code on ESP8266
- * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code on ESP8266
+ * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for
+ *   sending IR code on ESP8266
+ * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code
+ *   on ESP8266
  *
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
@@ -57,7 +64,8 @@ int MATCH_MARK(int measured_ticks, int desired_us) {
   Serial.print(measured_ticks, DEC);
   Serial.print(" <= ");
   Serial.println(TICKS_HIGH(desired_us + MARK_EXCESS), DEC);
-  return measured_ticks >= TICKS_LOW(desired_us + MARK_EXCESS) && measured_ticks <= TICKS_HIGH(desired_us + MARK_EXCESS);
+  return measured_ticks >= TICKS_LOW(desired_us + MARK_EXCESS) &&
+      measured_ticks <= TICKS_HIGH(desired_us + MARK_EXCESS);
 }
 
 int MATCH_SPACE(int measured_ticks, int desired_us) {
@@ -71,320 +79,334 @@ int MATCH_SPACE(int measured_ticks, int desired_us) {
   Serial.print(measured_ticks, DEC);
   Serial.print(" <= ");
   Serial.println(TICKS_HIGH(desired_us - MARK_EXCESS), DEC);
-  return measured_ticks >= TICKS_LOW(desired_us - MARK_EXCESS) && measured_ticks <= TICKS_HIGH(desired_us - MARK_EXCESS);
+  return measured_ticks >= TICKS_LOW(desired_us - MARK_EXCESS) &&
+      measured_ticks <= TICKS_HIGH(desired_us - MARK_EXCESS);
 }
 #else
-int MATCH(int measured, int desired) {return measured >= TICKS_LOW(desired) && measured <= TICKS_HIGH(desired);}
-int MATCH_MARK(int measured_ticks, int desired_us) {return MATCH(measured_ticks, (desired_us + MARK_EXCESS));}
-int MATCH_SPACE(int measured_ticks, int desired_us) {return MATCH(measured_ticks, (desired_us - MARK_EXCESS));}
+int MATCH(int measured, int desired) {return measured >= TICKS_LOW(desired) &&
+    measured <= TICKS_HIGH(desired);}
+int MATCH_MARK(int measured_ticks, int desired_us)
+    {return MATCH(measured_ticks, (desired_us + MARK_EXCESS));}
+int MATCH_SPACE(int measured_ticks, int desired_us)
+    {return MATCH(measured_ticks, (desired_us - MARK_EXCESS));}
 // Debugging versions are in IRremote.cpp
 #endif
 
-// IRsend -----------------------------------------------------------------------------------
+// IRsend ----------------------------------------------------------------------
 
-IRsend::IRsend(int IRsendPin)
-{
+IRsend::IRsend(int IRsendPin) {
 	IRpin = IRsendPin;
 }
 
-void IRsend::begin()
-{
+void IRsend::begin() {
 	pinMode(IRpin, OUTPUT);
 }
 
-void IRsend::sendCOOLIX(unsigned long data, int nbits)
-{
+void IRsend::sendCOOLIX(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(38);
+  // Header
   mark(COOLIX_HDR_MARK);
   space(COOLIX_HDR_SPACE);
-
-  // Sending 3 bytes of data. Each byte first beeing sendt straight, then followed by an inverted version.
+  // Data
+  // Sending 3 bytes of data. Each byte first being sent straight, then followed
+  // by an inverted version.
   unsigned long COOLIXmask;
   bool invert = 0;  // Initializing
   for (int j = 0; j < COOLIX_NBYTES * 2; j++) {
     for (int i = nbits; i > nbits-8; i--) {
-      COOLIXmask = (unsigned long) 1 << (i-1);  // Type cast necessary to perform correct for the one byte above 16bit
-      if (data & COOLIXmask) {
+      // Type cast necessary to perform correct for the one byte above 16bit
+      COOLIXmask = (unsigned long) 1 << (i-1);
+      if (data & COOLIXmask) {  // 1
         mark(COOLIX_BIT_MARK);
         space(COOLIX_ONE_SPACE);
-      }
-      else {
+      } else {  // 0
         mark(COOLIX_BIT_MARK);
         space(COOLIX_ZERO_SPACE);
       }
     }
-    data ^= 0xFFFFFFFF;       // Inverts all of the data each time we need to send an inverted byte
+    // Inverts all of the data each time we need to send an inverted byte
+    data ^= 0xFFFFFFFF;
     invert = !invert;
-    nbits -= invert ? 0 : 8;  // Subtract 8 from nbits each time we switch to a new byte.
+    // Subtract 8 from nbits each time we switch to a new byte.
+    nbits -= invert ? 0 : 8;
   }
+  // Footer
   mark(COOLIX_BIT_MARK);
   space(COOLIX_ZERO_SPACE);   // Stop bit (0)
   space(COOLIX_HDR_SPACE);    // Pause before repeating
 }
 
-void IRsend::sendNEC(unsigned long data, int nbits)
-{
+void IRsend::sendNEC (unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(38);
+  // Header
   mark(NEC_HDR_MARK);
   space(NEC_HDR_SPACE);
-  for (int i = 0; i < nbits; i++) {
-    if (data & TOPBIT) {
+  // Data
+  for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+    if (data & mask) {  // 1
       mark(NEC_BIT_MARK);
       space(NEC_ONE_SPACE);
-    } 
-    else {
+    } else {  // 0
       mark(NEC_BIT_MARK);
       space(NEC_ZERO_SPACE);
     }
-    data <<= 1;
   }
+  // Footer
   mark(NEC_BIT_MARK);
-  space(0);
+  space(0);  // Always end with the LED off
 }
 
-void IRsend::sendLG (unsigned long data, int nbits)
-{
-	enableIROut(38);
-	mark(LG_HDR_MARK);
-	space(LG_HDR_SPACE);
-	mark(LG_BIT_MARK);
-	for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
-		if (data & mask) {
-			space(LG_ONE_SPACE);
-			mark(LG_BIT_MARK);
-		} else {
-			space(LG_ZERO_SPACE);
-			mark(LG_BIT_MARK);
-		}
-	}
-	space(0);
+void IRsend::sendLG (unsigned long data, int nbits) {
+  // Set IR carrier frequency
+  enableIROut(38);
+  // Header
+  mark(LG_HDR_MARK);
+  space(LG_HDR_SPACE);
+  mark(LG_BIT_MARK);
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
+      space(LG_ONE_SPACE);
+      mark(LG_BIT_MARK);
+    } else {  // 0
+      space(LG_ZERO_SPACE);
+      mark(LG_BIT_MARK);
+    }
+  }
+  // Footer
+  space(0);  // Always end with the LED off
 }
 
 void IRsend::sendWhynter(unsigned long data, int nbits) {
-	enableIROut(38);
-	mark(WHYNTER_ZERO_MARK);
-	space(WHYNTER_ZERO_SPACE);
-	mark(WHYNTER_HDR_MARK);
-	space(WHYNTER_HDR_SPACE);
-    for (int i = 0; i < nbits; i++) {
-      if (data & TOPBIT) {
-        mark(WHYNTER_ONE_MARK);
-        space(WHYNTER_ONE_SPACE);
-      } 
-      else {
-        mark(WHYNTER_ZERO_MARK);
-        space(WHYNTER_ZERO_SPACE);
-      }
-      data <<= 1;
+  // Set IR carrier frequency
+  enableIROut(38);
+  // Header
+  mark(WHYNTER_ZERO_MARK);
+  space(WHYNTER_ZERO_SPACE);
+  mark(WHYNTER_HDR_MARK);
+  space(WHYNTER_HDR_SPACE);
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
+      mark(WHYNTER_ONE_MARK);
+      space(WHYNTER_ONE_SPACE);
+    } else {  // 0
+      mark(WHYNTER_ZERO_MARK);
+      space(WHYNTER_ZERO_SPACE);
     }
-	mark(WHYNTER_ZERO_MARK);
-	space(WHYNTER_ZERO_SPACE);
+  }
+  // Footer
+  mark(WHYNTER_ZERO_MARK);
+  space(WHYNTER_ZERO_SPACE);
 }
 
 void IRsend::sendSony(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(40);
+  // Header
   mark(SONY_HDR_MARK);
-  space(SONY_HDR_SPACE);
-  data = data << (32 - nbits);
-  for (int i = 0; i < nbits; i++) {
-    if (data & TOPBIT) {
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
       mark(SONY_ONE_MARK);
       space(SONY_HDR_SPACE);
-    } 
-    else {
+    } else {  // 0
       mark(SONY_ZERO_MARK);
       space(SONY_HDR_SPACE);
     }
-    data <<= 1;
   }
+  // Footer
 }
 
-void IRsend::sendRaw(unsigned int buf[], int len, int hz)
-{
+void IRsend::sendRaw(unsigned int buf[], int len, int hz) {
+  // Set IR carrier frequency
   enableIROut(hz);
   for (int i = 0; i < len; i++) {
-    if (i & 1) {
+    if (i & 1) { // Odd bit.
       space(buf[i]);
-    } 
-    else {
+    } else {  // Even bit.
       mark(buf[i]);
     }
   }
-  space(0); // Just to be sure
+  space(0);  // Always end with the LED off
 }
 
-// Global Cache format w/o emitter ID or request ID. Starts from hertz, 
+// Global Cache format w/o emitter ID or request ID. Starts from hertz,
 // followed by number of times to emit (count),
 // followed by offset for repeats, followed by code as units of periodic time.
-void IRsend::sendGC(unsigned int buf[], int len)
-{
+void IRsend::sendGC(unsigned int buf[], int len) {
   int khz = buf[0]/1000; // GC data starts with frequency in Hz.
-  enableIROut(khz); 
+  enableIROut(khz);
   int periodic_time = 1000/khz;
   int count = buf[1]; // Max 50 as per GC.
-
+  // Data
   for (int i = 0; i < count; i++) {
-    int j = i > 0 ? buf[2] + 2 : 3; // Account for offset if we're repeating, otherwise start at index 3.
+    // Account for offset if we're repeating, otherwise start at index 3.
+    int j = i > 0 ? buf[2] + 2 : 3;
     for (; j < len; j++) {
-      int microseconds = buf[j] * periodic_time; // Convert periodic units to microseconds. Minimum is 80 for actual GC units.
-      if (j & 1) {
-        mark(microseconds); // Our codes start at an odd index (not even as with sendRaw).
-      }
-      else {
+      // Convert periodic units to microseconds. Minimum is 80 for actual GC
+      // units.
+      int microseconds = buf[j] * periodic_time;
+      if (j & 1) {  // Odd bit.
+        // Our codes start at an odd index (not even as with sendRaw).
+        mark(microseconds);
+      } else {  // Even bit.
         space(microseconds);
       }
     }
   }
-  space(0);
+  // Footer
+  space(0);  // Always end with the LED off
 }
 
 // Note: first bit must be a one (start bit)
-void IRsend::sendRC5(unsigned long data, int nbits)
-{
+void IRsend::sendRC5(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(36);
-  data = data << (32 - nbits);
-  mark(RC5_T1); // First start bit
-  space(RC5_T1); // Second start bit
-  mark(RC5_T1); // Second start bit
-  for (int i = 0; i < nbits; i++) {
-    if (data & TOPBIT) {
-      space(RC5_T1); // 1 is space, then mark
+  // Header
+  mark(RC5_T1);  // First start bit
+  space(RC5_T1);  // Second start bit
+  mark(RC5_T1);  // Second start bit
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
+      space(RC5_T1);  // 1 is space, then mark
       mark(RC5_T1);
-    } 
-    else {
+    } else {  // 0
       mark(RC5_T1);
       space(RC5_T1);
     }
-    data <<= 1;
   }
-  space(0); // Turn off at end
+  // Footer
+  space(0);  // Always end with the LED off
 }
 
 // Caller needs to take care of flipping the toggle bit
-void IRsend::sendRC6(unsigned long data, int nbits)
-{
+void IRsend::sendRC6(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(36);
-  data = data << (32 - nbits);
+  // Header
   mark(RC6_HDR_MARK);
   space(RC6_HDR_SPACE);
-  mark(RC6_T1); // start bit
+  mark(RC6_T1);  // Start bit
   space(RC6_T1);
   int t;
-  for (int i = 0; i < nbits; i++) {
+  // Data
+  for (unsigned long i = 0, mask = 1UL << (nbits - 1); mask; i++, mask >>= 1) {
+    // The fourth bit we send is a "double width trailer bit".
     if (i == 3) {
       // double-wide trailer bit
       t = 2 * RC6_T1;
-    } 
-    else {
+    } else {
       t = RC6_T1;
     }
-    if (data & TOPBIT) {
+    if (data & mask) {  // 1
       mark(t);
       space(t);
-    } 
-    else {
+    } else {  // 0
       space(t);
       mark(t);
     }
-
-    data <<= 1;
   }
-  space(0); // Turn off at end
-}
-void IRsend::sendPanasonic(unsigned int address, unsigned long data) {
-    enableIROut(35);
-    mark(PANASONIC_HDR_MARK);
-    space(PANASONIC_HDR_SPACE);
-    
-    for(int i=0;i<16;i++)
-    {
-        mark(PANASONIC_BIT_MARK);
-        if (address & 0x8000) {
-            space(PANASONIC_ONE_SPACE);
-        } else {
-            space(PANASONIC_ZERO_SPACE);
-        }
-        address <<= 1;        
-    }    
-    for (int i=0; i < 32; i++) {
-        mark(PANASONIC_BIT_MARK);
-        if (data & TOPBIT) {
-            space(PANASONIC_ONE_SPACE);
-        } else {
-            space(PANASONIC_ZERO_SPACE);
-        }
-        data <<= 1;
-    }
-    mark(PANASONIC_BIT_MARK);
-    space(0);
-}
-void IRsend::sendJVC(unsigned long data, int nbits, int repeat)
-{
-    enableIROut(38);
-    data = data << (32 - nbits);
-    if (!repeat){
-        mark(JVC_HDR_MARK);
-        space(JVC_HDR_SPACE); 
-    }
-    for (int i = 0; i < nbits; i++) {
-        if (data & TOPBIT) {
-            mark(JVC_BIT_MARK);
-            space(JVC_ONE_SPACE); 
-        } 
-        else {
-            mark(JVC_BIT_MARK);
-            space(JVC_ZERO_SPACE); 
-        }
-        data <<= 1;
-    }
-    mark(JVC_BIT_MARK);
-    space(0);
+  // Footer
+  space(0);  // Always end with the LED off
 }
 
-void IRsend::sendSAMSUNG(unsigned long data, int nbits)
-{
+void IRsend::sendPanasonic(unsigned int address, unsigned long data) {
+  // Set IR carrier frequency
+  enableIROut(35);
+  // Header
+  mark(PANASONIC_HDR_MARK);
+  space(PANASONIC_HDR_SPACE);
+  // Address (16 bits)
+  for (unsigned long mask = 1UL << (16 - 1); mask; mask >>= 1) {
+    mark(PANASONIC_BIT_MARK);
+    if (address & mask) {  // 1
+      space(PANASONIC_ONE_SPACE);
+    } else {  // 0
+      space(PANASONIC_ZERO_SPACE);
+    }
+  }
+  // Data (32 bits)
+  for (unsigned long mask = 1UL << (32 - 1); mask; mask >>= 1) {
+    mark(PANASONIC_BIT_MARK);
+    if (data & mask) {  // 1
+      space(PANASONIC_ONE_SPACE);
+    } else {  // 0
+      space(PANASONIC_ZERO_SPACE);
+    }
+  }
+  // Footer
+  mark(PANASONIC_BIT_MARK);
+  space(0);  // Always end with the LED off
+}
+
+void IRsend::sendJVC(unsigned long data, int nbits, int repeat) {
+  // Set IR carrier frequency
   enableIROut(38);
+  // Header
+  if (!repeat) {
+    mark(JVC_HDR_MARK);
+    space(JVC_HDR_SPACE);
+  }
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
+       mark(JVC_BIT_MARK);
+       space(JVC_ONE_SPACE);
+    } else {  // 0
+       mark(JVC_BIT_MARK);
+       space(JVC_ZERO_SPACE);
+    }
+  }
+  // Footer
+  mark(JVC_BIT_MARK);
+  space(0);  // Always end with the LED off
+}
+
+void IRsend::sendSAMSUNG(unsigned long data, int nbits) {
+  // Set IR carrier frequency
+  enableIROut(38);
+  // Header
   mark(SAMSUNG_HDR_MARK);
   space(SAMSUNG_HDR_SPACE);
-  for (int i = 0; i < nbits; i++) {
-    if (data & TOPBIT) {
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
+    if (data & mask) {  // 1
       mark(SAMSUNG_BIT_MARK);
       space(SAMSUNG_ONE_SPACE);
-    } 
-    else {
+    } else { // 0
       mark(SAMSUNG_BIT_MARK);
       space(SAMSUNG_ZERO_SPACE);
     }
-    data <<= 1;
   }
+  // Footer
   mark(SAMSUNG_BIT_MARK);
-  space(0);
+  space(0);  // Always end with the LED off
 }
 
 // Denon, from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp
-void IRsend::sendDenon (unsigned long data,  int nbits)
-{
-	// Set IR carrier frequency
-	enableIROut(38);
-
-	// Header
-	mark (DENON_HDR_MARK);
-	space(DENON_HDR_SPACE);
-
-	// Data
-	for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
-		if (data & mask) {
-			mark (DENON_BIT_MARK);
-			space(DENON_ONE_SPACE);
-		} else {
-			mark (DENON_BIT_MARK);
-			space(DENON_ZERO_SPACE);
-		}
-	}
-
-	// Footer
-	mark(DENON_BIT_MARK);
-    space(0);  // Always end with the LED off
+void IRsend::sendDenon (unsigned long data,  int nbits) {
+  // Set IR carrier frequency
+  enableIROut(38);
+  // Header
+  mark(DENON_HDR_MARK);
+  space(DENON_HDR_SPACE);
+  // Data
+  for (unsigned long mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+    if (data & mask) {  // 1
+      mark (DENON_BIT_MARK);
+      space(DENON_ONE_SPACE);
+    } else {  // 0
+      mark (DENON_BIT_MARK);
+      space(DENON_ZERO_SPACE);
+    }
+  }
+  // Footer
+  mark(DENON_BIT_MARK);
+  space(0);  // Always end with the LED off
 }
 
 void IRsend::mark(int time) {
@@ -395,7 +417,8 @@ void IRsend::mark(int time) {
     digitalWrite(IRpin, HIGH);
     delayMicroseconds(halfPeriodicTime);
     digitalWrite(IRpin, LOW);
-    delayMicroseconds(halfPeriodicTime); //38 kHz -> T = 26.31 microsec (periodic time), half of it is 13
+    // 38 kHz -> T = 26.31 microsec (periodic time), half of it is 13
+    delayMicroseconds(halfPeriodicTime);
   }
 }
 
@@ -408,12 +431,16 @@ void IRsend::space(int time) {
 }
 
 void IRsend::enableIROut(int khz) {
-  // Enables IR output.  The khz value controls the modulation frequency in kilohertz.
-  halfPeriodicTime = 500/khz; // T = 1/f but we need T/2 in microsecond and f is in kHz
+  // Enables IR output.
+  // The khz value controls the modulation frequency in kilohertz.
+
+  // T = 1/f but we need T/2 in microsecond and f is in kHz
+  halfPeriodicTime = 500/khz;
 }
 
 
-/* Sharp and DISH support by Todd Treece ( http://unionbridge.org/design/ircommand )
+/* Sharp and DISH support by Todd Treece
+( http://unionbridge.org/design/ircommand )
 
 The Dish send function needs to be repeated 4 times, and the Sharp function
 has the necessary repeat built in because of the need to invert the signal.
@@ -436,22 +463,22 @@ linked LIRC file.
 */
 
 void IRsend::sendSharpRaw(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(38);
-
   // Sending codes in bursts of 3 (normal, inverted, normal) makes transmission
   // much more reliable. That's the exact behaviour of CD-S6470 remote control.
   for (int n = 0; n < 3; n++) {
-    for (int i = 1 << (nbits-1); i > 0; i>>=1) {
-      if (data & i) {
+    // Data
+    for (unsigned long mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+      if (data & mask) {  // 1
         mark(SHARP_BIT_MARK);
         space(SHARP_ONE_SPACE);
-      }
-      else {
+      } else {  // 0
         mark(SHARP_BIT_MARK);
         space(SHARP_ZERO_SPACE);
       }
     }
-    
+    // Footer
     mark(SHARP_BIT_MARK);
     space(SHARP_ZERO_SPACE);
     delay(40);
@@ -466,21 +493,24 @@ void IRsend::sendSharp(unsigned int address, unsigned int command) {
 }
 
 void IRsend::sendDISH(unsigned long data, int nbits) {
+  // Set IR carrier frequency
   enableIROut(56);
+  // Header
   mark(DISH_HDR_MARK);
   space(DISH_HDR_SPACE);
   for (int i = 0; i < nbits; i++) {
     if (data & DISH_TOP_BIT) {
       mark(DISH_BIT_MARK);
       space(DISH_ONE_SPACE);
-    }
-    else {
+    } else {
       mark(DISH_BIT_MARK);
       space(DISH_ZERO_SPACE);
     }
     data <<= 1;
   }
-} 
+  // Footer
+  space(0);  // Always end with the LED off
+}
 
 // From https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
 void IRsend::sendDaikin(unsigned char daikin[]) {
@@ -491,11 +521,12 @@ void IRsend::sendDaikin(unsigned char daikin[]) {
 
 void IRsend::sendDaikinChunk(unsigned char buf[], int len, int start) {
   int data2;
+  // Set IR carrier frequency
   enableIROut(38);
-
+  // Header
   mark(DAIKIN_HDR_MARK);
   space(DAIKIN_HDR_SPACE);
-
+  // Data
   for (int i = start; i < start+len; i++) {
     data2=buf[i];
 
@@ -503,13 +534,13 @@ void IRsend::sendDaikinChunk(unsigned char buf[], int len, int start) {
       if ((1 << j & data2)) {
         mark(DAIKIN_ONE_MARK);
         space(DAIKIN_ONE_SPACE);
-      }
-      else {
+      } else {
         mark(DAIKIN_ZERO_MARK);
         space(DAIKIN_ZERO_SPACE);
       }
     }
   }
+  // Footer
   mark(DAIKIN_ONE_MARK);
   space(DAIKIN_ZERO_SPACE);
 }
@@ -528,33 +559,32 @@ static ETSTimer timer;
 volatile irparams_t irparams;
 
 static void ICACHE_RAM_ATTR read_timeout(void *arg) {
-    os_intr_lock();
-    if (irparams.rawlen) {
-		irparams.rcvstate = STATE_STOP;
-    }
+  os_intr_lock();
+  if (irparams.rawlen) {
+    irparams.rcvstate = STATE_STOP;
+  }
 	os_intr_unlock();
 }
 
 static void ICACHE_RAM_ATTR gpio_intr() {
-    uint32_t gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
-    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status);
+  uint32_t gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
+  GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status);
 
 	if (irparams.rcvstate == STATE_STOP) {
 		return;
-	}	
-    static uint32_t start = 0;
-    uint32_t now = system_get_time();
+	}
+  static uint32_t start = 0;
+  uint32_t now = system_get_time();
 	if (irparams.rcvstate == STATE_IDLE) {
 		irparams.rcvstate = STATE_MARK;
-		irparams.rawbuf[irparams.rawlen++] = 20;		
-	}
-    else if (irparams.rawlen < RAWBUF) {
+		irparams.rawbuf[irparams.rawlen++] = 20;
+	} else if (irparams.rawlen < RAWBUF) {
 		irparams.rawbuf[irparams.rawlen++] = (now - start) / USECPERTICK + 1;
-    }
-    start = now;
+  }
+  start = now;
 
-    os_timer_disarm(&timer);
-    os_timer_arm(&timer, 15, 0);
+  os_timer_disarm(&timer);
+  os_timer_arm(&timer, 15, 0);
 }
 
 IRrecv::IRrecv(int recvpin) {
@@ -574,14 +604,13 @@ void IRrecv::enableIRIn() {
   
   // Attach Interrupt
   attachInterrupt(irparams.recvpin, gpio_intr, CHANGE);
-
 }
 
 void IRrecv::disableIRIn() {
-  //irReadTimer.stop();
-  //os_timer_disarm(&irReadTimer);   
-   ETS_INTR_LOCK();
-   ETS_GPIO_INTR_DISABLE();
+  // irReadTimer.stop();
+  // os_timer_disarm(&irReadTimer);
+  ETS_INTR_LOCK();
+  ETS_GPIO_INTR_DISABLE();
 }
 
 void IRrecv::resume() {
@@ -626,34 +655,34 @@ int IRrecv::decode(decode_results *results) {
   }
 #ifdef DEBUG
   Serial.println("Attempting RC5 decode");
-#endif  
+#endif
   if (decodeRC5(results)) {
     return DECODED;
   }
 #ifdef DEBUG
   Serial.println("Attempting RC6 decode");
-#endif 
+#endif
   if (decodeRC6(results)) {
     return DECODED;
   }
 #ifdef DEBUG
-    Serial.println("Attempting Panasonic decode");
-#endif 
-    if (decodePanasonic(results)) {
-        return DECODED;
-    }
+  Serial.println("Attempting Panasonic decode");
+#endif
+  if (decodePanasonic(results)) {
+    return DECODED;
+  }
 #ifdef DEBUG
-    Serial.println("Attempting LG decode");
-#endif 
-    if (decodeLG(results)) {
-        return DECODED;
-    }
+  Serial.println("Attempting LG decode");
+#endif
+  if (decodeLG(results)) {
+      return DECODED;
+  }
 #ifdef DEBUG
-    Serial.println("Attempting JVC decode");
-#endif 
-    if (decodeJVC(results)) {
-        return DECODED;
-    }
+  Serial.println("Attempting JVC decode");
+#endif
+  if (decodeJVC(results)) {
+    return DECODED;
+  }
 #ifdef DEBUG
   Serial.println("Attempting SAMSUNG decode");
 #endif
@@ -698,7 +727,7 @@ long IRrecv::decodeNEC(decode_results *results) {
   if (irparams.rawlen < 2 * NEC_BITS + 4) {
     return ERR;
   }
-  // Initial space  
+  // Initial space
   if (!MATCH_SPACE(results->rawbuf[offset], NEC_HDR_SPACE)) {
     return ERR;
   }
@@ -710,11 +739,9 @@ long IRrecv::decodeNEC(decode_results *results) {
     offset++;
     if (MATCH_SPACE(results->rawbuf[offset], NEC_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_SPACE(results->rawbuf[offset], NEC_ZERO_SPACE)) {
+    } else if (MATCH_SPACE(results->rawbuf[offset], NEC_ZERO_SPACE)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -758,11 +785,9 @@ long IRrecv::decodeSony(decode_results *results) {
     offset++;
     if (MATCH_MARK(results->rawbuf[offset], SONY_ONE_MARK)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_MARK(results->rawbuf[offset], SONY_ZERO_MARK)) {
+    } else if (MATCH_MARK(results->rawbuf[offset], SONY_ZERO_MARK)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -817,11 +842,9 @@ long IRrecv::decodeWhynter(decode_results *results) {
     offset++;
     if (MATCH_SPACE(results->rawbuf[offset], WHYNTER_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_SPACE(results->rawbuf[offset],WHYNTER_ZERO_SPACE)) {
+    } else if (MATCH_SPACE(results->rawbuf[offset],WHYNTER_ZERO_SPACE)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -848,7 +871,7 @@ long IRrecv::decodeSanyo(decode_results *results) {
   int offset = 1; // Skip first space
 
   
-  // Initial space  
+  // Initial space
   /* Put this back in for debugging - note can't use #DEBUG as if Debug on we don't see the repeat cos of the delay
   Serial.print("IR Gap: ");
   Serial.println( results->rawbuf[offset]);
@@ -884,11 +907,9 @@ long IRrecv::decodeSanyo(decode_results *results) {
     offset++;
     if (MATCH_MARK(results->rawbuf[offset], SANYO_ONE_MARK)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_MARK(results->rawbuf[offset], SANYO_ZERO_MARK)) {
+    } else if (MATCH_MARK(results->rawbuf[offset], SANYO_ZERO_MARK)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -907,14 +928,16 @@ long IRrecv::decodeSanyo(decode_results *results) {
 
 // Looks like Sony except for timings, 48 chars of data and time/space different
 long IRrecv::decodeMitsubishi(decode_results *results) {
-  // Serial.print("?!? decoding Mitsubishi:");Serial.print(irparams.rawlen); Serial.print(" want "); Serial.println( 2 * MITSUBISHI_BITS + 2);
+  // Serial.print("?!? decoding Mitsubishi:");Serial.print(irparams.rawlen);
+  // Serial.print(" want "); Serial.println( 2 * MITSUBISHI_BITS + 2);
   long data = 0;
   if (irparams.rawlen < 2 * MITSUBISHI_BITS + 2) {
     return ERR;
   }
   int offset = 1; // Skip first space
-  // Initial space  
-  /* Put this back in for debugging - note can't use #DEBUG as if Debug on we don't see the repeat cos of the delay
+  // Initial space
+  /* Put this back in for debugging - note can't use #DEBUG as if Debug on we
+     don't see the repeat cos of the delay
   Serial.print("IR Gap: ");
   Serial.println( results->rawbuf[offset]);
   Serial.println( "test against:");
@@ -933,7 +956,7 @@ long IRrecv::decodeMitsubishi(decode_results *results) {
   offset++;
 
   // Typical
-  // 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7 
+  // 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7
 
   // Initial Space
   if (!MATCH_MARK(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
@@ -943,11 +966,9 @@ long IRrecv::decodeMitsubishi(decode_results *results) {
   while (offset + 1 < irparams.rawlen) {
     if (MATCH_MARK(results->rawbuf[offset], MITSUBISHI_ONE_MARK)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_MARK(results->rawbuf[offset], MITSUBISHI_ZERO_MARK)) {
+    } else if (MATCH_MARK(results->rawbuf[offset], MITSUBISHI_ZERO_MARK)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       // Serial.println("A"); Serial.println(offset); Serial.println(results->rawbuf[offset]);
       return ERR;
     }
@@ -977,7 +998,8 @@ long IRrecv::decodeMitsubishi(decode_results *results) {
 // offset and used are updated to keep track of the current position.
 // t1 is the time interval for a single bit in microseconds.
 // Returns -1 for error (measured time interval is not a multiple of t1).
-int IRrecv::getRClevel(decode_results *results, int *offset, int *used, int t1) {
+int IRrecv::getRClevel(decode_results *results, int *offset, int *used,
+                       int t1) {
   if (*offset >= results->rawlen) {
     // After end of recorded buffer, assume SPACE.
     return SPACE;
@@ -989,14 +1011,11 @@ int IRrecv::getRClevel(decode_results *results, int *offset, int *used, int t1) 
   int avail;
   if (MATCH(width, t1 + correction)) {
     avail = 1;
-  } 
-  else if (MATCH(width, 2*t1 + correction)) {
+  } else if (MATCH(width, 2*t1 + correction)) {
     avail = 2;
-  } 
-  else if (MATCH(width, 3*t1 + correction)) {
+  } else if (MATCH(width, 3*t1 + correction)) {
     avail = 3;
-  } 
-  else {
+  } else {
     return -1;
   }
 
@@ -1008,12 +1027,11 @@ int IRrecv::getRClevel(decode_results *results, int *offset, int *used, int t1) 
 #ifdef DEBUG
   if (val == MARK) {
     Serial.println("MARK");
-  } 
-  else {
+  } else {
     Serial.println("SPACE");
   }
 #endif
-  return val;   
+  return val;
 }
 
 long IRrecv::decodeRC5(decode_results *results) {
@@ -1029,19 +1047,17 @@ long IRrecv::decodeRC5(decode_results *results) {
   if (getRClevel(results, &offset, &used, RC5_T1) != MARK) return ERR;
   int nbits;
   for (nbits = 0; offset < irparams.rawlen; nbits++) {
-    int levelA = getRClevel(results, &offset, &used, RC5_T1); 
+    int levelA = getRClevel(results, &offset, &used, RC5_T1);
     int levelB = getRClevel(results, &offset, &used, RC5_T1);
     if (levelA == SPACE && levelB == MARK) {
       // 1 bit
       data = (data << 1) | 1;
-    } 
-    else if (levelA == MARK && levelB == SPACE) {
+    } else if (levelA == MARK && levelB == SPACE) {
       // zero bit
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
-    } 
+    }
   }
 
   // Success
@@ -1073,27 +1089,25 @@ long IRrecv::decodeRC6(decode_results *results) {
   int nbits;
   for (nbits = 0; offset < results->rawlen; nbits++) {
     int levelA, levelB; // Next two levels
-    levelA = getRClevel(results, &offset, &used, RC6_T1); 
+    levelA = getRClevel(results, &offset, &used, RC6_T1);
     if (nbits == 3) {
       // T bit is double wide; make sure second half matches
       if (levelA != getRClevel(results, &offset, &used, RC6_T1)) return ERR;
-    } 
+    }
     levelB = getRClevel(results, &offset, &used, RC6_T1);
     if (nbits == 3) {
       // T bit is double wide; make sure second half matches
       if (levelB != getRClevel(results, &offset, &used, RC6_T1)) return ERR;
-    } 
+    }
     if (levelA == MARK && levelB == SPACE) { // reversed compared to RC5
       // 1 bit
       data = (data << 1) | 1;
-    } 
-    else if (levelA == SPACE && levelB == MARK) {
+    } else if (levelA == SPACE && levelB == MARK) {
       // zero bit
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR; // Error
-    } 
+    }
   }
   // Success
   results->bits = nbits;
@@ -1103,131 +1117,127 @@ long IRrecv::decodeRC6(decode_results *results) {
 }
 
 long IRrecv::decodePanasonic(decode_results *results) {
-    unsigned long long data = 0;
-	int offset = 1;  // Dont skip first space    
-    if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
-        return ERR;
+  unsigned long long data = 0;
+	int offset = 1;  // Dont skip first space
+  if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
+    return ERR;
+  }
+  offset++;
+  if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_SPACE)) {
+    return ERR;
+  }
+  offset++;
+  // decode address
+  for (int i = 0; i < PANASONIC_BITS; i++) {
+    if (!MATCH(results->rawbuf[offset++], PANASONIC_BIT_MARK)) {
+      return ERR;
     }
-    offset++;		
-    if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_SPACE)) {
-        return ERR;
+    if (MATCH(results->rawbuf[offset],PANASONIC_ONE_SPACE)) {
+      data = (data << 1) | 1;
+    } else if (MATCH(results->rawbuf[offset],PANASONIC_ZERO_SPACE)) {
+      data <<= 1;
+    } else {
+      return ERR;
     }
-    offset++;    
-    // decode address
-    for (int i = 0; i < PANASONIC_BITS; i++) {
-        if (!MATCH(results->rawbuf[offset++], PANASONIC_BIT_MARK)) {
-            return ERR;
-        }
-        if (MATCH(results->rawbuf[offset],PANASONIC_ONE_SPACE)) {
-            data = (data << 1) | 1;
-        } else if (MATCH(results->rawbuf[offset],PANASONIC_ZERO_SPACE)) {
-            data <<= 1;
-        } else {
-            return ERR;
-        }
-        offset++;
-    }
-    results->value = (unsigned long)data;
-    results->panasonicAddress = (unsigned int)(data >> 32);
-    results->decode_type = PANASONIC;
-    results->bits = PANASONIC_BITS;
-    return DECODED;
+    offset++;
+  }
+  results->value = (unsigned long)data;
+  results->panasonicAddress = (unsigned int)(data >> 32);
+  results->decode_type = PANASONIC;
+  results->bits = PANASONIC_BITS;
+  return DECODED;
 }
 
 long IRrecv::decodeLG(decode_results *results) {
-    long data = 0;
+  long data = 0;
 	int offset = 1; // Skip first space
   
-    // Initial mark
-    if (!MATCH_MARK(results->rawbuf[offset], LG_HDR_MARK)) {
-        return ERR;
-    }
-    offset++; 
-    if (irparams.rawlen < 2 * LG_BITS + 1 ) {
-        return ERR;
-    }
-    // Initial space 
-    if (!MATCH_SPACE(results->rawbuf[offset], LG_HDR_SPACE)) {
-        return ERR;
+  // Initial mark
+  if (!MATCH_MARK(results->rawbuf[offset], LG_HDR_MARK)) {
+    return ERR;
+  }
+  offset++;
+  if (irparams.rawlen < 2 * LG_BITS + 1 ) {
+    return ERR;
+  }
+  // Initial space
+  if (!MATCH_SPACE(results->rawbuf[offset], LG_HDR_SPACE)) {
+    return ERR;
+  }
+  offset++;
+  for (int i = 0; i < LG_BITS; i++) {
+    if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)) {
+      return ERR;
     }
     offset++;
-    for (int i = 0; i < LG_BITS; i++) {
-        if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)) {
-            return ERR;
-        }
-        offset++;
-        if (MATCH_SPACE(results->rawbuf[offset], LG_ONE_SPACE)) {
-            data = (data << 1) | 1;
-        } 
-        else if (MATCH_SPACE(results->rawbuf[offset], LG_ZERO_SPACE)) {
-            data <<= 1;
-        } 
-        else {
-            return ERR;
-        }
-        offset++;
+    if (MATCH_SPACE(results->rawbuf[offset], LG_ONE_SPACE)) {
+      data = (data << 1) | 1;
+    } else if (MATCH_SPACE(results->rawbuf[offset], LG_ZERO_SPACE)) {
+      data <<= 1;
+    } else {
+      return ERR;
     }
-    //Stop bit
-    if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)){
-        return ERR;
-    }
-    // Success
-    results->bits = LG_BITS;
-    results->value = data;
-    results->decode_type = LG;
-    return DECODED;
+    offset++;
+  }
+  //Stop bit
+  if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)){
+    return ERR;
+  }
+  // Success
+  results->bits = LG_BITS;
+  results->value = data;
+  results->decode_type = LG;
+  return DECODED;
 }
 
 long IRrecv::decodeJVC(decode_results *results) {
-    long data = 0;
+  long data = 0;
 	int offset = 1; // Skip first space
-    // Check for repeat
-    if (irparams.rawlen - 1 == 33 &&
-        MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK) &&
-        MATCH_MARK(results->rawbuf[irparams.rawlen-1], JVC_BIT_MARK)) {
-        results->bits = 0;
-        results->value = REPEAT;
-        results->decode_type = JVC;
-        return DECODED;
-    } 
-    // Initial mark
-    if (!MATCH_MARK(results->rawbuf[offset], JVC_HDR_MARK)) {
-        return ERR;
-    }
-    offset++; 
-    if (irparams.rawlen < 2 * JVC_BITS + 1 ) {
-        return ERR;
-    }
-    // Initial space 
-    if (!MATCH_SPACE(results->rawbuf[offset], JVC_HDR_SPACE)) {
-        return ERR;
-    }
-    offset++;
-    for (int i = 0; i < JVC_BITS; i++) {
-        if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)) {
-            return ERR;
-        }
-        offset++;
-        if (MATCH_SPACE(results->rawbuf[offset], JVC_ONE_SPACE)) {
-            data = (data << 1) | 1;
-        } 
-        else if (MATCH_SPACE(results->rawbuf[offset], JVC_ZERO_SPACE)) {
-            data <<= 1;
-        } 
-        else {
-            return ERR;
-        }
-        offset++;
-    }
-    //Stop bit
-    if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)){
-        return ERR;
-    }
-    // Success
-    results->bits = JVC_BITS;
-    results->value = data;
+  // Check for repeat
+  if (irparams.rawlen - 1 == 33 &&
+      MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK) &&
+      MATCH_MARK(results->rawbuf[irparams.rawlen-1], JVC_BIT_MARK)) {
+    results->bits = 0;
+    results->value = REPEAT;
     results->decode_type = JVC;
     return DECODED;
+  }
+  // Initial mark
+  if (!MATCH_MARK(results->rawbuf[offset], JVC_HDR_MARK)) {
+    return ERR;
+  }
+  offset++;
+  if (irparams.rawlen < 2 * JVC_BITS + 1 ) {
+    return ERR;
+  }
+  // Initial space
+  if (!MATCH_SPACE(results->rawbuf[offset], JVC_HDR_SPACE)) {
+    return ERR;
+  }
+  offset++;
+  for (int i = 0; i < JVC_BITS; i++) {
+    if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)) {
+      return ERR;
+    }
+    offset++;
+    if (MATCH_SPACE(results->rawbuf[offset], JVC_ONE_SPACE)) {
+      data = (data << 1) | 1;
+    } else if (MATCH_SPACE(results->rawbuf[offset], JVC_ZERO_SPACE)) {
+      data <<= 1;
+    } else {
+      return ERR;
+    }
+    offset++;
+  }
+  //Stop bit
+  if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)) {
+    return ERR;
+  }
+  // Success
+  results->bits = JVC_BITS;
+  results->value = data;
+  results->decode_type = JVC;
+  return DECODED;
 }
 
 // SAMSUNGs have a repeat only 4 items long
@@ -1241,8 +1251,8 @@ long IRrecv::decodeSAMSUNG(decode_results *results) {
   offset++;
   // Check for repeat
   if (irparams.rawlen == 4 &&
-    MATCH_SPACE(results->rawbuf[offset], SAMSUNG_RPT_SPACE) &&
-    MATCH_MARK(results->rawbuf[offset+1], SAMSUNG_BIT_MARK)) {
+      MATCH_SPACE(results->rawbuf[offset], SAMSUNG_RPT_SPACE) &&
+      MATCH_MARK(results->rawbuf[offset+1], SAMSUNG_BIT_MARK)) {
     results->bits = 0;
     results->value = REPEAT;
     results->decode_type = SAMSUNG;
@@ -1251,7 +1261,7 @@ long IRrecv::decodeSAMSUNG(decode_results *results) {
   if (irparams.rawlen < 2 * SAMSUNG_BITS + 2) {
     return ERR;
   }
-  // Initial space  
+  // Initial space
   if (!MATCH_SPACE(results->rawbuf[offset], SAMSUNG_HDR_SPACE)) {
     return ERR;
   }
@@ -1263,11 +1273,9 @@ long IRrecv::decodeSAMSUNG(decode_results *results) {
     offset++;
     if (MATCH_SPACE(results->rawbuf[offset], SAMSUNG_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } 
-    else if (MATCH_SPACE(results->rawbuf[offset], SAMSUNG_ZERO_SPACE)) {
+    } else if (MATCH_SPACE(results->rawbuf[offset], SAMSUNG_ZERO_SPACE)) {
       data <<= 1;
-    } 
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -1302,45 +1310,41 @@ long IRrecv::decodeDaikin(decode_results *results) {
 
   for (int i = 0; i < 32; i++) {
     if (!MATCH_MARK(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
-
-    return ERR;
+      return ERR;
     }
     offset++;
     if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
       data = (data << 1) | 1;
-    }
-    else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
+    } else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
       data <<= 1;
-    }
-    else {
+    } else {
       return ERR;
     }
     offset++;
   }
 
-unsigned long number = data ; // some number...
-int bits = 32 ; // nr of bits in some number
-unsigned long reversed = 0;
-for ( int b=0 ; b < bits ; b++ ) reversed = ( reversed << 1 ) | ( 0x0001 & ( number >> b ) );
+  unsigned long number = data ; // some number...
+  int bits = 32 ; // nr of bits in some number
+  unsigned long reversed = 0;
+  for ( int b=0 ; b < bits ; b++ ) {
+    reversed = ( reversed << 1 ) | ( 0x0001 & ( number >> b ) );
+  }
 
- Serial.print ("Code ");
-      Serial.println (reversed,  HEX);
+  Serial.print ("Code ");
+  Serial.println (reversed,  HEX);
 
- //==========
+  //==========
 
   for (int i = 0; i < 32; i++) {
     if (!MATCH_MARK(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
-
-    return ERR;
+      return ERR;
     }
     offset++;
     if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
       data = (data << 1) | 1;
-    }
-    else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
+    } else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
       data <<= 1;
-    }
-    else {
+    } else {
       return ERR;
     }
     offset++;
@@ -1349,14 +1353,16 @@ for ( int b=0 ; b < bits ; b++ ) reversed = ( reversed << 1 ) | ( 0x0001 & ( num
   number = data ; // some number...
   bits = 32 ; // nr of bits in some number
   reversed = 0;
-  for ( int b=0 ; b < bits ; b++ ) reversed = ( reversed << 1 ) | ( 0x0001 & ( number >> b ) );
+  for ( int b=0 ; b < bits ; b++ ) {
+    reversed = ( reversed << 1 ) | ( 0x0001 & ( number >> b ) );
+  }
 
- //Serial.print ("Code2 ");
-      //Serial.println (reversed,  HEX);
+  //Serial.print ("Code2 ");
+  //Serial.println (reversed,  HEX);
 
- //===========
- if (!MATCH_SPACE(results->rawbuf[offset], 29000)) {
-      //Serial.println ("no gap");
+  //===========
+  if (!MATCH_SPACE(results->rawbuf[offset], 29000)) {
+    //Serial.println ("no gap");
 	  return ERR;
   }
   offset++;
@@ -1369,34 +1375,45 @@ for ( int b=0 ; b < bits ; b++ ) reversed = ( reversed << 1 ) | ( 0x0001 & ( num
 }
 
 // Denon, from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp
-long IRrecv::decodeDenon (decode_results *results)
-{
-	unsigned long  data   = 0;  // Somewhere to build our code
-	int            offset = 1;  // Skip the Gap reading
+long IRrecv::decodeDenon (decode_results *results) {
+	unsigned long data   = 0;  // Somewhere to build our code
+	int offset = 1;  // Skip the Gap reading
 
 	// Check we have the right amount of data
-	if (irparams.rawlen != 1 + 2 + (2 * DENON_BITS) + 1)  return false ;
+	if (irparams.rawlen != 1 + 2 + (2 * DENON_BITS) + 1) {
+	  return false;
+	}
 
 	// Check initial Mark+Space match
-	if (!MATCH_MARK (results->rawbuf[offset++], DENON_HDR_MARK ))  return false ;
-	if (!MATCH_SPACE(results->rawbuf[offset++], DENON_HDR_SPACE))  return false ;
+	if (!MATCH_MARK (results->rawbuf[offset++], DENON_HDR_MARK )) {
+	  return false;
+	}
+	if (!MATCH_SPACE(results->rawbuf[offset++], DENON_HDR_SPACE)) {
+	  return false;
+	}
 
 	// Read the bits in
 	for (int i = 0;  i < DENON_BITS;  i++) {
 		// Each bit looks like: DENON_MARK + DENON_SPACE_1 -> 1
 		//                 or : DENON_MARK + DENON_SPACE_0 -> 0
-		if (!MATCH_MARK(results->rawbuf[offset++], DENON_BIT_MARK))  return false ;
+		if (!MATCH_MARK(results->rawbuf[offset++], DENON_BIT_MARK)) {
+		  return false;
+		}
 
 		// IR data is big-endian, so we shuffle it in from the right:
-		if      (MATCH_SPACE(results->rawbuf[offset], DENON_ONE_SPACE))   data = (data << 1) | 1 ;
-		else if (MATCH_SPACE(results->rawbuf[offset], DENON_ZERO_SPACE))  data = (data << 1) | 0 ;
-		else                                                        return false ;
+		if (MATCH_SPACE(results->rawbuf[offset], DENON_ONE_SPACE)) {
+		  data = (data << 1) | 1;
+		} else if (MATCH_SPACE(results->rawbuf[offset], DENON_ZERO_SPACE)) {
+		  data = (data << 1) | 0;
+		} else {
+		  return false;
+		}
 		offset++;
 	}
 
 	// Success
-	results->bits        = DENON_BITS;
-	results->value       = data;
+	results->bits = DENON_BITS;
+	results->value = data;
 	results->decode_type = DENON;
 	return DECODED;
 }
@@ -1422,11 +1439,9 @@ long IRrecv::decodeDenon (decode_results *results)
 int IRrecv::compare(unsigned int oldval, unsigned int newval) {
   if (newval < oldval * .8) {
     return 0;
-  } 
-  else if (oldval < newval * .8) {
+  } else if (oldval < newval * .8) {
     return 2;
-  } 
-  else {
+  } else {
     return 1;
   }
 }


### PR DESCRIPTION
* Fix issues with some IR send routines not handling unsigned longs correctly.
  E.g. sendNEC(0xC1A2B847, 32) was mangled. Values over 0x7FFFFFFF failed.
* Moved most cases of sendXXX calls to handle masking in a more generic
  and consistent way that should be more portable. Fixed several assumptions
  about bit sizes & masks to handle protocols with <= 32 bits.
* Add more comments and consistent structure to send routines.
* Change code style to a consistent one. Numerous contributors had resulted
  in a hodge-podge of indentation and code style.
* Tested and debugged most of the sendXXX procedures to ensure they handled
  values across all of the value ranges.
* Heavily borrowed code & style from https://github.com/z3t0/Arduino-IRremote
  when updating routines.
* Removed trailing white space.