### PR TITLE
Upgrade NEC routines to v2.0 spec.

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -123,7 +123,7 @@ public:
   // These are called by decode
   void copyIrParams(irparams_t *dest);
   int getRClevel(decode_results *results, int *offset, int *used, int t1);
-  bool decodeNEC(decode_results *results);
+  bool decodeNEC(decode_results *results, bool strict=false);
   bool decodeSony(decode_results *results);
   bool decodeSanyo(decode_results *results);
   bool decodeMitsubishi(decode_results *results);
@@ -182,7 +182,9 @@ public:
   };
   void sendCOOLIX(unsigned long data, int nbits);
   void sendWhynter(unsigned long data, int nbits);
-  void sendNEC(unsigned long data, int nbits=32, unsigned int repeat=0);
+  void sendNEC(unsigned long long data, unsigned int nbits=32,
+               unsigned int repeat=0);
+  unsigned long encodeNEC(unsigned int address, unsigned int command);
   void sendLG(unsigned long data, int nbits=28, unsigned int repeat=0);
   // sendSony() should typically be called with repeat=2 as Sony devices
   // expect the code to be sent at least 3 times. (code + 2 repeats = 3 codes)

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -59,6 +59,7 @@
 #define NEC_ZERO_SPACE	560
 #define NEC_RPT_SPACE	2250
 #define NEC_MIN_COMMAND_LENGTH 108000UL
+#define NEC_MIN_GAP 10000  // Not official, just a made up value.
 
 // Timings based on http://www.sbprojects.com/knowledge/ir/sirc.php
 #define SONY_HDR_MARK	2400


### PR DESCRIPTION
- Handle 64bit send requests. (Against protocol, but done for completeness.)
- Match the footer when decoding.
- Decode the address and command from a raw NEC message.
- Handle subtle differences between NEC & Extended NEC protocols.
- Allow for optional strict decoding. e.g. Checking the command is inverted per spec.
- Add function to synthesise a raw NEC message from a address & command.
- Add more comments.
- Add standard/style function comments.
- Code style cleanup.

Influenced by work done by @marcosamarinho 

#54 