### PR TITLE
Bump library to v1.1.0

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=1.0.2
+version=1.1.0
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)


### PR DESCRIPTION
Highlight of changes since v1.0.2:
* Finish conversion of applicable send*() procedures to use more standard code. i.e. sendData().
* Add repeat functionality to a number of protocols.
* Minor change to Sony IR protocol timings based on user reports/experience.
* Add appropriate gaps to ends of some protocols where we have inter-command interval timing data.
* Add default decoding of Denon IR signals.
* Mark procedures to run from flash, rather than defaulting to iram. Enabled by defining ICACHE_FLASH (compiled with -DICACHE_FLASH) in order to be enforced.