### PR TITLE
Significantly change how matching is performed and improve RCMM matching.

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -45,59 +45,6 @@
 #include "IRKelvinator.h"
 #include "IRMitsubishiAC.h"
 
-// These versions of MATCH, MATCH_MARK, and MATCH_SPACE are only for debugging.
-// To use them, set DEBUG in IRremoteInt.h
-// Normally macros are used for efficiency
-#ifdef DEBUG
-int MATCH(int measured, int desired) {
-  Serial.print("Testing: ");
-  Serial.print(TICKS_LOW(desired), DEC);
-  Serial.print(" <= ");
-  Serial.print(measured, DEC);
-  Serial.print(" <= ");
-  Serial.println(TICKS_HIGH(desired), DEC);
-  return measured >= TICKS_LOW(desired) && measured <= TICKS_HIGH(desired);
-}
-
-int MATCH_MARK(int measured_ticks, int desired_us) {
-  Serial.print("Testing mark ");
-  Serial.print(measured_ticks * USECPERTICK, DEC);
-  Serial.print(" vs ");
-  Serial.print(desired_us, DEC);
-  Serial.print(": ");
-  Serial.print(TICKS_LOW(desired_us + MARK_EXCESS), DEC);
-  Serial.print(" <= ");
-  Serial.print(measured_ticks, DEC);
-  Serial.print(" <= ");
-  Serial.println(TICKS_HIGH(desired_us + MARK_EXCESS), DEC);
-  return measured_ticks >= TICKS_LOW(desired_us + MARK_EXCESS) &&
-      measured_ticks <= TICKS_HIGH(desired_us + MARK_EXCESS);
-}
-
-int MATCH_SPACE(int measured_ticks, int desired_us) {
-  Serial.print("Testing space ");
-  Serial.print(measured_ticks * USECPERTICK, DEC);
-  Serial.print(" vs ");
-  Serial.print(desired_us, DEC);
-  Serial.print(": ");
-  Serial.print(TICKS_LOW(desired_us - MARK_EXCESS), DEC);
-  Serial.print(" <= ");
-  Serial.print(measured_ticks, DEC);
-  Serial.print(" <= ");
-  Serial.println(TICKS_HIGH(desired_us - MARK_EXCESS), DEC);
-  return measured_ticks >= TICKS_LOW(desired_us - MARK_EXCESS) &&
-      measured_ticks <= TICKS_HIGH(desired_us - MARK_EXCESS);
-}
-#else
-int ICACHE_FLASH_ATTR MATCH(int measured, int desired) {return measured >= TICKS_LOW(desired) &&
-    measured <= TICKS_HIGH(desired);}
-int ICACHE_FLASH_ATTR MATCH_MARK(int measured_ticks, int desired_us)
-    {return MATCH(measured_ticks, (desired_us + MARK_EXCESS));}
-int ICACHE_FLASH_ATTR MATCH_SPACE(int measured_ticks, int desired_us)
-    {return MATCH(measured_ticks, (desired_us - MARK_EXCESS));}
-// Debugging versions are in IRremote.cpp
-#endif
-
 // IRtimer ---------------------------------------------------------------------
 // This class performs a simple time in useconds since instantiated.
 // Handles when the system timer wraps around (once).
@@ -418,8 +365,9 @@ void ICACHE_FLASH_ATTR IRsend::sendRCMM(uint32_t data, uint8_t nbits) {
   }
   // Footer
   mark(RCMM_BIT_MARK);
-  // Protocol requires us to wait RCMM_RPT_LENGTH usecs from the start.
-  space(RCMM_RPT_LENGTH - usecs.elapsed());
+  // Protocol requires us to wait at least RCMM_RPT_LENGTH usecs from the start
+  // or RCMM_MIN_GAP usecs.
+  space(max(RCMM_RPT_LENGTH - usecs.elapsed(), RCMM_MIN_GAP));
 }
 
 void ICACHE_FLASH_ATTR IRsend::sendPanasonic(unsigned int address,
@@ -906,19 +854,114 @@ bool ICACHE_FLASH_ATTR IRrecv::decode(decode_results *results) {
   return false;
 }
 
+// Calculate the lower bound of the nr. of ticks.
+//
+// Args:
+//   usecs:  Nr. of uSeconds.
+//   tolerance:  Percent as an integer. e.g. 10 is 10%
+// Returns:
+//   Nr. of ticks.
+uint32_t IRrecv::ticksLow(uint32_t usecs, uint8_t tolerance) {
+  // max() used to ensure the result can't drop below 0 before the cast.
+  return((uint32_t) max(usecs * (1.0 - tolerance/100.)/USECPERTICK, 0));
+}
+
+// Calculate the upper bound of the nr. of ticks.
+//
+// Args:
+//   usecs:  Nr. of uSeconds.
+//   tolerance:  Percent as an integer. e.g. 10 is 10%
+// Returns:
+//   Nr. of ticks.
+uint32_t IRrecv::ticksHigh(uint32_t usecs, uint8_t tolerance) {
+  return((uint32_t) usecs * (1.0 + tolerance/100.)/USECPERTICK + 1);
+}
+
+// Check if we match a pulse(measured_ticks) with the desired_us within
+// +/-tolerance percent.
+//
+// Args:
+//   measured_ticks:  The recorded period of the signal pulse.
+//   desired_us:  The expected period (in useconds) we are matching against.
+//   tolerance:  A percentage expressed as an integer. e.g. 10 is 10%.
+//
+// Returns:
+//   Boolean: true if it matches, false if it doesn't.
+bool ICACHE_FLASH_ATTR IRrecv::match(uint32_t measured_ticks,
+                                     uint32_t desired_us,
+                                     uint8_t tolerance) {
+  #ifdef DEBUG
+    Serial.print("Matching: ");
+    Serial.print(ticksLow(desired_us, tolerance), DEC);
+    Serial.print(" <= ");
+    Serial.print(measured_ticks, DEC);
+    Serial.print(" <= ");
+    Serial.println(ticksHigh(desired_us, tolerance), DEC);
+  #endif
+  return (measured_ticks >= ticksLow(desired_us, tolerance) &&
+          measured_ticks <= ticksHigh(desired_us, tolerance));
+}
+
+// Check if we match a mark signal(measured_ticks) with the desired_us within
+// +/-tolerance percent, after an expected is excess is added.
+//
+// Args:
+//   measured_ticks:  The recorded period of the signal pulse.
+//   desired_us:  The expected period (in useconds) we are matching against.
+//   tolerance:  A percentage expressed as an integer. e.g. 10 is 10%.
+//   excess:  Nr. of useconds.
+//
+// Returns:
+//   Boolean: true if it matches, false if it doesn't.
+bool ICACHE_FLASH_ATTR IRrecv::matchMark(uint32_t measured_ticks,
+                                         uint32_t desired_us,
+                                         uint8_t tolerance, int excess) {
+  #ifdef DEBUG
+    Serial.print("Matching MARK ");
+    Serial.print(measured_ticks * USECPERTICK, DEC);
+    Serial.print(" vs ");
+    Serial.print(desired_us, DEC);
+    Serial.print(". ");
+  #endif
+  return match(measured_ticks, desired_us + excess, tolerance);
+}
+// Check if we match a space signal(measured_ticks) with the desired_us within
+// +/-tolerance percent, after an expected is excess is removed.
+//
+// Args:
+//   measured_ticks:  The recorded period of the signal pulse.
+//   desired_us:  The expected period (in useconds) we are matching against.
+//   tolerance:  A percentage expressed as an integer. e.g. 10 is 10%.
+//   excess:  Nr. of useconds.
+//
+// Returns:
+//   Boolean: true if it matches, false if it doesn't.
+bool ICACHE_FLASH_ATTR IRrecv::matchSpace(uint32_t measured_ticks,
+                                          uint32_t desired_us,
+                                          uint8_t tolerance, int excess) {
+  #ifdef DEBUG
+    Serial.print("Matching SPACE ");
+    Serial.print(measured_ticks * USECPERTICK, DEC);
+    Serial.print(" vs ");
+    Serial.print(desired_us, DEC);
+    Serial.print(". ");
+  #endif
+  return match(measured_ticks, desired_us - excess, tolerance);
+}
+
 // NECs have a repeat only 4 items long
 bool ICACHE_FLASH_ATTR IRrecv::decodeNEC(decode_results *results) {
   long data = 0;
   int offset = 1; // Skip initial space
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], NEC_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], NEC_HDR_MARK)) {
     return false;
   }
   offset++;
   // Check for repeat
   if (irparams.rawlen == 4 &&
-    MATCH_SPACE(results->rawbuf[offset], NEC_RPT_SPACE) &&
-    MATCH_MARK(results->rawbuf[offset+1], NEC_BIT_MARK)) {
+    matchSpace(results->rawbuf[offset], NEC_RPT_SPACE) &&
+    matchMark(results->rawbuf[offset+1], NEC_BIT_MARK)) {
     results->bits = 0;
     results->value = REPEAT;
     results->decode_type = NEC;
@@ -928,18 +971,18 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeNEC(decode_results *results) {
     return false;
   }
   // Initial space
-  if (!MATCH_SPACE(results->rawbuf[offset], NEC_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], NEC_HDR_SPACE)) {
     return false;
   }
   offset++;
   for (int i = 0; i < NEC_BITS; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], NEC_BIT_MARK)) {
+    if (!matchMark(results->rawbuf[offset], NEC_BIT_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], NEC_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], NEC_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], NEC_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], NEC_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -973,19 +1016,19 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeSony(decode_results *results) {
   offset++;
 
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], SONY_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], SONY_HDR_MARK)) {
     return false;
   }
   offset++;
 
   while (offset + 1 < irparams.rawlen) {
-    if (!MATCH_SPACE(results->rawbuf[offset], SONY_HDR_SPACE)) {
+    if (!matchSpace(results->rawbuf[offset], SONY_HDR_SPACE)) {
       break;
     }
     offset++;
-    if (MATCH_MARK(results->rawbuf[offset], SONY_ONE_MARK)) {
+    if (matchMark(results->rawbuf[offset], SONY_ONE_MARK)) {
       data = (data << 1) | 1;
-    } else if (MATCH_MARK(results->rawbuf[offset], SONY_ZERO_MARK)) {
+    } else if (matchMark(results->rawbuf[offset], SONY_ZERO_MARK)) {
       data <<= 1;
     } else {
       return false;
@@ -1015,34 +1058,34 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeWhynter(decode_results *results) {
 
 
   // sequence begins with a bit mark and a zero space
-  if (!MATCH_MARK(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
+  if (!matchMark(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
     return false;
   }
   offset++;
-  if (!MATCH_SPACE(results->rawbuf[offset], WHYNTER_ZERO_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], WHYNTER_ZERO_SPACE)) {
     return false;
   }
   offset++;
 
   // header mark and space
-  if (!MATCH_MARK(results->rawbuf[offset], WHYNTER_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], WHYNTER_HDR_MARK)) {
     return false;
   }
   offset++;
-  if (!MATCH_SPACE(results->rawbuf[offset], WHYNTER_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], WHYNTER_HDR_SPACE)) {
     return false;
   }
   offset++;
 
   // data bits
   for (int i = 0; i < WHYNTER_BITS; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
+    if (!matchMark(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], WHYNTER_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], WHYNTER_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset],WHYNTER_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset],WHYNTER_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1051,7 +1094,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeWhynter(decode_results *results) {
   }
 
   // trailing mark
-  if (!MATCH_MARK(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
+  if (!matchMark(results->rawbuf[offset], WHYNTER_BIT_MARK)) {
     return false;
   }
   // Success
@@ -1089,25 +1132,25 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeSanyo(decode_results *results) {
   offset++;
 
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], SANYO_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], SANYO_HDR_MARK)) {
     return false;
   }
   offset++;
 
   // Skip Second Mark
-  if (!MATCH_MARK(results->rawbuf[offset], SANYO_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], SANYO_HDR_MARK)) {
     return false;
   }
   offset++;
 
   while (offset + 1 < irparams.rawlen) {
-    if (!MATCH_SPACE(results->rawbuf[offset], SANYO_HDR_SPACE)) {
+    if (!matchSpace(results->rawbuf[offset], SANYO_HDR_SPACE)) {
       break;
     }
     offset++;
-    if (MATCH_MARK(results->rawbuf[offset], SANYO_ONE_MARK)) {
+    if (matchMark(results->rawbuf[offset], SANYO_ONE_MARK)) {
       data = (data << 1) | 1;
-    } else if (MATCH_MARK(results->rawbuf[offset], SANYO_ZERO_MARK)) {
+    } else if (matchMark(results->rawbuf[offset], SANYO_ZERO_MARK)) {
       data <<= 1;
     } else {
       return false;
@@ -1159,21 +1202,21 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeMitsubishi(decode_results *results) {
   // 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7
 
   // Initial Space
-  if (!MATCH_MARK(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
+  if (!matchMark(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
     return false;
   }
   offset++;
   while (offset + 1 < irparams.rawlen) {
-    if (MATCH_MARK(results->rawbuf[offset], MITSUBISHI_ONE_MARK)) {
+    if (matchMark(results->rawbuf[offset], MITSUBISHI_ONE_MARK)) {
       data = (data << 1) | 1;
-    } else if (MATCH_MARK(results->rawbuf[offset], MITSUBISHI_ZERO_MARK)) {
+    } else if (matchMark(results->rawbuf[offset], MITSUBISHI_ZERO_MARK)) {
       data <<= 1;
     } else {
       // Serial.println("A"); Serial.println(offset); Serial.println(results->rawbuf[offset]);
       return false;
     }
     offset++;
-    if (!MATCH_SPACE(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
+    if (!matchSpace(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
       // Serial.println("B"); Serial.println(offset); Serial.println(results->rawbuf[offset]);
       break;
     }
@@ -1209,11 +1252,11 @@ int ICACHE_FLASH_ATTR IRrecv::getRClevel(decode_results *results, int *offset,
   int correction = (val == MARK) ? MARK_EXCESS : - MARK_EXCESS;
 
   int avail;
-  if (MATCH(width, t1 + correction)) {
+  if (match(width, t1 + correction)) {
     avail = 1;
-  } else if (MATCH(width, 2*t1 + correction)) {
+  } else if (match(width, 2*t1 + correction)) {
     avail = 2;
-  } else if (MATCH(width, 3*t1 + correction)) {
+  } else if (match(width, 3*t1 + correction)) {
     avail = 3;
   } else {
     return -1;
@@ -1273,11 +1316,11 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeRC6(decode_results *results) {
   }
   int offset = 1; // Skip first space
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], RC6_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], RC6_HDR_MARK)) {
     return false;
   }
   offset++;
-  if (!MATCH_SPACE(results->rawbuf[offset], RC6_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], RC6_HDR_SPACE)) {
     return false;
   }
   offset++;
@@ -1330,30 +1373,36 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeRCMM(decode_results *results) {
   if (bitSize < 12 || bitSize > 32)
     return false;
   // Header decode
-  if (!MATCH_MARK(results->rawbuf[offset++], RCMM_HDR_MARK))
+  if (!matchMark(results->rawbuf[offset++], RCMM_HDR_MARK))
     return false;
-  if (!MATCH_MARK(results->rawbuf[offset++], RCMM_HDR_SPACE))
+  if (!matchSpace(results->rawbuf[offset++], RCMM_HDR_SPACE))
     return false;
   // Data decode
   // RC-MM has two bits of data per mark/space pair.
   for (int i = 0; i < bitSize; i += 2) {
     data <<= 2;
-    if (!MATCH(results->rawbuf[offset++], RCMM_BIT_MARK))
+    // Use non-default tolerance & excess for matching some of the spaces as the
+    // defaults are too generous and causes mis-matches in some cases.
+    if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK, RCMM_TOLERANCE))
       return false;
-    if (MATCH(results->rawbuf[offset], RCMM_BIT_SPACE_0))
+    if (matchSpace(results->rawbuf[offset],
+                   RCMM_BIT_SPACE_0, TOLERANCE, RCMM_EXCESS))
       data += 0;
-    else if (MATCH(results->rawbuf[offset], RCMM_BIT_SPACE_1))
+    else if (matchSpace(results->rawbuf[offset],
+                        RCMM_BIT_SPACE_1, TOLERANCE, RCMM_EXCESS))
       data += 1;
-    else if (MATCH(results->rawbuf[offset], RCMM_BIT_SPACE_2))
+    else if (matchSpace(results->rawbuf[offset],
+                        RCMM_BIT_SPACE_2, RCMM_TOLERANCE, RCMM_EXCESS))
       data += 2;
-    else if (MATCH(results->rawbuf[offset], RCMM_BIT_SPACE_3))
+    else if (matchSpace(results->rawbuf[offset],
+                        RCMM_BIT_SPACE_3, RCMM_TOLERANCE, RCMM_EXCESS))
       data += 3;
     else
       return false;
     offset++;
   }
   // Footer decode
-  if (!MATCH(results->rawbuf[offset], RCMM_BIT_MARK))
+  if (!matchMark(results->rawbuf[offset], RCMM_BIT_MARK))
     return false;
 
   // Success
@@ -1366,22 +1415,22 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeRCMM(decode_results *results) {
 bool ICACHE_FLASH_ATTR IRrecv::decodePanasonic(decode_results *results) {
   unsigned long long data = 0;
 	int offset = 1;  // Dont skip first space
-  if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], PANASONIC_HDR_MARK)) {
     return false;
   }
   offset++;
-  if (!MATCH_MARK(results->rawbuf[offset], PANASONIC_HDR_SPACE)) {
+  if (!matchMark(results->rawbuf[offset], PANASONIC_HDR_SPACE)) {
     return false;
   }
   offset++;
   // decode address
   for (int i = 0; i < PANASONIC_BITS; i++) {
-    if (!MATCH(results->rawbuf[offset++], PANASONIC_BIT_MARK)) {
+    if (!match(results->rawbuf[offset++], PANASONIC_BIT_MARK)) {
       return false;
     }
-    if (MATCH(results->rawbuf[offset],PANASONIC_ONE_SPACE)) {
+    if (match(results->rawbuf[offset],PANASONIC_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH(results->rawbuf[offset],PANASONIC_ZERO_SPACE)) {
+    } else if (match(results->rawbuf[offset],PANASONIC_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1400,7 +1449,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeLG(decode_results *results) {
 	int offset = 1; // Skip first space
 
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], LG_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], LG_HDR_MARK)) {
     return false;
   }
   offset++;
@@ -1408,18 +1457,18 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeLG(decode_results *results) {
     return false;
   }
   // Initial space
-  if (!MATCH_SPACE(results->rawbuf[offset], LG_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], LG_HDR_SPACE)) {
     return false;
   }
   offset++;
   for (int i = 0; i < LG_BITS; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)) {
+    if (!matchMark(results->rawbuf[offset], LG_BIT_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], LG_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], LG_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], LG_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], LG_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1427,7 +1476,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeLG(decode_results *results) {
     offset++;
   }
   //Stop bit
-  if (!MATCH_MARK(results->rawbuf[offset], LG_BIT_MARK)){
+  if (!matchMark(results->rawbuf[offset], LG_BIT_MARK)){
     return false;
   }
   // Success
@@ -1442,15 +1491,15 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeJVC(decode_results *results) {
 	int offset = 1; // Skip first space
   // Check for repeat
   if (irparams.rawlen - 1 == 33 &&
-      MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK) &&
-      MATCH_MARK(results->rawbuf[irparams.rawlen-1], JVC_BIT_MARK)) {
+      matchMark(results->rawbuf[offset], JVC_BIT_MARK) &&
+      matchMark(results->rawbuf[irparams.rawlen-1], JVC_BIT_MARK)) {
     results->bits = 0;
     results->value = REPEAT;
     results->decode_type = JVC;
     return true;
   }
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], JVC_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], JVC_HDR_MARK)) {
     return false;
   }
   offset++;
@@ -1458,18 +1507,18 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeJVC(decode_results *results) {
     return false;
   }
   // Initial space
-  if (!MATCH_SPACE(results->rawbuf[offset], JVC_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], JVC_HDR_SPACE)) {
     return false;
   }
   offset++;
   for (int i = 0; i < JVC_BITS; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)) {
+    if (!matchMark(results->rawbuf[offset], JVC_BIT_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], JVC_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], JVC_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], JVC_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], JVC_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1477,7 +1526,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeJVC(decode_results *results) {
     offset++;
   }
   //Stop bit
-  if (!MATCH_MARK(results->rawbuf[offset], JVC_BIT_MARK)) {
+  if (!matchMark(results->rawbuf[offset], JVC_BIT_MARK)) {
     return false;
   }
   // Success
@@ -1492,14 +1541,14 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeSAMSUNG(decode_results *results) {
   long data = 0;
   int offset = 1;  // Dont skip first space
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], SAMSUNG_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], SAMSUNG_HDR_MARK)) {
     return false;
   }
   offset++;
   // Check for repeat
   if (irparams.rawlen == 4 &&
-      MATCH_SPACE(results->rawbuf[offset], SAMSUNG_RPT_SPACE) &&
-      MATCH_MARK(results->rawbuf[offset+1], SAMSUNG_BIT_MARK)) {
+      matchSpace(results->rawbuf[offset], SAMSUNG_RPT_SPACE) &&
+      matchMark(results->rawbuf[offset+1], SAMSUNG_BIT_MARK)) {
     results->bits = 0;
     results->value = REPEAT;
     results->decode_type = SAMSUNG;
@@ -1509,18 +1558,18 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeSAMSUNG(decode_results *results) {
     return false;
   }
   // Initial space
-  if (!MATCH_SPACE(results->rawbuf[offset], SAMSUNG_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], SAMSUNG_HDR_SPACE)) {
     return false;
   }
   offset++;
   for (int i = 0; i < SAMSUNG_BITS; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], SAMSUNG_BIT_MARK)) {
+    if (!matchMark(results->rawbuf[offset], SAMSUNG_BIT_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], SAMSUNG_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], SAMSUNG_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], SAMSUNG_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], SAMSUNG_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1545,24 +1594,24 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDaikin(decode_results *results) {
   }
 
   // Initial mark
-  if (!MATCH_MARK(results->rawbuf[offset], DAIKIN_HDR_MARK)) {
+  if (!matchMark(results->rawbuf[offset], DAIKIN_HDR_MARK)) {
       return false;
   }
   offset++;
 
-  if (!MATCH_SPACE(results->rawbuf[offset], DAIKIN_HDR_SPACE)) {
+  if (!matchSpace(results->rawbuf[offset], DAIKIN_HDR_SPACE)) {
       return false;
   }
   offset++;
 
   for (int i = 0; i < 32; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
+    if (!matchMark(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1583,13 +1632,13 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDaikin(decode_results *results) {
   //==========
 
   for (int i = 0; i < 32; i++) {
-    if (!MATCH_MARK(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
+    if (!matchMark(results->rawbuf[offset], DAIKIN_ONE_MARK)) {
       return false;
     }
     offset++;
-    if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
+    if (matchSpace(results->rawbuf[offset], DAIKIN_ONE_SPACE)) {
       data = (data << 1) | 1;
-    } else if (MATCH_SPACE(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
+    } else if (matchSpace(results->rawbuf[offset], DAIKIN_ZERO_SPACE)) {
       data <<= 1;
     } else {
       return false;
@@ -1608,7 +1657,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDaikin(decode_results *results) {
   //Serial.println (reversed,  HEX);
 
   //===========
-  if (!MATCH_SPACE(results->rawbuf[offset], 29000)) {
+  if (!matchSpace(results->rawbuf[offset], 29000)) {
     //Serial.println ("no gap");
 	  return false;
   }
@@ -1632,10 +1681,10 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDenon (decode_results *results) {
 	}
 
 	// Check initial Mark+Space match
-	if (!MATCH_MARK (results->rawbuf[offset++], DENON_HDR_MARK )) {
+	if (!matchMark (results->rawbuf[offset++], DENON_HDR_MARK )) {
 	  return false;
 	}
-	if (!MATCH_SPACE(results->rawbuf[offset++], DENON_HDR_SPACE)) {
+	if (!matchSpace(results->rawbuf[offset++], DENON_HDR_SPACE)) {
 	  return false;
 	}
 
@@ -1643,14 +1692,14 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDenon (decode_results *results) {
 	for (int i = 0;  i < DENON_BITS;  i++) {
 		// Each bit looks like: DENON_MARK + DENON_SPACE_1 -> 1
 		//                 or : DENON_MARK + DENON_SPACE_0 -> 0
-		if (!MATCH_MARK(results->rawbuf[offset++], DENON_BIT_MARK)) {
+		if (!matchMark(results->rawbuf[offset++], DENON_BIT_MARK)) {
 		  return false;
 		}
 
 		// IR data is big-endian, so we shuffle it in from the right:
-		if (MATCH_SPACE(results->rawbuf[offset], DENON_ONE_SPACE)) {
+		if (matchSpace(results->rawbuf[offset], DENON_ONE_SPACE)) {
 		  data = (data << 1) | 1;
-		} else if (MATCH_SPACE(results->rawbuf[offset], DENON_ZERO_SPACE)) {
+		} else if (matchSpace(results->rawbuf[offset], DENON_ZERO_SPACE)) {
 		  data = (data << 1) | 0;
 		} else {
 		  return false;

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -32,6 +32,7 @@
 #define IRremote_h
 
 #include <stdint.h>
+#include "IRremoteInt.h"
 
 // The following are compile-time library options.
 // If you change them, recompile the library.
@@ -135,6 +136,14 @@ public:
   bool decodeDaikin(decode_results *results);
   bool decodeDenon(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
+  uint32_t ticksLow(uint32_t usecs, uint8_t tolerance=TOLERANCE);
+  uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance=TOLERANCE);
+  bool match(uint32_t measured_ticks, uint32_t desired_us,
+             uint8_t tolerance=TOLERANCE);
+  bool matchMark(uint32_t measured_ticks, uint32_t desired_us,
+                 uint8_t tolerance=TOLERANCE, int excess=MARK_EXCESS);
+  bool matchSpace(uint32_t measured_ticks, uint32_t desired_us,
+                  uint8_t tolerance=TOLERANCE, int excess=MARK_EXCESS);
 };
 
 // Only used for testing; can remove virtual for shorter code
@@ -143,6 +152,7 @@ public:
 #else
 #define VIRTUAL
 #endif
+
 class IRsend
 {
 public:
@@ -218,13 +228,5 @@ public:
 private:
   uint32_t start;
 };
-
-// Some useful constants
-#define USECPERTICK 50  // microseconds per clock interrupt tick
-#define RAWBUF 100 // Length of raw duration buffer
-
-// Marks tend to be 100us too long, and spaces 100us too short
-// when received due to sensor lag.
-#define MARK_EXCESS 100
 
 #endif

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -110,11 +110,15 @@
 #define RCMM_HDR_MARK 416
 #define RCMM_HDR_SPACE 277
 #define RCMM_BIT_MARK 166
-#define RCMM_BIT_SPACE_0 177
+#define RCMM_BIT_SPACE_0 277
 #define RCMM_BIT_SPACE_1 444
 #define RCMM_BIT_SPACE_2 611
 #define RCMM_BIT_SPACE_3 777
 #define RCMM_RPT_LENGTH 27778
+#define RCMM_MIN_GAP 3360
+// Use a tolerance of +/-10% when matching some data spaces.
+#define RCMM_TOLERANCE 10
+#define RCMM_EXCESS 50
 
 #define SHARP_BIT_MARK 245
 #define SHARP_ONE_SPACE 1805
@@ -194,15 +198,18 @@
 #define KELVINATOR_GAP_SPACE	19950U
 #define KELVINATOR_CMD_FOOTER	2U
 
-#define TOLERANCE 25  // percent tolerance in measurements
-#define LTOL (1.0 - TOLERANCE/100.)
-#define UTOL (1.0 + TOLERANCE/100.)
+// Some useful constants
+#define USECPERTICK 50  // microseconds per clock interrupt tick
+#define RAWBUF 100 // Length of raw duration buffer
+
+// Marks tend to be 100us too long, and spaces 100us too short
+// when received due to sensor lag.
+#define MARK_EXCESS 100
 
 #define _GAP 5000 // Minimum map between transmissions
 #define GAP_TICKS (_GAP/USECPERTICK)
 
-#define TICKS_LOW(us) (int) (((us)*LTOL/USECPERTICK))
-#define TICKS_HIGH(us) (int) (((us)*UTOL/USECPERTICK + 1))
+#define TOLERANCE 25  // default percent tolerance in measurements
 
 // receiver states
 #define STATE_IDLE     2


### PR DESCRIPTION
* Move the match routines inside the irrecv object.
* Relocate some defines to a more appropriate location.
* Change the match routines have runtime definable tolerance and excess.
* Match routines now return boolean, rather than int.
* Add plenty of comments.
* Change the way DEBUGing is handled for the match routines.
* Turn the TICKS_LOW & TICKS_HIGH macros into proper functions.
* Use a tolerance of +/-10% for matching the data 'spaces' as the default
  tolerance was to high and caused mismatches. (#21)
* Allow for different excesses to be used in the matching functions.
* Fix the incorrect RC-MM '0' space value
* Enforce the minimum gap between RC-MM codes per spec.