### PR TITLE
Add initial support for Mitsubishi A/C IR remote emulation.

### DIFF
--- a/IRMitsubishiAC.cpp
+++ b/IRMitsubishiAC.cpp
@@ -10,7 +10,7 @@ IRMitsubishiAC::IRMitsubishiAC(int pin) : _irsend(pin) {
 }
 
 void IRMitsubishiAC::stateReset() {
-  for (uint8_t i = 0; i < KELVINATOR_STATE_LENGTH; i++)
+  for (uint8_t i = 0; i < MITSUBISHI_AC_STATE_LENGTH; i++)
     remote_state[i] = known_good_state[i];
   checksum();  // Calculate the checksum
 }
@@ -62,7 +62,7 @@ bool IRMitsubishiAC::getPower() {
 // Set the temp. in deg C
 void IRMitsubishiAC::setTemp(uint8_t temp) {
     temp = max(MITSUBISHI_AC_MIN_TEMP, temp);
-    temp = min(MITSUBISHI_AC_TEMP, temp);
+    temp = min(MITSUBISHI_AC_MAX_TEMP, temp);
     remote_state[7] = temp - MITSUBISHI_AC_MIN_TEMP;
 }
 

--- a/IRMitsubishiAC.cpp
+++ b/IRMitsubishiAC.cpp
@@ -1,0 +1,127 @@
+/*
+Code to emulate Mitsubishi A/C IR remote control unit.
+Inspired and derived from https://github.com/r45635/HVAC-IR-Control
+*/
+
+#include <IRMitsubishiAC.h>
+
+IRMitsubishiAC::IRMitsubishiAC(int pin) : _irsend(pin) {
+  stateReset();
+}
+
+void IRMitsubishiAC::stateReset() {
+  for (uint8_t i = 0; i < KELVINATOR_STATE_LENGTH; i++)
+    remote_state[i] = known_good_state[i];
+  checksum();  // Calculate the checksum
+}
+
+void IRMitsubishiAC::begin() {
+    _irsend.begin();
+}
+
+void IRMitsubishiAC::send() {
+  checksum();   // Ensure correct checksum before sending.
+  _irsend.sendMitsubishiAC(remote_state);
+}
+
+uint8_t* IRMitsubishiAC::getRaw() {
+  checksum();
+  return remote_state;
+}
+
+void IRMitsubishiAC::checksum() {
+  uint8_t sum = 0;
+  // Checksum is simple addition of all previous bytes stored
+  // as a 8 bit value.
+  for (uint8_t i = 0; i < 17; i++)
+    sum += remote_state[i];
+  remote_state[17] = sum & 0xFFU;
+}
+
+void IRMitsubishiAC::on() {
+    //state = ON;
+    remote_state[5] |= MITSUBISHI_AC_POWER;
+}
+
+void IRMitsubishiAC::off() {
+    //state = OFF;
+    remote_state[5] &= ~MITSUBISHI_AC_POWER;
+}
+
+void IRMitsubishiAC::setPower(bool state) {
+  if (state)
+    on();
+  else
+    off();
+}
+
+bool IRMitsubishiAC::getPower() {
+    return((remote_state[5] & MITSUBISHI_AC_POWER) != 0);
+}
+
+// Set the temp. in deg C
+void IRMitsubishiAC::setTemp(uint8_t temp) {
+    temp = max(MITSUBISHI_AC_MIN_TEMP, temp);
+    temp = min(MITSUBISHI_AC_TEMP, temp);
+    remote_state[7] = temp - MITSUBISHI_AC_MIN_TEMP;
+}
+
+// Return the set temp. in deg C
+uint8_t IRMitsubishiAC::getTemp() {
+    return(remote_state[7] + MITSUBISHI_AC_MIN_TEMP);
+}
+
+// Set the speed of the fan, 0-6.
+// 0 is auto, 1-5 is the speed, 6 is silent.
+void IRMitsubishiAC::setFan(uint8_t fan) {
+  // Bounds check
+  if (fan > MITSUBISHI_AC_FAN_SILENT)
+    fan = MITSUBISHI_AC_FAN_MAX;  // Set the fan to maximum if out of range.
+  if (fan == MITSUBISHI_AC_FAN_AUTO) {   // Automatic is a special case.
+    remote_state[9] = B10000000 | (remote_state[9] & B01111000);
+    return;
+  } else if (fan >= MITSUBISHI_AC_FAN_MAX) {
+    fan--;  // There is no spoon^H^H^Heed 5 (max), pretend it doesn't exist.
+  }
+  remote_state[9] |= fan;
+}
+
+uint8_t IRMitsubishiAC::getFan() {
+    uint8_t fan = remote_state[9] & B111;
+    if (fan == MITSUBISHI_AC_FAN_MAX)
+      return MITSUBISHI_AC_FAN_SILENT;
+    return fan;
+}
+
+uint8_t IRMitsubishiAC::getMode() {
+  /*
+  MITSUBISHI_AC_AUTO
+  MITSUBISHI_AC_COOL
+  MITSUBISHI_AC_DRY
+  MITSUBISHI_AC_HEAT
+  */
+    return(remote_state[6]);
+}
+
+void IRMitsubishiAC::setMode(uint8_t mode) {
+  // If we get an unexpected mode, default to AUTO.
+  switch (mode) {
+    case MITSUBISHI_AC_AUTO: break;
+    case MITSUBISHI_AC_COOL: break;
+    case MITSUBISHI_AC_DRY: break;
+    case MITSUBISHI_AC_HEAT: break;
+    default: mode = MITSUBISHI_AC_AUTO;
+  }
+  remote_state[6] = mode;
+}
+
+void IRMitsubishiAC::setVane(uint8_t mode) {
+  mode = max(mode, B111);  // bounds check
+  mode |= B1000;
+  mode <<= 3;
+  remote_state[9] |= mode;
+}
+
+uint8_t IRMitsubishiAC::getVane() {
+  return ((remote_state[9] & B00111000) >> 3);
+}

--- a/IRMitsubishiAC.h
+++ b/IRMitsubishiAC.h
@@ -1,0 +1,50 @@
+
+#include <IRremoteESP8266.h>
+#include <Arduino.h>
+
+#define MITSUBISHI_AC_AUTO 0x20U
+#define MITSUBISHI_AC_COOL 0x18U
+#define MITSUBISHI_AC_DRY 0x10U
+#define MITSUBISHI_AC_HEAT 0x08U
+#define MITSUBISHI_AC_POWER 0x20U
+#define MITSUBISHI_AC_FAN_AUTO 0U
+#define MITSUBISHI_AC_FAN_MAX 5U
+#define MITSUBISHI_AC_FAN_SILENT 6U
+#define MITSUBISHI_AC_MIN_TEMP 16U  // 16C
+#define MITSUBISHI_AC_MAX_TEMP 31U  // 31C
+#define MITSUBISHI_AC_VANE_AUTO 0U
+#define MITSUBISHI_AC_VANE_AUTO_MOVE 7U
+#define MITSUBISHI_AC_STATE_LENGTH 18
+
+class IRMitsubishiAC
+{
+    public:
+        IRMitsubishiAC(int pin);
+
+        void stateReset();
+        void send();
+
+        void begin();
+        void on();
+        void off();
+        void setPower(bool state);
+        bool getPower();
+        void setTemp(uint8_t temp);
+        uint8_t getTemp();
+        void setFan(uint8_t fan);
+        uint8_t getFan();
+        void setMode(uint8_t mode);
+        uint8_t getMode();
+        void setVane(uint8_t mode);
+        uint8_t getVane();
+        uint8_t* getRaw();
+
+
+    private:
+        // The state of the IR remote in IR code form.
+        uint8_t known_good_state[MITSUBISHI_AC_STATE_LENGTH] = { 0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x06, 0x30, 0x45, 0x67, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F };
+        uint8_t remote_state[MITSUBISHI_AC_STATE_LENGTH];
+
+        void checksum();
+        IRsend _irsend;
+};

--- a/IRMitsubishiAC.h
+++ b/IRMitsubishiAC.h
@@ -42,6 +42,8 @@ class IRMitsubishiAC
 
     private:
         // The state of the IR remote in IR code form.
+        // Known good state obtained from:
+        //   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266.ino#L108
         uint8_t known_good_state[MITSUBISHI_AC_STATE_LENGTH] = { 0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x06, 0x30, 0x45, 0x67, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F };
         uint8_t remote_state[MITSUBISHI_AC_STATE_LENGTH];
 

--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -29,7 +29,7 @@
  *   (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
- *     (based on https://github.com/r45635/HVAC-IR-Control)
+ *     (derived from https://github.com/r45635/HVAC-IR-Control)
  *
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for
  *   sending IR code on ESP8266

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -65,7 +65,8 @@ enum decode_type_t {
   DAIKIN,
   DENON,
   KELVINATOR,
-  SHERWOOD
+  SHERWOOD,
+  MITSUBISHI_AC
 };
 
 // Results returned from the decoder
@@ -102,6 +103,7 @@ public:
 #define DENON 17
 #define KELVINATOR 18  // Currently not implemented
 #define SHERWOOD 19   // Not implemented. It decodes as an NEC code.
+#define MITSUBISHI_AC 20  // Not implemented.
 #define UNKNOWN -1
 
 // Decoded value for NEC when a repeat code is received
@@ -203,6 +205,7 @@ public:
   void sendKelvinator(unsigned char data[]);
   void sendSherwood(unsigned long data, int nbits);
   void sendSherwood(unsigned long data, int nbits, int repeats);
+  void sendMitsubishiAC(unsigned char data[]);
   void enableIROut(int khz);
   VIRTUAL void mark(int usec);
   VIRTUAL void space(unsigned long usec);
@@ -210,6 +213,7 @@ private:
   int halfPeriodicTime;
   int IRpin;
   void sendKelvinatorChunk(unsigned char data, unsigned char nbits);
+  void sendMitsubishiACChunk(unsigned char data);
 } ;
 
 // Some useful constants

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -87,6 +87,8 @@
 // #define MITSUBISHI_RPT_LENGTH 45000
 
 // Mitsubishi A/C
+// Values were initially obtained from:
+//   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266.ino#L84
 #define MITSUBISHI_AC_HDR_MARK    3400
 #define MITSUBISHI_AC_HDR_SPACE   1750
 #define MITSUBISHI_AC_BIT_MARK    450

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -18,6 +18,8 @@
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C added by crankyoldgit
+ * Mitsubishi A/C added by crankyoldgit
+ *     (based on https://github.com/r45635/HVAC-IR-Control)
  *
  * 09/23/2015 : Samsung pulse parameters updated by Sebastien Warin to be compatible with EUxxD6200
  *
@@ -83,6 +85,15 @@
 #define MITSUBISHI_ZERO_MARK  750 // 17*50-100
 // #define MITSUBISHI_DOUBLE_SPACE_USECS  800  // usually ssee 713 - not using ticks as get number wrapround
 // #define MITSUBISHI_RPT_LENGTH 45000
+
+// Mitsubishi A/C
+#define MITSUBISHI_AC_HDR_MARK    3400
+#define MITSUBISHI_AC_HDR_SPACE   1750
+#define MITSUBISHI_AC_BIT_MARK    450
+#define MITSUBISHI_AC_ONE_SPACE   1300
+#define MITSUBISHI_AC_ZERO_SPACE  420
+#define MITSUBISHI_AC_RPT_MARK    440
+#define MITSUBISHI_AC_RPT_SPACE   17100L
 
 
 #define RC5_T1		889

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -1,0 +1,43 @@
+
+#include <IRMitsubishiAC.h>
+
+IRMitsubishiAC mitsubir(D1);  // IR led controlled by Pin D1.
+
+void printState() {
+  // Display the settings.
+  Serial.println("Mitsubishi A/C remote is in the following state:");
+  Serial.printf("  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d, Vane Mode: %d\n",
+                mitsubir.getPower(), mitsubir.getMode(), mitsubir.getTemp(),
+                mitsubir.getFan(), mitsubir.getVane());
+  // Display the encoded IR sequence.
+  unsigned char* ir_code = mitsubir.getRaw();
+  Serial.print("IR Code: 0x");
+  for (int i = 0; i < MITSUBISHI_AC_STATE_LENGTH; i++)
+    Serial.printf("%02X", ir_code[i]);
+  Serial.println();
+}
+
+void setup(){
+  mitsubir.begin();
+  Serial.begin(115200);
+  delay(200);
+
+  // Set up what we want to send. See IRKelvinator.cpp for all the options.
+  // Most things default to off.
+  Serial.println("Default state of the remote.");
+  printState();
+  Serial.println("Setting desired state for A/C.");
+  mitsubir.on();
+  mitsubir.setFan(1);
+  mitsubir.setMode(MITSUBISHI_AC_COOL);
+  mitsubir.setTemp(26);
+  mitsubir.setVane(MITSUBISHI_AC_VANE_AUTO);
+}
+
+void loop() {
+  // Now send the IR signal.
+  Serial.println("Sending IR command to A/C ...");
+  mitsubir.send();
+  printState();
+  delay(5000);
+}

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -22,8 +22,7 @@ void setup(){
   Serial.begin(115200);
   delay(200);
 
-  // Set up what we want to send. See IRKelvinator.cpp for all the options.
-  // Most things default to off.
+  // Set up what we want to send. See IRMitsubishiAC.cpp for all the options.
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");


### PR DESCRIPTION
Per [request](https://github.com/markszabo/IRremoteESP8266/issues/70), I've added Mitsubishi A/C remote emulation. This is based on @r45635's [work](https://github.com/r45635/HVAC-IR-Control).
I didn't end up directly using the code @r45635 has, but the work certainly made my job a lot easier and influenced me heavily. I did however directly lift the IR timing values and basic layout of the Mitsubishi A/C IR code/packets.