### PR TITLE
Remove duplicate RAWBUF definition.

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -218,8 +218,6 @@
 #define STATE_SPACE    4
 #define STATE_STOP     5
 
-#define RAWBUF 100 // Length of raw duration buffer
-
 // information for the interrupt handler
 typedef struct {
   uint8_t recvpin;              // pin for IR data from detector


### PR DESCRIPTION
@kiralikbeyin spotted we have a duplicate #define RAWBUF. Remove it. #198 