### PR TITLE
Add yield()s in decodes to reduce WDTs.

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -1757,7 +1757,7 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDenon (decode_results *results) {
 	}
 
 	// Success
-	results->bits = DENON_BITS;
+  results->bits = DENON_BITS;
 	results->value = data;
 	results->decode_type = DENON;
 	return true;

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -17,7 +17,7 @@ decode_results results;
 
 void setup()
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
   irrecv.enableIRIn(); // Start the receiver
 }
 
@@ -68,6 +68,8 @@ void dump(decode_results *results) {
   Serial.print("): ");
 
   for (int i = 1; i < count; i++) {
+    if (i % 100 == 0)
+      yield();  // Preemptive yield every 100th entry to feed the WDT.
     if (i & 1) {
       Serial.print(results->rawbuf[i]*USECPERTICK, DEC);
     }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -95,6 +95,8 @@ void dumpRaw(decode_results *results) {
   Serial.println("]: ");
 
   for (int i = 1;  i < results->rawlen;  i++) {
+    if (i % 100 == 0)
+      yield();  // Preemptive yield every 100th entry to feed the WDT.
     unsigned long  x = results->rawbuf[i] * USECPERTICK;
     if (!(i & 1)) {  // even
       Serial.print("-");


### PR DESCRIPTION
Add more yield()s to the IRrecvDump examples.
This is to reduce the likelihood we trip the WDT when we move to larger capture buffers.

For issue #91