### PR TITLE
Fix disableIRIn disabling interrupts and enableIRIn not enabling

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -734,17 +734,15 @@ void IRrecv::enableIRIn() {
 
   // Initialize timer
   os_timer_disarm(&timer);
-  os_timer_setfn(&timer, (os_timer_func_t *)read_timeout, &timer);
+  os_timer_setfn(&timer, (os_timer_func_t *)read_timeout, NULL);
 
   // Attach Interrupt
   attachInterrupt(irparams.recvpin, gpio_intr, CHANGE);
 }
 
 void IRrecv::disableIRIn() {
-  // irReadTimer.stop();
-  // os_timer_disarm(&irReadTimer);
-  ETS_INTR_LOCK();
-  ETS_GPIO_INTR_DISABLE();
+  os_timer_disarm(&timer);
+  detachInterrupt(irparams.recvpin);
 }
 
 void IRrecv::resume() {


### PR DESCRIPTION
In enableIRIn we initialize a timer and attach an interrupt.
In disableIRIn we need to disable the timer and detach the interrupt.

Fixes #57
Signed-off-by: Roi Dayan <roi.dayan@gmail.com>