### PR TITLE
Upgrade Dish to v2.0 spec & Add decodeDISH().

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -30,6 +30,7 @@
  * Kelvinator A/C and Sherwood added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
  *     (derived from https://github.com/r45635/HVAC-IR-Control)
+ * DISH decode by marcosamarinho
  *
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for
  *   sending IR code on ESP8266
@@ -765,19 +766,33 @@ void ICACHE_FLASH_ATTR IRsend::sendSharp(unsigned int address,
   sendSharpRaw((address << 10) | (command << 2) | 2, 15);
 }
 
-// Send an IR command to a DISH device.
-// Note: Typically a DISH device needs to get a command a total of at least 4
-//       times to accept it.
+// Send an IR command to a DISH NETWORK device.
+//
 // Args:
 //   data:   The contents of the command you want to send.
 //   nbits:  The bit size of the command being sent.
 //   repeat: The number of times you want the command to be repeated.
-void ICACHE_FLASH_ATTR IRsend::sendDISH(unsigned long data, int nbits,
+//
+// Note:
+//   Dishplayer is a different protocol.
+//   Typically a DISH device needs to get a command a total of at least 4
+//   times to accept it. e.g. repeat=3
+//   DISH support by Todd Treece (http://unionbridge.org/design/ircommand)
+//
+//   Here is the LIRC file I found that seems to match the remote codes from the
+//   oscilloscope:
+//     DISH NETWORK (echostar 301):
+//     http://lirc.sourceforge.net/remotes/echostar/301_501_3100_5100_58xx_59xx
+//
+// Ref:
+//   http://www.hifi-remote.com/wiki/index.php?title=Dish
+void ICACHE_FLASH_ATTR IRsend::sendDISH(unsigned long long data,
+                                        unsigned int nbits,
                                         unsigned int repeat) {
-  // Set IR carrier frequency
-  enableIROut(56);
+  // Set 57.6kHz IR carrier frequency, duty cycle is unknown.
+  enableIROut(58);
   // We always send a command, even for repeat=0, hence '<= repeat'.
-  for (unsigned int i = 0; i <= repeat; i++) {
+  for (uint16_t i = 0; i <= repeat; i++) {
     // Header
     mark(DISH_HDR_MARK);
     space(DISH_HDR_SPACE);
@@ -785,6 +800,7 @@ void ICACHE_FLASH_ATTR IRsend::sendDISH(unsigned long data, int nbits,
     sendData(DISH_BIT_MARK, DISH_ONE_SPACE, DISH_BIT_MARK, DISH_ZERO_SPACE,
              data, nbits, true);
     // Footer
+    mark(DISH_BIT_MARK);
     space(DISH_RPT_SPACE);
   }
 }
@@ -1141,6 +1157,11 @@ bool ICACHE_FLASH_ATTR IRrecv::decode(decode_results *results,
   if (decodeDenon(results)) {
     return true;
   }
+#ifdef DEBUG
+  Serial.println("Attempting DISH decode");
+#endif
+  if (decodeDISH(results))
+    return true;
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.
   // If you add any decodes, add them before this.
@@ -2157,6 +2178,69 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeDenon (decode_results *results) {
 	return true;
 }
 
+// Decode the supplied DISH NETWORK message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of bits to expect in the data portion. Typically DISH_BITS.
+//   strict:  Flag to indicate if we strictly adhere to the specification.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status:  ALPHA (untested and unconfirmed.)
+//
+// Note:
+//   Dishplayer is a different protocol.
+//   Typically a DISH device needs to get a command a total of at least 4
+//   times to accept it.
+// Ref:
+//   http://www.hifi-remote.com/wiki/index.php?title=Dish
+//   http://lirc.sourceforge.net/remotes/echostar/301_501_3100_5100_58xx_59xx
+//   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Dish.cpp
+bool IRrecv::decodeDISH(decode_results *results, uint16_t nbits, bool strict) {
+  if (results->rawlen < 2 * nbits + HEADER + FOOTER)
+    return false;  // Not enough entries to be valid.
+  if (strict && nbits != DISH_BITS)
+    return false;  // Not strictly compliant.
+
+  uint64_t data = 0;
+  uint16_t offset = OFFSET_START;
+
+  // Header
+  if (!matchMark(results->rawbuf[offset++], DISH_HDR_MARK))
+    return false;
+  if (!matchSpace(results->rawbuf[offset++], DISH_HDR_SPACE))
+    return false;
+
+  // Data
+  for (uint16_t i = 0; i < nbits; i++, offset++) {
+    if (!matchMark(results->rawbuf[offset++], DISH_BIT_MARK))
+      return false;
+    if (matchSpace(results->rawbuf[offset], DISH_ONE_SPACE))
+      data = (data << 1) | 1;  // 1
+    else if (matchSpace(results->rawbuf[offset], DISH_ZERO_SPACE))
+      data = data << 1;  // 0
+    else
+      return false;
+  }
+
+  // Footer
+  if (!matchMark(results->rawbuf[offset++], DISH_HDR_MARK))
+    return false;
+  // The DISH protocol calls for a repeated message, so strictly speaking
+  // there should be a code following this. Only require it if we are set to
+  // strict matching.
+  if (strict && !matchSpace(results->rawbuf[offset], DISH_RPT_SPACE))
+    return false;
+
+  // Success
+  results->decode_type = DISH;
+  results->bits = nbits;
+  results->value = data;
+  results->address = 0;
+  results->command = 0;
+  return true;
+}
 
 /* -----------------------------------------------------------------------
  * hashdecode - decode an arbitrary IR code.

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -19,6 +19,7 @@
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
+ * DISH decode by marcosamarinho
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for sending IR code on ESP8266
  * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code on ESP8266
  *
@@ -146,6 +147,8 @@ public:
   //  bool decodeCOOLIX(decode_results *results);
   bool decodeDaikin(decode_results *results);
   bool decodeDenon(decode_results *results);
+  bool decodeDISH(decode_results *results, uint16_t nbits=DISH_BITS,
+                  bool strict=true);
   int compare(unsigned int oldval, unsigned int newval);
   uint32_t ticksLow(uint32_t usecs, uint8_t tolerance=TOLERANCE);
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance=TOLERANCE);
@@ -209,9 +212,10 @@ public:
   void sendRCMM(uint32_t data, uint8_t nbits=24);
   // sendDISH() should typically be called with repeat=3 as DISH devices
   // expect the code to be sent at least 4 times. (code + 3 repeats = 4 codes)
-  // As the legacy use of this procedure was only to send a single code
-  // it defaults to repeat=0 for backward compatiblity.
-  void sendDISH(unsigned long data, int nbits, unsigned int repeat=0);
+  // Legacy use of this procedure was only to send a single code
+  // so use repeat=0 for backward compatiblity.
+  void sendDISH(unsigned long long data, unsigned int nbits=DISH_BITS,
+                unsigned int repeat=DISH_MIN_REPEAT);
   void sendSharp(unsigned int address, unsigned int command);
   void sendSharpRaw(unsigned long data, int nbits);
   void sendPanasonic64(unsigned long long data,

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -20,6 +20,7 @@
  * Kelvinator A/C added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
  *     (based on https://github.com/r45635/HVAC-IR-Control)
+ * DISH decode by marcosamarinho
  *
  * 09/23/2015 : Samsung pulse parameters updated by Sebastien Warin to be compatible with EUxxD6200
  *
@@ -129,12 +130,16 @@
 #define SHARP_TOGGLE_MASK 0x3FF
 #define SHARP_RPT_SPACE 3000
 
-#define DISH_HDR_MARK 400
-#define DISH_HDR_SPACE 6100
-#define DISH_BIT_MARK 400
-#define DISH_ONE_SPACE 1700
+// Ref:
+//   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Dish.cpp
+//   http://www.hifi-remote.com/wiki/index.php?title=Dish
+#define DISH_HDR_MARK    400
+#define DISH_HDR_SPACE  6100
+#define DISH_BIT_MARK    400
+#define DISH_ONE_SPACE  1700
 #define DISH_ZERO_SPACE 2800
-#define DISH_RPT_SPACE 6200
+#define DISH_RPT_SPACE  6200
+#define DISH_MIN_REPEAT    3
 
 // Ref: http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
 #define PANASONIC_HDR_MARK             3456


### PR DESCRIPTION
- Add decodeDISH() from @marcosamarinho
- Support 64bit messages.
- Function descriptions.
- Repeat functionality.
- Stacks-o-comments.
- Correct the modulation frequency.

#54 