### PR TITLE
Update gpio intr handling

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -709,6 +709,7 @@ static void ICACHE_RAM_ATTR gpio_intr() {
   GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status);
 
   if (irparams.rawlen >= RAWBUF) {
+    irparams.overflow = true;
     irparams.rcvstate = STATE_STOP;
   }
 
@@ -717,6 +718,7 @@ static void ICACHE_RAM_ATTR gpio_intr() {
   }
 
   if (irparams.rcvstate == STATE_IDLE) {
+    irparams.overflow = false;
     irparams.rcvstate = STATE_MARK;
     irparams.rawbuf[irparams.rawlen++] = 1;
   } else {
@@ -762,9 +764,12 @@ void IRrecv::resume() {
 int IRrecv::decode(decode_results *results) {
   results->rawbuf = irparams.rawbuf;
   results->rawlen = irparams.rawlen;
+  results->overflow = irparams.overflow;
+
   if (irparams.rcvstate != STATE_STOP) {
     return ERR;
   }
+
 #ifdef DEBUG
   Serial.println("Attempting NEC decode");
 #endif

--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -722,7 +722,10 @@ static void ICACHE_RAM_ATTR gpio_intr() {
     irparams.rcvstate = STATE_MARK;
     irparams.rawbuf[irparams.rawlen++] = 1;
   } else {
-    irparams.rawbuf[irparams.rawlen++] = (now - start) / USECPERTICK + 1;
+    if (now < start)
+      irparams.rawbuf[irparams.rawlen++] = (0xFFFFFFFF - start + now) / USECPERTICK + 1;
+    else
+      irparams.rawbuf[irparams.rawlen++] = (now - start) / USECPERTICK + 1;
   }
 
   start = now;

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -81,6 +81,7 @@ public:
   int bits; // Number of bits in decoded value
   volatile unsigned int *rawbuf; // Raw intervals in .5 us ticks
   int rawlen; // Number of records in rawbuf.
+  bool overflow;
 };
 
 // Values for decode_type

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -211,6 +211,7 @@ typedef struct {
   unsigned int timer;     // state timer, counts 50uS ticks.
   unsigned int rawbuf[RAWBUF]; // raw data
   uint8_t rawlen;         // counter of entries in rawbuf
+  uint8_t overflow;
 }
 irparams_t;
 

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -62,6 +62,11 @@ void  encoding (decode_results *results)
 //
 void  dumpInfo (decode_results *results)
 {
+  if (results->overflow) {
+    Serial.println("IR code too long. Edit IRremoteInt.h and increase RAWBUF");
+    return;
+  }
+
   // Show Encoding standard
   Serial.print("Encoding  : ");
   encoding(results);


### PR DESCRIPTION
- Make it more readable, fix indentation
- rawbuf contains ticks measurement and initial space should be 1 tick.
  this also match from the Arduino library
- When rawbuf exhausted change state to stop
- disarm timeout timer earlier
- get current time earlier

Related #31
Signed-off-by: Roi Dayan <roi.dayan@gmail.com>