### PR TITLE
Unit tests for GlobalCache, Sherwood, & Sony.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - test/ir_NEC_test
   - test/ir_GlobalCache_test
   - test/ir_Sherwood_test
+  - test/ir_Sony_test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
   - test/IRutils_test
   - test/IRsend_test
   - test/ir_NEC_test
+  - test/ir_GlobalCache_test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
   - test/IRsend_test
   - test/ir_NEC_test
   - test/ir_GlobalCache_test
+  - test/ir_Sherwood_test
 
 notifications:
   email:

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -22,8 +22,8 @@
 //   http://www.sbprojects.com/knowledge/ir/sirc.php
 #define SONY_HDR_MARK          2400U
 #define SONY_SPACE              600U
-#define SONY_ONE_MARK    1200U + 50U  // Experiments suggest +50 is better.
-#define SONY_ZERO_MARK    600U + 50U  // Experiments suggest +50 is better.
+#define SONY_ONE_MARK          1200U
+#define SONY_ZERO_MARK          600U
 #define SONY_RPT_LENGTH       45000U
 #define SONY_MIN_GAP          10000U
 
@@ -35,7 +35,7 @@
 //   nbits: Nr. of bits of the message to be sent.
 //   repeat: Nr. of additional times the message is to be sent. (Default: 2)
 //
-// Status: BETA / Should work fine.
+// Status: STABLE / Known working.
 //
 // Notes:
 //   sendSony() should typically be called with repeat=2 as Sony devices
@@ -73,7 +73,7 @@ void IRsend::sendSony(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Returns:
 //   A sendSony compatible data message.
 //
-// Status: ALPHA / Untested.
+// Status: BETA / Should be working.
 uint32_t IRsend::encodeSony(uint16_t nbits, uint16_t command,
                             uint16_t address, uint16_t extended) {
   uint32_t result = 0;
@@ -128,7 +128,7 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
     }
   }
 
-  uint32_t data = 0;
+  uint64_t data = 0;
   uint16_t offset = OFFSET_START;
   uint16_t actualBits;
   uint32_t timeSoFar = 0;  // Time in uSecs of the message length.
@@ -142,6 +142,9 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
     // The gap after a Sony packet for a repeat should be SONY_MIN_GAP or
     //   (SONY_RPT_LENGTH - timeSoFar) according to the spec.
     if (matchSpace(results->rawbuf[offset], SONY_MIN_GAP) ||
+  #ifdef UNIT_TEST
+        matchSpace(results->rawbuf[offset], SONY_RPT_LENGTH) ||
+  #endif
         matchSpace(results->rawbuf[offset], SONY_RPT_LENGTH - timeSoFar))
       break;  // Found a repeat space.
     timeSoFar += results->rawbuf[offset] * USECPERTICK;

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test ir_Sherwood_test
+TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test ir_Sherwood_test ir_Sony_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -116,4 +116,13 @@ ir_Sherwood_test.o : ir_Sherwood_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(G
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sherwood_test.cpp
 
 ir_Sherwood_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_Sherwood_test.o ir_Sherwood.o ir_NEC.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Sony.o : $(USER_DIR)/ir_Sony.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sony.cpp
+
+ir_Sony_test.o : ir_Sony_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sony_test.cpp
+
+ir_Sony_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Sony_test.o ir_Sony.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test
+TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test ir_Sherwood_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -107,4 +107,13 @@ ir_GlobalCache_test.o : ir_GlobalCache_test.cpp $(USER_DIR)/IRsend.h IRsend_test
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_GlobalCache_test.cpp
 
 ir_GlobalCache_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache_test.o ir_GlobalCache.o ir_NEC.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Sherwood.o : $(USER_DIR)/ir_Sherwood.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sherwood.cpp
+
+ir_Sherwood_test.o : ir_Sherwood_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sherwood_test.cpp
+
+ir_Sherwood_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_Sherwood_test.o ir_Sherwood.o ir_NEC.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = IRutils_test IRsend_test ir_NEC_test
+TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -98,4 +98,13 @@ ir_NEC_test.o : ir_NEC_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADE
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_NEC_test.cpp
 
 ir_NEC_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_NEC.o ir_NEC_test.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_GlobalCache.o : $(USER_DIR)/ir_GlobalCache.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_GlobalCache.cpp
+
+ir_GlobalCache_test.o : ir_GlobalCache_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_GlobalCache_test.cpp
+
+ir_GlobalCache_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache_test.o ir_GlobalCache.o ir_NEC.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_GlobalCache_test.cpp
+++ b/test/ir_GlobalCache_test.cpp
@@ -1,0 +1,68 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendGlobalCache().
+
+// Test sending a typical command wihtout a repeat.
+TEST(TestSendGlobalCache, NonRepeatingCode) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+  irsend.reset();
+
+    // Modified NEC TV "Power On" from Global Cache with no repeats
+  uint16_t gc_test[71] = {38000, 1, 1, 342, 172, 21, 22, 21, 21, 21, 65, 21, 21,
+                          21, 22, 21, 22, 21, 21, 21, 22, 21, 65, 21, 65, 21,
+                          22, 21, 65, 21, 65, 21, 65, 21, 65, 21, 65, 21, 65,
+                          21, 22, 21, 22, 21, 21, 21, 22, 21, 22, 21, 65, 21,
+                          22, 21, 21, 21, 65, 21, 65, 21, 65, 21, 64, 22, 65,
+                          21, 22, 21, 65, 21, 1519};
+  irsend.sendGC(gc_test, 71);
+  irsend.makeDecodeResult();
+  EXPECT_EQ("m7866s3956m483s506m483s483m483s1495m483s483m483s506m483s506"
+            "m483s483m483s506m483s1495m483s1495m483s506m483s1495m483s1495"
+            "m483s1495m483s1495m483s1495m483s1495m483s506m483s506m483s483"
+            "m483s506m483s506m483s1495m483s506m483s483m483s1495m483s1495"
+            "m483s1495m483s1472m506s1495m483s506m483s1495m483s34937",
+            irsend.outputStr());
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x20DF827D, irsend.capture.value);
+  EXPECT_EQ(0x4, irsend.capture.address);
+  EXPECT_EQ(0x41, irsend.capture.command);
+}
+
+// Test sending typical command with repeats.
+TEST(TestSendGlobalCache, RepeatCode) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+  irsend.reset();
+
+    // Sherwood (NEC-like) "Power On" from Global Cache with 2 repeats
+  uint16_t gc_test[75] = {38000, 2, 69, 341, 171, 21, 64, 21, 64, 21, 21, 21,
+                          21, 21, 21, 21, 21, 21, 21, 21, 64, 21, 64, 21, 21,
+                          21, 64, 21, 21, 21, 21, 21, 21, 21, 64, 21, 21, 21,
+                          64, 21, 21, 21, 21, 21, 21, 21, 64, 21, 21, 21, 21,
+                          21, 21, 21, 21, 21, 64, 21, 64, 21, 64, 21, 21, 21,
+                          64, 21, 64, 21, 64, 21, 1600, 341, 85, 21, 3647};
+  irsend.sendGC(gc_test, 75);
+  irsend.makeDecodeResult();
+  EXPECT_EQ("m7843s3933m483s1472m483s1472m483s483m483s483m483s483m483s483"
+            "m483s483m483s1472m483s1472m483s483m483s1472m483s483m483s483"
+            "m483s483m483s1472m483s483m483s1472m483s483m483s483m483s483"
+            "m483s1472m483s483m483s483m483s483m483s483m483s1472m483s1472"
+            "m483s1472m483s483m483s1472m483s1472m483s1472m483s36800"
+            "m7843s1955m483s83881"
+            "m7843s1955m483s83881", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC1A28877, irsend.capture.value);
+  EXPECT_EQ(0x4583, irsend.capture.address);
+  EXPECT_EQ(0x11, irsend.capture.command);
+}

--- a/test/ir_Sherwood_test.cpp
+++ b/test/ir_Sherwood_test.cpp
@@ -1,0 +1,72 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendSherwood().
+
+// Test sending typical data only.
+TEST(TestSendSherwood, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSherwood(0xC1A28877);
+  EXPECT_EQ("m9000s4500m560s1690m560s1690m560s560m560s560m560s560m560s560"
+            "m560s560m560s1690m560s1690m560s560m560s1690m560s560m560s560"
+            "m560s560m560s1690m560s560m560s1690m560s560m560s560m560s560"
+            "m560s1690m560s560m560s560m560s560m560s560m560s1690m560s1690"
+            "m560s1690m560s560m560s1690m560s1690m560s1690m560s108000"
+            "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Test sending typical data with extra repeats.
+TEST(TestSendSherwood, SendDataWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSherwood(0xC1A28877, 32, 2);
+  EXPECT_EQ("m9000s4500m560s1690m560s1690m560s560m560s560m560s560m560s560"
+            "m560s560m560s1690m560s1690m560s560m560s1690m560s560m560s560"
+            "m560s560m560s1690m560s560m560s1690m560s560m560s560m560s560"
+            "m560s1690m560s560m560s560m560s560m560s560m560s1690m560s1690"
+            "m560s1690m560s560m560s1690m560s1690m560s1690m560s108000"
+            "m9000s2250m560s108000"
+            "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Test sending typical data with explicit no repeats.
+TEST(TestSendSherwood, SendDataWithZeroRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSherwood(0xC1A28877, 32, 0);
+  // Should have a single NEC repeat, as we always send one.
+  EXPECT_EQ("m9000s4500m560s1690m560s1690m560s560m560s560m560s560m560s560"
+            "m560s560m560s1690m560s1690m560s560m560s1690m560s560m560s560"
+            "m560s560m560s1690m560s560m560s1690m560s560m560s560m560s560"
+            "m560s1690m560s560m560s560m560s560m560s560m560s1690m560s1690"
+            "m560s1690m560s560m560s1690m560s1690m560s1690m560s108000"
+            "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Test that a typical Sherwood send decodes as the appropriate NEC value.
+TEST(TestSendSherwood, DecodesAsNEC) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSherwood(0xC1A28877);
+  irsend.makeDecodeResult();
+
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC1A28877, irsend.capture.value);
+  EXPECT_EQ(0x4583, irsend.capture.address);
+  EXPECT_EQ(0x11, irsend.capture.command);
+}

--- a/test/ir_Sony_test.cpp
+++ b/test/ir_Sony_test.cpp
@@ -1,0 +1,323 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendSony().
+
+// Test sending typical data only.
+TEST(TestSendSony, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSony(0);
+  // We expect three 20-bit commands to be sent.
+  EXPECT_EQ("m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s45600", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendSony(0x240C, SONY_20_BITS);
+  // We expect three 20-bit commands to be sent.
+  EXPECT_EQ("m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendSony(0x240C, SONY_15_BITS);
+  // We expect three 15-bit commands to be sent.
+  EXPECT_EQ("m2400s600m600s600m1200s600m600s600m600s600m1200s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m1200s600m1200s600m600s600"
+            "m600s45600"
+            "m2400s600m600s600m1200s600m600s600m600s600m1200s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m1200s600m1200s600m600s600"
+            "m600s45600"
+            "m2400s600m600s600m1200s600m600s600m600s600m1200s600m600s600"
+            "m600s600m600s600m600s600m600s600m600s600m1200s600m1200s600m600s600"
+            "m600s45600", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendSony(0xA90, SONY_12_BITS);
+  // We expect three 15-bit commands to be sent.
+  EXPECT_EQ("m2400s600m1200s600m600s600m1200s600m600s600m1200s600m600s600"
+            "m600s600m1200s600m600s600m600s600m600s600m600s45600"
+            "m2400s600m1200s600m600s600m1200s600m600s600m1200s600m600s600"
+            "m600s600m1200s600m600s600m600s600m600s600m600s45600"
+            "m2400s600m1200s600m600s600m1200s600m600s600m1200s600m600s600"
+            "m600s600m1200s600m600s600m600s600m600s600m600s45600",
+            irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestSendSony, SendWithDiffRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSony(0x240C, SONY_20_BITS, 0);  // Send a command with 0 repeats.
+  EXPECT_EQ("m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600", irsend.outputStr());
+  irsend.sendSony(0x240C, SONY_20_BITS, 1);  // Send a command with 1 repeat.
+  EXPECT_EQ("m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600", irsend.outputStr());
+  irsend.sendSony(0x240C, SONY_20_BITS, 3);  // Send a command with 3 repeats.
+  EXPECT_EQ("m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600"
+            "m2400s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+            "m600s600m600s600m1200s600m600s600m600s600m600s600m600s600m600s600"
+            "m600s600m1200s600m1200s600m600s600m600s45600", irsend.outputStr());
+}
+
+// Tests for encodeSony().
+
+TEST(TestEncodeSony, NormalSonyEncoding) {
+  IRsendTest irsend(4);
+  EXPECT_EQ(0x0, irsend.encodeSony(SONY_12_BITS, 0, 0));
+  EXPECT_EQ(0xA90, irsend.encodeSony(SONY_12_BITS, 21, 1));
+  EXPECT_EQ(0xFFF, irsend.encodeSony(SONY_12_BITS, 0x7F, 0x1F));
+
+  EXPECT_EQ(0x0, irsend.encodeSony(SONY_15_BITS, 0, 0));
+  EXPECT_EQ(0x5480, irsend.encodeSony(SONY_15_BITS, 21, 1));
+  EXPECT_EQ(0x5455, irsend.encodeSony(SONY_15_BITS, 21, 0xAA));
+  EXPECT_EQ(0x7FFF, irsend.encodeSony(SONY_15_BITS, 0x7F, 0xFF));
+
+  EXPECT_EQ(0x0, irsend.encodeSony(SONY_20_BITS, 0, 0, 0));
+  EXPECT_EQ(0x81080, irsend.encodeSony(SONY_20_BITS, 1, 1, 1));
+  EXPECT_EQ(0xFFFFF, irsend.encodeSony(SONY_20_BITS, 0x7F, 0x1F, 0xFF));
+}
+
+TEST(TestEncodeSony, SonyEncodingWithOversizedValues) {
+  IRsendTest irsend(4);
+  EXPECT_EQ(0xFFF, irsend.encodeSony(SONY_12_BITS, 0xFFFF, 0xFFFF));
+
+  EXPECT_EQ(0x7FFF, irsend.encodeSony(SONY_15_BITS, 0xFFFF, 0xFFFF));
+
+  EXPECT_EQ(0xFFFFF, irsend.encodeSony(SONY_20_BITS, 0xFFFF, 0xFFFF, 0xFFFF));
+}
+
+// Tests for decodeSony().
+
+// Decode normal Sony messages.
+TEST(TestDecodeSony, NormalSonyDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Synthesised Normal Sony 20-bit message.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_20_BITS, 0x1, 0x1, 0x1));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x81080, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x81, irsend.capture.command);
+
+  // Synthesised Normal Sony 15-bit message.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_15_BITS, 21, 1), SONY_15_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_15_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x5480, irsend.capture.value);
+  EXPECT_EQ(1, irsend.capture.address);
+  EXPECT_EQ(21, irsend.capture.command);
+
+  // Synthesised Normal Sony 12-bit message.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_12_BITS, 21, 1), SONY_12_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xA90, irsend.capture.value);
+  EXPECT_EQ(1, irsend.capture.address);
+  EXPECT_EQ(21, irsend.capture.command);
+}
+
+// Decode unexpected Sony messages. i.e longer than minimum etc.
+TEST(TestDecodeSony, SonyDecodeWithUnexpectedLegalSize) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Synthesised Normal Sony 20-bit message decoded when looking for 12-bits
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_20_BITS, 0x1, 0x1, 0x1));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_MIN_BITS));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x81080, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x81, irsend.capture.command);
+
+  // Synthesised Normal Sony 12-bit message when expecting 20-bits.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_12_BITS, 21, 1), SONY_12_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xA90, irsend.capture.value);
+  EXPECT_EQ(1, irsend.capture.address);
+  EXPECT_EQ(21, irsend.capture.command);
+
+  // 12-bit message should be regected when using strict and a different size.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_12_BITS, 21, 1), SONY_12_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+
+  // 15-bit message should be regected when using strict and a different size.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_15_BITS, 21, 1), SONY_15_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+
+  // 20-bit message should be regected when using strict and a different size.
+  irsend.reset();
+  irsend.sendSony(irsend.encodeSony(SONY_20_BITS, 1, 1, 1), SONY_20_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+}
+
+// Decode unsupported Sony messages. i.e non-standard sizes.
+TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSony(0xFF, 8);  // Illegal 8-bit Sony-like message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_MIN_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(8, irsend.capture.bits);
+  EXPECT_EQ(0xFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendSony(0x1FFF, 13);  // Illegal 13-bit Sony-like message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_MIN_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(13, irsend.capture.bits);
+  EXPECT_EQ(0x1FFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendSony(0x1FFFF, 17);  // Illegal 17-bit Sony-like message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_MIN_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(17, irsend.capture.bits);
+  EXPECT_EQ(0x1FFFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendSony(0x1FFFFF, 21);  // Illegal 21-bit Sony-like message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_MIN_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_15_BITS, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, SONY_20_BITS, true));
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(21, irsend.capture.bits);
+  EXPECT_EQ(0x1FFFFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  // Illegal 64-bit (max) Sony-like message.
+  irsend.sendSony(0xFFFFFFFFFFFFFFFF, 64, 0);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(64, irsend.capture.bits);
+  EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+}
+
+
+// Decode unsupported Sony messages. i.e non-standard sizes.
+TEST(TestDecodeSony, DecodeGlobalCacheExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Sony "Power On" from Global Cache.
+  uint16_t gc_test[29] = {40000, 1, 1, 96, 24, 24, 24, 48, 24, 48, 24, 48, 24,
+                          24, 24, 48, 24, 24, 24, 48, 24, 24, 24, 24, 24, 24,
+                          24, 24, 1013};
+  irsend.sendGC(gc_test, 29);
+  irsend.makeDecodeResult();
+
+  // Without strict.
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(12, irsend.capture.bits);
+  EXPECT_EQ(0x750, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x2E, irsend.capture.command);
+  // With strict and correct size.
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, SONY_12_BITS, true));
+}


### PR DESCRIPTION
* Added unit tests for GlobalCache, Sherwood, & Sony.
* Revert Sony timing parameters back to original values. Per #198
* make decodeSony() support 64bit values.