### PR TITLE
IDE 1.8.1 board manager 2.3.0 Compilation is currently KO due to undefined constants call

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -39,6 +39,7 @@
 
 #include "IRremoteESP8266.h"
 #include "IRremoteInt.h"
+#include "IRKelvinator.h"
 
 // These versions of MATCH, MATCH_MARK, and MATCH_SPACE are only for debugging.
 // To use them, set DEBUG in IRremoteInt.h


### PR DESCRIPTION
including the library IRKelvinator.h wich define the missing constants