### PR TITLE
Handle unsigned long values in the URL

### DIFF
--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -26,7 +26,7 @@ void handleIr(){
   for (uint8_t i=0; i<server.args(); i++){
     if(server.argName(i) == "code") 
     {
-      unsigned long code = server.arg(i).toInt();
+      unsigned long code = strtoul(server.arg(i).c_str(), NULL, 10);
       irsend.sendNEC(code, 32);
     }
   }


### PR DESCRIPTION
toInt() only handles long correctly, not unsigned long. Use strtoul() instead.

Fixes #141 

FYI @carlostorrez