### PR TITLE
Update linter options in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - arduino --verify --board $BD $PWD/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
   # Check for lint issues.
   - shopt -s nullglob
-  - python cpplint.py --extensions=c,cc,cpp,ino --headers=h,hpp {lib,examples}/*/*.{h,c,cc,cpp,hpp,ino}
+  - python cpplint.py --extensions=c,cc,cpp,ino --headers=h,hpp {src,test}/*.{h,c,cc,cpp,hpp,ino} examples/*/*.{h,c,cc,cpp,hpp,ino}
   - shopt -u nullglob
   # Build and run the unit tests.
   - (cd test; make)


### PR DESCRIPTION
Update the Google C++ linter to point to the correct directory after
the directory change a while back. Add the unit test directory as well.