### PR TITLE
Add support for 64bit results in decode_results.

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -76,15 +76,15 @@ enum decode_type_t {
 // Results returned from the decoder
 class decode_results {
 public:
-  int decode_type; // NEC, SONY, RC5, UNKNOWN
+  decode_type_t decode_type; // NEC, SONY, RC5, UNKNOWN
   union { // This is used for decoding Panasonic and Sharp data
     unsigned int panasonicAddress;
     unsigned int sharpAddress;
   };
-  unsigned long value; // Decoded value
-  int bits; // Number of bits in decoded value
+  unsigned long long value; // Decoded value
+  unsigned int bits; // Number of bits in decoded value
   volatile unsigned int *rawbuf; // Raw intervals in .5 us ticks
-  int rawlen; // Number of records in rawbuf.
+  unsigned int rawlen; // Number of records in rawbuf.
   bool overflow;
 };
 

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -21,7 +21,11 @@ void setup()
 
 void loop() {
   if (irrecv.decode(&results)) {
-    Serial.println(results.value, HEX);
+    // print() & println() can't handle printing long longs. (uint64_t)
+    // So we have to print the top and bottom halves separately.
+    if (results.value >> 32)
+      Serial.print((unsigned long) (results.value >> 32), HEX);
+    Serial.println((unsigned long) (results.value & 0xFFFFFFFF), HEX);
     irrecv.resume(); // Receive the next value
   }
   delay(100);

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -82,7 +82,11 @@ void dump(decode_results *results) {
 
 void loop() {
   if (irrecv.decode(&results)) {
-    Serial.println(results.value, HEX);
+    // print() & println() can't handle printing long longs. (uint64_t)
+    // So we have to print the top and bottom halves separately.
+    if (results.value >> 32)
+      Serial.print((unsigned long) (results.value >> 32), HEX);
+    Serial.println((unsigned long) (results.value & 0xFFFFFFFF), HEX);
     dump(&results);
     irrecv.resume(); // Receive the next value
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -35,7 +35,11 @@ void ircode(decode_results *results) {
     Serial.print(":");
   }
   // Print Code
-  Serial.print(results->value, HEX);
+  //   print() & println() can't handle printing long longs. (uint64_t)
+  //   So we have to print the top and bottom halves separately.
+  if (results->value >> 32)
+    Serial.print((unsigned long) (results->value >> 32), HEX);
+  Serial.println((unsigned long) (results->value & 0xFFFFFFFF), HEX);
 }
 
 //+=============================================================================
@@ -154,7 +158,11 @@ void dumpCode (decode_results *results) {
 
     // All protocols have data
     Serial.print("unsigned int  data = 0x");
-    Serial.print(results->value, HEX);
+    //   print() & println() can't handle printing long longs. (uint64_t)
+    //   So we have to print the top and bottom halves separately.
+    if (results->value >> 32)
+      Serial.print((unsigned long) (results->value >> 32), HEX);
+    Serial.print((unsigned long) (results->value & 0xFFFFFFFF), HEX);
     Serial.println(";");
   }
 }


### PR DESCRIPTION
Clean up misc other items in structure:
- Use the enum for the type
- unsigned for the bit length and length of buffer.