### PR TITLE
Fix almost all Google cpplint issues & use c99 types.

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,2 @@
+set noparent
+linelength=80

--- a/IRDaikinESP.cpp
+++ b/IRDaikinESP.cpp
@@ -1,152 +1,136 @@
 /*
 An Arduino sketch to emulate IR Daikin ARC433** remote control unit
-Read more on http://harizanov.com/2012/02/control-daikin-air-conditioner-over-the-internet/
+Read more at:
+http://harizanov.com/2012/02/control-daikin-air-conditioner-over-the-internet/
+
+Copyright 2016 sillyfrog
 */
 
 #include <IRDaikinESP.h>
 
-IRDaikinESP::IRDaikinESP(int pin) : _irsend(pin)
-{
+IRDaikinESP::IRDaikinESP(uint16_t pin) : _irsend(pin) {
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::begin()
-{
-    _irsend.begin();
+void ICACHE_FLASH_ATTR IRDaikinESP::begin() {
+  _irsend.begin();
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::send()
-{
+void ICACHE_FLASH_ATTR IRDaikinESP::send() {
   _irsend.sendDaikin(daikin);
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::checksum()
-{
-    uint8_t sum = 0;
-    uint8_t i;
+void ICACHE_FLASH_ATTR IRDaikinESP::checksum() {
+  uint8_t sum = 0;
+  uint8_t i;
 
-    for(i = 0; i <= 6; i++){
-        sum += daikin[i];
-    }
+  for (i = 0; i <= 6; i++)
+    sum += daikin[i];
 
-    daikin[7] = sum &0xFF;
-    sum=0;
-    for(i = 8; i <= 25; i++){
-        sum += daikin[i];
-    }
-    daikin[26] = sum &0xFF;
+  daikin[7] = sum & 0xFF;
+  sum = 0;
+  for (i = 8; i <= 25; i++)
+    sum += daikin[i];
+  daikin[26] = sum & 0xFF;
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::on()
-{
-    //state = ON;
-    daikin[13] |= 0x01;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::on() {
+  // state = ON;
+  daikin[13] |= 0x01;
+  checksum();
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::off()
-{
-    //state = OFF;
-    daikin[13] &= 0xFE;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::off() {
+  // state = OFF;
+  daikin[13] &= 0xFE;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getPower()
-{
-    return (daikin[13])&0x01;
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getPower() {
+  return daikin[13] & 0x01;
 }
 
 // DAIKIN_SILENT or DAIKIN_POWERFUL
-void ICACHE_FLASH_ATTR IRDaikinESP::setAux(uint8_t aux)
-{
-    daikin[21] = aux;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setAux(uint8_t aux) {
+  daikin[21] = aux;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getAux(){
-    return daikin[21];
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getAux() {
+  return daikin[21];
 }
 
 
 // Set the temp in deg C
-void ICACHE_FLASH_ATTR IRDaikinESP::setTemp(uint8_t temp)
-{
-    if (temp < 18)
-        temp = 18;
-    else if (temp > 32)
-        temp = 32;
-    daikin[14] = (temp)*2;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setTemp(uint8_t temp) {
+  if (temp < 18)
+    temp = 18;
+  else if (temp > 32)
+    temp = 32;
+  daikin[14] = temp * 2;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getTemp()
-{
-    return (daikin[14])/2;
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getTemp() {
+  return daikin[14] / 2;
 }
 
 // Set the speed of the fan, 0-5, 0 is auto, 1-5 is the speed
-void ICACHE_FLASH_ATTR IRDaikinESP::setFan(uint8_t fan)
-{
-    // Set the fan speed bits, leave low 4 bits alone
-    uint8_t fanset;
-    daikin[16] = daikin[16] & 0x0F;
-    if (fan >= 1 && fan <= 5)
-        fanset = 0x20 + (0x10 * fan);
-    else
-        fanset = 0xA0;
-    daikin[16] = daikin[16] | fanset;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setFan(uint8_t fan) {
+  // Set the fan speed bits, leave low 4 bits alone
+  uint8_t fanset;
+  daikin[16] &= 0x0F;
+  if (fan >= 1 && fan <= 5)
+    fanset = 0x20 + (0x10 * fan);
+  else
+    fanset = 0xA0;
+  daikin[16] |= fanset;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getFan()
-{
-    uint8_t fan = daikin[16] >> 4;
-    fan = fan - 2;
-    if (fan > 5)
-        fan = 0;
-    return fan;
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getFan() {
+  uint8_t fan = daikin[16] >> 4;
+  fan -= 2;
+  if (fan > 5)
+    fan = 0;
+  return fan;
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getMode()
-{/*
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getMode() {
+  /*
   DAIKIN_COOL
   DAIKIN_HEAT
   DAIKIN_FAN
   DAIKIN_AUTO
   DAIKIN_DRY
   */
-    return (daikin[13])>>4;
+  return daikin[13] >> 4;
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::setMode(uint8_t mode)
-{
-    daikin[13]=mode<<4 | getPower();
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setMode(uint8_t mode) {
+  daikin[13] = (mode << 4) | getPower();
+  checksum();
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::setSwingVertical(uint8_t swing)
-{
-    if (swing)
-        daikin[16] = daikin[16] | 0x0F;
-    else
-        daikin[16] = daikin[16] & 0xF0;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setSwingVertical(uint8_t swing) {
+  if (swing)
+    daikin[16] |= 0x0F;
+  else
+    daikin[16] &= 0xF0;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getSwingVertical()
-{
-    return (daikin[16])&0x01;
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getSwingVertical() {
+  return daikin[16] & 0x01;
 }
 
-void ICACHE_FLASH_ATTR IRDaikinESP::setSwingHorizontal(uint8_t swing)
-{
-    if (swing)
-        daikin[17] = daikin[17] | 0x0F;
-    else
-        daikin[17] = daikin[17] & 0xF0;
-    checksum();
+void ICACHE_FLASH_ATTR IRDaikinESP::setSwingHorizontal(uint8_t swing) {
+  if (swing)
+    daikin[17] |= 0x0F;
+  else
+    daikin[17] &= 0xF0;
+  checksum();
 }
 
-uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getSwingHorizontal()
-{
-    return (daikin[17])&0x01;
+uint8_t ICACHE_FLASH_ATTR IRDaikinESP::getSwingHorizontal() {
+  return daikin[17] & 0x01;
 }

--- a/IRDaikinESP.h
+++ b/IRDaikinESP.h
@@ -1,3 +1,6 @@
+/* Copyright 2016 sillyfrog */
+#ifndef IRDAIKINESP_H_
+#define IRDAIKINESP_H_
 
 #include <IRremoteESP8266.h>
 #include <Arduino.h>
@@ -54,47 +57,39 @@
 
 #define DAIKIN_COMMAND_LENGTH 27
 
-class IRDaikinESP
-{
-    public:
-        IRDaikinESP(int pin);
-        //: IRsend(pin){};
+class IRDaikinESP {
+ public:
+  explicit IRDaikinESP(uint16_t pin);
 
-        void send();
+  void send();
+  void begin();
+  void on();
+  void off();
+  uint8_t getPower();
+  void setAux(uint8_t aux);
+  uint8_t getAux();
+  void setTemp(uint8_t temp);
+  uint8_t getTemp();
+  void setFan(uint8_t fan);
+  uint8_t getFan();
+  uint8_t getMode();
+  void setMode(uint8_t mode);
+  void setSwingVertical(uint8_t swing);
+  uint8_t getSwingVertical();
+  void setSwingHorizontal(uint8_t swing);
+  uint8_t getSwingHorizontal();
 
-        void begin();
-        void on();
-        void off();
-        uint8_t getPower();
-
-        void setAux(uint8_t aux);
-        uint8_t getAux();
-
-        void setTemp(uint8_t temp);
-        uint8_t getTemp();
-
-        void setFan(uint8_t fan);
-        uint8_t getFan();
-
-        uint8_t getMode();
-        void setMode(uint8_t mode);
-
-        void setSwingVertical(uint8_t swing);
-        uint8_t getSwingVertical();
-        void setSwingHorizontal(uint8_t swing);
-        uint8_t getSwingHorizontal();
-
-    private:
-        // # of bytes per command
-        unsigned char daikin[DAIKIN_COMMAND_LENGTH] = {
-        0x11,0xDA,0x27,0xF0,0x00,0x00,0x00,0x20,
-        //0    1    2   3    4    5     6   7
-        0x11,0xDA,0x27,0x00,0x00,0x41,0x1E,0x00,
-        //8    9   10   11   12    13   14   15
-        0xB0,0x00,0x00,0x00,0x00,0x00,0x00,0xC0,0x00,0x00,0xE3 };
-        //16  17    18  19   20    21   22  23   24   25   26
-
-        void checksum();
-
-        IRsend _irsend;
+ private:
+  // # of bytes per command
+  unsigned char daikin[DAIKIN_COMMAND_LENGTH] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
+      // 0     1     2     3     4     5     6     7
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
+      // 8     9    10    11    12    13    14    15
+      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
+      // 16   17    18    19    20    21    22    23    24    25    26
+  void checksum();
+  IRsend _irsend;
 };
+
+#endif  // IRDAIKINESP_H_

--- a/IRKelvinator.h
+++ b/IRKelvinator.h
@@ -1,4 +1,11 @@
+/***************************************************
+* Kelvinator A/C
+*
+* Copyright 2016 David Conran
+***************************************************/
 
+#ifndef IRKELVINATOR_H_
+#define IRKELVINATOR_H_
 #include <IRremoteESP8266.h>
 #include <Arduino.h>
 
@@ -113,48 +120,45 @@
 
 #define KELVINATOR_STATE_LENGTH 16
 
-class IRKelvinatorAC
-{
-    public:
-        IRKelvinatorAC(int pin);
-        //: IRsend(pin){};
+class IRKelvinatorAC {
+ public:
+  explicit IRKelvinatorAC(uint16_t pin);
 
-        void stateReset();
-        void send();
+  void stateReset();
+  void send();
+  void begin();
+  void on();
+  void off();
+  void setPower(bool state);
+  bool getPower();
+  void setTemp(uint8_t temp);
+  uint8_t getTemp();
+  void setFan(uint8_t fan);
+  uint8_t getFan();
+  void setMode(uint8_t mode);
+  uint8_t getMode();
+  void setSwingVertical(bool state);
+  bool getSwingVertical();
+  void setSwingHorizontal(bool state);
+  bool getSwingHorizontal();
+  void setQuiet(bool state);
+  bool getQuiet();
+  void setIonFilter(bool state);
+  bool getIonFilter();
+  void setLight(bool state);
+  bool getLight();
+  void setXFan(bool state);
+  bool getXFan();
+  void setTurbo(bool state);
+  bool getTurbo();
+  uint8_t* getRaw();
 
-        void begin();
-        void on();
-        void off();
-        void setPower(bool state);
-        bool getPower();
-        void setTemp(uint8_t temp);
-        uint8_t getTemp();
-        void setFan(uint8_t fan);
-        uint8_t getFan();
-        void setMode(uint8_t mode);
-        uint8_t getMode();
-        void setSwingVertical(bool state);
-        bool getSwingVertical();
-        void setSwingHorizontal(bool state);
-        bool getSwingHorizontal();
-        void setQuiet(bool state);
-        bool getQuiet();
-        void setIonFilter(bool state);
-        bool getIonFilter();
-        void setLight(bool state);
-        bool getLight();
-        void setXFan(bool state);
-        bool getXFan();
-        void setTurbo(bool state);
-        bool getTurbo();
-        uint8_t* getRaw();
-
-
-    private:
-        // The state of the IR remote in IR code form.
-        uint8_t remote_state[KELVINATOR_STATE_LENGTH];
-
-        void checksum();
-        void fixup();
-        IRsend _irsend;
+ private:
+  // The state of the IR remote in IR code form.
+  uint8_t remote_state[KELVINATOR_STATE_LENGTH];
+  void checksum();
+  void fixup();
+  IRsend _irsend;
 };
+
+#endif  // IRKELVINATOR_H_

--- a/IRMitsubishiAC.cpp
+++ b/IRMitsubishiAC.cpp
@@ -1,4 +1,4 @@
-/*
+/* Copyright 2017 David Conran
 Code to emulate Mitsubishi A/C IR remote control unit.
 Inspired and derived from the work done at:
   https://github.com/r45635/HVAC-IR-Control
@@ -12,7 +12,7 @@ Equipment it seems compatible with:
 #include <IRMitsubishiAC.h>
 
 // Initialise the object.
-IRMitsubishiAC::IRMitsubishiAC(int pin) : _irsend(pin) {
+IRMitsubishiAC::IRMitsubishiAC(uint16_t pin) : _irsend(pin) {
   stateReset();
 }
 
@@ -52,14 +52,14 @@ void ICACHE_FLASH_ATTR IRMitsubishiAC::checksum() {
 
 // Set the requested power state of the A/C to off.
 void ICACHE_FLASH_ATTR IRMitsubishiAC::on() {
-    //state = ON;
-    remote_state[5] |= MITSUBISHI_AC_POWER;
+  // state = ON;
+  remote_state[5] |= MITSUBISHI_AC_POWER;
 }
 
 // Set the requested power state of the A/C to off.
 void ICACHE_FLASH_ATTR IRMitsubishiAC::off() {
-    //state = OFF;
-    remote_state[5] &= ~MITSUBISHI_AC_POWER;
+  // state = OFF;
+  remote_state[5] &= ~MITSUBISHI_AC_POWER;
 }
 
 // Set the requested power state of the A/C.
@@ -72,19 +72,19 @@ void ICACHE_FLASH_ATTR IRMitsubishiAC::setPower(bool state) {
 
 // Return the requested power state of the A/C.
 bool ICACHE_FLASH_ATTR IRMitsubishiAC::getPower() {
-    return((remote_state[5] & MITSUBISHI_AC_POWER) != 0);
+  return((remote_state[5] & MITSUBISHI_AC_POWER) != 0);
 }
 
 // Set the temp. in deg C
 void ICACHE_FLASH_ATTR IRMitsubishiAC::setTemp(uint8_t temp) {
-    temp = max(MITSUBISHI_AC_MIN_TEMP, temp);
-    temp = min(MITSUBISHI_AC_MAX_TEMP, temp);
-    remote_state[7] = temp - MITSUBISHI_AC_MIN_TEMP;
+  temp = max(MITSUBISHI_AC_MIN_TEMP, temp);
+  temp = min(MITSUBISHI_AC_MAX_TEMP, temp);
+  remote_state[7] = temp - MITSUBISHI_AC_MIN_TEMP;
 }
 
 // Return the set temp. in deg C
 uint8_t ICACHE_FLASH_ATTR IRMitsubishiAC::getTemp() {
-    return(remote_state[7] + MITSUBISHI_AC_MIN_TEMP);
+  return(remote_state[7] + MITSUBISHI_AC_MIN_TEMP);
 }
 
 // Set the speed of the fan, 0-6.
@@ -104,10 +104,10 @@ void ICACHE_FLASH_ATTR IRMitsubishiAC::setFan(uint8_t fan) {
 
 // Return the requested state of the unit's fan.
 uint8_t ICACHE_FLASH_ATTR IRMitsubishiAC::getFan() {
-    uint8_t fan = remote_state[9] & B111;
-    if (fan == MITSUBISHI_AC_FAN_MAX)
-      return MITSUBISHI_AC_FAN_SILENT;
-    return fan;
+  uint8_t fan = remote_state[9] & B111;
+  if (fan == MITSUBISHI_AC_FAN_MAX)
+    return MITSUBISHI_AC_FAN_SILENT;
+  return fan;
 }
 
 // Return the requested climate operation mode of the a/c unit.
@@ -118,7 +118,7 @@ uint8_t ICACHE_FLASH_ATTR IRMitsubishiAC::getMode() {
   MITSUBISHI_AC_DRY
   MITSUBISHI_AC_HEAT
   */
-    return(remote_state[6]);
+  return(remote_state[6]);
 }
 
 // Set the requested climate operation mode of the a/c unit.
@@ -136,6 +136,7 @@ void ICACHE_FLASH_ATTR IRMitsubishiAC::setMode(uint8_t mode) {
 
 // Set the requested vane operation mode of the a/c unit.
 void ICACHE_FLASH_ATTR IRMitsubishiAC::setVane(uint8_t mode) {
+  // NOLINTNEXTLINE(build/include_what_you_use)
   mode = max(mode, B111);  // bounds check
   mode |= B1000;
   mode <<= 3;

--- a/IRMitsubishiAC.h
+++ b/IRMitsubishiAC.h
@@ -1,3 +1,7 @@
+/* Copyright 2017 David Conran */
+
+#ifndef IRMITSUBISHIAC_H_
+#define IRMITSUBISHIAC_H_
 
 #include <IRremoteESP8266.h>
 #include <Arduino.h>
@@ -16,37 +20,37 @@
 #define MITSUBISHI_AC_VANE_AUTO_MOVE 7U
 #define MITSUBISHI_AC_STATE_LENGTH 18
 
-class IRMitsubishiAC
-{
-    public:
-        IRMitsubishiAC(int pin);
+class IRMitsubishiAC {
+ public:
+  explicit IRMitsubishiAC(uint16_t pin);
 
-        void stateReset();
-        void send();
+  void stateReset();
+  void send();
+  void begin();
+  void on();
+  void off();
+  void setPower(bool state);
+  bool getPower();
+  void setTemp(uint8_t temp);
+  uint8_t getTemp();
+  void setFan(uint8_t fan);
+  uint8_t getFan();
+  void setMode(uint8_t mode);
+  uint8_t getMode();
+  void setVane(uint8_t mode);
+  uint8_t getVane();
+  uint8_t* getRaw();
 
-        void begin();
-        void on();
-        void off();
-        void setPower(bool state);
-        bool getPower();
-        void setTemp(uint8_t temp);
-        uint8_t getTemp();
-        void setFan(uint8_t fan);
-        uint8_t getFan();
-        void setMode(uint8_t mode);
-        uint8_t getMode();
-        void setVane(uint8_t mode);
-        uint8_t getVane();
-        uint8_t* getRaw();
-
-
-    private:
-        // The state of the IR remote in IR code form.
-        // Known good state obtained from:
-        //   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266.ino#L108
-        uint8_t known_good_state[MITSUBISHI_AC_STATE_LENGTH] = { 0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x06, 0x30, 0x45, 0x67, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F };
-        uint8_t remote_state[MITSUBISHI_AC_STATE_LENGTH];
-
-        void checksum();
-        IRsend _irsend;
+ private:
+  // The state of the IR remote in IR code form.
+  // Known good state obtained from:
+  //   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266.ino#L108
+  uint8_t known_good_state[MITSUBISHI_AC_STATE_LENGTH] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x06, 0x30, 0x45, 0x67, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x1F};
+  uint8_t remote_state[MITSUBISHI_AC_STATE_LENGTH];
+  void checksum();
+  IRsend _irsend;
 };
+
+#endif  // IRMITSUBISHIAC_H_

--- a/IRremoteESP8266.h
+++ b/IRremoteESP8266.h
@@ -32,19 +32,20 @@
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
 
-#ifndef IRremote_h
-#define IRremote_h
+#ifndef IRREMOTEESP8266_H_
+#define IRREMOTEESP8266_H_
 
 #include <stdint.h>
 #include "IRremoteInt.h"
 
 // The following are compile-time library options.
 // If you change them, recompile the library.
-// If DEBUG is defined, a lot of debugging output will be printed during decoding.
+// If DEBUG is defined, a lot of debugging output will be printed during
+// decoding.
 // TEST must be defined for the IRtest unittests to work.  It will make some
 // methods virtual, which will be slightly slower, which is why it is optional.
-//#define DEBUG
-//#define TEST
+// #define DEBUG
+// #define TEST
 
 /*
  * Always add to the end of the list and should never remove entries
@@ -80,22 +81,22 @@ enum decode_type_t {
 
 // Results returned from the decoder
 class decode_results {
-public:
-  decode_type_t decode_type; // NEC, SONY, RC5, UNKNOWN
-  union { // This is used for decoding Panasonic and Sharp data
-    unsigned int panasonicAddress;
-    unsigned int sharpAddress;
+ public:
+  decode_type_t decode_type;  // NEC, SONY, RC5, UNKNOWN
+  union {  // This is used for decoding Panasonic and Sharp data
+    uint16_t panasonicAddress;
+    uint16_t sharpAddress;
   };
-  unsigned long long value; // Decoded value
-  unsigned int bits; // Number of bits in decoded value
-  volatile unsigned int *rawbuf; // Raw intervals in .5 us ticks
-  unsigned int rawlen; // Number of records in rawbuf.
+  uint64_t value;  // Decoded value
+  uint16_t bits;  // Number of bits in decoded value
+  volatile uint16_t *rawbuf;  // Raw intervals in .5 us ticks
+  uint16_t rawlen;  // Number of records in rawbuf.
   bool overflow;
-  unsigned long address;  // Decoded device address.
-  unsigned long command;  // Decoded command.
+  uint32_t address;  // Decoded device address.
+  uint32_t command;  // Decoded command.
 };
 
-uint64_t reverseBits(uint64_t input, uint16_t nbits=64);
+uint64_t reverseBits(uint64_t input, uint16_t nbits = 64);
 uint8_t calcLGChecksum(uint16_t data);
 
 // Decoded value for NEC when a repeat code is received
@@ -114,67 +115,71 @@ uint8_t calcLGChecksum(uint16_t data);
 #define SEND_PROTOCOL_DENON    case DENON: sendDenon(data, nbits); break;
 #define SEND_PROTOCOL_SHERWOOD case SHERWOOD: sendSherwood(data, nbits); break;
 #define SEND_PROTOCOL_RCMM     case RCMM: sendRCMM(data, nbits); break;
-#define SEND_PROTOCOL_MITSUBISHI case MITSUBISHI: sendMitsubishi(data, nbits); break;
+#define SEND_PROTOCOL_MITSUBISHI case MITSUBISHI: sendMitsubishi(data, nbits);\
+                                 break;
 #define SEND_PROTOCOL_SHARP    case SHARP: sendSharpRaw(data, nbits); break;
 
 // main class for receiving IR
-class IRrecv
-{
-public:
-  IRrecv(int recvpin);
-  bool decode(decode_results *results, irparams_t *save=NULL);
+class IRrecv {
+ public:
+  explicit IRrecv(uint16_t recvpin);
+  bool decode(decode_results *results, irparams_t *save = NULL);
   void enableIRIn();
   void disableIRIn();
   void resume();
-  private:
+
+ private:
   // These are called by decode
   void copyIrParams(irparams_t *dest);
-  int getRClevel(decode_results *results, int *offset, int *used, int t1);
-  bool decodeNEC(decode_results *results, uint16_t nbits=NEC_BITS,
-                 bool strict=false);
-  bool decodeSony(decode_results *results, uint16_t nbits=SONY_MIN_BITS,
-                  bool strict=false);
-  bool decodeSanyo(decode_results *results, uint16_t nbits=SANYO_SA8650B_BITS,
-                   bool strict=false);
+  int16_t getRClevel(decode_results *results, int *offset, int *used,
+                     uint16_t t1);
+  bool decodeNEC(decode_results *results, uint16_t nbits = NEC_BITS,
+                 bool strict = false);
+  bool decodeSony(decode_results *results, uint16_t nbits = SONY_MIN_BITS,
+                  bool strict = false);
+  bool decodeSanyo(decode_results *results, uint16_t nbits = SANYO_SA8650B_BITS,
+                   bool strict = false);
   bool decodeSanyoLC7461(decode_results *results,
-                         uint16_t nbits=SANYO_LC7461_BITS, bool strict=true);
-  bool decodeMitsubishi(decode_results *results, uint16_t nbits=MITSUBISHI_BITS,
-                        bool strict=false);
+                         uint16_t nbits = SANYO_LC7461_BITS,
+                         bool strict = true);
+  bool decodeMitsubishi(decode_results *results,
+                        uint16_t nbits = MITSUBISHI_BITS,
+                        bool strict = false);
   bool decodeRC5(decode_results *results);
   bool decodeRC6(decode_results *results);
   bool decodeRCMM(decode_results *results);
-  bool decodePanasonic(decode_results *results, uint16_t nbits=PANASONIC_BITS,
-                       bool strict=false);
-  bool decodeLG(decode_results *results, uint16_t nbits=LG_BITS,
-                bool strict=false);
-  bool decodeJVC(decode_results *results, uint16_t nbits=JVC_BITS,
-                 bool strict=true);
-  bool decodeSAMSUNG(decode_results *results, uint16_t nbits=SAMSUNG_BITS,
-                     bool strict=false);
-  bool decodeWhynter(decode_results *results, uint16_t nbits=WHYNTER_BITS,
-                     bool strict=true);
+  bool decodePanasonic(decode_results *results, uint16_t nbits = PANASONIC_BITS,
+                       bool strict = false);
+  bool decodeLG(decode_results *results, uint16_t nbits = LG_BITS,
+                bool strict = false);
+  bool decodeJVC(decode_results *results, uint16_t nbits = JVC_BITS,
+                 bool strict = true);
+  bool decodeSAMSUNG(decode_results *results, uint16_t nbits = SAMSUNG_BITS,
+                     bool strict = false);
+  bool decodeWhynter(decode_results *results, uint16_t nbits = WHYNTER_BITS,
+                     bool strict = true);
   bool decodeHash(decode_results *results);
-  bool decodeCOOLIX(decode_results *results, uint16_t nbits=COOLIX_BITS,
-                    bool strict=true);
+  bool decodeCOOLIX(decode_results *results, uint16_t nbits = COOLIX_BITS,
+                    bool strict = true);
   /* DISABLED: This is not even finished code.
   bool decodeDaikin(decode_results *results, uint16_t nbits=DAIKIN_BITS,
                     bool strict=false);
   */
-  bool decodeDenon(decode_results *results, uint16_t nbits=DENON_BITS,
-                   bool strict=true);
-  bool decodeDISH(decode_results *results, uint16_t nbits=DISH_BITS,
-                  bool strict=true);
-  bool decodeSharp(decode_results *results, uint16_t nbits=SHARP_BITS,
-                   bool strict=true);
-  int compare(unsigned int oldval, unsigned int newval);
-  uint32_t ticksLow(uint32_t usecs, uint8_t tolerance=TOLERANCE);
-  uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance=TOLERANCE);
+  bool decodeDenon(decode_results *results, uint16_t nbits = DENON_BITS,
+                   bool strict = true);
+  bool decodeDISH(decode_results *results, uint16_t nbits = DISH_BITS,
+                  bool strict = true);
+  bool decodeSharp(decode_results *results, uint16_t nbits = SHARP_BITS,
+                   bool strict = true);
+  int16_t compare(uint16_t oldval, uint16_t newval);
+  uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = TOLERANCE);
+  uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE);
   bool match(uint32_t measured_ticks, uint32_t desired_us,
-             uint8_t tolerance=TOLERANCE);
+             uint8_t tolerance = TOLERANCE);
   bool matchMark(uint32_t measured_ticks, uint32_t desired_us,
-                 uint8_t tolerance=TOLERANCE, int excess=MARK_EXCESS);
+                 uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
   bool matchSpace(uint32_t measured_ticks, uint32_t desired_us,
-                  uint8_t tolerance=TOLERANCE, int excess=MARK_EXCESS);
+                  uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
 };
 
 // Only used for testing; can remove virtual for shorter code
@@ -184,12 +189,11 @@ public:
 #define VIRTUAL
 #endif
 
-class IRsend
-{
-public:
-  IRsend(int IRsendPin);
+class IRsend {
+ public:
+  explicit IRsend(uint16_t IRsendPin);
   void begin();
-  void send(unsigned int type, unsigned long long data, unsigned int nbits) {
+  void send(uint16_t type, uint64_t data, uint16_t nbits) {
     switch (type) {
         SEND_PROTOCOL_NEC
         SEND_PROTOCOL_SONY
@@ -207,95 +211,88 @@ public:
         SEND_PROTOCOL_MITSUBISHI
         SEND_PROTOCOL_SHARP
       }
-  };
-  void sendCOOLIX(unsigned long long data, unsigned int nbits=COOLIX_BITS,
-                  unsigned int repeat=0);
-  void sendWhynter(unsigned long long data, unsigned int nbits=WHYNTER_BITS,
-                   unsigned int repeat=0);
-  void sendNEC(unsigned long long data, unsigned int nbits=NEC_BITS,
-               unsigned int repeat=0);
-  unsigned long encodeNEC(unsigned int address, unsigned int command);
-  void sendLG(unsigned long long data, unsigned int nbits=28,
-              unsigned int repeat=0);
-  unsigned long encodeLG(uint8_t address, uint16_t command);
+  }
+  void sendCOOLIX(uint64_t data, uint16_t nbits = COOLIX_BITS,
+                  uint16_t repeat = 0);
+  void sendWhynter(uint64_t data, uint16_t nbits = WHYNTER_BITS,
+                   uint16_t repeat = 0);
+  void sendNEC(uint64_t data, uint16_t nbits = NEC_BITS, uint16_t repeat = 0);
+  uint32_t encodeNEC(uint16_t address, uint16_t command);
+  void sendLG(uint64_t data, uint16_t nbits = LG_BITS, uint16_t repeat = 0);
+  uint32_t encodeLG(uint8_t address, uint16_t command);
   // sendSony() should typically be called with repeat=2 as Sony devices
   // expect the code to be sent at least 3 times. (code + 2 repeats = 3 codes)
   // Legacy use of this procedure was to only send a single code so call it with
   // repeat=0 for backward compatiblity. As of v2.0 it defaults to sending
   // a Sony command that will be accepted be a device.
-  void sendSony(unsigned long long data, unsigned int nbits=20,
-                unsigned int repeat=2);
-  unsigned long encodeSony(unsigned int nbits, unsigned int command,
-                           unsigned int address, unsigned int extended=0);
-  unsigned long long encodeSanyoLC7461(unsigned int address,
-                                       unsigned int command);
-  void sendSanyoLC7461(unsigned long long data,
-                       unsigned int nbits=SANYO_LC7461_BITS,
-                       unsigned int repeat=0);
-  void sendMitsubishi(unsigned long long data,
-                      unsigned int nbits=MITSUBISHI_BITS,
-                      unsigned int repeat=MITSUBISHI_MIN_REPEAT);
-  void sendRaw(unsigned int buf[], unsigned int len, unsigned int hz);
-  void sendGC(unsigned int buf[], unsigned int len);
-  void sendRC5(unsigned long data, int nbits);
-  void sendRC6(unsigned long long data, unsigned int nbits, unsigned int repeat=0);
-  void sendRCMM(uint32_t data, uint8_t nbits=24);
+  void sendSony(uint64_t data, uint16_t nbits = SONY_20_BITS,
+                uint16_t repeat = SONY_MIN_REPEAT);
+  uint32_t encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
+                      uint16_t extended = 0);
+  uint64_t encodeSanyoLC7461(uint16_t address, uint16_t command);
+  void sendSanyoLC7461(uint64_t data, uint16_t nbits = SANYO_LC7461_BITS,
+                       uint16_t repeat = 0);
+  void sendMitsubishi(uint64_t data, uint16_t nbits = MITSUBISHI_BITS,
+                      uint16_t repeat = MITSUBISHI_MIN_REPEAT);
+  void sendRaw(uint16_t buf[], uint16_t len, uint16_t hz);
+  void sendGC(uint16_t buf[], uint16_t len);
+  void sendRC5(uint32_t data, uint16_t nbits);
+  void sendRC6(uint64_t data, uint16_t nbits, uint16_t repeat = 0);
+  void sendRCMM(uint32_t data, uint16_t nbits = RCMM_BITS);
   // sendDISH() should typically be called with repeat=3 as DISH devices
   // expect the code to be sent at least 4 times. (code + 3 repeats = 4 codes)
   // Legacy use of this procedure was only to send a single code
   // so use repeat=0 for backward compatiblity.
-  void sendDISH(unsigned long long data, unsigned int nbits=DISH_BITS,
-                unsigned int repeat=DISH_MIN_REPEAT);
-  unsigned long encodeSharp(unsigned int address, unsigned int command,
-                            unsigned int expansion=1, unsigned int check=0,
-                            bool MSBfirst=false);
-  void sendSharp(unsigned int address, unsigned int command,
-                 unsigned int nbits=SHARP_BITS,
-                 unsigned int repeat=0);
-  void sendSharpRaw(unsigned long long data, unsigned int nbits=SHARP_BITS,
-                    unsigned int repeat=0);
-  void sendPanasonic64(unsigned long long data,
-                       unsigned int nbits=PANASONIC_BITS,
-                       unsigned int repeat=0);
-  void sendPanasonic(unsigned int address, unsigned long data,
-                     unsigned int nbits=PANASONIC_BITS, unsigned int repeat=0);
-  unsigned long long encodePanasonic(uint8_t device, uint8_t subdevice,
-                                   uint8_t function);
-  void sendJVC(unsigned long long data, unsigned int nbits=JVC_BITS,
-               unsigned int repeat=0);
-  unsigned int encodeJVC(uint8_t address, uint8_t command);
-  void sendSAMSUNG(unsigned long long data, unsigned int nbits=32,
-                   unsigned int repeat=0);
-  unsigned long encodeSAMSUNG(uint8_t customer, uint8_t command);
+  void sendDISH(uint64_t data, uint16_t nbits = DISH_BITS,
+                uint16_t repeat = DISH_MIN_REPEAT);
+  uint32_t encodeSharp(uint16_t address, uint16_t command,
+                       uint16_t expansion = 1, uint16_t check = 0,
+                       bool MSBfirst = false);
+  void sendSharp(uint16_t address, uint16_t command,
+                 uint16_t nbits = SHARP_BITS, uint16_t repeat = 0);
+  void sendSharpRaw(uint64_t data, uint16_t nbits = SHARP_BITS,
+                    uint16_t repeat = 0);
+  void sendPanasonic64(uint64_t data, uint16_t nbits = PANASONIC_BITS,
+                       uint16_t repeat = 0);
+  void sendPanasonic(uint16_t address, uint32_t data,
+                     uint16_t nbits = PANASONIC_BITS, uint16_t repeat = 0);
+  uint64_t encodePanasonic(uint8_t device, uint8_t subdevice, uint8_t function);
+  void sendJVC(uint64_t data, uint16_t nbits = JVC_BITS, uint16_t repeat = 0);
+  uint16_t encodeJVC(uint8_t address, uint8_t command);
+  void sendSAMSUNG(uint64_t data, uint16_t nbits = SAMSUNG_BITS,
+                   uint16_t repeat = 0);
+  uint32_t encodeSAMSUNG(uint8_t customer, uint8_t command);
   void sendDaikin(unsigned char data[]);
-  void sendDenon(unsigned long long data, unsigned int nbits=DENON_BITS,
-                 unsigned int repeat=0);
+  void sendDenon(uint64_t data, uint16_t nbits = DENON_BITS,
+                 uint16_t repeat = 0);
   void sendKelvinator(unsigned char data[]);
-  void sendSherwood(unsigned long long data, unsigned int nbits=SHERWOOD_BITS,
-                    unsigned int repeat=SHERWOOD_MIN_REPEAT);
+  void sendSherwood(uint64_t data, uint16_t nbits = SHERWOOD_BITS,
+                    uint16_t repeat = SHERWOOD_MIN_REPEAT);
   void sendMitsubishiAC(unsigned char data[]);
-  void enableIROut(unsigned long freq, uint8_t duty=50);
-  VIRTUAL void mark(unsigned int usec);
-  VIRTUAL void space(unsigned long usec);
-private:
+  void enableIROut(uint32_t freq, uint8_t duty = 50);
+  VIRTUAL void mark(uint16_t usec);
+  VIRTUAL void space(uint32_t usec);
+
+ private:
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
-  int IRpin;
+  uint16_t IRpin;
   uint32_t calcUSecPeriod(uint32_t hz);
   void sendMitsubishiACChunk(unsigned char data);
-  void sendData(uint16_t onemark, uint32_t onespace,
-                uint16_t zeromark, uint32_t zerospace,
-                uint64_t data, uint16_t nbits, bool MSBfirst=true);
+  void sendData(uint16_t onemark, uint32_t onespace, uint16_t zeromark,
+                uint32_t zerospace, uint64_t data, uint16_t nbits,
+                bool MSBfirst = true);
   void ledOff();
 };
 
 class IRtimer {
-public:
+ public:
   IRtimer();
   void reset();
   uint32_t elapsed();
-private:
+
+ private:
   uint32_t start;
 };
 
-#endif
+#endif  // IRREMOTEESP8266_H_

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -28,8 +28,8 @@
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
 
-#ifndef IRremoteint_h
-#define IRremoteint_h
+#ifndef IRREMOTEINT_H_
+#define IRREMOTEINT_H_
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>
@@ -47,13 +47,16 @@
 #define COOLIX_HDR_SPACE  COOLIX_BIT_MARK * 8U
 #define COOLIX_MIN_GAP    COOLIX_HDR_SPACE + COOLIX_ZERO_SPACE
 
+#define WHYNTER_BITS                   32U
 #define WHYNTER_HDR_MARK             2850U
 #define WHYNTER_HDR_SPACE            2850U
 #define WHYNTER_BIT_MARK              750U
 #define WHYNTER_ONE_SPACE            2150U
 #define WHYNTER_ZERO_SPACE            750U
 #define WHYNTER_MIN_COMMAND_LENGTH 108000UL  // Completely made up value.
-#define WHYNTER_MIN_GAP WHYNTER_MIN_COMMAND_LENGTH - 2 * (WHYNTER_BIT_MARK + WHYNTER_ZERO_SPACE) - WHYNTER_BITS * (WHYNTER_BIT_MARK + WHYNTER_ONE_SPACE)
+#define WHYNTER_MIN_GAP WHYNTER_MIN_COMMAND_LENGTH - \
+    (2 * (WHYNTER_BIT_MARK + WHYNTER_ZERO_SPACE) + \
+     WHYNTER_BITS * (WHYNTER_BIT_MARK + WHYNTER_ONE_SPACE))
 
 #define NEC_HDR_MARK             9000U
 #define NEC_HDR_SPACE            4500U
@@ -63,7 +66,9 @@
 #define NEC_RPT_SPACE            2250U
 #define NEC_RPT_LENGTH              4U
 #define NEC_MIN_COMMAND_LENGTH 108000UL
-#define NEC_MIN_GAP NEC_MIN_COMMAND_LENGTH - NEC_HDR_MARK - NEC_HDR_SPACE - NEC_BITS * (NEC_BIT_MARK + NEC_ONE_SPACE) + NEC_BIT_MARK
+#define NEC_MIN_GAP NEC_MIN_COMMAND_LENGTH - \
+    (NEC_HDR_MARK + NEC_HDR_SPACE + NEC_BITS * (NEC_BIT_MARK + NEC_ONE_SPACE) \
+     + NEC_BIT_MARK)
 
 #define SHERWOOD_MIN_REPEAT 1U
 
@@ -78,6 +83,7 @@
 #define SONY_12_BITS            12U
 #define SONY_15_BITS            15U
 #define SONY_20_BITS            20U
+#define SONY_MIN_REPEAT          2U
 
 // Sanyo SA 8650B
 // Ref:
@@ -86,7 +92,8 @@
 #define SANYO_SA8650B_HDR_SPACE          950U  // seen 950
 #define SANYO_SA8650B_ONE_MARK          2400U  // seen 2400
 #define SANYO_SA8650B_ZERO_MARK          700U  // seen 700
-#define SANYO_SA8650B_DOUBLE_SPACE_USECS 800U  // usually see 713 - not using ticks as get number wrapround
+// usually see 713 - not using ticks as get number wrapround
+#define SANYO_SA8650B_DOUBLE_SPACE_USECS 800U
 #define SANYO_SA8650B_RPT_LENGTH       45000U
 
 // Sanyo LC7461
@@ -96,7 +103,8 @@
 //   http://pdf.datasheetcatalog.com/datasheet/sanyo/LC7461.pdf
 #define SANYO_LC7461_ADDRESS_BITS           13U
 #define SANYO_LC7461_COMMAND_BITS            8U
-#define SANYO_LC7461_BITS ((SANYO_LC7461_ADDRESS_BITS + SANYO_LC7461_COMMAND_BITS) * 2)
+#define SANYO_LC7461_BITS ((SANYO_LC7461_ADDRESS_BITS + \
+                            SANYO_LC7461_COMMAND_BITS) * 2)
 #define SANYO_LC7461_ADDRESS_MASK ((1 << SANYO_LC7461_ADDRESS_BITS) - 1)
 #define SANYO_LC7461_COMMAND_MASK ((1 << SANYO_LC7461_COMMAND_BITS) - 1)
 #define SANYO_LC7461_HDR_MARK             9000U
@@ -105,7 +113,11 @@
 #define SANYO_LC7461_ONE_SPACE            1690U  // 3T
 #define SANYO_LC7461_ZERO_SPACE            560U  // 1T
 #define SANYO_LC7461_MIN_COMMAND_LENGTH 108000UL
-#define SANYO_LC7461_MIN_GAP SANYO_LC7461_MIN_COMMAND_LENGTH - (SANYO_LC7461_HDR_MARK + SANYO_LC7461_HDR_SPACE + SANYO_LC7461_BITS * (SANYO_LC7461_BIT_MARK + (SANYO_LC7461_ONE_SPACE + SANYO_LC7461_ZERO_SPACE) / 2) + SANYO_LC7461_BIT_MARK)
+#define SANYO_LC7461_MIN_GAP SANYO_LC7461_MIN_COMMAND_LENGTH - \
+    (SANYO_LC7461_HDR_MARK + SANYO_LC7461_HDR_SPACE + SANYO_LC7461_BITS * \
+     (SANYO_LC7461_BIT_MARK + (SANYO_LC7461_ONE_SPACE + \
+                               SANYO_LC7461_ZERO_SPACE) / 2) \
+     + SANYO_LC7461_BIT_MARK)
 
 // Mitsubishi period time is 1/33000Hz = 30.303 uSeconds (T)
 // Ref:
@@ -116,7 +128,7 @@
 #define MITSUBISHI_ZERO_SPACE           909U  // T * 30
 #define MITSUBISHI_MIN_COMMAND_LENGTH 54121U  // T * 1786
 #define MITSUBISHI_MIN_GAP            28364U  // T * 936
-// TODO: Verify that the repeat is really needed.
+// TODO(anyone): Verify that the repeat is really needed.
 #define MITSUBISHI_MIN_REPEAT             1U  // Based on marcosamarinho's code.
 
 // Mitsubishi A/C
@@ -246,7 +258,9 @@
 #define DENON_ONE_SPACE            1842U  // The length of a Bit:Space for 1's
 #define DENON_ZERO_SPACE            789U  // The length of a Bit:Space for 0's
 #define DENON_MIN_COMMAND_LENGTH 134052UL
-#define DENON_MIN_GAP DENON_MIN_COMMAND_LENGTH - DENON_HDR_MARK - DENON_HDR_SPACE - DENON_BITS * (DENON_BIT_MARK + DENON_ONE_SPACE) - DENON_BIT_MARK
+#define DENON_MIN_GAP DENON_MIN_COMMAND_LENGTH - \
+    (DENON_HDR_MARK + DENON_HDR_SPACE + DENON_BITS * \
+     (DENON_BIT_MARK + DENON_ONE_SPACE) + DENON_BIT_MARK)
 
 #define KELVINATOR_HDR_MARK    8990U
 #define KELVINATOR_HDR_SPACE   4490U
@@ -265,7 +279,7 @@
 
 // Some useful constants
 #define USECPERTICK  50U  // microseconds per clock interrupt tick
-#define RAWBUF      100U // Length of raw duration buffer
+#define RAWBUF      100U  // Length of raw duration buffer
 #define HEADER        2U  // Usual nr. of header entries.
 #define FOOTER        2U  // Usual nr. of footer (stop bits) entries.
 #define OFFSET_START  1U  // Usual rawbuf entry to start processing from.
@@ -283,8 +297,8 @@
 typedef struct {
   uint8_t recvpin;              // pin for IR data from detector
   uint8_t rcvstate;             // state machine
-  unsigned int timer;           // state timer, counts 50uS ticks.
-  unsigned int rawbuf[RAWBUF];  // raw data
+  uint16_t timer;               // state timer, counts 50uS ticks.
+  uint16_t rawbuf[RAWBUF];      // raw data
   // uint16_t is used for rawlen as it saves 3 bytes of iram in the interrupt
   // handler. Don't ask why, I don't know. It just does.
   uint16_t rawlen;              // counter of entries in rawbuf.
@@ -309,8 +323,8 @@ extern volatile irparams_t irparams;
 #define JVC_BITS           16U
 #define LG_BITS            28U
 #define SAMSUNG_BITS       32U
-#define WHYNTER_BITS       32U
 #define COOLIX_BITS        24U
 #define DAIKIN_BITS        99U
+#define RCMM_BITS          24U
 
-#endif
+#endif  // IRREMOTEINT_H_

--- a/examples/IRGCSendDemo/IRGCSendDemo.ino
+++ b/examples/IRGCSendDemo/IRGCSendDemo.ino
@@ -1,20 +1,29 @@
 /*
- * IRremoteESP8266: IRsendGCDemo - demonstrates sending Global Cache-formatted IR codes with IRsend
+ * IRremoteESP8266: IRsendGCDemo
+ * demonstrates sending Global Cache-formatted IR codes with IRsend
+ *
  * An IR LED must be connected to ESP8266 pin 0.
  * Version 0.1 30 March, 2016
- * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009, Copyright 2009 Ken Shirriff, http://arcfn.com
+ * Based on Ken Shirriff's IrsendDemo
+ * Version 0.1 July, 2009
+ * Copyright 2009 Ken Shirriff
+ * http://arcfn.com
  */
 
 #include <IRremoteESP8266.h>
 
-// Codes are in Global Cache format less the emitter ID and request ID. These codes can be found in GC's Control Tower database.
+// Codes are in Global Cache format less the emitter ID and request ID.
+// These codes can be found in GC's Control Tower database.
 
-unsigned int Samsung_power_toggle[71] = {38000,1,1,170,170,20,63,20,63,20,63,20,20,20,20,20,20,20,20,20,20,20,63,20,63,20,63,20,20,20,20,20,20,20,20,20,20,20,20,20,63,20,20,20,20,20,20,20,20,20,20,20,20,20,63,20,20,20,63,20,63,20,63,20,63,20,63,20,63,20,1798};
+uint16_t Samsung_power_toggle[71] = {
+    38000, 1, 1, 170, 170, 20, 63, 20, 63, 20, 63, 20, 20, 20, 20, 20, 20, 20,
+    20, 20, 20, 20, 63, 20, 63, 20, 63, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
+    20, 20, 20, 63, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 63, 20,
+    20, 20, 63, 20, 63, 20, 63, 20, 63, 20, 63, 20, 63, 20, 1798};
 
-IRsend irsend(4); //an IR emitter led is connected to GPIO pin 4
+IRsend irsend(4);  // an IR emitter led is connected to GPIO pin 4
 
-void setup()
-{
+void setup() {
   irsend.begin();
   Serial.begin(115200);
 }

--- a/examples/IRGCTCPServer/IRGCTCPServer.ino
+++ b/examples/IRGCTCPServer/IRGCTCPServer.ino
@@ -2,11 +2,11 @@
  * IRremoteESP8266: IRGCTCPServer - send Global Cache-formatted codes via TCP.
  * An IR emitter must be connected to GPIO pin 4.
  * Version 0.1 1 April, 2016
- * Hisham Khalifa, http://www.hishamkhalifa.com
+ * Copyright 2016 Hisham Khalifa, http://www.hishamkhalifa.com
  *
  * Example command - Samsung TV power toggle: 38000,1,1,170,170,20,63,20,63,20,63,20,20,20,20,20,20,20,20,20,20,20,63,20,63,20,63,20,20,20,20,20,20,20,20,20,20,20,20,20,63,20,20,20,20,20,20,20,20,20,20,20,20,20,63,20,20,20,63,20,63,20,63,20,63,20,63,20,63,20,1798\r\n
  */
- 
+
 #include <IRremoteESP8266.h>
 #include <IRremoteInt.h>
 
@@ -17,36 +17,40 @@
 const char* ssid = "...";
 const char* password = "...";
 
-WiFiServer server(4998); // Uses port 4998.
+WiFiServer server(4998);  // Uses port 4998.
 WiFiClient client;
 
-unsigned int *codeArray;
-IRsend irsend(4); //an IR emitter led is connected to GPIO pin 4
+uint16_t *codeArray;
+IRsend irsend(4);  // an IR emitter led is connected to GPIO pin 4
 
 void parseString(String str) {
-  int nextIndex;
-  int codeLength = 1;
-  int currentIndex = 0;
+  int16_t nextIndex;
+  uint16_t codeLength = 1;
+  uint16_t currentIndex = 0;
   nextIndex = str.indexOf(',');
 
   // change to do/until and remove superfluous repetition below...
   while (nextIndex != -1) {
-    if (codeLength > 1) {
-        codeArray = (unsigned int*) realloc(codeArray, codeLength * sizeof(unsigned int));
-    } else {
-        codeArray = (unsigned int*) malloc(codeLength * sizeof(unsigned int));
-    }
+    if (codeLength > 1)
+      codeArray = reinterpret_cast<uint16_t*>(
+          realloc(codeArray, codeLength * sizeof(uint16_t)));
+    else
+      codeArray = reinterpret_cast<uint16_t*>(
+          malloc(codeLength * sizeof(uint16_t)));
 
-    codeArray[codeLength-1] = (unsigned int) (str.substring(currentIndex, nextIndex).toInt());
-  
+    codeArray[codeLength - 1] = (uint16_t) (
+        str.substring(currentIndex, nextIndex).toInt());
+
     codeLength++;
     currentIndex = nextIndex + 1;
-    nextIndex = str.indexOf(',', currentIndex);       
+    nextIndex = str.indexOf(',', currentIndex);
   }
-  codeArray = (unsigned int*) realloc(codeArray, codeLength * sizeof(unsigned int));
-  codeArray[codeLength-1] = (unsigned int) (str.substring(currentIndex, nextIndex).toInt());
-  
-  irsend.sendGC(codeArray,codeLength);
+  codeArray = reinterpret_cast<uint16_t*>(
+      realloc(codeArray, codeLength * sizeof(uint16_t)));
+  codeArray[codeLength - 1] = (uint16_t) (
+      str.substring(currentIndex, nextIndex).toInt());
+
+  irsend.sendGC(codeArray, codeLength);
 }
 
 void setup() {
@@ -54,32 +58,31 @@ void setup() {
   Serial.begin(115200);
   Serial.println(" ");
   Serial.println("IR TCP Server");
-  
- while (WiFi.status() != WL_CONNECTED) {
+
+  while (WiFi.status() != WL_CONNECTED) {
     delay(900);
     Serial.print(".");
   }
 
-    server.begin();
-    IPAddress myAddress = WiFi.localIP();
-    Serial.println(myAddress);
-    irsend.begin();
+  server.begin();
+  IPAddress myAddress = WiFi.localIP();
+  Serial.println(myAddress);
+  irsend.begin();
 }
 
 void loop() {
-  while(!client) {
+  while (!client)
     client = server.available();
-  }
 
-  while(!client.connected()){
+  while (!client.connected()) {
     delay(900);
     client = server.available();
   }
-  
-  if(client.available()){
-    String irCode = client.readStringUntil('\r'); // Exclusive of \r
-    client.readStringUntil('\n'); // Skip new line as well
+
+  if (client.available()) {
+    String irCode = client.readStringUntil('\r');  // Exclusive of \r
+    client.readStringUntil('\n');  // Skip new line as well
     client.flush();
     parseString(irCode);
-  }  
+  }
 }

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -2,6 +2,7 @@
  * IRremoteESP8266: IRServer - demonstrates sending IR codes controlled from a webserver
  * An IR LED must be connected to ESP8266 pin 0.
  * Version 0.1 June, 2015
+ * Copyright 2015 Mark Szabo
  */
 
 #include <ESP8266WiFi.h>
@@ -9,7 +10,7 @@
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
 #include <IRremoteESP8266.h>
- 
+
 const char* ssid = ".....";
 const char* password = ".....";
 MDNSResponder mdns;
@@ -19,21 +20,30 @@ ESP8266WebServer server(80);
 IRsend irsend(0);
 
 void handleRoot() {
- server.send(200, "text/html", "<html><head> <title>ESP8266 Demo</title></head><body><h1>Hello from ESP8266, you can send NEC encoded IR signals from here!</h1><p><a href=\"ir?code=16769055\">Send 0xFFE01F</a></p><p><a href=\"ir?code=16429347\">Send 0xFAB123</a></p><p><a href=\"ir?code=16771222\">Send 0xFFE896</a></p></body></html>");
+  server.send(200, "text/html",
+              "<html>" \
+                "<head><title>ESP8266 Demo</title></head>" \
+                "<body>" \
+                  "<h1>Hello from ESP8266, you can send NEC encoded IR" \
+                      "signals from here!</h1>" \
+                  "<p><a href=\"ir?code=16769055\">Send 0xFFE01F</a></p>" \
+                  "<p><a href=\"ir?code=16429347\">Send 0xFAB123</a></p>" \
+                  "<p><a href=\"ir?code=16771222\">Send 0xFFE896</a></p>" \
+                "</body>" \
+              "</html>");
 }
 
-void handleIr(){
-  for (uint8_t i=0; i<server.args(); i++){
-    if(server.argName(i) == "code") 
-    {
-      unsigned long code = strtoul(server.arg(i).c_str(), NULL, 10);
+void handleIr() {
+  for (uint8_t i = 0; i < server.args(); i++) {
+    if (server.argName(i) == "code") {
+      uint32_t code = strtoul(server.arg(i).c_str(), NULL, 10);
       irsend.sendNEC(code, 32);
     }
   }
   handleRoot();
 }
 
-void handleNotFound(){
+void handleNotFound() {
   String message = "File Not Found\n\n";
   message += "URI: ";
   message += server.uri();
@@ -42,15 +52,14 @@ void handleNotFound(){
   message += "\nArguments: ";
   message += server.args();
   message += "\n";
-  for (uint8_t i=0; i<server.args(); i++){
+  for (uint8_t i = 0; i < server.args(); i++)
     message += " " + server.argName(i) + ": " + server.arg(i) + "\n";
-  }
   server.send(404, "text/plain", message);
 }
- 
-void setup(void){
+
+void setup(void) {
   irsend.begin();
-  
+
   Serial.begin(115200);
   WiFi.begin(ssid, password);
   Serial.println("");
@@ -65,24 +74,24 @@ void setup(void){
   Serial.println(ssid);
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP());
-  
+
   if (mdns.begin("esp8266", WiFi.localIP())) {
     Serial.println("MDNS responder started");
   }
-  
+
   server.on("/", handleRoot);
-  server.on("/ir", handleIr); 
- 
+  server.on("/ir", handleIr);
+
   server.on("/inline", [](){
     server.send(200, "text/plain", "this works as well");
   });
 
   server.onNotFound(handleNotFound);
-  
+
   server.begin();
   Serial.println("HTTP server started");
 }
- 
-void loop(void){
+
+void loop(void) {
   server.handleClient();
-} 
+}

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -2,21 +2,23 @@
  * IRremoteESP8266: IRrecvDemo - demonstrates receiving IR codes with IRrecv
  * An IR detector/demodulator must be connected to the input RECV_PIN.
  * Version 0.1 Sept, 2015
- * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009, Copyright 2009 Ken Shirriff, http://arcfn.com
+ * Based on Ken Shirriff's IrsendDemo
+ * Version 0.1 July, 2009
+ * Copyright 2009 Ken Shirriff, http://arcfn.com
  */
 
 #include <IRremoteESP8266.h>
 
-int RECV_PIN = 2; //an IR detector/demodulatord is connected to GPIO pin 2
+// an IR detector/demodulator is connected to GPIO pin 2
+uint16_t RECV_PIN = 2;
 
 IRrecv irrecv(RECV_PIN);
 
 decode_results results;
 
-void setup()
-{
+void setup() {
   Serial.begin(9600);
-  irrecv.enableIRIn(); // Start the receiver
+  irrecv.enableIRIn();  // Start the receiver
 }
 
 void loop() {
@@ -24,9 +26,9 @@ void loop() {
     // print() & println() can't handle printing long longs. (uint64_t)
     // So we have to print the top and bottom halves separately.
     if (results.value >> 32)
-      Serial.print((unsigned long) (results.value >> 32), HEX);
-    Serial.println((unsigned long) (results.value & 0xFFFFFFFF), HEX);
-    irrecv.resume(); // Receive the next value
+      Serial.print((uint32_t) (results.value >> 32), HEX);
+    Serial.println((uint32_t) (results.value & 0xFFFFFFFF), HEX);
+    irrecv.resume();  // Receive the next value
   }
   delay(100);
 }

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -2,61 +2,53 @@
  * IRremoteESP8266: IRrecvDump - dump details of IR codes with IRrecv
  * An IR detector/demodulator must be connected to the input RECV_PIN.
  * Version 0.1 Sept, 2015
- * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009, Copyright 2009 Ken Shirriff, http://arcfn.com
- * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
+ * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
+ * Copyright 2009 Ken Shirriff, http://arcfn.com
+ * JVC and Panasonic protocol added by Kristian Lauszus
+ *   (Thanks to zenwheel and other people at the original blog post)
  * LG added by Darryl Smith (based on the JVC protocol)
  */
 
 #include <IRremoteESP8266.h>
 
-int RECV_PIN = 2; //an IR detector/demodulatord is connected to GPIO pin 2
+// an IR detector/demodulator is connected to GPIO pin 2
+uint16_t RECV_PIN = 2;
 
 IRrecv irrecv(RECV_PIN);
 
 decode_results results;
 
-void setup()
-{
+void setup() {
   Serial.begin(115200);
-  irrecv.enableIRIn(); // Start the receiver
+  irrecv.enableIRIn();  // Start the receiver
 }
 
 
 void dump(decode_results *results) {
   // Dumps out the decode_results structure.
   // Call this after IRrecv::decode()
-  int count = results->rawlen;
+  uint16_t count = results->rawlen;
   if (results->decode_type == UNKNOWN) {
     Serial.print("Unknown encoding: ");
-  }
-  else if (results->decode_type == NEC) {
+  } else if (results->decode_type == NEC) {
     Serial.print("Decoded NEC: ");
-
-  }
-  else if (results->decode_type == SONY) {
+  } else if (results->decode_type == SONY) {
     Serial.print("Decoded SONY: ");
-  }
-  else if (results->decode_type == RC5) {
+  } else if (results->decode_type == RC5) {
     Serial.print("Decoded RC5: ");
-  }
-  else if (results->decode_type == RC6) {
+  } else if (results->decode_type == RC6) {
     Serial.print("Decoded RC6: ");
-  }
-  else if (results->decode_type == PANASONIC) {
+  } else if (results->decode_type == PANASONIC) {
     Serial.print("Decoded PANASONIC - Address: ");
     Serial.print(results->panasonicAddress, HEX);
     Serial.print(" Value: ");
-  }
-  else if (results->decode_type == LG) {
+  } else if (results->decode_type == LG) {
     Serial.print("Decoded LG: ");
-  }
-  else if (results->decode_type == JVC) {
+  } else if (results->decode_type == JVC) {
     Serial.print("Decoded JVC: ");
-  }
-  else if (results->decode_type == AIWA_RC_T501) {
+  } else if (results->decode_type == AIWA_RC_T501) {
     Serial.print("Decoded AIWA RC T501: ");
-  }
-  else if (results->decode_type == WHYNTER) {
+  } else if (results->decode_type == WHYNTER) {
     Serial.print("Decoded Whynter: ");
   }
   Serial.print(results->value, HEX);
@@ -67,15 +59,14 @@ void dump(decode_results *results) {
   Serial.print(count, DEC);
   Serial.print("): ");
 
-  for (int i = 1; i < count; i++) {
+  for (uint16_t i = 1; i < count; i++) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
     if (i & 1) {
-      Serial.print(results->rawbuf[i]*USECPERTICK, DEC);
-    }
-    else {
+      Serial.print(results->rawbuf[i] * USECPERTICK, DEC);
+    } else {
       Serial.write('-');
-      Serial.print((unsigned long) results->rawbuf[i]*USECPERTICK, DEC);
+      Serial.print((uint32_t) results->rawbuf[i] * USECPERTICK, DEC);
     }
     Serial.print(" ");
   }
@@ -87,9 +78,9 @@ void loop() {
     // print() & println() can't handle printing long longs. (uint64_t)
     // So we have to print the top and bottom halves separately.
     if (results.value >> 32)
-      Serial.print((unsigned long) (results.value >> 32), HEX);
-    Serial.println((unsigned long) (results.value & 0xFFFFFFFF), HEX);
+      Serial.print((uint32_t) (results.value >> 32), HEX);
+    Serial.println((uint32_t) (results.value & 0xFFFFFFFF), HEX);
     dump(&results);
-    irrecv.resume(); // Receive the next value
+    irrecv.resume();  // Receive the next value
   }
 }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -12,16 +12,18 @@
 
 #include <IRremoteESP8266.h>
 
-// An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU board).
-int RECV_PIN = 14;
+// An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU
+// board).
+uint16_t RECV_PIN = 14;
 
 IRrecv irrecv(RECV_PIN);
 
-decode_results results; // Somewhere to store the results
-irparams_t save;        // A place to copy the interrupt state while decoding.
+decode_results results;  // Somewhere to store the results
+irparams_t save;         // A place to copy the interrupt state while decoding.
 
 void setup() {
-  Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);  // Status message will be sent to the PC at 115200 baud
+  // Status message will be sent to the PC at 115200 baud
+  Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
   irrecv.enableIRIn();  // Start the receiver
 }
 
@@ -38,8 +40,8 @@ void ircode(decode_results *results) {
   //   print() & println() can't handle printing long longs. (uint64_t)
   //   So we have to print the top and bottom halves separately.
   if (results->value >> 32)
-    Serial.print((unsigned long) (results->value >> 32), HEX);
-  Serial.println((unsigned long) (results->value & 0xFFFFFFFF), HEX);
+    Serial.print((uint32_t) (results->value >> 32), HEX);
+  Serial.println((uint32_t) (results->value & 0xFFFFFFFF), HEX);
 }
 
 //+=============================================================================
@@ -48,31 +50,31 @@ void ircode(decode_results *results) {
 void encoding(decode_results *results) {
   switch (results->decode_type) {
     default:
-    case UNKNOWN:      Serial.print("UNKNOWN");       break ;
-    case NEC:          Serial.print("NEC");           break ;
-    case SONY:         Serial.print("SONY");          break ;
-    case RC5:          Serial.print("RC5");           break ;
-    case RC6:          Serial.print("RC6");           break ;
-    case DISH:         Serial.print("DISH");          break ;
-    case SHARP:        Serial.print("SHARP");         break ;
-    case JVC:          Serial.print("JVC");           break ;
-    case SANYO:        Serial.print("SANYO");         break ;
-    case SANYO_LC7461: Serial.print("SANYO_LC7461");  break ;
-    case MITSUBISHI:   Serial.print("MITSUBISHI");    break ;
-    case SAMSUNG:      Serial.print("SAMSUNG");       break ;
-    case LG:           Serial.print("LG");            break ;
-    case WHYNTER:      Serial.print("WHYNTER");       break ;
-    case AIWA_RC_T501: Serial.print("AIWA_RC_T501");  break ;
-    case PANASONIC:    Serial.print("PANASONIC");     break ;
-    case DENON:        Serial.print("DENON");         break ;
-    case COOLIX:       Serial.print("COOLIX");        break ;
+    case UNKNOWN:      Serial.print("UNKNOWN");       break;
+    case NEC:          Serial.print("NEC");           break;
+    case SONY:         Serial.print("SONY");          break;
+    case RC5:          Serial.print("RC5");           break;
+    case RC6:          Serial.print("RC6");           break;
+    case DISH:         Serial.print("DISH");          break;
+    case SHARP:        Serial.print("SHARP");         break;
+    case JVC:          Serial.print("JVC");           break;
+    case SANYO:        Serial.print("SANYO");         break;
+    case SANYO_LC7461: Serial.print("SANYO_LC7461");  break;
+    case MITSUBISHI:   Serial.print("MITSUBISHI");    break;
+    case SAMSUNG:      Serial.print("SAMSUNG");       break;
+    case LG:           Serial.print("LG");            break;
+    case WHYNTER:      Serial.print("WHYNTER");       break;
+    case AIWA_RC_T501: Serial.print("AIWA_RC_T501");  break;
+    case PANASONIC:    Serial.print("PANASONIC");     break;
+    case DENON:        Serial.print("DENON");         break;
+    case COOLIX:       Serial.print("COOLIX");        break;
   }
 }
 
 //+=============================================================================
 // Dump out the decode_results structure.
 //
-void dumpInfo (decode_results *results) {
+void dumpInfo(decode_results *results) {
   if (results->overflow) {
     Serial.println("IR code too long. Edit IRremoteInt.h and increase RAWBUF");
     return;
@@ -97,46 +99,48 @@ void dumpInfo (decode_results *results) {
 void dumpRaw(decode_results *results) {
   // Print Raw data
   Serial.print("Timing[");
-  Serial.print(results->rawlen-1, DEC);
+  Serial.print(results->rawlen - 1, DEC);
   Serial.println("]: ");
 
-  for (int i = 1;  i < results->rawlen;  i++) {
+  for (uint16_t i = 1;  i < results->rawlen;  i++) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
-    unsigned long  x = results->rawbuf[i] * USECPERTICK;
+    uint32_t x = results->rawbuf[i] * USECPERTICK;
     if (!(i & 1)) {  // even
       Serial.print("-");
-      if (x < 1000)  Serial.print(" ") ;
-      if (x < 100)   Serial.print(" ") ;
+      if (x < 1000) Serial.print(" ");
+      if (x < 100) Serial.print(" ");
       Serial.print(x, DEC);
     } else {  // odd
       Serial.print("     ");
       Serial.print("+");
-      if (x < 1000)  Serial.print(" ") ;
-      if (x < 100)   Serial.print(" ") ;
+      if (x < 1000) Serial.print(" ");
+      if (x < 100) Serial.print(" ");
       Serial.print(x, DEC);
-      if (i < results->rawlen-1) Serial.print(", "); //',' not needed for last one
+      if (i < results->rawlen - 1)
+        Serial.print(", ");  // ',' not needed for last one
     }
-    if (!(i % 8))  Serial.println("");
+    if (!(i % 8)) Serial.println("");
   }
-  Serial.println("");                    // Newline
+  Serial.println("");  // Newline
 }
 
 //+=============================================================================
 // Dump out the decode_results structure.
 //
-void dumpCode (decode_results *results) {
+void dumpCode(decode_results *results) {
   // Start declaration
-  Serial.print("unsigned int  ");          // variable type
+  Serial.print("uint16_t  ");              // variable type
   Serial.print("rawData[");                // array name
   Serial.print(results->rawlen - 1, DEC);  // array size
   Serial.print("] = {");                   // Start declaration
 
   // Dump data
-  for (int i = 1;  i < results->rawlen;  i++) {
+  for (uint16_t i = 1; i < results->rawlen; i++) {
     Serial.print(results->rawbuf[i] * USECPERTICK, DEC);
-    if ( i < results->rawlen-1 ) Serial.print(","); // ',' not needed on last one
-    if (!(i & 1))  Serial.print(" ");
+    if (i < results->rawlen - 1)
+      Serial.print(",");  // ',' not needed on last one
+    if (!(i & 1)) Serial.print(" ");
   }
 
   // End declaration
@@ -155,18 +159,18 @@ void dumpCode (decode_results *results) {
   if (results->decode_type != UNKNOWN) {
     // Some protocols have an address
     if (results->decode_type == PANASONIC) {
-      Serial.print("unsigned int  addr = 0x");
+      Serial.print("uint16_t  addr = 0x");
       Serial.print(results->panasonicAddress, HEX);
       Serial.println(";");
     }
 
     // All protocols have data
-    Serial.print("unsigned int  data = 0x");
-    //   print() & println() can't handle printing long longs. (uint64_t)
-    //   So we have to print the top and bottom halves separately.
+    Serial.print("uint64_t  data = 0x");
+    // print() & println() can't handle printing long longs. (uint64_t)
+    // So we have to print the top and bottom halves separately.
     if (results->value >> 32)
-      Serial.print((unsigned long) (results->value >> 32), HEX);
-    Serial.print((unsigned long) (results->value & 0xFFFFFFFF), HEX);
+      Serial.print((uint32_t) (results->value >> 32), HEX);
+    Serial.print((uint32_t) (results->value & 0xFFFFFFFF), HEX);
     Serial.println(";");
   }
 }

--- a/examples/IRsendDemo/IRsendDemo.ino
+++ b/examples/IRsendDemo/IRsendDemo.ino
@@ -1,10 +1,13 @@
-/*
- * IRremoteESP8266: IRsendDemo - demonstrates sending IR codes with IRsend.
+/* IRremoteESP8266: IRsendDemo - demonstrates sending IR codes with IRsend.
+ *
+ * Version 1.0 April, 2017
+ * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
+ * Copyright 2009 Ken Shirriff, http://arcfn.com
  *
  * An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
  *
  * TL;DR: The IR LED needs to be driven by a transistor for a good result.
- * 
+ *
  * Suggested circuit:
  *     https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
  *
@@ -22,17 +25,13 @@
  *     * Pin 3/RX/RXD0: Any serial transmissions to the ESP8266 will interfere.
  *   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
  *     for your first time. e.g. ESP-12 etc.
- *
- * Version 1.0 April, 2017
- * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009, Copyright 2009 Ken Shirriff, http://arcfn.com
  */
 
 #include <IRremoteESP8266.h>
 
-IRsend irsend(4); //an IR led is connected to GPIO pin 4 (D2)
+IRsend irsend(4);  // an IR led is connected to GPIO pin 4 (D2)
 
-void setup()
-{
+void setup() {
   irsend.begin();
   Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
 }

--- a/examples/JVCPanasonicSendDemo/JVCPanasonicSendDemo.ino
+++ b/examples/JVCPanasonicSendDemo/JVCPanasonicSendDemo.ino
@@ -6,24 +6,25 @@
  * JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
  */
 #include <IRremoteESP8266.h>
- 
-#define PanasonicAddress      0x4004     // Panasonic address (Pre data) 
+
+#define PanasonicAddress      0x4004     // Panasonic address (Pre data)
 #define PanasonicPower        0x100BCBD  // Panasonic Power button
 
 #define JVCPower              0xC5E8
 
-IRsend irsend(0); //an IR led is connected to GPIO pin 0
+IRsend irsend(0);  // an IR led is connected to GPIO pin 0
 
-void setup()
-{
-   irsend.begin();
+void setup() {
+  irsend.begin();
 }
 
 void loop() {
-  irsend.sendPanasonic(PanasonicAddress,PanasonicPower); // This should turn your TV on and off
-  
-  irsend.sendJVC(JVCPower, 16,0); // hex value, 16 bits, no repeat
-  delayMicroseconds(50); // see http://www.sbprojects.com/knowledge/ir/jvc.php for information
-  irsend.sendJVC(JVCPower, 16,1); // hex value, 16 bits, repeat
+  // This should turn your TV on and off
+  irsend.sendPanasonic(PanasonicAddress, PanasonicPower);
+
+  irsend.sendJVC(JVCPower, 16, 0);  // hex value, 16 bits, no repeat
+  // see http://www.sbprojects.com/knowledge/ir/jvc.php for information
+  delayMicroseconds(50);
+  irsend.sendJVC(JVCPower, 16, 1);  // hex value, 16 bits, repeat
   delayMicroseconds(50);
 }

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -1,15 +1,15 @@
-
+/* Copyright 2016 sillyfrog */
 #include <IRDaikinESP.h>
 
 IRDaikinESP dakinir(D1);
 
-void setup(){
+void setup() {
   dakinir.begin();
   Serial.begin(115200);
 }
 
 
-void loop(){
+void loop() {
   Serial.println("Sending...");
 
   // Set up what we want to send. See IRDaikinESP.cpp for all the options.

--- a/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
+++ b/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
@@ -1,4 +1,4 @@
-
+/* Copyright 2016 David Conran */
 #include <IRKelvinator.h>
 
 IRKelvinatorAC kelvir(D1);  // IR led controlled by Pin D1.
@@ -17,12 +17,12 @@ void printState() {
   // Display the encoded IR sequence.
   unsigned char* ir_code = kelvir.getRaw();
   Serial.print("IR Code: 0x");
-  for (int i = 0; i < KELVINATOR_STATE_LENGTH; i++)
+  for (uint8_t i = 0; i < KELVINATOR_STATE_LENGTH; i++)
     Serial.printf("%02X", ir_code[i]);
   Serial.println();
 }
 
-void setup(){
+void setup() {
   kelvir.begin();
   Serial.begin(115200);
   delay(200);

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -1,3 +1,4 @@
+/* Copyright 2017 David Conran */
 
 #include <IRMitsubishiAC.h>
 
@@ -6,18 +7,19 @@ IRMitsubishiAC mitsubir(D1);  // IR led controlled by Pin D1.
 void printState() {
   // Display the settings.
   Serial.println("Mitsubishi A/C remote is in the following state:");
-  Serial.printf("  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d, Vane Mode: %d\n",
+  Serial.printf("  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d," \
+                    " Vane Mode: %d\n",
                 mitsubir.getPower(), mitsubir.getMode(), mitsubir.getTemp(),
                 mitsubir.getFan(), mitsubir.getVane());
   // Display the encoded IR sequence.
   unsigned char* ir_code = mitsubir.getRaw();
   Serial.print("IR Code: 0x");
-  for (int i = 0; i < MITSUBISHI_AC_STATE_LENGTH; i++)
+  for (uint8_t i = 0; i < MITSUBISHI_AC_STATE_LENGTH; i++)
     Serial.printf("%02X", ir_code[i]);
   Serial.println();
 }
 
-void setup(){
+void setup() {
   mitsubir.begin();
   Serial.begin(115200);
   delay(200);


### PR DESCRIPTION
WARNING: Hippopotamic PR ahead. Take caution. Have a good lay down before & after reviewing,
and grab a large beverage.

- Fix/address about a gajillion lint issues found by cpplint.py from Google.
- Correct some style issues.
- Minor changes in examples to use c99 types in output text.
- Use only c99 types
  o except fully in RC-5/6/MM because they are under another PR currently. (#176)
- Add CPPLINT.cfg file.

There really should not be anything significant code-wise that has
changed except for data types of course. There are however minor code changes.