### PR TITLE
Update sendSAMSUNG to use sendData().

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -429,15 +429,8 @@ void IRsend::sendSAMSUNG(unsigned long data, int nbits) {
   mark(SAMSUNG_HDR_MARK);
   space(SAMSUNG_HDR_SPACE);
   // Data
-  for (unsigned long mask = 1UL << (nbits - 1); mask; mask >>= 1) {
-    if (data & mask) {  // 1
-      mark(SAMSUNG_BIT_MARK);
-      space(SAMSUNG_ONE_SPACE);
-    } else { // 0
-      mark(SAMSUNG_BIT_MARK);
-      space(SAMSUNG_ZERO_SPACE);
-    }
-  }
+  sendData(SAMSUNG_BIT_MARK, SAMSUNG_ONE_SPACE, SAMSUNG_BIT_MARK,
+           SAMSUNG_ZERO_SPACE, data, nbits, true);
   // Footer
   mark(SAMSUNG_BIT_MARK);
   ledOff();

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -181,7 +181,7 @@ public:
   void sendSharpRaw(unsigned long data, int nbits);
   void sendPanasonic(unsigned int address, unsigned long data);
   void sendJVC(unsigned long data, int nbits, int repeat); // *Note instead of sending the REPEAT constant if you want the JVC repeat signal sent, send the original code value and change the repeat argument from 0 to 1. JVC protocol repeats by skipping the header NOT by sending a separate code value like NEC does.
-  void sendSAMSUNG(unsigned long data, int nbits);
+  void sendSAMSUNG(unsigned long data, int nbits=32);
   void sendDaikin(unsigned char daikin[]);
   void sendDaikinChunk(unsigned char buf[], int len, int start);
   void sendDenon(unsigned long data, int nbits=14);


### PR DESCRIPTION
Set default bit length to 32, which seems to be the default for the protocol.