### PR TITLE
Get rid of redundant ERR and DECODED definitions

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -128,29 +128,29 @@ class IRrecv
 {
 public:
   IRrecv(int recvpin);
-  int decode(decode_results *results);
+  bool decode(decode_results *results);
   void enableIRIn();
   void disableIRIn();
   void resume();
   private:
   // These are called by decode
   int getRClevel(decode_results *results, int *offset, int *used, int t1);
-  long decodeNEC(decode_results *results);
-  long decodeSony(decode_results *results);
-  long decodeSanyo(decode_results *results);
-  long decodeMitsubishi(decode_results *results);
-  long decodeRC5(decode_results *results);
-  long decodeRC6(decode_results *results);
-  long decodePanasonic(decode_results *results);
-  long decodeLG(decode_results *results);
-  long decodeJVC(decode_results *results);
-  long decodeSAMSUNG(decode_results *results);
-  long decodeWhynter(decode_results *results);
-  long decodeHash(decode_results *results);
+  bool decodeNEC(decode_results *results);
+  bool decodeSony(decode_results *results);
+  bool decodeSanyo(decode_results *results);
+  bool decodeMitsubishi(decode_results *results);
+  bool decodeRC5(decode_results *results);
+  bool decodeRC6(decode_results *results);
+  bool decodePanasonic(decode_results *results);
+  bool decodeLG(decode_results *results);
+  bool decodeJVC(decode_results *results);
+  bool decodeSAMSUNG(decode_results *results);
+  bool decodeWhynter(decode_results *results);
+  bool decodeHash(decode_results *results);
   // COOLIX decode is not implemented yet
-  //  long decodeCOOLIX(decode_results *results);
-  long decodeDaikin(decode_results *results);
-  long decodeDenon(decode_results *results);
+  //  bool decodeCOOLIX(decode_results *results);
+  bool decodeDaikin(decode_results *results);
+  bool decodeDenon(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
 };
 

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -201,9 +201,6 @@
 #define STATE_SPACE    4
 #define STATE_STOP     5
 
-#define ERR 0
-#define DECODED 1
-
 // information for the interrupt handler
 typedef struct {
   uint8_t recvpin;           // pin for IR data from detector


### PR DESCRIPTION
There was a mix in their usage instead of just bool.
Decode functions were returning ERR on error but true on success.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>