### PR TITLE
Upgrade Mitsubishi (TV) to v2.0 spec. Add sendMitsubishi().

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -28,6 +28,7 @@
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
  *   (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
+ * Mitsubishi (TV) sending added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
  *     (derived from https://github.com/r45635/HVAC-IR-Control)
  * DISH decode by marcosamarinho
@@ -966,6 +967,41 @@ void ICACHE_FLASH_ATTR IRsend::sendSherwood(unsigned long data, int nbits,
   sendNEC(data, nbits, max(1, repeat));
 }
 
+// Send a Mitsubishi message
+//
+// Args:
+//   data:   Contents of the message to be sent.
+//   nbits:  Nr. of bits of data to be sent. Typically MITSUBISHI_BITS.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: ALPHA / untested.
+//
+// Notes:
+//   This protocol appears to have no header.
+// Ref:
+//   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Mitsubishi.cpp
+//   GlobalCache's Control Tower's Mitsubishi TV data.
+void ICACHE_FLASH_ATTR IRsend::sendMitsubishi(unsigned long long data,
+                                              unsigned int nbits,
+                                              unsigned int repeat) {
+  enableIROut(33);  // Set IR carrier frequency
+  IRtimer usecTimer = IRtimer();
+
+  for (unsigned int i = 0; i <= repeat; i++) {
+    usecTimer.reset();
+    // No header
+
+    // Data
+    sendData(MITSUBISHI_BIT_MARK, MITSUBISHI_ONE_SPACE,
+             MITSUBISHI_BIT_MARK, MITSUBISHI_ZERO_SPACE,
+             data, nbits, true);
+    // Footer
+    mark(MITSUBISHI_BIT_MARK);
+    space(max(MITSUBISHI_MIN_COMMAND_LENGTH - usecTimer.elapsed(),
+              MITSUBISHI_MIN_GAP));
+  }
+}
+
 void ICACHE_FLASH_ATTR IRsend::sendMitsubishiAC(unsigned char data[]) {
   // Set IR carrier frequency
   enableIROut(38);
@@ -1174,9 +1210,8 @@ bool ICACHE_FLASH_ATTR IRrecv::decode(decode_results *results,
 #ifdef DEBUG
   Serial.println("Attempting Mitsubishi decode");
 #endif
-  if (decodeMitsubishi(results)) {
+  if (decodeMitsubishi(results))
     return true;
-  }
 #ifdef DEBUG
   Serial.println("Attempting RC5 decode");
 #endif
@@ -1617,69 +1652,59 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeSanyo(decode_results *results) {
   return true;
 }
 
-// Looks like Sony except for timings, 48 chars of data and time/space different
-bool ICACHE_FLASH_ATTR IRrecv::decodeMitsubishi(decode_results *results) {
-  // Serial.print("?!? decoding Mitsubishi:");Serial.print(results->rawlen);
-  // Serial.print(" want "); Serial.println( 2 * MITSUBISHI_BITS + 2);
-  long data = 0;
-  if (results->rawlen < 2 * MITSUBISHI_BITS + 2) {
-    return false;
-  }
-  int offset = 1; // Skip first space
-  // Initial space
-  /* Put this back in for debugging - note can't use #DEBUG as if Debug on we
-     don't see the repeat cos of the delay
-  Serial.print("IR Gap: ");
-  Serial.println( results->rawbuf[offset]);
-  Serial.println( "test against:");
-  Serial.println(results->rawbuf[offset]);
-  */
-  /* Not seeing double keys from Mitsubishi
-  if (results->rawbuf[offset] < MITSUBISHI_DOUBLE_SPACE_USECS) {
-    // Serial.print("IR Gap found: ");
-    results->bits = 0;
-    results->value = REPEAT;
-    results->decode_type = MITSUBISHI;
-    return true;
-  }
-  */
+// Decode the supplied Mitsubishi message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of data bits to expect.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: BETA / previously working.
+//
+// Notes:
+//   This protocol appears to have no header.
+//
+// Ref:
+//   GlobalCache's Control Tower's Mitsubishi TV data.
+bool ICACHE_FLASH_ATTR IRrecv::decodeMitsubishi(decode_results *results,
+                                                uint16_t nbits, bool strict) {
+  if (results->rawlen < 2 * nbits + FOOTER)
+    return false;  // Shorter than shortest possibly expected.
+  if (strict && nbits != MITSUBISHI_BITS)
+    return false;  // Request is out of spec.
 
-  offset++;
+  uint16_t offset = OFFSET_START;
+  uint64_t data = 0;
 
-  // Typical
-  // 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7
+  // No Header
 
-  // Initial Space
-  if (!matchMark(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
-    return false;
-  }
-  offset++;
-  while (offset + 1 < irparams.rawlen) {
-    if (matchMark(results->rawbuf[offset], MITSUBISHI_ONE_MARK)) {
-
-      data = (data << 1) | 1;
-    } else if (matchMark(results->rawbuf[offset], MITSUBISHI_ZERO_MARK)) {
-      data <<= 1;
-    } else {
-      // Serial.println("A"); Serial.println(offset); Serial.println(results->rawbuf[offset]);
+  // Data
+  uint16_t actualBits;
+  for (actualBits = 0; offset < results->rawlen - 1; actualBits++, offset++) {
+    if (!matchMark(results->rawbuf[offset++], MITSUBISHI_BIT_MARK))
       return false;
-    }
-    offset++;
-    if (!matchSpace(results->rawbuf[offset], MITSUBISHI_HDR_SPACE)) {
-      // Serial.println("B"); Serial.println(offset); Serial.println(results->rawbuf[offset]);
+    if (matchSpace(results->rawbuf[offset], MITSUBISHI_ONE_SPACE))
+      data = (data << 1) | 1;  // 1
+    else if (matchSpace(results->rawbuf[offset], MITSUBISHI_ZERO_SPACE))
+      data <<= 1;  // 0
+    else
       break;
-    }
-    offset++;
   }
+
+  // Footer is matched by the last iteration of the data loop.
+
+  // Compliance
+  if (strict && actualBits != nbits)
+    return false;  // Not as we expected.
 
   // Success
-  results->bits = (offset - 1) / 2;
-  if (results->bits < MITSUBISHI_BITS) {
-    results->bits = 0;
-    return false;
-  }
-  results->value = data;
   results->decode_type = MITSUBISHI;
+  results->bits = actualBits;
+  results->value = data;
+  results->address = 0;
+  results->command = 0;
   return true;
 }
 

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -19,6 +19,9 @@
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
+ * Mitsubishi (TV) sending added by crankyoldgit
+ * Mitsubishi A/C added by crankyoldgit
+ *     (derived from https://github.com/r45635/HVAC-IR-Control)
  * DISH decode by marcosamarinho
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for sending IR code on ESP8266
  * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code on ESP8266
@@ -110,6 +113,7 @@ uint8_t calcLGChecksum(uint16_t data);
 #define SEND_PROTOCOL_DENON    case DENON: sendDenon(data, nbits); break;
 #define SEND_PROTOCOL_SHERWOOD case SHERWOOD: sendSherwood(data, nbits); break;
 #define SEND_PROTOCOL_RCMM     case RCMM: sendRCMM(data, nbits); break;
+#define SEND_PROTOCOL_MITSUBISHI case MITSUBISHI: sendMitsubishi(data, nbits); break;
 
 
 // main class for receiving IR
@@ -129,7 +133,8 @@ public:
                  bool strict=false);
   bool decodeSony(decode_results *results);
   bool decodeSanyo(decode_results *results);
-  bool decodeMitsubishi(decode_results *results);
+  bool decodeMitsubishi(decode_results *results, uint16_t nbits=MITSUBISHI_BITS,
+                        bool strict=false);
   bool decodeRC5(decode_results *results);
   bool decodeRC6(decode_results *results);
   bool decodeRCMM(decode_results *results);
@@ -174,7 +179,7 @@ class IRsend
 public:
   IRsend(int IRsendPin);
   void begin();
-  void send(int type, unsigned long data, int nbits) {
+  void send(unsigned int type, unsigned long long data, unsigned int nbits) {
     switch (type) {
         SEND_PROTOCOL_NEC
         SEND_PROTOCOL_SONY
@@ -189,6 +194,7 @@ public:
         SEND_PROTOCOL_DENON
         SEND_PROTOCOL_SHERWOOD
         SEND_PROTOCOL_RCMM
+        SEND_PROTOCOL_MITSUBISHI
       }
   };
   void sendCOOLIX(unsigned long data, int nbits);
@@ -209,9 +215,11 @@ public:
                 unsigned int repeat=2);
   unsigned long encodeSony(unsigned int nbits, unsigned int command,
                            unsigned int address, unsigned int extended=0);
-  // Neither Sanyo nor Mitsubishi send is implemented yet
+  // Sanyo send is not implemented yet
   //  void sendSanyo(unsigned long data, int nbits);
-  //  void sendMitsubishi(unsigned long data, int nbits);
+  void sendMitsubishi(unsigned long long data,
+                      unsigned int nbits=MITSUBISHI_BITS,
+                      unsigned int repeat=MITSUBISHI_MIN_REPEAT);
   void sendRaw(unsigned int buf[], int len, int hz);
   void sendGC(unsigned int buf[], int len);
   void sendRC5(unsigned long data, int nbits);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -18,8 +18,9 @@
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C added by crankyoldgit
+ * Mitsubishi (TV) sending added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
- *     (based on https://github.com/r45635/HVAC-IR-Control)
+ *     (derived from https://github.com/r45635/HVAC-IR-Control)
  * DISH decode by marcosamarinho
  *
  * 09/23/2015 : Samsung pulse parameters updated by Sebastien Warin to be compatible with EUxxD6200
@@ -79,15 +80,17 @@
 #define SANYO_DOUBLE_SPACE_USECS  800  // usually see 713 - not using ticks as get number wrapround
 #define SANYO_RPT_LENGTH 45000
 
-// Mitsubishi RM 75501
-// 14200 7 41 7 42 7 42 7 17 7 17 7 18 7 41 7 18 7 17 7 17 7 18 7 41 8 17 7 17 7 18 7 17 7
-
-// #define MITSUBISHI_HDR_MARK	250  // seen range 3500
-#define MITSUBISHI_HDR_SPACE	350 //  7*50+100
-#define MITSUBISHI_ONE_MARK	1950 // 41*50-100
-#define MITSUBISHI_ZERO_MARK  750 // 17*50-100
-// #define MITSUBISHI_DOUBLE_SPACE_USECS  800  // usually ssee 713 - not using ticks as get number wrapround
-// #define MITSUBISHI_RPT_LENGTH 45000
+// Mitsubishi period time is 1/33000Hz = 30.303 uSeconds (T)
+// Ref:
+//   GlobalCache's Control Tower's Mitsubishi TV data.
+//   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Mitsubishi.cpp
+#define MITSUBISHI_BIT_MARK             303U  // T * 10
+#define MITSUBISHI_ONE_SPACE           2121U  // T * 70
+#define MITSUBISHI_ZERO_SPACE           909U  // T * 30
+#define MITSUBISHI_MIN_COMMAND_LENGTH 54121U  // T * 1786
+#define MITSUBISHI_MIN_GAP            28364U  // T * 936
+// TODO: Verify that the repeat is really needed.
+#define MITSUBISHI_MIN_REPEAT             1U  // Based on marcosamarinho's code.
 
 // Mitsubishi A/C
 // Values were initially obtained from:


### PR DESCRIPTION
- Support 64 bit messages.
- Base timings off Global Cache data.
- Improve decode code understandablity and make it consistent.
- Function descriptions.
- Add optional strict compliance.
- Add initial support for sending Mitsubishi codes.
- Code style fixes.
- Etc etc.
- Add attributions.