### PR TITLE
Make IR message capture resume faster

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -32,6 +32,7 @@
 #define IRremote_h
 
 #include <stdint.h>
+#include "IRremoteInt.h"
 
 // The following are compile-time library options.
 // If you change them, recompile the library.
@@ -110,12 +111,13 @@ class IRrecv
 {
 public:
   IRrecv(int recvpin);
-  bool decode(decode_results *results);
+  bool decode(decode_results *results, irparams_t *save=NULL);
   void enableIRIn();
   void disableIRIn();
   void resume();
   private:
   // These are called by decode
+  void copyIrParams(irparams_t *dest);
   int getRClevel(decode_results *results, int *offset, int *used, int t1);
   bool decodeNEC(decode_results *results);
   bool decodeSony(decode_results *results);
@@ -221,7 +223,6 @@ private:
 
 // Some useful constants
 #define USECPERTICK 50  // microseconds per clock interrupt tick
-#define RAWBUF 100 // Length of raw duration buffer
 
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -210,6 +210,8 @@
 #define STATE_SPACE    4
 #define STATE_STOP     5
 
+#define RAWBUF 100 // Length of raw duration buffer
+
 // information for the interrupt handler
 typedef struct {
   uint8_t recvpin;           // pin for IR data from detector


### PR DESCRIPTION
Instead of decoding from the interrupt's buffer/data, which meant decoding
& printing of the results had to complete before we re-enabled capture,
make a copy the interrupt buffer/data immediately, resume capture, then
decode & print from the copy.

Library:
- Allow decode() to be able to work from a copy of the interrupt state & data.
- Make all the decodeBlah() routines no longer access the interrupt data
  directly. Also more consistent.
Example:
- Use new faster/safer decode & resume method to reduce captures of message
  fragments. Repeating codes now captured without mangling of results. \o/
- Fix Denon decoding text.
- Minor code cleanup.

[Tested on a NodeMCU board against NEC, Samsung, & Sherwood remotes.]