### PR TITLE
Make repeat in sendSony() similar to other uses & improve comments.

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -260,15 +260,24 @@ void IRsend::sendWhynter(unsigned long data, int nbits) {
   space(WHYNTER_ZERO_SPACE);
 }
 
-// sendSony() should typically be called with repeat=3 as Sony devices
-// expect the code to be sent at least 3 times.
-// Timings and details are taken from:
-//   http://www.sbprojects.com/knowledge/ir/sirc.php
 void IRsend::sendSony(unsigned long data, int nbits, unsigned int repeat) {
-  // Set IR carrier frequency
-  enableIROut(40);
+  // Send an IR command to a compatible Sony device.
+  //
+  // Args:
+  //   data: IR command to be sent.
+  //   nbits: Nr. of bits of the IR command to be sent.
+  //   repeat: Nr. of additional times the IR command is to be sent.
+  //
+  // sendSony() should typically be called with repeat=2 as Sony devices
+  // expect the code to be sent at least 3 times.
+  //
+  // Timings and details are taken from:
+  //   http://www.sbprojects.com/knowledge/ir/sirc.php
+
+  enableIROut(40);  // Sony devices use a 40kHz IR carrier frequency.
   IRtimer usecs = IRtimer();
-  for (uint16_t i = 0; i < repeat; i++) {  // Typically loop 3 or more times.
+
+  for (uint16_t i = 0; i <= repeat; i++) {  // Typically loop 3 or more times.
     usecs.reset();
     // Header
     mark(SONY_HDR_MARK);
@@ -281,6 +290,7 @@ void IRsend::sendSony(unsigned long data, int nbits, unsigned int repeat) {
     // start of the next one. A 10ms minimum gap is also required.
     space(max(10000, 45000 - usecs.elapsed()));
   }
+  // A space() is always performed last, so no need to turn off the LED.
 }
 
 void IRsend::sendRaw(unsigned int buf[], int len, int hz) {

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -164,11 +164,11 @@ public:
   void sendWhynter(unsigned long data, int nbits);
   void sendNEC(unsigned long data, int nbits=32, unsigned int repeat=0);
   void sendLG(unsigned long data, int nbits);
-  // sendSony() should typically be called with repeat=3 as Sony devices
-  // expect the code to be sent at least 3 times.
+  // sendSony() should typically be called with repeat=2 as Sony devices
+  // expect the code to be sent at least 3 times. (code + 2 repeats = 3 codes)
   // As the legacy use of this procedure was only to send a single code
-  // it defaults to repeat=1 for backward compatiblity.
-  void sendSony(unsigned long data, int nbits, unsigned int repeat=1);
+  // it defaults to repeat=0 for backward compatiblity.
+  void sendSony(unsigned long data, int nbits, unsigned int repeat=0);
   // Neither Sanyo nor Mitsubishi send is implemented yet
   //  void sendSanyo(unsigned long data, int nbits);
   //  void sendMitsubishi(unsigned long data, int nbits);


### PR DESCRIPTION
A 'repeat' of 0 in the context of sending a command should mean send the command once, with no repeats.
I incorrectly set the defaults to 1 and required a repeat=1 to send the command at all.
This fixes that mistake.

Add plenty of comments and describe the args to sendSony to make this clear.