### PR TITLE
Faster IR capture, Less IRAM usage, and Better RC-MM & Panasonic support.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=1.1.1
+version=1.2.0
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)


### PR DESCRIPTION
* Add ability to copy IR capture buffer, and continue capturing. Means faster and better IR command decoding.
* Reduce IRAM usage by 28 bytes. 
* Improve capture of RC-MM & Panasonic protocols.
* Upgrade IRrecvDumpV2 to new IR capture buffer. Much fewer corrupted/truncated IR messages.