### PR TITLE
Unit tests & improvements for RC-6.

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -110,10 +110,14 @@ class IRsend {
                      bool key_released = false);
   uint16_t encodeRC5X(uint8_t address, uint8_t command,
                       bool key_released = false);
+  uint64_t toggleRC5(uint64_t data);
 #endif
 #if SEND_RC6
   void sendRC6(uint64_t data, uint16_t nbits = RC6_MODE0_BITS,
                uint16_t repeat = 0);
+  uint64_t encodeRC6(uint32_t address, uint8_t command,
+                     uint16_t mode = RC6_MODE0_BITS);
+  uint64_t toggleRC6(uint64_t data, uint16_t nbits = RC6_MODE0_BITS);
 #endif
 #if SEND_RCMM
   void sendRCMM(uint64_t data, uint16_t nbits = RCMM_BITS, uint16_t repeat = 0);


### PR DESCRIPTION
- Test coverage for the RC-6 methods, and toggleRC5().
- Add helper functions for encoding, and toggling the required bit to simulate
  key press/release state change.
- Support decoding of repeated messages.
- Fix a potential issue where matching the wide-bit in RC6 wasn't always
  successful. Discovered in unit tests.
- Code cleanup.
- Confirmed support for RC-6 36-bit mode (i.e. Xbox-360) in simulation. #43 