### PR TITLE
Update Coolix to v2.0 spec. Add decodeCOOLIX().

### DIFF
--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -15,7 +15,7 @@
  * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
  * LG added by Darryl Smith (based on the JVC protocol)
  * Whynter A/C ARC-110WD added by Francesco Meschia
- * Coolix A/C / heatpump added by bakrus
+ * Coolix A/C / heatpump added by (send) bakrus & (decode) crankyoldgit
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
@@ -144,8 +144,8 @@ public:
   bool decodeWhynter(decode_results *results, uint16_t nbits=WHYNTER_BITS,
                      bool strict=true);
   bool decodeHash(decode_results *results);
-  // COOLIX decode is not implemented yet
-  //  bool decodeCOOLIX(decode_results *results);
+  bool decodeCOOLIX(decode_results *results, uint16_t nbits=COOLIX_BITS,
+                    bool strict=true);
   bool decodeDaikin(decode_results *results);
   bool decodeDenon(decode_results *results, uint16_t nbits=DENON_BITS,
                    bool strict=true);
@@ -194,7 +194,8 @@ public:
         SEND_PROTOCOL_SHARP
       }
   };
-  void sendCOOLIX(unsigned long data, int nbits);
+  void sendCOOLIX(unsigned long long data, unsigned int nbits=COOLIX_BITS,
+                  unsigned int repeat=0);
   void sendWhynter(unsigned long long data, unsigned int nbits=WHYNTER_BITS,
                    unsigned int repeat=0);
   void sendNEC(unsigned long long data, unsigned int nbits=NEC_BITS,

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -14,7 +14,7 @@
  *
  * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
  * Whynter A/C ARC-110WD added by Francesco Meschia
- * Coolix A/C / heatpump added by bakrus
+ * Coolix A/C / heatpump added by (send) bakrus & (decode) crankyoldgit
  * Denon: sendDenon, decodeDenon added by Massimiliano Pinto
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C added by crankyoldgit
@@ -39,11 +39,12 @@
 // Pulse parms are *50-100 for the Mark and *50+100 for the space
 // First MARK is the one after the long gap
 // pulse parameters in usec
-#define COOLIX_BIT_MARK	560       // Approximately 21 cycles at 38kHz
-#define COOLIX_ONE_SPACE	COOLIX_BIT_MARK * 3
-#define COOLIX_ZERO_SPACE	COOLIX_BIT_MARK * 1
-#define COOLIX_HDR_MARK	COOLIX_BIT_MARK * 8
-#define COOLIX_HDR_SPACE	COOLIX_BIT_MARK * 8
+#define COOLIX_BIT_MARK   560U  // Approximately 21 cycles at 38kHz
+#define COOLIX_ONE_SPACE  COOLIX_BIT_MARK * 3
+#define COOLIX_ZERO_SPACE COOLIX_BIT_MARK * 1
+#define COOLIX_HDR_MARK   COOLIX_BIT_MARK * 8
+#define COOLIX_HDR_SPACE  COOLIX_BIT_MARK * 8
+#define COOLIX_MIN_GAP    COOLIX_HDR_SPACE + COOLIX_ZERO_SPACE
 
 #define WHYNTER_HDR_MARK             2850U
 #define WHYNTER_HDR_SPACE            2850U
@@ -274,7 +275,7 @@ extern volatile irparams_t irparams;
 #define LG_BITS 28
 #define SAMSUNG_BITS 32
 #define WHYNTER_BITS 32U
-#define COOLIX_NBYTES 3
+#define COOLIX_BITS 24
 #define DAIKIN_BITS 99
 
 #endif

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -64,6 +64,7 @@ void encoding(decode_results *results) {
     case AIWA_RC_T501: Serial.print("AIWA_RC_T501");  break ;
     case PANASONIC:    Serial.print("PANASONIC");     break ;
     case DENON:        Serial.print("DENON");         break ;
+    case COOLIX:       Serial.print("COOLIX");        break ;
   }
 }
 


### PR DESCRIPTION
- Handle 64 bit.
- Function descriptions
- Clean up ugly code in sendCOOLIX() to make it far more readable.
- Code style cleanup.
- Add new decodeCOOLIX() routine. (Untested. Something is better than nothing)
- Update example(s) for decodeCOOLIX.