### PR TITLE
Upgrade Sharp to v2.0 spec. Add Sharp encode and decode.

### DIFF
--- a/IRremoteESP8266.cpp
+++ b/IRremoteESP8266.cpp
@@ -791,51 +791,129 @@ void ICACHE_FLASH_ATTR IRsend::enableIROut(unsigned long freq, uint8_t duty) {
   offTimePeriod = period - onTimePeriod;
 }
 
+// Send a (raw) Sharp message
+//
+// Args:
+//   data:   Contents of the message to be sent.
+//   nbits:  Nr. of bits of data to be sent. Typically SHARP_BITS.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: Beta / Previously working fine.
+//
+// Notes:
+//   This procedure handles the inversion of bits required per protocol.
+//   The protocol spec says to send the LSB first, but legacy code & usage
+//   has us sending the MSB first. Grrrr. Normal invocation of encodeSharp()
+//   handles this for you, assuming you are using the correct/standard values.
+//   e.g. sendSharpRaw(encodeSharp(address, command));
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/sharp.htm
+//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
+//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+//   http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+void ICACHE_FLASH_ATTR IRsend::sendSharpRaw(unsigned long long data,
+                                            unsigned int nbits,
+                                            unsigned int repeat) {
+  // Set 38kHz IR carrier frequency & a 1/3 (33%) duty cycle.
+  enableIROut(38, 33);
 
-/* Sharp and DISH support by Todd Treece
-( http://unionbridge.org/design/ircommand )
+  for (uint16_t i = 0; i <= repeat; i++) {
+    // Protocol demands that the data be sent twice; once normally,
+    // then with all but the address bits inverted.
+    // Note: Previously this used to be performed 3 times (normal, inverted,
+    //       normal), however all data points to that being incorrect.
+    for (uint8_t n = 0; n < 2; n++) {
+      // No Header
 
-The Dish send function needs to be repeated 4 times, and the Sharp function
-has the necessary repeat built in because of the need to invert the signal.
+      // Data
+      sendData(SHARP_BIT_MARK, SHARP_ONE_SPACE,
+               SHARP_BIT_MARK, SHARP_ZERO_SPACE,
+               data, nbits, true);
+      // Footer
+      mark(SHARP_BIT_MARK);
+      space(SHARP_GAP);
 
-Sharp protocol documentation:
-http://www.sbprojects.com/knowledge/ir/sharp.htm
-
-Here are the LIRC files that I found that seem to match the remote codes
-from the oscilloscope:
-
-Sharp LCD TV:
-http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
-
-DISH NETWORK (echostar 301):
-http://lirc.sourceforge.net/remotes/echostar/301_501_3100_5100_58xx_59xx
-
-For the DISH codes, only send the last for characters of the hex.
-i.e. use 0x1C10 instead of 0x0000000000001C10 which is listed in the
-linked LIRC file.
-*/
-
-void ICACHE_FLASH_ATTR IRsend::sendSharpRaw(unsigned long data, int nbits) {
-  // Set IR carrier frequency
-  enableIROut(38);
-  // Sending codes in bursts of 3 (normal, inverted, normal) makes transmission
-  // much more reliable. That's the exact behaviour of CD-S6470 remote control.
-  for (int n = 0; n < 3; n++) {
-    // Data
-    sendData(SHARP_BIT_MARK, SHARP_ONE_SPACE, SHARP_BIT_MARK, SHARP_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(SHARP_BIT_MARK);
-    space(SHARP_ZERO_SPACE + 40000);
-
-    data = data ^ SHARP_TOGGLE_MASK;
+      // Invert the data per protocol. This is always called twice, so it's
+      // retured to original upon exiting the inner loop.
+      data ^= SHARP_TOGGLE_MASK;
+    }
   }
 }
 
-// Sharp send compatible with data obtained through decodeSharp
+// Encode a (raw) Sharp message from it's components.
+//
+// Args:
+//   address:   The value of the address to be sent.
+//   command:   The value of the address to be sent. (8 bits)
+//   expansion: The value of the expansion bit to use. (0 or 1, typically 1)
+//   check:     The value of the check bit to use. (0 or 1, typically 0)
+//   MSBfirst:  Flag indicating MSB first or LSB first order. (Default: false)
+// Returns:
+//   An unsigned long containing the raw Sharp message for sendSharpRaw().
+//
+// Status: ALPHA / Untested
+//
+// Notes:
+//   Assumes the standard Sharp bit sizes.
+//   Historically sendSharp() sends address & command in
+//     MSB first order. This is actually incorrect. It should be sent in LSB
+//     order. The behaviour of sendSharp() hasn't been changed to maintain
+//     backward compatiblity.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/sharp.htm
+//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
+//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+unsigned long ICACHE_FLASH_ATTR IRsend::encodeSharp(unsigned int address,
+                                                    unsigned int command,
+                                                    unsigned int expansion,
+                                                    unsigned int check,
+                                                    bool MSBfirst) {
+  // Mask any unexpected bits.
+  address &= ((1 << SHARP_ADDRESS_BITS) - 1);
+  command &= ((1 << SHARP_COMMAND_BITS) - 1);
+  expansion &= 1;
+  check &= 1;
+
+  if (!MSBfirst) {  // Correct bit order if needed.
+    address = reverseBits(address, SHARP_ADDRESS_BITS);
+    command = reverseBits(command, SHARP_COMMAND_BITS);
+  }
+  // Concatinate all the bits.
+  return (unsigned long) ((address << (SHARP_COMMAND_BITS + 2)) |
+                          (command << 2) | (expansion << 1) | check);
+}
+
+// Send a Sharp message
+//
+// Args:
+//   address:  Address value to be sent.
+//   command:  Command value to be sent.
+//   nbits:    Nr. of bits of data to be sent. Typically SHARP_BITS.
+//   repeat:   Nr. of additional times the message is to be sent.
+//
+// Status:  DEPRICATED / Previously working fine.
+//
+// Notes:
+//   This procedure has a non-standard invocation style compared to similar
+//     sendProtocol() routines. This is due to legacy, compatiblity, & historic
+//     reasons. Normally the calling syntax version is like sendSharpRaw().
+//   This procedure transmits the address & command in MSB first order, which is
+//     incorrect. This behaviour is left as-is to maintain backward
+//     compatiblity with legacy code.
+//   In short, you should use sendSharpRaw(), encodeSharp(), and the correct
+//     values of address & command instead of using this, & the wrong values.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/sharp.htm
+//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
+//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
 void ICACHE_FLASH_ATTR IRsend::sendSharp(unsigned int address,
-                                         unsigned int command) {
-  sendSharpRaw((address << 10) | (command << 2) | 2, 15);
+                                         unsigned int command,
+                                         unsigned int nbits,
+                                         unsigned int repeat) {
+  sendSharpRaw(encodeSharp(address, command, 1, 0, true), nbits, repeat);
 }
 
 // Send an IR command to a DISH NETWORK device.
@@ -1234,6 +1312,11 @@ bool ICACHE_FLASH_ATTR IRrecv::decode(decode_results *results,
   if (decodeDISH(results)) {
     return true;
   }
+#ifdef DEBUG
+  Serial.println("Attempting Sharp decode");
+#endif
+  if (decodeSharp(results))
+    return true;
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.
   // If you add any decodes, add them before this.
@@ -1858,6 +1941,112 @@ bool ICACHE_FLASH_ATTR IRrecv::decodeRCMM(decode_results *results) {
   results->value = (unsigned long) data;
   results->decode_type = RCMM;
   results->bits = bitSize;
+  return true;
+}
+
+// Decode the supplied Sharp message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of data bits to expect. Typically SHARP_BITS.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: ALPHA / Untested.
+// Note:
+//   This procedure returns a value suitable for use in sendSharpRaw().
+// TODO:
+//   Need to ensure capture of the inverted message as it can be missed
+//   due to the interrupt timeout used to detect an end of message.
+//   Several compliance checks are disabled until that is resolved.
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/sharp.php
+//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+//   http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+bool ICACHE_FLASH_ATTR IRrecv::decodeSharp(decode_results *results,
+                                           uint16_t nbits,
+                                           bool strict) {
+  if (results->rawlen < 2 * nbits + FOOTER)
+    return false;  // Not enough entries to be a Sharp message.
+  // Compliance
+  if (strict) {
+    if (nbits != SHARP_BITS)
+      return false;  // Request is out of spec.
+    /* DISABLED - See TODO
+    // An in spec message has the data sent normally, then inverted. So we
+    // expect twice as many entries than to just get the results.
+    if (results->rawlen < 2 * (2 * nbits + FOOTER))
+      return false;
+    */
+  }
+
+  uint64_t data = 0;
+  uint16_t offset = OFFSET_START;
+
+  // No header
+
+  // Data
+  for (uint16_t i = 0; i < nbits; i++, offset++) {
+    if (!matchMark(results->rawbuf[offset++], SHARP_BIT_MARK))
+      return false;
+    if (matchSpace(results->rawbuf[offset], SHARP_ONE_SPACE))
+      data = (data << 1) | 1;  // 1
+    else if (matchSpace(results->rawbuf[offset], SHARP_ZERO_SPACE))
+      data <<= 1;  // 0
+    else
+      return false;
+  }
+
+  // Footer
+  if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
+    return false;
+
+
+  // Compliance
+  if (strict) {
+    // We expect the expansion bit to be set, and the check bit cleared
+    // in a normal message.
+    if ((data & B11) != B10)
+      return false;
+    /* DISABLED - See TODO
+    // Grab the second copy of the data (i.e. inverted)
+    // Header
+    // i.e. The inter-data/command repeat gap.
+    if (!matchSpace(results->rawbuf[offset++], SHARP_GAP))
+      return false;
+
+    // Data
+    uint64_t second_data = 0;
+    for (uint16_t i = 0; i < nbits; i++, offset++) {
+      if (!matchMark(results->rawbuf[offset++], SHARP_BIT_MARK))
+        return false;
+      if (matchSpace(results->rawbuf[offset], SHARP_ONE_SPACE))
+        second_data = (second_data << 1) | 1;  // 1
+      else if (matchSpace(results->rawbuf[offset], SHARP_ZERO_SPACE))
+        second_data <<= 1;  // 0
+      else
+        return false;
+    }
+    // Footer
+    if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
+      return false;
+
+    // Check that second_data has been inverted correctly.
+    if (data != (second_data ^ SHARP_TOGGLE_MASK))
+      return false;
+    */
+  }
+
+  // Success
+  results->decode_type = SHARP;
+  results->bits = nbits;
+  results->value = data;
+  // Address & command are actually transmitted in LSB first order.
+  results->address = reverseBits(data, nbits) & SHARP_ADDRESS_MASK;
+  results->sharpAddress = results->address;
+  results->command = reverseBits((data >> 2) & SHARP_COMMAND_MASK,
+                                 SHARP_COMMAND_BITS);
   return true;
 }
 

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -110,7 +110,7 @@ uint8_t calcLGChecksum(uint16_t data);
 #define SEND_PROTOCOL_DENON    case DENON: sendDenon(data, nbits); break;
 #define SEND_PROTOCOL_SHERWOOD case SHERWOOD: sendSherwood(data, nbits); break;
 #define SEND_PROTOCOL_RCMM     case RCMM: sendRCMM(data, nbits); break;
-
+#define SEND_PROTOCOL_SHARP    case SHARP: sendSharpRaw(data, nbits); break;
 
 // main class for receiving IR
 class IRrecv
@@ -151,6 +151,8 @@ public:
                    bool strict=true);
   bool decodeDISH(decode_results *results, uint16_t nbits=DISH_BITS,
                   bool strict=true);
+  bool decodeSharp(decode_results *results, uint16_t nbits=SHARP_BITS,
+                   bool strict=true);
   int compare(unsigned int oldval, unsigned int newval);
   uint32_t ticksLow(uint32_t usecs, uint8_t tolerance=TOLERANCE);
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance=TOLERANCE);
@@ -189,6 +191,7 @@ public:
         SEND_PROTOCOL_DENON
         SEND_PROTOCOL_SHERWOOD
         SEND_PROTOCOL_RCMM
+        SEND_PROTOCOL_SHARP
       }
   };
   void sendCOOLIX(unsigned long data, int nbits);
@@ -223,8 +226,14 @@ public:
   // so use repeat=0 for backward compatiblity.
   void sendDISH(unsigned long long data, unsigned int nbits=DISH_BITS,
                 unsigned int repeat=DISH_MIN_REPEAT);
-  void sendSharp(unsigned int address, unsigned int command);
-  void sendSharpRaw(unsigned long data, int nbits);
+  unsigned long encodeSharp(unsigned int address, unsigned int command,
+                            unsigned int expansion=1, unsigned int check=0,
+                            bool MSBfirst=false);
+  void sendSharp(unsigned int address, unsigned int command,
+                 unsigned int nbits=SHARP_BITS,
+                 unsigned int repeat=0);
+  void sendSharpRaw(unsigned long long data, unsigned int nbits=SHARP_BITS,
+                    unsigned int repeat=0);
   void sendPanasonic64(unsigned long long data,
                        unsigned int nbits=PANASONIC_BITS,
                        unsigned int repeat=0);

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -123,12 +123,21 @@
 #define RCMM_TOLERANCE 10
 #define RCMM_EXCESS 50
 
-#define SHARP_BIT_MARK 245
-#define SHARP_ONE_SPACE 1805
-#define SHARP_ZERO_SPACE 795
-#define SHARP_GAP 600000
-#define SHARP_TOGGLE_MASK 0x3FF
-#define SHARP_RPT_SPACE 3000
+// Sharp period time = 1/38000Hz = 26.316 microseconds.
+// Ref:
+//   GlobalCache's IR Control Tower data.
+//   http://www.sbprojects.com/knowledge/ir/sharp.php
+#define SHARP_ADDRESS_BITS     5U
+#define SHARP_COMMAND_BITS     8U
+#define SHARP_BIT_MARK       316U  // 12 * T
+#define SHARP_ONE_SPACE     1684U  // 64 * T
+#define SHARP_ZERO_SPACE     684U  // 26 * T
+#define SHARP_GAP          43606U  // 1657 * T
+// Address(5) + Command(8) + Expansion(1) + Check(1)
+#define SHARP_BITS         SHARP_ADDRESS_BITS + SHARP_COMMAND_BITS + 2
+#define SHARP_TOGGLE_MASK  ((1 << (SHARP_BITS - SHARP_ADDRESS_BITS)) - 1)
+#define SHARP_ADDRESS_MASK ((1 << SHARP_ADDRESS_BITS) - 1)
+#define SHARP_COMMAND_MASK ((1 << SHARP_COMMAND_BITS) - 1)
 
 // Ref:
 //   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Dish.cpp
@@ -182,7 +191,6 @@
 #define SAMSUNG_MIN_GAP   20000  // Completely made up figure.
 #define SAMSUNG_MIN_MESSAGE_LENGTH 108000UL
 
-#define SHARP_BITS 15
 #define DISH_BITS 16
 
 // Daikin, from https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote


### PR DESCRIPTION
- Support 64 bit messages.
- Function descriptions.
- Correct the inversion in sendSharpRaw()
- Add repeat functionality.
- Improve timings based on references.
- Add encoder and correctly handle LSB order of address & command.
- Add a decoder and support decoding of address & command values.
- Mark sendSharp() as depricated as it really has been using the
    wrong values of address & command.
- Code & style cleanup.
- Add compliance checks.
- Moar commentz!!!one!