### PR TITLE
Reduce IRAM usage in the interrupt handler routines.

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -736,10 +736,9 @@ volatile irparams_t irparams;
 
 static void ICACHE_RAM_ATTR read_timeout(void *arg __attribute__((unused))) {
   os_intr_lock();
-  if (irparams.rawlen) {
+  if (irparams.rawlen)
     irparams.rcvstate = STATE_STOP;
-  }
-	os_intr_unlock();
+  os_intr_unlock();
 }
 
 static void ICACHE_RAM_ATTR gpio_intr() {
@@ -750,25 +749,32 @@ static void ICACHE_RAM_ATTR gpio_intr() {
   os_timer_disarm(&timer);
   GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status);
 
-  if (irparams.rawlen >= RAWBUF) {
+  // Grab a local copy of rawlen to reduce instructions used in IRAM.
+  // This is an ugly premature optimisation code-wise, but we do everything we
+  // can to save IRAM.
+  // It seems referencing the value via the structure uses more instructions.
+  // Less instructions means faster and less IRAM used.
+  // N.B. It saves about 13 bytes of IRAM.
+  uint16_t rawlen = irparams.rawlen;
+
+  if (rawlen >= RAWBUF) {
     irparams.overflow = true;
     irparams.rcvstate = STATE_STOP;
   }
 
-  if (irparams.rcvstate == STATE_STOP) {
+  if (irparams.rcvstate == STATE_STOP)
     return;
-  }
 
   if (irparams.rcvstate == STATE_IDLE) {
-    irparams.overflow = false;
     irparams.rcvstate = STATE_MARK;
-    irparams.rawbuf[irparams.rawlen++] = 1;
+    irparams.rawbuf[rawlen] = 1;
   } else {
     if (now < start)
-      irparams.rawbuf[irparams.rawlen++] = (0xFFFFFFFF - start + now) / USECPERTICK + 1;
+      irparams.rawbuf[rawlen] = (0xFFFFFFFF - start + now) / USECPERTICK + 1;
     else
-      irparams.rawbuf[irparams.rawlen++] = (now - start) / USECPERTICK + 1;
+      irparams.rawbuf[rawlen] = (now - start) / USECPERTICK + 1;
   }
+  irparams.rawlen++;
 
   start = now;
   #define ONCE 0
@@ -782,8 +788,7 @@ IRrecv::IRrecv(int recvpin) {
 // initialization
 void ICACHE_FLASH_ATTR IRrecv::enableIRIn() {
   // initialize state machine variables
-  irparams.rcvstate = STATE_IDLE;
-  irparams.rawlen = 0;
+  resume();
 
   // Initialize timer
   os_timer_disarm(&timer);
@@ -801,6 +806,7 @@ void ICACHE_FLASH_ATTR IRrecv::disableIRIn() {
 void ICACHE_FLASH_ATTR IRrecv::resume() {
   irparams.rcvstate = STATE_IDLE;
   irparams.rawlen = 0;
+  irparams.overflow = false;
 }
 
 // Decodes the received IR message

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -212,12 +212,14 @@
 
 // information for the interrupt handler
 typedef struct {
-  uint8_t recvpin;           // pin for IR data from detector
-  uint8_t rcvstate;          // state machine
-  unsigned int timer;     // state timer, counts 50uS ticks.
-  unsigned int rawbuf[RAWBUF]; // raw data
-  uint8_t rawlen;         // counter of entries in rawbuf
-  uint8_t overflow;
+  uint8_t recvpin;              // pin for IR data from detector
+  uint8_t rcvstate;             // state machine
+  unsigned int timer;           // state timer, counts 50uS ticks.
+  unsigned int rawbuf[RAWBUF];  // raw data
+  // uint16_t is used for rawlen as it saves 3 bytes of iram in the interrupt
+  // handler. Don't ask why, I don't know. It just does.
+  uint16_t rawlen;              // counter of entries in rawbuf.
+  uint8_t overflow;             // Buffer overflow indicator.
 }
 irparams_t;
 


### PR DESCRIPTION
_Note to reviewers: I want multiple independent confirmations that these changes don't negatively affect things before we merge it into master. Please take a detailed look and perform adequate testing._

These changes/optimisations save approx 28 bytes of precious IRAM as reported by
  `memanalyzer.py ~/.platformio/packages/toolchain-xtensa/bin/xtensa-lx106-elf-objdump IRrecvDumpV2.ino.elf`
Previously our IRAM footprint was [288 bytes](https://github.com/letscontrolit/ESPEasy/blob/mega/dist/Plugin_sizes.txt), this should bring us down to 260.
We can reduce another ~10 bytes but at the expense of missing an edge case when the microsecond timer wraps. i.e. a possible failed read every 71 mins.

The changes:
  * Move resetting the overflow flag outside of the interrupt handler. Saved a few bytes.
  * Move incrementing rawlen from out of each structure reference. Having a single increment instruction saved us a few bytes.
  * Use a cached copy of rawlen, rather than referencing the underlying structure. Saves approx 13 bytes. Not really expected, but hey, it worked. I tried it for other structure references, no savings there.
  * Use uint16_t for rawlen in irparams_t. Saves 3 bytes. Weird.
  * Misc: Code style cleanups.

Ref #138, [letscontrolit/ESPEasy/issues/188](https://github.com/letscontrolit/ESPEasy/issues/188), [memanalyzer.py](https://raw.githubusercontent.com/SmingHub/Sming/develop/tools/memanalyzer.py)

FYI @psy0rz

[Tested on a NodeMCU V1.0 board. Appears to still work as expected.]