### PR TITLE
Rework/Upgrade RC5/RC6 to v2.0 spec.

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -43,6 +43,8 @@ void dump(decode_results *results) {
     Serial.print("Decoded SONY: ");
   } else if (results->decode_type == RC5) {
     Serial.print("Decoded RC5: ");
+  } else if (results->decode_type == RC5X) {
+    Serial.print("Decoded RC5X: ");
   } else if (results->decode_type == RC6) {
     Serial.print("Decoded RC6: ");
   } else if (results->decode_type == PANASONIC) {

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -27,7 +27,6 @@ void setup() {
   irrecv.enableIRIn();  // Start the receiver
 }
 
-//+=============================================================================
 // Print a uint64_t in Hex, to the Serial interface.
 //
 void serialPrintUint64Hex(uint64_t value) {
@@ -38,7 +37,6 @@ void serialPrintUint64Hex(uint64_t value) {
   Serial.print((uint32_t) (value & 0xFFFFFFFF), HEX);
 }
 
-//+=============================================================================
 // Display encoding type
 //
 void encoding(decode_results *results) {
@@ -66,7 +64,6 @@ void encoding(decode_results *results) {
   if (results->repeat) Serial.print(" (Repeat)");
 }
 
-//+=============================================================================
 // Dump out the decode_results structure.
 //
 void dumpInfo(decode_results *results) {
@@ -88,7 +85,6 @@ void dumpInfo(decode_results *results) {
   Serial.println(" bits)");
 }
 
-//+=============================================================================
 // Dump out the decode_results structure.
 //
 void dumpRaw(decode_results *results) {
@@ -120,7 +116,6 @@ void dumpRaw(decode_results *results) {
   Serial.println("");  // Newline
 }
 
-//+=============================================================================
 // Dump out the decode_results structure.
 //
 void dumpCode(decode_results *results) {
@@ -171,7 +166,6 @@ void dumpCode(decode_results *results) {
   }
 }
 
-//+=============================================================================
 // The repeating section of the code
 //
 void loop() {

--- a/lib/IRremoteESP8266/IRremoteESP8266.cpp
+++ b/lib/IRremoteESP8266/IRremoteESP8266.cpp
@@ -476,36 +476,89 @@ void ICACHE_FLASH_ATTR IRsend::sendGC(uint16_t buf[], uint16_t len) {
   ledOff();
 }
 
-// Note: first bit must be a one (start bit)
-void ICACHE_FLASH_ATTR IRsend::sendRC5(uint32_t data, uint16_t nbits) {
-  // Set 36kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(36, 33);
-  // Header
-  mark(RC5_T1);  // First start bit
-  space(RC5_T1);  // Second start bit
-  mark(RC5_T1);  // Second start bit
-  // Data
-  for (uint32_t mask = 1UL << (nbits - 1); mask; mask >>= 1) {
-    if (data & mask) {  // 1
-      space(RC5_T1);  // 1 is space, then mark
+// Send a Philips RC-5/RC-5X packet.
+//
+// Args:
+//   data:    The message you wish to send.
+//   nbits:   Bit size of the protocol you want to send.
+//   repeat:  Nr. of extra times the data will be sent.
+//
+// Status: RC-5 (stable), RC-5X (alpha)
+//
+// Note:
+//   Caller needs to take care of flipping the toggle bit (3rd transmitted
+//   bit/Most Significant data bit). e.g. data ^= 1ULL<<(nbits-1).).
+//   That bit differentiates between key press & key release.
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rc5.php
+//   https://en.wikipedia.org/wiki/RC-5
+//   https://en.wikipedia.org/wiki/Manchester_code
+// TODO(anyone):
+//   Testing of the RC-5X components.
+void ICACHE_FLASH_ATTR IRsend::sendRC5(uint64_t data, uint16_t nbits,
+                                       uint16_t repeat) {
+  bool skipSpace = true;
+  uint16_t field_bit = 1;
+  // Set 36kHz IR carrier frequency & a 1/4 (25%) duty cycle.
+  enableIROut(36, 25);
+
+  if (nbits == RC5X_BITS) {  // Is this a RC-5X message?
+    // For RC-5X, invert the 7th bit and send it as the field/2nd start bit.
+    field_bit = (data & (1 << (7-1))) ? 0 : 1;
+    // Cut out the 7th bit from data, as we send it as the field/2nd start bit.
+    data = ((data >> 7) << 6) | (data & ((1 << 7) - 1));
+  }
+
+  IRtimer usecTimer = IRtimer();
+  for (uint16_t i = 0; i <= repeat; i++) {
+    usecTimer.reset();
+
+    // Header
+    // First start bit (0x1). space, then mark.
+    if (skipSpace)
+      skipSpace = false;  // First time through, we assume the leading space().
+    else
+      space(RC5_T1);
+    mark(RC5_T1);
+    // Field/Second start bit.
+    if (field_bit) {  // Send a 1. Normal for RC-5.
+      space(RC5_T1);
       mark(RC5_T1);
-    } else {  // 0
+    } else {  // Send a 0. Special case for RC-5X. Means 7th command bit is 1.
       mark(RC5_T1);
       space(RC5_T1);
     }
+
+    // Data
+    for (uint64_t mask = 1ULL << (nbits - 1); mask; mask >>= 1)
+      if (data & mask) {  // 1
+        space(RC5_T1);  // 1 is space, then mark.
+        mark(RC5_T1);
+      } else {  // 0
+        mark(RC5_T1);  // 0 is mark, then space.
+        space(RC5_T1);
+      }
+
+    // Footer
+    space(std::max(RC5_MIN_GAP, RC5_MIN_COMMAND_LENGTH - usecTimer.elapsed()));
   }
-  // Footer
-  ledOff();
 }
 
 // Send a Philips RC-6 packet.
 // Note: Caller needs to take care of flipping the toggle bit (The 4th Most
 //   Significant Bit). That bit differentiates between key press & key release.
-// Based on http://www.sbprojects.com/knowledge/ir/rc6.php
+//
 // Args:
-//   data:    The code you wish to send.
+//   data:    The message you wish to send.
 //   nbits:   Bit size of the protocol you want to send.
 //   repeat:  Nr. of extra times the data will be sent.
+//
+// Status: Stable.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rc6.php
+//   http://www.righto.com/2010/12/64-bit-rc6-codes-arduino-and-xbox.html
+//   https://en.wikipedia.org/wiki/Manchester_code
 void ICACHE_FLASH_ATTR IRsend::sendRC6(uint64_t data, uint16_t nbits,
                                        uint16_t repeat) {
   // Check we can send the number of bits requested.
@@ -517,22 +570,22 @@ void ICACHE_FLASH_ATTR IRsend::sendRC6(uint64_t data, uint16_t nbits,
     // Header
     mark(RC6_HDR_MARK);
     space(RC6_HDR_SPACE);
-    mark(RC6_T1);  // Start bit
+    // Start bit.
+    mark(RC6_T1);  // mark, then space == 0x1.
     space(RC6_T1);
-    uint16_t t;
     // Data
-    for (uint64_t i = 0, mask = 1ULL << (nbits - 1); mask; i++, mask >>= 1) {
-      // The fourth bit we send is a "double width trailer bit".
-      if (i == 3)
-        t = 2 * RC6_T1;  // double-wide trailer bit
+    uint16_t bitTime;
+    for (uint64_t i = 1, mask = 1ULL << (nbits - 1); mask; i++, mask >>= 1) {
+      if (i == 4)  // The fourth bit we send is a "double width trailer bit".
+        bitTime = 2 * RC6_T1;  // double-wide trailer bit
       else
-        t = RC6_T1;
+        bitTime = RC6_T1;  // Normal bit
       if (data & mask) {  // 1
-        mark(t);
-        space(t);
+        mark(bitTime);
+        space(bitTime);
       } else {  // 0
-        space(t);
-        mark(t);
+        space(bitTime);
+        mark(bitTime);
       }
     }
     // Footer
@@ -547,7 +600,7 @@ void ICACHE_FLASH_ATTR IRsend::sendRC6(uint64_t data, uint16_t nbits,
 //   nbits: The number of bits of data to send. (Typically 12, 24, or 32[Nokia])
 //
 // Status:  ALPHA (untested and unconfirmed.)
-void ICACHE_FLASH_ATTR IRsend::sendRCMM(uint32_t data, uint16_t nbits) {
+void ICACHE_FLASH_ATTR IRsend::sendRCMM(uint32_t data, uint8_t nbits) {
   // Set 36kHz IR carrier frequency & a 1/3 (33%) duty cycle.
   enableIROut(36, 33);
   IRtimer usecs = IRtimer();
@@ -2200,124 +2253,227 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeMitsubishi(decode_results *results,
 // E.g. if the buffer has MARK for 2 time intervals and SPACE for 1,
 // successive calls to getRClevel will return MARK, MARK, SPACE.
 // offset and used are updated to keep track of the current position.
-// t1 is the time interval for a single bit in microseconds.
-// Returns -1 for error (measured time interval is not a multiple of t1).
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  Ptr to the currect offset to the rawbuf.
+//   used:    Ptr to the current used counter.
+//   bitTime: Time interval of single bit in microseconds.
+// Returns:
+//   int: MARK, SPACE, or -1 for error (The measured time interval is not a
+//                                      multiple of t1.)
+// Ref:
+//   https://en.wikipedia.org/wiki/Manchester_code
 int16_t ICACHE_FLASH_ATTR IRrecv::getRClevel(decode_results *results,
-                                             int *offset, int *used,
-                                             uint16_t t1) {
-  if (*offset >= results->rawlen) {
-    // After end of recorded buffer, assume SPACE.
-    return SPACE;
-  }
-  int width = results->rawbuf[*offset];
-  int val = ((*offset) % 2) ? MARK : SPACE;
-  int correction = (val == MARK) ? MARK_EXCESS : - MARK_EXCESS;
+                                             uint16_t *offset, uint16_t *used,
+                                             uint16_t bitTime) {
+  if (*offset >= results->rawlen)
+    return SPACE;  // After end of recorded buffer, assume SPACE.
+  uint16_t width = results->rawbuf[*offset];
+  //  If the value of offset is odd, it's a MARK. Even, it's a SPACE.
+  uint16_t val = ((*offset) % 2) ? MARK : SPACE;
+  int16_t correction = (val == MARK) ? MARK_EXCESS : - MARK_EXCESS;
 
-  int avail;
-  if (match(width, t1 + correction)) {
+  // Calculate the look-ahead for our current position in the buffer.
+  uint16_t avail;
+  if (match(width, bitTime + correction))
     avail = 1;
-  } else if (match(width, 2*t1 + correction)) {
+  else if (match(width, 2 * bitTime + correction))
     avail = 2;
-  } else if (match(width, 3*t1 + correction)) {
+  else if (match(width, 3 * bitTime + correction))
     avail = 3;
-  } else {
-    return -1;
-  }
+  else
+    return -1;  // The width is not what we expected.
 
-  (*used)++;
-  if (*used >= avail) {
+  (*used)++;  // Count another one of the avail slots as used.
+  if (*used >= avail) {  // Are we out of look-ahead/avail slots?
+    // Yes, so reset the used counter, and move the offset ahead.
     *used = 0;
     (*offset)++;
   }
+
 #ifdef DEBUG
-  if (val == MARK) {
+  if (val == MARK)
     Serial.println("MARK");
-  } else {
+  else
     Serial.println("SPACE");
-  }
 #endif
   return val;
 }
 
-bool ICACHE_FLASH_ATTR IRrecv::decodeRC5(decode_results *results) {
-  if (results->rawlen < MIN_RC5_SAMPLES + 2) {
-    return false;
+// Decode the supplied RC-5/RC5X message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: RC-5 (stable), RC-5X (alpha)
+//
+// Note:
+//   The 'toggle' bit is included as the 6th (MSB) address bit, the MSB of data,
+//   & in the count of bits decoded.
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rc5.php
+//   https://en.wikipedia.org/wiki/RC-5
+//   https://en.wikipedia.org/wiki/Manchester_code
+// TODO(anyone):
+//   Serious testing of the RC-5X and strict aspects needs to be done.
+bool ICACHE_FLASH_ATTR IRrecv::decodeRC5(decode_results *results,
+                                         uint16_t nbits, bool strict) {
+  if (results->rawlen < MIN_RC5_SAMPLES + HEADER) return false;
+
+  // Compliance
+  if (strict && nbits != RC5_BITS && nbits != RC5X_BITS)
+    return false;  // It's neither RC-5 or RC-5X.
+
+  uint16_t offset = OFFSET_START;
+  uint16_t used = 0;
+  uint16_t field_bit;  // a.k.a. second start bit.
+  bool is_rc5x = false;
+  if (nbits == RC5X_BITS) is_rc5x = true;
+
+  // Header
+  // Get start bit #1.
+  if (getRClevel(results, &offset, &used, RC5_T1) != MARK) return false;
+  // Get field/start bit #2 (inverted bit-7 of the command if RC-5X protocol)
+  int16_t levelA = getRClevel(results, &offset, &used, RC5_T1);
+  int16_t levelB = getRClevel(results, &offset, &used, RC5_T1);
+  if (levelA == SPACE && levelB == MARK) {
+    field_bit = 1;  // Matched a 1.
+  } else if (levelA == MARK && levelB == SPACE) {
+    field_bit = 0;  // Matched a 0.
+    is_rc5x = true;
+    if (strict && nbits == RC5_BITS)
+      return false;  // Can't strictly be RC-5X with only RC5_BITS.
+  } else {
+    return false;  // Not what we expected.
   }
-  int offset = 1;  // Skip gap space
-  uint32_t data = 0;
-  int used = 0;
-  // Get start bits
-  if (getRClevel(results, &offset, &used, RC5_T1) != MARK) return false;
-  if (getRClevel(results, &offset, &used, RC5_T1) != SPACE) return false;
-  if (getRClevel(results, &offset, &used, RC5_T1) != MARK) return false;
-  int nbits;
-  for (nbits = 0; offset < results->rawlen; nbits++) {
-    int levelA = getRClevel(results, &offset, &used, RC5_T1);
-    int levelB = getRClevel(results, &offset, &used, RC5_T1);
-    if (levelA == SPACE && levelB == MARK) {
-      // 1 bit
-      data = (data << 1) | 1;
-    } else if (levelA == MARK && levelB == SPACE) {
-      // zero bit
-      data <<= 1;
-    } else {
+
+  uint16_t actual_bits = 0;
+  if (is_rc5x) actual_bits = 1;  // We've already have our first (field) bit.
+
+  // Data
+  uint64_t data = 0;
+  for (; offset < results->rawlen; actual_bits++) {
+    int16_t levelA = getRClevel(results, &offset, &used, RC5_T1);
+    int16_t levelB = getRClevel(results, &offset, &used, RC5_T1);
+    if (levelA == SPACE && levelB == MARK)
+      data = (data << 1) | 1;  // 1
+    else if (levelA == MARK && levelB == SPACE)
+      data <<= 1;  // 0
+    else
       return false;
-    }
+  }
+  // Footer (None)
+
+  // Compliance
+  if (strict) {
+    if (actual_bits != RC5_BITS && actual_bits != RC5X_BITS) return false;
+    if (actual_bits != nbits) return false;
   }
 
   // Success
-  results->bits = nbits;
+  results->bits = actual_bits;
+  if (is_rc5x) {
+    results->decode_type = RC5X;
+    // Bit juggling. Insert a new 7th command bit.
+    data = ((data >> 6) << 7) | (data & ((1 << 7) - 1));
+    // Set the 7th bit to the value of the inverted field/2nd start bit.
+    data ^= (uint64_t) field_bit << (7 - 1);
+    results->address = data >> 7;
+    results->command = data & ((1 << 7) - 1);
+  } else {
+    results->decode_type = RC5;
+    results->address = data >> 6;
+    results->command = data & ((1 << 6) - 1);
+  }
   results->value = data;
-  results->decode_type = RC5;
   return true;
 }
 
-bool ICACHE_FLASH_ATTR IRrecv::decodeRC6(decode_results *results) {
-  if (results->rawlen < MIN_RC6_SAMPLES) {
-    return false;
+// Decode the supplied RC6 message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Stable.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rc6.php
+//   https://en.wikipedia.org/wiki/Manchester_code
+// TODO(anyone):
+//   Testing of the strict compliance aspects.
+bool ICACHE_FLASH_ATTR IRrecv::decodeRC6(decode_results *results,
+                                         uint16_t nbits, bool strict) {
+  if (results->rawlen < HEADER + 2)  // Header + start bit.
+    return false;  // Smaller than absolute smallest possible RC6 message.
+
+  if (strict) {  // Compliance
+    // Unlike typical protocols, the ability to have mark+space, and space+mark
+    // as data bits means it is possible to only have nbits of entries for the
+    // data portion, rather than the typically required 2 * nbits.
+    // Also due to potential melding with the start bit, we can only count
+    // the start bit as 1, instead of a more typical 2 value. The header still
+    // remains as normal.
+    if (results->rawlen < nbits + HEADER + 1)
+      return false;  // Don't have enough entries/samples to be valid.
+    if (nbits != RC6_MODE0_BITS && nbits != RC6_36_BITS)
+      return false;  // Asking for the wrong number of bits.
   }
-  int offset = 1;  // Skip first space
-  // Initial mark
-  if (!matchMark(results->rawbuf[offset], RC6_HDR_MARK)) {
-    return false;
-  }
-  offset++;
-  if (!matchSpace(results->rawbuf[offset], RC6_HDR_SPACE)) {
-    return false;
-  }
-  offset++;
-  int32_t data = 0;
-  int used = 0;
-  // Get start bit (1)
+
+  uint16_t offset = OFFSET_START;
+
+  // Header
+  if (!matchMark(results->rawbuf[offset++], RC6_HDR_MARK)) return false;
+  if (!matchSpace(results->rawbuf[offset++], RC6_HDR_SPACE)) return false;
+
+  uint16_t used = 0;
+
+  // Get the start bit. e.g. 1.
   if (getRClevel(results, &offset, &used, RC6_T1) != MARK) return false;
   if (getRClevel(results, &offset, &used, RC6_T1) != SPACE) return false;
-  int nbits;
-  for (nbits = 0; offset < results->rawlen; nbits++) {
-    int levelA, levelB;  // Next two levels
+
+  uint16_t actual_bits;
+  uint64_t data = 0;
+
+  // Data (Warning: Here be dragons^Wpointers!!)
+  for (actual_bits = 0; offset < results->rawlen; actual_bits++) {
+    int16_t levelA, levelB;  // Next two levels
     levelA = getRClevel(results, &offset, &used, RC6_T1);
-    if (nbits == 3) {
-      // T bit is double wide; make sure second half matches
-      if (levelA != getRClevel(results, &offset, &used, RC6_T1)) return false;
-    }
+    // T bit is double wide; make sure second half matches
+    if (actual_bits == 3 &&
+        levelA != getRClevel(results, &offset, &used, RC6_T1))
+      return false;
     levelB = getRClevel(results, &offset, &used, RC6_T1);
-    if (nbits == 3) {
-      // T bit is double wide; make sure second half matches
-      if (levelB != getRClevel(results, &offset, &used, RC6_T1)) return false;
-    }
-    if (levelA == MARK && levelB == SPACE) {  // reversed compared to RC5
-      // 1 bit
-      data = (data << 1) | 1;
-    } else if (levelA == SPACE && levelB == MARK) {
-      // zero bit
-      data <<= 1;
-    } else {
-      return false;  // Error
-    }
+    // T bit is double wide; make sure second half matches
+    if (actual_bits == 3 &&
+        levelB != getRClevel(results, &offset, &used, RC6_T1))
+      return false;
+    if (levelA == MARK && levelB == SPACE)  // reversed compared to RC5
+      data = (data << 1) | 1;  // 1
+    else if (levelA == SPACE && levelB == MARK)
+      data <<= 1;  // 0
+    else
+      return false;
   }
+
+  // More compliance
+  if (strict && actual_bits != nbits)
+    return false;  // Actual nr. of bits didn't match expected.
+
   // Success
-  results->bits = nbits;
-  results->value = data;
   results->decode_type = RC6;
+  results->bits = actual_bits;
+  results->value = data;
+  results->address = data >> (actual_bits - 4);  // Top four bits are the mode.
+  results->command = data & ((1ULL << (actual_bits - 4)) - 1);  // The rest.
   return true;
 }
 

--- a/lib/IRremoteESP8266/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266/IRremoteESP8266.h
@@ -76,7 +76,8 @@ enum decode_type_t {
   SHERWOOD,
   MITSUBISHI_AC,
   RCMM,
-  SANYO_LC7461
+  SANYO_LC7461,
+  RC5X
 };
 
 // Results returned from the decoder
@@ -128,8 +129,8 @@ class IRrecv {
  private:
   // These are called by decode
   void copyIrParams(irparams_t *dest);
-  int16_t getRClevel(decode_results *results, int *offset, int *used,
-                     uint16_t t1);
+  int16_t getRClevel(decode_results *results, uint16_t *offset, uint16_t *used,
+                     uint16_t bitTime);
   bool decodeNEC(decode_results *results, uint16_t nbits = NEC_BITS,
                  bool strict = true);
   bool decodeSony(decode_results *results, uint16_t nbits = SONY_MIN_BITS,
@@ -142,8 +143,10 @@ class IRrecv {
   bool decodeMitsubishi(decode_results *results,
                         uint16_t nbits = MITSUBISHI_BITS,
                         bool strict = false);
-  bool decodeRC5(decode_results *results);
-  bool decodeRC6(decode_results *results);
+  bool decodeRC5(decode_results *results, uint16_t nbits = RC5X_BITS,
+                 bool strict = false);
+  bool decodeRC6(decode_results *results, uint16_t nbits = RC6_MODE0_BITS,
+                 bool strict = false);
   bool decodeRCMM(decode_results *results);
   bool decodePanasonic(decode_results *results, uint16_t nbits = PANASONIC_BITS,
                        bool strict = false);
@@ -233,9 +236,10 @@ class IRsend {
                       uint16_t repeat = MITSUBISHI_MIN_REPEAT);
   void sendRaw(uint16_t buf[], uint16_t len, uint16_t hz);
   void sendGC(uint16_t buf[], uint16_t len);
-  void sendRC5(uint32_t data, uint16_t nbits);
-  void sendRC6(uint64_t data, uint16_t nbits, uint16_t repeat = 0);
-  void sendRCMM(uint32_t data, uint16_t nbits = RCMM_BITS);
+  void sendRC5(uint64_t data, uint16_t nbits = RC5X_BITS, uint16_t repeat = 0);
+  void sendRC6(uint64_t data, uint16_t nbits = RC6_MODE0_BITS,
+               uint16_t repeat = 0);
+  void sendRCMM(uint32_t data, uint8_t nbits = RCMM_BITS);
   // sendDISH() should typically be called with repeat=3 as DISH devices
   // expect the code to be sent at least 4 times. (code + 3 repeats = 4 codes)
   // Legacy use of this procedure was only to send a single code

--- a/lib/IRremoteESP8266/IRremoteInt.h
+++ b/lib/IRremoteESP8266/IRremoteInt.h
@@ -142,14 +142,21 @@
 #define MITSUBISHI_AC_RPT_MARK     440U
 #define MITSUBISHI_AC_RPT_SPACE  17100UL
 
+// Ref:
+//   https://en.wikipedia.org/wiki/RC-5
+//   http://www.sbprojects.com/knowledge/ir/rc5.php
+#define RC5_RAW_BITS               14U
+#define RC5_T1                    889U
+#define RC5_MIN_COMMAND_LENGTH 113778UL
+#define RC5_MIN_GAP RC5_MIN_COMMAND_LENGTH - RC5_RAW_BITS * (2 * RC5_T1)
 
-#define RC5_T1           889U
-#define RC5_RPT_LENGTH 46000U
-
-#define RC6_HDR_MARK    2666U
-#define RC6_HDR_SPACE    889U
-#define RC6_T1           444U
-#define RC6_RPT_LENGTH 46000U
+// Ref:
+//   https://en.wikipedia.org/wiki/RC-6
+//   http://www.pcbheaven.com/userpages/The_Philips_RC6_Protocol/
+#define RC6_HDR_MARK             2666U
+#define RC6_HDR_SPACE             889U
+#define RC6_T1                    444U
+#define RC6_RPT_LENGTH          83000UL
 
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/rcmm.php
@@ -162,6 +169,7 @@
 #define RCMM_BIT_SPACE_3   777U
 #define RCMM_RPT_LENGTH  27778U
 #define RCMM_MIN_GAP      3360U
+
 // Use a tolerance of +/-10% when matching some data spaces.
 #define RCMM_TOLERANCE      10U
 #define RCMM_EXCESS         50U
@@ -319,6 +327,10 @@ extern volatile irparams_t irparams;
 #define MITSUBISHI_BITS    16U
 #define MIN_RC5_SAMPLES    11U
 #define MIN_RC6_SAMPLES     1U
+#define RC5_BITS           RC5_RAW_BITS - 2U
+#define RC5X_BITS          RC5_RAW_BITS - 1U
+#define RC6_MODE0_BITS     20U  // Excludes the 'start' bit.
+#define RC6_36_BITS        36U  // Excludes the 'start' bit.
 #define PANASONIC_BITS     48U
 #define JVC_BITS           16U
 #define LG_BITS            28U


### PR DESCRIPTION
- Add support for 64 bit values.
- Add sending/decoding of RC-5X (Extended RC-5) protocol.
- Code clean up.
- Code style clean up.
- Function descriptions.
- More comments.
- Update examples to handle RC-5X protocol and minor clean up.
- Add strict compliance options for the protocols.
- Add repeat functionality, and calculate/obtain repeat timing data.
- Develop a deep loathing of Manchester code, and thus RC-5, RC-5X, & RC-6.
- Add sarcastic comments.
- Fix some compiler warnings.

#43 