### PR TITLE
Upgrade Denon routines to v2.0 spec.

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -143,7 +143,8 @@ public:
   // COOLIX decode is not implemented yet
   //  bool decodeCOOLIX(decode_results *results);
   bool decodeDaikin(decode_results *results);
-  bool decodeDenon(decode_results *results);
+  bool decodeDenon(decode_results *results, uint16_t nbits=DENON_BITS,
+                   bool strict=true);
   int compare(unsigned int oldval, unsigned int newval);
   uint32_t ticksLow(uint32_t usecs, uint8_t tolerance=TOLERANCE);
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance=TOLERANCE);
@@ -220,7 +221,8 @@ public:
                    unsigned int repeat=0);
   unsigned long encodeSAMSUNG(uint8_t customer, uint8_t command);
   void sendDaikin(unsigned char data[]);
-  void sendDenon(unsigned long data, int nbits=14);
+  void sendDenon(unsigned long long data, unsigned int nbits=DENON_BITS,
+                 unsigned int repeat=0);
   void sendKelvinator(unsigned char data[]);
   void sendSherwood(unsigned long data, int nbits=32, unsigned int repeat=1);
   void sendMitsubishiAC(unsigned char data[]);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -182,12 +182,14 @@
 #define DAIKIN_ZERO_SPACE 428
 
 //Denon, from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp
-#define DENON_BITS          14  // The number of bits in the command
-#define DENON_HDR_MARK     300  // The length of the Header:Mark
-#define DENON_HDR_SPACE    750  // The lenght of the Header:Space
-#define DENON_BIT_MARK     300  // The length of a Bit:Mark
-#define DENON_ONE_SPACE   1800  // The length of a Bit:Space for 1's
-#define DENON_ZERO_SPACE   750  // The length of a Bit:Space for 0's
+#define DENON_BITS                   14  // The number of bits in the command
+#define DENON_HDR_MARK              263  // The length of the Header:Mark
+#define DENON_HDR_SPACE             789  // The lenght of the Header:Space
+#define DENON_BIT_MARK              263  // The length of a Bit:Mark
+#define DENON_ONE_SPACE            1842  // The length of a Bit:Space for 1's
+#define DENON_ZERO_SPACE            789  // The length of a Bit:Space for 0's
+#define DENON_MIN_COMMAND_LENGTH 134052UL
+#define DENON_MIN_GAP DENON_MIN_COMMAND_LENGTH - DENON_HDR_MARK - DENON_HDR_SPACE - DENON_BITS * (DENON_BIT_MARK + DENON_ONE_SPACE) - DENON_BIT_MARK
 
 #define KELVINATOR_HDR_MARK	  8990U
 #define KELVINATOR_HDR_SPACE	4490U


### PR DESCRIPTION
- Support up to 64bit messages.
- Add detection of Footer to decodeDenon().
- Allow for decoding different bit lengths if needed.
- Enable automatically sending repeats.
- Function descriptions.
- Code style guide changes.
- Enfore an appropriate gap after message has been sent.