### PR TITLE
Reduce IRAM usage in the interrupt handler routines.

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -212,12 +212,14 @@
 
 // information for the interrupt handler
 typedef struct {
-  uint8_t recvpin;           // pin for IR data from detector
-  uint8_t rcvstate;          // state machine
-  unsigned int timer;     // state timer, counts 50uS ticks.
-  unsigned int rawbuf[RAWBUF]; // raw data
-  uint8_t rawlen;         // counter of entries in rawbuf
-  uint8_t overflow;
+  uint8_t recvpin;              // pin for IR data from detector
+  uint8_t rcvstate;             // state machine
+  unsigned int timer;           // state timer, counts 50uS ticks.
+  unsigned int rawbuf[RAWBUF];  // raw data
+  // uint16_t is used for rawlen as it saves 3 bytes of iram in the interrupt
+  // handler. Don't ask why, I don't know. It just does.
+  uint16_t rawlen;              // counter of entries in rawbuf.
+  uint8_t overflow;             // Buffer overflow indicator.
 }
 irparams_t;
 


### PR DESCRIPTION
These changes/optimisations save 28 bytes of precious IRAM as reported by
  memanalyzer.py ~/.platformio/packages/toolchain-xtensa/bin/xtensa-lx106-elf-objdump IRrecvDumpV2.ino.elf
Previously our IRAM footprint was 288 bytes, this should bring us down to 260.
We can reduce another ~10 bytes but at the expense of missing an edge case when the microsecond timer wraps. i.e. a possible failed read every 71 mins.

The changes:
  * Move resetting the overflow flag outside of the interrupt handler. Saves 12 bytes.
  * Use a cached copy of rawlen, rather than referencing the underlying structure. Saves approx 13 bytes.
  * Use uint16_t for rawlen in irparams_t. Saves 3 bytes.