### PR TITLE
Unit tests for Kelvinator A/C & JVC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   - test/ir_Sherwood_test
   - test/ir_Sony_test
   - test/ir_Samsung_test
+  - test/ir_Kelvinator_test
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
   - test/ir_Sony_test
   - test/ir_Samsung_test
   - test/ir_Kelvinator_test
+  - test/ir_JVC_test
 
 notifications:
   email:

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -133,7 +133,9 @@ class IRsend {
   void sendGC(uint16_t buf[], uint16_t len);
 #endif
 #if SEND_KELVINATOR
-  void sendKelvinator(unsigned char data[]);
+  void sendKelvinator(unsigned char data[],
+                      uint16_t nbytes = KELVINATOR_STATE_LENGTH,
+                      uint16_t repeat = 0);
 #endif
 #if SEND_DAIKIN
   void sendDaikin(unsigned char data[]);

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -70,7 +70,7 @@ void IRsend::sendJVC(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Returns:
 //   A raw JVC message.
 //
-// Status: ALPHA / Untested.
+// Status: BETA / Should work fine.
 //
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/jvc.php
@@ -138,8 +138,8 @@ bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits,  bool strict) {
   results->bits = nbits;
   results->value = data;
   // command & address are transmitted LSB first, so we need to reverse them.
-  results->command = reverseBits(data >> 8, 8);  // The first 8 bits sent.
-  results->address = reverseBits(data & 0xFF, 8);  // The last 8 bits sent.
+  results->address = reverseBits(data >> 8, 8);  // The first 8 bits sent.
+  results->command = reverseBits(data & 0xFF, 8);  // The last 8 bits sent.
   results->repeat = isRepeat;
   return true;
 }

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -12,7 +12,7 @@
 //    - "I Feel" button & mode.
 //    - Energy Saving mode.
 //    - Low Heat mode.
-//   - Fahrenheit.
+//    - Fahrenheit.
 
 #include "ir_Kelvinator.h"
 #include <algorithm>
@@ -32,6 +32,7 @@
 #define KELVINATOR_GAP_SPACE               19950U
 #define KELVINATOR_CMD_FOOTER                  2U
 
+#define KELVINATOR_POWER                       8U
 #define KELVINATOR_MODE_MASK                0xF8U
 #define KELVINATOR_FAN_OFFSET                  4U
 #define KELVINATOR_BASIC_FAN_MASK uint8_t(0xFFU ^ (3U << KELVINATOR_FAN_OFFSET))
@@ -57,62 +58,69 @@
 // Send a Kelvinator A/C message.
 //
 // Args:
-//   data: An array of KELVINATOR_STATE_LENGTH bytes containing the IR command.
+//   data: An array of bytes containing the IR command.
+//   nbytes: Nr. of bytes of data in the array. (>=KELVINATOR_STATE_LENGTH)
+//   repeat: Nr. of times the message is to be repeated. (Default = 0).
 //
 // Status: STABLE / Known working.
 //
-// Ref:
-//   IRKelvinator.cpp
-void IRsend::sendKelvinator(unsigned char data[]) {
-  uint8_t i = 0;
+void IRsend::sendKelvinator(unsigned char data[], uint16_t nbytes,
+                            uint16_t repeat) {
+  if (nbytes < KELVINATOR_STATE_LENGTH)
+    return;  // Not enough bytes to send a proper message.
+
   // Set IR carrier frequency
   enableIROut(38);
-  // Header #1
-  mark(KELVINATOR_HDR_MARK);
-  space(KELVINATOR_HDR_SPACE);
-  // Data (command)
-  // Send the first command data (4 bytes)
-  for (; i < 4; i++)
+
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header #1
+    mark(KELVINATOR_HDR_MARK);
+    space(KELVINATOR_HDR_SPACE);
+    // Data (command)
+    // Send the first command data (4 bytes)
+    uint8_t i;
+    for (i = 0; i < 4; i++)
+      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
+               KELVINATOR_ZERO_SPACE, data[i], 8, false);
+    // Send Footer for the command data (3 bits (0b010))
     sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, data[i], 8, false);
-  // Send Footer for the command data (3 bits (B010))
-  sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-           KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER, 3, false);
-  // Send an interdata gap.
-  mark(KELVINATOR_BIT_MARK);
-  space(KELVINATOR_GAP_SPACE);
-  // Data (options)
-  // Send the 1st option chunk of data (4 bytes).
-  for (; i < 8; i++)
+             KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER, 3, false);
+    // Send an interdata gap.
+    mark(KELVINATOR_BIT_MARK);
+    space(KELVINATOR_GAP_SPACE);
+    // Data (options)
+    // Send the 1st option chunk of data (4 bytes).
+    for (; i < 8; i++)
+      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
+               KELVINATOR_ZERO_SPACE, data[i], 8, false);
+    // Send a double data gap to signify we are starting a new command sequence.
+    mark(KELVINATOR_BIT_MARK);
+    space(KELVINATOR_GAP_SPACE * 2);
+    // Header #2
+    mark(KELVINATOR_HDR_MARK);
+    space(KELVINATOR_HDR_SPACE);
+    // Data (command)
+    // Send the 2nd command data (4 bytes).
+    // Basically an almost identical repeat of the earlier command data.
+    for (; i < 12; i++)
+      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
+               KELVINATOR_ZERO_SPACE, data[i], 8, false);
+    // Send Footer for the command data (3 bits (B010))
     sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, data[i], 8, false);
-  // Send a double data gap to signify we are starting a new command sequence.
-  mark(KELVINATOR_BIT_MARK);
-  space(KELVINATOR_GAP_SPACE * 2);
-  // Header #2
-  mark(KELVINATOR_HDR_MARK);
-  space(KELVINATOR_HDR_SPACE);
-  // Data (command)
-  // Send the 2nd command data (4 bytes).
-  // Basically an almost identical repeat of the earlier command data.
-  for (; i < 12; i++)
-    sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, data[i], 8, false);
-  // Send Footer for the command data (3 bits (B010))
-  sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-           KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER, 3, false);
-  // Send an interdata gap.
-  mark(KELVINATOR_BIT_MARK);
-  space(KELVINATOR_GAP_SPACE);
-  // Data (options)
-  // Send the 2nd option chunk of data (4 bytes).
-  // Unlike the commands, definitely not a repeat of the earlier option data.
-  for (; i < KELVINATOR_STATE_LENGTH; i++)
-    sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, data[i], 8, false);
-  // Footer
-  mark(KELVINATOR_BIT_MARK);
-  ledOff();
+             KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER, 3, false);
+    // Send an interdata gap.
+    mark(KELVINATOR_BIT_MARK);
+    space(KELVINATOR_GAP_SPACE);
+    // Data (options)
+    // Send the 2nd option chunk of data (4 bytes).
+    // Unlike the commands, definitely not a repeat of the earlier option data.
+    for (; i < KELVINATOR_STATE_LENGTH; i++)
+      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
+               KELVINATOR_ZERO_SPACE, data[i], 8, false);
+    // Footer
+    mark(KELVINATOR_BIT_MARK);
+    space(KELVINATOR_GAP_SPACE * 2);
+  }
 }
 
 IRKelvinatorAC::IRKelvinatorAC(uint16_t pin) : _irsend(pin) {
@@ -127,7 +135,7 @@ void IRKelvinatorAC::stateReset() {
 }
 
 void IRKelvinatorAC::begin() {
-    _irsend.begin();
+  _irsend.begin();
 }
 
 void IRKelvinatorAC::fixup() {
@@ -153,13 +161,11 @@ void IRKelvinatorAC::checksum() {
   for (uint8_t offset = 0; offset < KELVINATOR_STATE_LENGTH; offset += 8) {
     uint8_t sum = KELVINATOR_CHECKSUM_START;
     // Sum the lower half of the first 4 bytes of this block.
-    for (uint8_t i = 0; i < 4; i++) {
+    for (uint8_t i = 0; i < 4; i++)
       sum += (remote_state[i + offset] & 0xFU);
-    }
     // then sum the upper half of the next 3 bytes.
-    for (uint8_t i = 4; i < 7; i++) {
+    for (uint8_t i = 4; i < 7; i++)
       sum += (remote_state[i + offset] >> 4);
-    }
     // Trim it down to fit into the 4 bits allowed. i.e. Mod 16.
     sum &= 0xFU;
     // Place it into the IR code in the top half of the 8th & 16th byte.
@@ -168,15 +174,13 @@ void IRKelvinatorAC::checksum() {
 }
 
 void IRKelvinatorAC::on() {
-    // state = ON;
-    remote_state[0] |= KELVINATOR_POWER;
-    remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
+  remote_state[0] |= KELVINATOR_POWER;
+  remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
 void IRKelvinatorAC::off() {
-    // state = OFF;
-    remote_state[0] &= ~KELVINATOR_POWER;
-    remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
+  remote_state[0] &= ~KELVINATOR_POWER;
+  remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
 void IRKelvinatorAC::setPower(bool state) {
@@ -187,20 +191,20 @@ void IRKelvinatorAC::setPower(bool state) {
 }
 
 bool IRKelvinatorAC::getPower() {
-    return ((remote_state[0] & KELVINATOR_POWER) != 0);
+  return ((remote_state[0] & KELVINATOR_POWER) != 0);
 }
 
 // Set the temp. in deg C
 void IRKelvinatorAC::setTemp(uint8_t temp) {
-    temp = std::max((uint8_t) KELVINATOR_MIN_TEMP, temp);
-    temp = std::min((uint8_t) KELVINATOR_MAX_TEMP, temp);
-    remote_state[1] = (remote_state[1] & 0xF0U) | (temp - KELVINATOR_MIN_TEMP);
-    remote_state[9] = remote_state[1];  // Duplicate to the 2nd command chunk.
+  temp = std::max((uint8_t) KELVINATOR_MIN_TEMP, temp);
+  temp = std::min((uint8_t) KELVINATOR_MAX_TEMP, temp);
+  remote_state[1] = (remote_state[1] & 0xF0U) | (temp - KELVINATOR_MIN_TEMP);
+  remote_state[9] = remote_state[1];  // Duplicate to the 2nd command chunk.
 }
 
 // Return the set temp. in deg C
 uint8_t IRKelvinatorAC::getTemp() {
-    return ((remote_state[1] & 0xFU) + KELVINATOR_MIN_TEMP);
+  return ((remote_state[1] & 0xFU) + KELVINATOR_MIN_TEMP);
 }
 
 // Set the speed of the fan, 0-5, 0 is auto, 1-5 is the speed
@@ -222,18 +226,11 @@ void IRKelvinatorAC::setFan(uint8_t fan) {
 }
 
 uint8_t IRKelvinatorAC::getFan() {
-    return ((remote_state[14] & ~KELVINATOR_FAN_MASK) >> KELVINATOR_FAN_OFFSET);
+  return ((remote_state[14] & ~KELVINATOR_FAN_MASK) >> KELVINATOR_FAN_OFFSET);
 }
 
 uint8_t IRKelvinatorAC::getMode() {
-  /*
-  KELVINATOR_AUTO
-  KELVINATOR_COOL
-  KELVINATOR_DRY
-  KELVINATOR_FAN
-  KELVINATOR_HEAT
-  */
-    return (remote_state[0] & ~KELVINATOR_MODE_MASK);
+  return (remote_state[0] & ~KELVINATOR_MODE_MASK);
 }
 
 void IRKelvinatorAC::setMode(uint8_t mode) {
@@ -241,8 +238,9 @@ void IRKelvinatorAC::setMode(uint8_t mode) {
   if (mode > KELVINATOR_HEAT) mode = KELVINATOR_AUTO;
   remote_state[0] = (remote_state[0] & KELVINATOR_MODE_MASK) | mode;
   remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
-  if (mode == KELVINATOR_AUTO)
-    // When the remote is set to Auto, it defaults to 25C and doesn't show it.
+  if (mode == KELVINATOR_AUTO || KELVINATOR_DRY)
+    // When the remote is set to Auto or Dry, it defaults to 25C and doesn't
+    // show it.
     setTemp(KELVINATOR_AUTO_TEMP);
 }
 

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -22,7 +22,6 @@
 #define KELVINATOR_DRY                         2U
 #define KELVINATOR_FAN                         3U
 #define KELVINATOR_HEAT                        4U
-#define KELVINATOR_POWER                       8U
 #define KELVINATOR_BASIC_FAN_MAX               3U
 #define KELVINATOR_FAN_MAX                     5U
 #define KELVINATOR_MIN_TEMP                   16U  // 16C

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -43,20 +43,22 @@ class IRsendTest: public IRsend {
     return result.str();
   }
 
-  void makeDecodeResult() {
+  void makeDecodeResult(uint16_t offset = 0) {
     capture.decode_type = UNKNOWN;
     capture.bits = 0;
-    capture.rawlen = last + 1;
-    capture.overflow = (last >= RAW_BUF);
+    capture.rawlen = last + 1 - offset;
+    capture.overflow = (last - offset >= (int16_t) RAW_BUF);
     capture.repeat = false;
     capture.address = 0;
     capture.command = 0;
     capture.rawbuf = rawbuf;
-    for (uint16_t i = 0; (i < RAW_BUF -1 ) && (i < OUTPUT_BUF); i++)
-      if (output[i] > UINT16_MAX)
+    for (uint16_t i = 0;
+         (i < RAW_BUF - 1) && (offset < OUTPUT_BUF);
+         i++, offset++)
+      if (output[offset] > UINT16_MAX)
         rawbuf[i + 1] = UINT16_MAX / USECPERTICK;
       else
-        rawbuf[i + 1] = output[i] / USECPERTICK;
+        rawbuf[i + 1] = output[offset] / USECPERTICK;
   }
 
  protected:

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,7 +26,8 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
 TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
-        ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test
+        ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
+        ir_JVC_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -144,4 +145,13 @@ ir_Kelvinator_test.o : ir_Kelvinator_test.cpp $(USER_DIR)/ir_Kelvinator.h $(USER
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Kelvinator_test.cpp
 
 ir_Kelvinator_test : IRsend.o IRtimer.o IRutils.o ir_Kelvinator_test.o ir_Kelvinator.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_JVC.o : $(USER_DIR)/ir_JVC.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_JVC.cpp
+
+ir_JVC_test.o : ir_JVC_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_JVC_test.cpp
+
+ir_JVC_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_JVC_test.o ir_JVC.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,7 +26,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
 TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
-        ir_Sherwood_test ir_Sony_test ir_Samsung_test
+        ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -135,4 +135,13 @@ ir_Samsung_test.o : ir_Samsung_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTE
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Samsung_test.cpp
 
 ir_Samsung_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Samsung_test.o ir_Samsung.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Kelvinator.o : $(USER_DIR)/ir_Kelvinator.cpp $(USER_DIR)/ir_Kelvinator.h $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Kelvinator.cpp
+
+ir_Kelvinator_test.o : ir_Kelvinator_test.cpp $(USER_DIR)/ir_Kelvinator.h $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Kelvinator_test.cpp
+
+ir_Kelvinator_test : IRsend.o IRtimer.o IRutils.o ir_Kelvinator_test.o ir_Kelvinator.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_JVC_test.cpp
+++ b/test/ir_JVC_test.cpp
@@ -1,0 +1,303 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendJVC().
+
+// Test sending typical data only.
+TEST(TestSendJVC, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendJVC(0xC2B8);  // JVC VCR Power On.
+  EXPECT_EQ(
+      "m8400s4200"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000", irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestSendJVC, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendJVC(0xC2B8, JVC_BITS, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m8400s4200"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000", irsend.outputStr());
+  irsend.sendJVC(0xC2B8, JVC_BITS, 2);  // 2 repeats.
+  EXPECT_EQ(
+      "m8400s4200"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000"
+      "m525s1725m525s1725m525s525m525s525m525s525m525s525m525s1725m525s525"
+      "m525s1725m525s525m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s60000", irsend.outputStr());
+}
+
+// Test sending an atypical data size.
+TEST(TestSendJVC, SendUsualSize) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendJVC(0x0, 8);
+  EXPECT_EQ(
+      "m8400s4200"
+      "m525s525m525s525m525s525m525s525m525s525m525s525m525s525m525s525"
+      "m525s60000", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendJVC(0x1234567890ABCDEF, 64);
+  EXPECT_EQ(
+      "m8400s4200"
+      "m525s525m525s525m525s525m525s1725m525s525m525s525m525s1725m525s525"
+      "m525s525m525s525m525s1725m525s1725m525s525m525s1725m525s525m525s525"
+      "m525s525m525s1725m525s525m525s1725m525s525m525s1725m525s1725m525s525"
+      "m525s525m525s1725m525s1725m525s1725m525s1725m525s525m525s525m525s525"
+      "m525s1725m525s525m525s525m525s1725m525s525m525s525m525s525m525s525"
+      "m525s1725m525s525m525s1725m525s525m525s1725m525s525m525s1725m525s1725"
+      "m525s1725m525s1725m525s525m525s525m525s1725m525s1725m525s525m525s1725"
+      "m525s1725m525s1725m525s1725m525s525m525s1725m525s1725m525s1725m525s1725"
+      "m525s60000", irsend.outputStr());
+}
+
+// Tests for encodeJVC().
+
+TEST(TestEncodeJVC, NormalEncoding) {
+  IRsendTest irsend(4);
+  EXPECT_EQ(0x0, irsend.encodeJVC(0, 0));
+  EXPECT_EQ(0x8080, irsend.encodeJVC(1, 1));
+  EXPECT_EQ(0x8040, irsend.encodeJVC(1, 2));
+  EXPECT_EQ(0xC2B8, irsend.encodeJVC(0x43, 0x1D));
+  EXPECT_EQ(0x55AA, irsend.encodeJVC(0xAA, 0x55));
+  EXPECT_EQ(0xFFFF, irsend.encodeJVC(0xFF, 0xFF));
+}
+
+// Tests for decodeJVC().
+
+// Decode normal JVC messages.
+TEST(TestDecodeJVC, NormalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal JVC 16-bit message.
+  irsend.reset();
+  irsend.sendJVC(0xC2B8);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_EQ(0x43, irsend.capture.address);
+  EXPECT_EQ(0x1D, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Synthesised Normal JVC 16-bit message.
+  irsend.reset();
+  irsend.sendJVC(irsend.encodeJVC(0x07, 0x99));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xE099, irsend.capture.value);
+  EXPECT_EQ(0x07, irsend.capture.address);
+  EXPECT_EQ(0x99, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Synthesised Normal JVC 16-bit message.
+  irsend.reset();
+  irsend.sendJVC(irsend.encodeJVC(0x1, 0x1));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x8080, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x1, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode normal repeated JVC messages.
+TEST(TestDecodeJVC, NormalDecodeWithRepeatAndStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal JVC 16-bit message with 2 repeats.
+  irsend.reset();
+  irsend.sendJVC(0xC2B8, JVC_BITS, 2);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_EQ(0x43, irsend.capture.address);
+  EXPECT_EQ(0x1D, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.makeDecodeResult(2 * JVC_BITS + 4);
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_TRUE(irsend.capture.repeat);
+
+  irsend.makeDecodeResult(2 * JVC_BITS + 4 + 2 * JVC_BITS + 2);
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_TRUE(irsend.capture.repeat);
+
+  // Simulate 'just' a JVC repeat command.
+  // JVC VCR Power On from Global Cache, but modified to be a repeat message.
+  uint16_t gc_test[37] = {38000, 1, 1, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 20, 20, 61, 20, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.reset();
+  irsend.sendGC(gc_test, 37);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_EQ(0x43, irsend.capture.address);
+  EXPECT_EQ(0x1D, irsend.capture.command);
+  EXPECT_TRUE(irsend.capture.repeat);
+}
+
+// Decode unsupported JVC messages.
+TEST(TestDecodeJVC, DecodeWithNonStrictValues) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendJVC(0x0, 8);  // Illegal value JVC 8-bit message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, 8, false));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(8, irsend.capture.bits);
+  EXPECT_EQ(0x0, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendJVC(0x12345678, 32);  // Illegal value JVC 32-bit message.
+  irsend.makeDecodeResult();
+  // Should pass with strict when we ask for less bits than we got.
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+
+  irsend.makeDecodeResult();
+  // Should fail with strict when we ask for the wrong bit size.
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, 32, true));
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, 32, false));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(32, irsend.capture.bits);
+  EXPECT_EQ(0x12345678, irsend.capture.value);
+  EXPECT_EQ(0x12346A, irsend.capture.address);
+  EXPECT_EQ(0x1E, irsend.capture.command);
+
+  // Illegal over length (36-bit) message.
+  irsend.reset();
+  irsend.sendJVC(irsend.encodeJVC(2, 3), 36);
+  irsend.makeDecodeResult();
+
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, false));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x0, irsend.capture.value);  // We told it to expect 20 bits less.
+  EXPECT_EQ(0x00, irsend.capture.address);
+  EXPECT_EQ(0x00, irsend.capture.command);
+  // Re-decode with correct bit size.
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, 36, true));
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, 36, false));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(36, irsend.capture.bits);
+  EXPECT_EQ(0x40C0, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);
+  EXPECT_EQ(0x3, irsend.capture.command);
+}
+
+// Decode (non-standard) 64-bit messages.
+TEST(TestDecodeJVC, Decode64BitMessages) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Illegal value & size JVC 64-bit message.
+  irsend.sendJVC(0xFFFFFFFFFFFFFFFF, 64);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, 64, false));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(64, irsend.capture.bits);
+  EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
+  EXPECT_EQ(0xFFFFFFFF, irsend.capture.address);
+  EXPECT_EQ(0xFF, irsend.capture.command);
+}
+
+// Decode a 'real' example via GlobalCache
+TEST(TestDecodeJVC, DecodeGlobalCacheExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // JVC VCR Power On from Global Cache.
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 20, 20, 61, 20, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+    // 38000,1,37,320,161,21,59,21,59,21,19,21,19,21,19,21,19,21,59,21,19,21,59,21,59,21,19,21,59,21,19,21,19,21,19,21,19,21,838,21,59,21,59,21,19,21,19,21,19,21,19,21,59,21,19,21,59,21,19,21,59,21,59,21,59,21,19,21,19,21,19,21,850};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC2B8, irsend.capture.value);
+  EXPECT_EQ(0x43, irsend.capture.address);
+  EXPECT_EQ(0x1D, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Fail to decode a non-JVC example via GlobalCache
+TEST(TestDecodeJVC, FailToDecodeNonJVCExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Modified a few entries to unexpected values, based on previous test case.
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 127, 20, 61, 9, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture));
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, false));
+}

--- a/test/ir_Kelvinator_test.cpp
+++ b/test/ir_Kelvinator_test.cpp
@@ -1,0 +1,432 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "ir_Kelvinator.h"
+#include "gtest/gtest.h"
+
+// Tests for sendKelvinator().
+
+// Test sending typical data only.
+TEST(TestSendKelvinator, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t kelv_code[KELVINATOR_STATE_LENGTH] = {
+      0x19, 0x0B, 0x80, 0x50, 0x00, 0x00, 0x00, 0xE0,
+      0x19, 0x0B, 0x80, 0x70, 0x00, 0x00, 0x10, 0xf0};
+  irsend.reset();
+  irsend.sendKelvinator(kelv_code);
+  EXPECT_EQ(
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900", irsend.outputStr());
+}
+
+// Test sending with repeats.
+TEST(TestSendKelvinator, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  uint8_t kelv_code[KELVINATOR_STATE_LENGTH] = {
+      0x19, 0x0B, 0x80, 0x50, 0x00, 0x00, 0x00, 0xE0,
+      0x19, 0x0B, 0x80, 0x70, 0x00, 0x00, 0x10, 0xf0};
+  irsend.reset();
+
+  irsend.sendKelvinator(kelv_code, KELVINATOR_STATE_LENGTH, 1);
+  EXPECT_EQ(
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900", irsend.outputStr());
+}
+
+// Test sending atypical sizes.
+TEST(TestSendKelvinator, SendUnexpectedSizes) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t kelv_short_code[15] = {0x19, 0x0B, 0x80, 0x50, 0x00, 0x00, 0x00, 0xE0,
+                                 0x19, 0x0B, 0x80, 0x70, 0x00, 0x00, 0x10};
+  uint8_t kelv_long_code[17] = {0x19, 0x0B, 0x80, 0x50, 0x00, 0x00, 0x00, 0xE0,
+                                0x19, 0x0B, 0x80, 0x70, 0x00, 0x00, 0x10, 0xf0,
+                                0x00};
+  irsend.reset();
+  irsend.sendKelvinator(kelv_short_code, 15);
+  ASSERT_EQ("", irsend.outputStr());
+
+  irsend.reset();
+  // Shouldn't be different from the SendDataOnly. We just don't send the
+  // extra data.
+  irsend.sendKelvinator(kelv_long_code, 17);
+  ASSERT_EQ(
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s520m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900", irsend.outputStr());
+}
+
+
+// Tests for IRKelvinatorAC class.
+
+TEST(TestKelvinatorClass, Power) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.on();
+  EXPECT_TRUE(irkelv.getPower());
+
+  irkelv.off();
+  EXPECT_FALSE(irkelv.getPower());
+
+  irkelv.setPower(true);
+  EXPECT_TRUE(irkelv.getPower());
+
+  irkelv.setPower(false);
+  EXPECT_FALSE(irkelv.getPower());
+}
+
+TEST(TestKelvinatorClass, Temperature) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setTemp(0);
+  EXPECT_EQ(KELVINATOR_MIN_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(255);
+  EXPECT_EQ(KELVINATOR_MAX_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(KELVINATOR_MIN_TEMP);
+  EXPECT_EQ(KELVINATOR_MIN_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(KELVINATOR_MAX_TEMP);
+  EXPECT_EQ(KELVINATOR_MAX_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(KELVINATOR_MIN_TEMP - 1);
+  EXPECT_EQ(KELVINATOR_MIN_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(KELVINATOR_MAX_TEMP + 1);
+  EXPECT_EQ(KELVINATOR_MAX_TEMP, irkelv.getTemp());
+
+  irkelv.setTemp(17);
+  EXPECT_EQ(17, irkelv.getTemp());
+
+  irkelv.setTemp(21);
+  EXPECT_EQ(21, irkelv.getTemp());
+
+  irkelv.setTemp(25);
+  EXPECT_EQ(25, irkelv.getTemp());
+
+  irkelv.setTemp(29);
+  EXPECT_EQ(29, irkelv.getTemp());
+}
+
+TEST(TestKelvinatorClass, OperatingMode) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setTemp(24);
+  irkelv.setMode(KELVINATOR_AUTO);
+  EXPECT_EQ(KELVINATOR_AUTO, irkelv.getMode());
+  EXPECT_EQ(KELVINATOR_AUTO_TEMP, irkelv.getTemp());
+
+  irkelv.setMode(KELVINATOR_COOL);
+  EXPECT_EQ(KELVINATOR_COOL, irkelv.getMode());
+
+  irkelv.setMode(KELVINATOR_HEAT);
+  EXPECT_EQ(KELVINATOR_HEAT, irkelv.getMode());
+
+  irkelv.setTemp(24);
+  irkelv.setMode(KELVINATOR_DRY);
+  EXPECT_EQ(KELVINATOR_DRY, irkelv.getMode());
+  EXPECT_EQ(KELVINATOR_AUTO_TEMP, irkelv.getTemp());
+
+  irkelv.setMode(KELVINATOR_FAN);
+  EXPECT_EQ(KELVINATOR_FAN, irkelv.getMode());
+
+  irkelv.setMode(KELVINATOR_HEAT + 1);
+  EXPECT_EQ(KELVINATOR_AUTO, irkelv.getMode());
+
+  irkelv.setMode(255);
+  EXPECT_EQ(KELVINATOR_AUTO, irkelv.getMode());
+}
+
+TEST(TestKelvinatorClass, VaneSwing) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setSwingHorizontal(true);
+  irkelv.setSwingVertical(false);
+
+  irkelv.setSwingHorizontal(true);
+  EXPECT_TRUE(irkelv.getSwingHorizontal());
+  EXPECT_FALSE(irkelv.getSwingVertical());
+
+  irkelv.setSwingVertical(true);
+  EXPECT_TRUE(irkelv.getSwingHorizontal());
+  EXPECT_TRUE(irkelv.getSwingVertical());
+
+  irkelv.setSwingHorizontal(false);
+  EXPECT_FALSE(irkelv.getSwingHorizontal());
+  EXPECT_TRUE(irkelv.getSwingVertical());
+
+  irkelv.setSwingVertical(false);
+  EXPECT_FALSE(irkelv.getSwingHorizontal());
+  EXPECT_FALSE(irkelv.getSwingVertical());
+}
+
+TEST(TestKelvinatorClass, QuietMode) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setQuiet(true);
+  EXPECT_TRUE(irkelv.getQuiet());
+
+  irkelv.setQuiet(false);
+  EXPECT_FALSE(irkelv.getQuiet());
+
+  irkelv.setQuiet(true);
+  EXPECT_TRUE(irkelv.getQuiet());
+}
+
+TEST(TestKelvinatorClass, IonFilter) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setIonFilter(true);
+  EXPECT_TRUE(irkelv.getIonFilter());
+
+  irkelv.setIonFilter(false);
+  EXPECT_FALSE(irkelv.getIonFilter());
+
+  irkelv.setIonFilter(true);
+  EXPECT_TRUE(irkelv.getIonFilter());
+}
+
+TEST(TestKelvinatorClass, Light) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setLight(true);
+  EXPECT_TRUE(irkelv.getLight());
+
+  irkelv.setLight(false);
+  EXPECT_FALSE(irkelv.getLight());
+
+  irkelv.setLight(true);
+  EXPECT_TRUE(irkelv.getLight());
+}
+
+TEST(TestKelvinatorClass, XFan) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setXFan(true);
+  EXPECT_TRUE(irkelv.getXFan());
+
+  irkelv.setXFan(false);
+  EXPECT_FALSE(irkelv.getXFan());
+
+  irkelv.setXFan(true);
+  EXPECT_TRUE(irkelv.getXFan());
+}
+
+TEST(TestKelvinatorClass, TurboFan) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setTurbo(true);
+  EXPECT_TRUE(irkelv.getTurbo());
+
+  irkelv.setTurbo(false);
+  EXPECT_FALSE(irkelv.getTurbo());
+
+  irkelv.setFan(2);
+  irkelv.setTurbo(true);
+  EXPECT_TRUE(irkelv.getTurbo());
+
+  // Turbo mode is turned off if the temperature is changed.
+  irkelv.setFan(3);
+  EXPECT_FALSE(irkelv.getTurbo());
+
+  // But only when it is changed, not set to the same value again.
+  irkelv.setTurbo(true);
+  irkelv.setFan(3);
+  EXPECT_TRUE(irkelv.getTurbo());
+}
+
+TEST(TestKelvinatorClass, FanSpeed) {
+  IRKelvinatorAC irkelv(0);
+  irkelv.begin();
+
+  irkelv.setFan(0);
+  EXPECT_EQ(0, irkelv.getFan());
+
+  irkelv.setFan(255);
+  EXPECT_EQ(KELVINATOR_FAN_MAX, irkelv.getFan());
+
+  irkelv.setFan(KELVINATOR_FAN_MAX);
+  EXPECT_EQ(KELVINATOR_FAN_MAX, irkelv.getFan());
+
+  irkelv.setFan(KELVINATOR_FAN_MAX + 1);
+  EXPECT_EQ(KELVINATOR_FAN_MAX, irkelv.getFan());
+
+  irkelv.setFan(KELVINATOR_FAN_MAX - 1);
+  EXPECT_EQ(KELVINATOR_FAN_MAX - 1, irkelv.getFan());
+
+  irkelv.setFan(1);
+  EXPECT_EQ(1, irkelv.getFan());
+
+  irkelv.setFan(1);
+  EXPECT_EQ(1, irkelv.getFan());
+
+  irkelv.setFan(3);
+  EXPECT_EQ(3, irkelv.getFan());
+}
+
+
+TEST(TestKelvinatorClass, MessageConstuction) {
+  IRKelvinatorAC irkelv(0);
+  IRsendTest irsend(4);
+  irkelv.begin();
+  irsend.begin();
+
+  irkelv.setFan(1);
+  irkelv.setMode(KELVINATOR_COOL);
+  irkelv.setTemp(27);
+  irkelv.setSwingVertical(false);
+  irkelv.setSwingHorizontal(true);
+  irkelv.setIonFilter(true);
+  irkelv.setQuiet(false);
+  irkelv.setLight(false);
+  irkelv.setPower(true);
+  irkelv.setTurbo(false);
+  irkelv.setXFan(true);
+
+  // Check everything for kicks.
+  EXPECT_EQ(1, irkelv.getFan());
+  EXPECT_EQ(KELVINATOR_COOL, irkelv.getMode());
+  EXPECT_EQ(27, irkelv.getTemp());
+  EXPECT_FALSE(irkelv.getSwingVertical());
+  EXPECT_TRUE(irkelv.getSwingHorizontal());
+  EXPECT_TRUE(irkelv.getIonFilter());
+  EXPECT_FALSE(irkelv.getQuiet());
+  EXPECT_FALSE(irkelv.getLight());
+  EXPECT_TRUE(irkelv.getPower());
+  EXPECT_FALSE(irkelv.getTurbo());
+  EXPECT_TRUE(irkelv.getXFan());
+
+  irsend.reset();
+  irsend.sendKelvinator(irkelv.getRaw());
+  EXPECT_EQ(
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s1560m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900"
+      "m8990s4490"
+      "m675s1560m675s520m675s520m675s1560m675s1560m675s520m675s1560m675s520"
+      "m675s1560m675s1560m675s520m675s1560m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s1560m675s1560"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s520"
+      "m675s520m675s1560m675s520"
+      "m675s19950"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s520m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s520m675s520m675s520"
+      "m675s520m675s520m675s520m675s520m675s1560m675s1560m675s1560m675s1560"
+      "m675s39900", irsend.outputStr());
+}


### PR DESCRIPTION
- Kelvinator
  - Unit test coverage for sendKelvinator() and the message construction class.
  - Add repeats to sendKelvinator(), make it look like a more standard call.
  - White space and code style cleanups.
  - Set the default temp for Dry mode.
  - Minor cleanups.

- JVC
  - Add unit test coverage for sendJVC(), encodeJVC(), & decodeJVC().
  - Extend the unit test helper makeDecodeResults() to start from a given offset.
  - [bug fix] decodeJVC() had the address & command values swapped.