### PR TITLE
Prep sendRC6() for v2.0

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -182,7 +182,7 @@ public:
   void sendRaw(unsigned int buf[], int len, int hz);
   void sendGC(unsigned int buf[], int len);
   void sendRC5(unsigned long data, int nbits);
-  void sendRC6(unsigned long data, int nbits);
+  void sendRC6(unsigned long long data, unsigned int nbits, unsigned int repeat=0);
   void sendRCMM(uint32_t data, uint8_t nbits=24);
   // sendDISH() should typically be called with repeat=3 as DISH devices
   // expect the code to be sent at least 4 times. (code + 3 repeats = 4 codes)


### PR DESCRIPTION
- Add support for sending upto 64bit RC6 codes.
- Add repeat functionality to sendRC6()
- Bail out if asked to send more bits than we have data for.
- Add standard comments for procedure.
- Clean up style.

#13 #43 #54  