### PR TITLE
Improve duty cycle and frequency setting.

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -234,13 +234,14 @@ public:
   void sendKelvinator(unsigned char data[]);
   void sendSherwood(unsigned long data, int nbits=32, unsigned int repeat=1);
   void sendMitsubishiAC(unsigned char data[]);
-  void enableIROut(unsigned int khz, uint8_t duty=50);
+  void enableIROut(unsigned long freq, uint8_t duty=50);
   VIRTUAL void mark(unsigned int usec);
   VIRTUAL void space(unsigned long usec);
 private:
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
   int IRpin;
+  uint32_t calcUSecPeriod(uint32_t hz);
   void sendMitsubishiACChunk(unsigned char data);
   void sendData(uint16_t onemark, uint32_t onespace,
                 uint16_t zeromark, uint32_t zerospace,


### PR DESCRIPTION
- Use the correct math for implementing round().
- Simplify the math & readablity involved in calculating the duty cycle.
- Add support for non-round kHz frequency setting. e.g. Panasonic's 36700Hz
- Use a common function to calculate periods/cycle times.
- Minor changes to sendGC to reflect the above.