### PR TITLE
Upgrade the Sony routines for v2.0

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -186,9 +186,13 @@ public:
   void sendLG(unsigned long data, int nbits=28, unsigned int repeat=0);
   // sendSony() should typically be called with repeat=2 as Sony devices
   // expect the code to be sent at least 3 times. (code + 2 repeats = 3 codes)
-  // As the legacy use of this procedure was only to send a single code
-  // it defaults to repeat=0 for backward compatiblity.
-  void sendSony(unsigned long data, int nbits, unsigned int repeat=0);
+  // Legacy use of this procedure was to only send a single code so call it with
+  // repeat=0 for backward compatiblity. As of v2.0 it defaults to sending
+  // a Sony command that will be accepted be a device.
+  void sendSony(unsigned long long data, unsigned int nbits=20,
+                unsigned int repeat=2);
+  unsigned long encodeSony(unsigned int nbits, unsigned int command,
+                           unsigned int address, unsigned int extended=0);
   // Neither Sanyo nor Mitsubishi send is implemented yet
   //  void sendSanyo(unsigned long data, int nbits);
   //  void sendMitsubishi(unsigned long data, int nbits);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -61,12 +61,12 @@
 #define NEC_MIN_COMMAND_LENGTH 108000UL
 
 // Timings based on http://www.sbprojects.com/knowledge/ir/sirc.php
-#define SONY_HDR_MARK	2400
-#define SONY_HDR_SPACE	600
-#define SONY_ONE_MARK	1250  // Experiments suggest +50 to spec is better.
-#define SONY_ZERO_MARK	650  // Experiments suggest +50 to spec is better.
+#define SONY_HDR_MARK	  2400
+#define SONY_SPACE      600
+#define SONY_ONE_MARK	  1200 + 50  // Experiments suggest +50 to spec is better.
+#define SONY_ZERO_MARK	600 + 50  // Experiments suggest +50 to spec is better.
 #define SONY_RPT_LENGTH 45000
-#define SONY_DOUBLE_SPACE_USECS  500  // usually see 713 - not using ticks as get number wrapround
+#define SONY_MIN_GAP    10000
 
 // SA 8650B
 #define SANYO_HDR_MARK	3500  // seen range 3500
@@ -242,7 +242,7 @@ extern volatile irparams_t irparams;
 #define TOPBIT 0x80000000
 
 #define NEC_BITS 32
-#define SONY_BITS 12
+#define SONY_MIN_BITS 12
 #define SANYO_BITS 12
 #define MITSUBISHI_BITS 16
 #define MIN_RC5_SAMPLES 11


### PR DESCRIPTION
Update sendSony():
- Move and update sendSony description comment.
- Support 64 bit data values, even though the protocol doesn't use > 20.
- Define some constants for values used.
- Set default sending bit length to 20.
- Add a way to encode command & address format into our native format.

Update decodeSony() to do better matching.
- Based on PR #54 by @marcosamarinho
- Support decoding of the standard Sony bit lengths.
- Better matching of sequential (repeating) Sony packets. For Issue #144
- Add command and address decoding.