### PR TITLE
Incorrect frequency & timing for Panasonic

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -423,7 +423,7 @@ void ICACHE_FLASH_ATTR IRsend::sendRCMM(uint32_t data, uint8_t nbits) {
 void ICACHE_FLASH_ATTR IRsend::sendPanasonic(unsigned int address,
                                              unsigned long data) {
   // Set IR carrier frequency
-  enableIROut(35);
+  enableIROut(37);
   // Header
   mark(PANASONIC_HDR_MARK);
   space(PANASONIC_HDR_SPACE);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -130,11 +130,12 @@
 #define DISH_ZERO_SPACE 2800
 #define DISH_RPT_SPACE 6200
 
-#define PANASONIC_HDR_MARK 3502
-#define PANASONIC_HDR_SPACE 1750
-#define PANASONIC_BIT_MARK 502
-#define PANASONIC_ONE_SPACE 1244
-#define PANASONIC_ZERO_SPACE 400
+// Ref: http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
+#define PANASONIC_HDR_MARK             3456
+#define PANASONIC_HDR_SPACE            1728
+#define PANASONIC_BIT_MARK              432
+#define PANASONIC_ONE_SPACE            1296
+#define PANASONIC_ZERO_SPACE            432
 
 #define JVC_HDR_MARK 8000
 #define JVC_HDR_SPACE 4000


### PR DESCRIPTION
It appears the freq. for Panasonic is 37kHz.
Also adjust timings based on Global Cache and other reference sites I found.

This is a back-ported patch from the v2.0-dev tree.

Results are similar to those found in #36.

Fixes #36 

@rahuljawale for a code review.