### PR TITLE
Unit tests and improvements for the RC-MM protocol.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
   - test/ir_Samsung_test
   - test/ir_Kelvinator_test
   - test/ir_JVC_test
+  - test/ir_RCMM_test
 
 notifications:
   email:

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -122,7 +122,8 @@ class IRrecv {
                  bool strict = false);
 #endif
 #if DECODE_RCMM
-  bool decodeRCMM(decode_results *results);
+  bool decodeRCMM(decode_results *results, uint16_t nbits = RCMM_BITS,
+                  bool strict = false);
 #endif
 #if DECODE_PANASONIC
   bool decodePanasonic(decode_results *results, uint16_t nbits = PANASONIC_BITS,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -112,7 +112,7 @@ class IRsend {
                uint16_t repeat = 0);
 #endif
 #if SEND_RCMM
-  void sendRCMM(uint32_t data, uint8_t nbits = RCMM_BITS);
+  void sendRCMM(uint64_t data, uint16_t nbits = RCMM_BITS, uint16_t repeat = 0);
 #endif
 #if SEND_COOLIX
   void sendCOOLIX(uint64_t data, uint16_t nbits = COOLIX_BITS,

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -31,58 +31,83 @@
 
 #if SEND_RCMM
 // Send a Philips RC-MM packet.
-// Based on http://www.sbprojects.com/knowledge/ir/rcmm.php
+//
 // Args:
 //   data: The data we want to send. MSB first.
 //   nbits: The number of bits of data to send. (Typically 12, 24, or 32[Nokia])
+//   repeat: The nr. of times the message should be sent.
 //
-// Status:  ALPHA (untested and unconfirmed.)
-void IRsend::sendRCMM(uint32_t data, uint8_t nbits) {
+// Status:  BETA / Should be working.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rcmm.php
+void IRsend::sendRCMM(uint64_t data, uint16_t nbits, uint16_t repeat) {
   // Set 36kHz IR carrier frequency & a 1/3 (33%) duty cycle.
   enableIROut(36, 33);
   IRtimer usecs = IRtimer();
 
-  // Header
-  mark(RCMM_HDR_MARK);
-  space(RCMM_HDR_SPACE);
-  // Data
-  uint32_t mask = 0b11 << (nbits - 2);
-  // RC-MM sends data 2 bits at a time.
-  for (uint8_t i = nbits; i > 0; i -= 2) {
-    mark(RCMM_BIT_MARK);
-    // Grab the next Most Significant Bits to send.
-    switch ((data & mask) >> (i - 2)) {
-      case 0b00: space(RCMM_BIT_SPACE_0); break;
-      case 0b01: space(RCMM_BIT_SPACE_1); break;
-      case 0b10: space(RCMM_BIT_SPACE_2); break;
-      case 0b11: space(RCMM_BIT_SPACE_3); break;
+  for (uint16_t r = 0; r <= repeat; r++) {
+    usecs.reset();
+    // Header
+    mark(RCMM_HDR_MARK);
+    space(RCMM_HDR_SPACE);
+    // Data
+    uint64_t mask = 0b11ULL << (nbits - 2);
+    // RC-MM sends data 2 bits at a time.
+    for (int32_t i = nbits; i > 0; i -= 2) {
+      mark(RCMM_BIT_MARK);
+      // Grab the next Most Significant Bits to send.
+      switch ((data & mask) >> (i - 2)) {
+        case 0b00: space(RCMM_BIT_SPACE_0); break;
+        case 0b01: space(RCMM_BIT_SPACE_1); break;
+        case 0b10: space(RCMM_BIT_SPACE_2); break;
+        case 0b11: space(RCMM_BIT_SPACE_3); break;
+      }
+      mask >>= 2;
     }
-    mask >>= 2;
+    // Footer
+    mark(RCMM_BIT_MARK);
+    // Protocol requires us to wait at least RCMM_RPT_LENGTH usecs from the
+    // start or RCMM_MIN_GAP usecs.
+    space(std::max(RCMM_RPT_LENGTH - usecs.elapsed(), RCMM_MIN_GAP));
   }
-  // Footer
-  mark(RCMM_BIT_MARK);
-  // Protocol requires us to wait at least RCMM_RPT_LENGTH usecs from the start
-  // or RCMM_MIN_GAP usecs.
-  space(std::max(RCMM_RPT_LENGTH - usecs.elapsed(), RCMM_MIN_GAP));
 }
 #endif
 
 #if DECODE_RCMM
 // Decode a Philips RC-MM packet (between 12 & 32 bits) if possible.
 // Places successful decode information in the results pointer.
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of bits to expect in the data portion. Typically RCMM_BITS.
+//   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
-//   The decode success status.
+//   boolean: True if it can decode it, false if it can't.
 //
-// Status:  ALPHA (untested and unconfirmed.)
+// Status:  BETA / Should be working.
+//
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/rcmm.php
-bool IRrecv::decodeRCMM(decode_results *results) {
-  uint32_t data = 0;
+bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
+  uint64_t data = 0;
   uint16_t offset = OFFSET_START;
 
-  int16_t bitSize = results->rawlen - 4;
-  if (bitSize < 12 || bitSize > 32)
-    return false;
+  if (results->rawlen <= 4)
+    return false;  // Not enough entries to ever be RCMM.
+
+  // Calc the maximum size in bits, the message can be, or that we can accept.
+  int16_t maxBitSize = std::min((uint16_t) results->rawlen - 4,
+                                (uint16_t) sizeof(data) * 8);
+  // Compliance
+  if (strict) {
+    // Technically the spec says bit sizes should be 12 xor 24. however
+    // 32 bits has been seen from a device. We are going to assume
+    // 12 <= bits <= 32 is the 'required' bit length for the spec.
+    if (maxBitSize < 12 || maxBitSize > 32)
+      return false;
+    if (maxBitSize < nbits)
+      return false;  // Short cut, we can never reach the expected nr. of bits.
+  }
   // Header decode
   if (!matchMark(results->rawbuf[offset++], RCMM_HDR_MARK))
     return false;
@@ -90,12 +115,14 @@ bool IRrecv::decodeRCMM(decode_results *results) {
     return false;
   // Data decode
   // RC-MM has two bits of data per mark/space pair.
-  for (uint16_t i = 0; i < bitSize; i += 2, offset++) {
+  uint16_t actualBits;
+  for (actualBits = 0; actualBits < maxBitSize; actualBits += 2, offset++) {
+    if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK))
+      return false;
+
     data <<= 2;
     // Use non-default tolerance & excess for matching some of the spaces as the
     // defaults are too generous and causes mis-matches in some cases.
-    if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK, RCMM_TOLERANCE))
-      return false;
     if (matchSpace(results->rawbuf[offset],
                    RCMM_BIT_SPACE_0, TOLERANCE, RCMM_EXCESS))
       data += 0;
@@ -115,10 +142,14 @@ bool IRrecv::decodeRCMM(decode_results *results) {
   if (!matchMark(results->rawbuf[offset], RCMM_BIT_MARK))
     return false;
 
+  // Compliance
+  if (strict && actualBits != nbits)
+    return false;
+
   // Success
   results->value = data;
   results->decode_type = RCMM;
-  results->bits = bitSize;
+  results->bits = actualBits;
   results->address = 0;
   results->command = 0;
   return true;

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 # created to the list.
 TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
-        ir_JVC_test
+        ir_JVC_test ir_RCMM_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -154,4 +154,13 @@ ir_JVC_test.o : ir_JVC_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADE
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_JVC_test.cpp
 
 ir_JVC_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_JVC_test.o ir_JVC.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_RCMM.o : $(USER_DIR)/ir_RCMM.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_RCMM.cpp
+
+ir_RCMM_test.o : ir_RCMM_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_RCMM_test.cpp
+
+ir_RCMM_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_RCMM_test.o ir_RCMM.o gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_RCMM_test.cpp
+++ b/test/ir_RCMM_test.cpp
@@ -1,0 +1,214 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendRCMM().
+
+// Test sending typical data only.
+TEST(TestSendRCMM, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendRCMM(0xe0a600);
+  EXPECT_EQ("m416s277"
+            "m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s27778", irsend.outputStr());
+  irsend.reset();
+  irsend.sendRCMM(0x28e0a600UL, 32);
+  EXPECT_EQ("m416s277"
+            "m166s277m166s611m166s611m166s277m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s27778", irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestSendRCMM, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendRCMM(0x28e0a600, 32, 2);  // 2 repeats.
+  EXPECT_EQ("m416s277"
+            "m166s277m166s611m166s611m166s277m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s27778"
+            "m416s277"
+            "m166s277m166s611m166s611m166s277m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s27778"
+            "m416s277"
+            "m166s277m166s611m166s611m166s277m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s27778", irsend.outputStr());
+}
+
+// Test sending an atypical data size.
+TEST(TestSendRCMM, SendUsualSize) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendRCMM(0xE0, 8);
+  EXPECT_EQ("m416s277"
+            "m166s777m166s611m166s277m166s277"
+            "m166s27778", irsend.outputStr());
+  irsend.reset();
+  irsend.sendRCMM(0x28e0a60000UL, 40);
+  EXPECT_EQ("m416s277"
+            "m166s277m166s611m166s611m166s277m166s777m166s611m166s277m166s277"
+            "m166s611m166s611m166s444m166s611m166s277m166s277m166s277m166s277"
+            "m166s277m166s277m166s277m166s277m166s27778", irsend.outputStr());
+}
+
+// Tests for decodeRCMM().
+
+// Decode normal RCMM messages.
+TEST(TestDecodeRCMM, NormalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal RCMM 24-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0xe0a600);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, RCMM_BITS, true));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(RCMM_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xe0a600, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Normal RCMM 12-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x600, 12);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, true));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(12, irsend.capture.bits);
+  EXPECT_EQ(0x600, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Normal RCMM 32-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x28e0a600, 32);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 32, true));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(32, irsend.capture.bits);
+  EXPECT_EQ(0x28e0a600, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decodes should fail for illegal bit sizes when in strict mode.
+TEST(TestDecodeRCMM, IllegalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Illegal RCMM 8-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x0, 8);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 8, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 12, true));
+
+  // Illegal RCMM 36-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x0, 36);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 12, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 36, true));
+}
+
+// Decodes without strict mode.
+TEST(TestDecodeRCMM, DecodeWithoutStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Illegal RCMM 8-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x55, 8);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 8, false));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(8, irsend.capture.bits);
+  EXPECT_EQ(0x55, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, false));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(8, irsend.capture.bits);
+  EXPECT_EQ(0x55, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  // Illiegal RCMM 36-bit message.
+  irsend.reset();
+  irsend.sendRCMM(0x123456789, 36);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, false));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(36, irsend.capture.bits);
+  EXPECT_EQ(0x123456789, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 24, false));
+  EXPECT_EQ(36, irsend.capture.bits);
+  EXPECT_EQ(0x123456789, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 36, false));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(36, irsend.capture.bits);
+  EXPECT_EQ(0x123456789, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+}
+
+// Decode (non-standard) 64-bit messages.
+TEST(TestDecodeRCMM, Decode64BitMessages) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Illegal value & size RCMM 64-bit message.
+  irsend.sendRCMM(0xFEDCBA9876543210, 64);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 64, false));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(64, irsend.capture.bits);
+  EXPECT_EQ(0xFEDCBA9876543210, irsend.capture.value);
+  EXPECT_EQ(0, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
+}
+
+// Fail to decode a non-RCMM example via GlobalCache
+TEST(TestDecodeRCMM, FailToDecodeNonRCMMExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Modified a few entries to unexpected values, based on previous test case.
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 127, 20, 61, 9, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, RCMM_BITS, false));
+}


### PR DESCRIPTION
- Unit test coverage for sendRCMM() and decodeRCMM()
- Update status for those to Beta as tests now work on them.
- Minor code/ordering optimisation.
- [Fix] Removed special tolerence for the bit mark which caused issues in
  decoding.
- Bring RC-MM up to v2.0 spec & 64bit support.
- Add repeating to sendRCMM.

This should address issue #21 when v2.0 is released.