### PR TITLE
Improve the accuracy of software PWM in mark().

### DIFF
--- a/lib/IRremoteESP8266/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266/IRremoteESP8266.h
@@ -193,6 +193,7 @@ class IRsend {
  public:
   explicit IRsend(uint16_t IRsendPin);
   void begin();
+  void calibrate(uint16_t hz = 38000U);
   void send(uint16_t type, uint64_t data, uint16_t nbits) {
     switch (type) {
         SEND_PROTOCOL_NEC
@@ -271,13 +272,14 @@ class IRsend {
                     uint16_t repeat = SHERWOOD_MIN_REPEAT);
   void sendMitsubishiAC(unsigned char data[]);
   void enableIROut(uint32_t freq, uint8_t duty = 50);
-  VIRTUAL void mark(uint16_t usec);
+  VIRTUAL uint16_t mark(uint16_t usec);
   VIRTUAL void space(uint32_t usec);
 
  private:
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
   uint16_t IRpin;
+  int8_t periodOffset;
   uint32_t calcUSecPeriod(uint32_t hz);
   void sendMitsubishiACChunk(unsigned char data);
   void sendData(uint16_t onemark, uint32_t onespace, uint16_t zeromark,

--- a/lib/IRremoteESP8266/IRremoteInt.h
+++ b/lib/IRremoteESP8266/IRremoteInt.h
@@ -295,6 +295,10 @@
 // when received due to sensor lag.
 #define MARK_EXCESS 100U
 #define TOLERANCE    25U  // default percent tolerance in measurements
+// Offset (in microseconds) to use in Period time calculations to account for
+// code excution time in producing the software PWM signal.
+// Value determined in https://github.com/markszabo/IRremoteESP8266/issues/62
+#define PERIOD_OFFSET -3
 // receiver states
 #define STATE_IDLE    2U
 #define STATE_MARK    3U


### PR DESCRIPTION
Apply an external offset for the period calculation so we
allow for code/execution time in producing the software based PWM signal
in mark().
For Issue #62