### PR TITLE
Upgrade Panasonic routines to v2.0 spec.

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -131,7 +131,8 @@ public:
   bool decodeRC5(decode_results *results);
   bool decodeRC6(decode_results *results);
   bool decodeRCMM(decode_results *results);
-  bool decodePanasonic(decode_results *results);
+  bool decodePanasonic(decode_results *results, uint16_t nbits=PANASONIC_BITS,
+                       bool strict=false);
   bool decodeLG(decode_results *results, uint16_t nbits=LG_BITS,
                 bool strict=false);
   bool decodeJVC(decode_results *results, uint16_t nbits=JVC_BITS,
@@ -212,7 +213,13 @@ public:
   void sendDISH(unsigned long data, int nbits, unsigned int repeat=0);
   void sendSharp(unsigned int address, unsigned int command);
   void sendSharpRaw(unsigned long data, int nbits);
-  void sendPanasonic(unsigned int address, unsigned long data);
+  void sendPanasonic64(unsigned long long data,
+                       unsigned int nbits=PANASONIC_BITS,
+                       unsigned int repeat=0);
+  void sendPanasonic(unsigned int address, unsigned long data,
+                     unsigned int nbits=PANASONIC_BITS, unsigned int repeat=0);
+  unsigned long long encodePanasonic(uint8_t device, uint8_t subdevice,
+                                   uint8_t function);
   void sendJVC(unsigned long long data, unsigned int nbits=JVC_BITS,
                unsigned int repeat=0);
   unsigned int encodeJVC(uint8_t address, uint8_t command);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -135,11 +135,17 @@
 #define DISH_ZERO_SPACE 2800
 #define DISH_RPT_SPACE 6200
 
-#define PANASONIC_HDR_MARK 3502
-#define PANASONIC_HDR_SPACE 1750
-#define PANASONIC_BIT_MARK 502
-#define PANASONIC_ONE_SPACE 1244
-#define PANASONIC_ZERO_SPACE 400
+// Ref: http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
+#define PANASONIC_HDR_MARK             3456
+#define PANASONIC_HDR_SPACE            1728
+#define PANASONIC_BIT_MARK              432
+#define PANASONIC_ONE_SPACE            1296
+#define PANASONIC_ZERO_SPACE            432
+#define PANASONIC_MIN_COMMAND_LENGTH 130000UL
+// 130000 - 3456 - 1728 - 48*(432+1296) - 432 = 41440
+#define PANASONIC_MIN_GAP             41440
+#define PANASONIC_MANUFACTURER       0x2002ULL
+
 
 // Ref: http://www.sbprojects.com/knowledge/ir/jvc.php
 #define JVC_HDR_MARK    8400


### PR DESCRIPTION
- Fix: We were using the wrong frequency. Correct is 37kHz. #36 
- Support 64 bit codes.
- Implement repeating.
- Better decoding.
- Adjust timings based on reference docs. #36 
- Add encode routine.
- Function descriptions.
- More comments.
- Decode address & command.
- Enable specifying bit size for decoding.
- Optional strict complience following for decode.
- Reasonable defaults for new function args.