### PR TITLE
Better JVC repeat decoding. Print out command & address in dump example.

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -23,6 +23,13 @@ void setup() {
   irrecv.enableIRIn();  // Start the receiver
 }
 
+void serialPrintUint64Hex(uint64_t value) {
+  // Serial.print() can't handle printing long longs. (uint64_t)
+  // So we have to print the top and bottom halves separately.
+  if (value >> 32)
+    Serial.print((uint32_t) (value >> 32), HEX);
+  Serial.print((uint32_t) (value & 0xFFFFFFFF), HEX);
+}
 
 void dump(decode_results *results) {
   // Dumps out the decode_results structure.
@@ -40,7 +47,7 @@ void dump(decode_results *results) {
     Serial.print("Decoded RC6: ");
   } else if (results->decode_type == PANASONIC) {
     Serial.print("Decoded PANASONIC - Address: ");
-    Serial.print(results->panasonicAddress, HEX);
+    Serial.print(results->address, HEX);
     Serial.print(" Value: ");
   } else if (results->decode_type == LG) {
     Serial.print("Decoded LG: ");
@@ -51,7 +58,7 @@ void dump(decode_results *results) {
   } else if (results->decode_type == WHYNTER) {
     Serial.print("Decoded Whynter: ");
   }
-  Serial.print(results->value, HEX);
+  serialPrintUint64Hex(results->value);
   Serial.print(" (");
   Serial.print(results->bits, DEC);
   Serial.println(" bits)");
@@ -75,11 +82,7 @@ void dump(decode_results *results) {
 
 void loop() {
   if (irrecv.decode(&results)) {
-    // print() & println() can't handle printing long longs. (uint64_t)
-    // So we have to print the top and bottom halves separately.
-    if (results.value >> 32)
-      Serial.print((uint32_t) (results.value >> 32), HEX);
-    Serial.println((uint32_t) (results.value & 0xFFFFFFFF), HEX);
+    serialPrintUint64Hex(results.value);
     dump(&results);
     irrecv.resume();  // Receive the next value
   }

--- a/lib/IRremoteESP8266/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266/IRremoteESP8266.h
@@ -83,15 +83,12 @@ enum decode_type_t {
 class decode_results {
  public:
   decode_type_t decode_type;  // NEC, SONY, RC5, UNKNOWN
-  union {  // This is used for decoding Panasonic and Sharp data
-    uint16_t panasonicAddress;
-    uint16_t sharpAddress;
-  };
   uint64_t value;  // Decoded value
   uint16_t bits;  // Number of bits in decoded value
   volatile uint16_t *rawbuf;  // Raw intervals in .5 us ticks
   uint16_t rawlen;  // Number of records in rawbuf.
   bool overflow;
+  bool repeat;  // Is the result a repeat code?
   uint32_t address;  // Decoded device address.
   uint32_t command;  // Decoded command.
 };


### PR DESCRIPTION
- Add a repeat flag to decoding. Enables us to capture the code value
  of a repeat command if it has a non-trivial value. e.g. JVC.
- Display address & command values for decoded commands in IRrecvDumpV2.
- Use a common function to print uint64_t hex values in the dump examples.
- Remove old way of storing Panasonic and Sharp addresses.
- Reset any decode results on resume().