### PR TITLE
Denon Unit Tests and complete re-work.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - test/ir_Panasonic_test
   - test/ir_Dish_test
   - test/ir_Whynter_test
+  - test/ir_Denon_test
 
 notifications:
   email:

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -280,7 +280,9 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
 #ifdef DEBUG
   Serial.println("Attempting Denon decode");
 #endif
-  if (decodeDenon(results))
+  if (decodeDenon(results, DENON_48_BITS) ||
+      decodeDenon(results, DENON_BITS) ||
+      decodeDenon(results, DENON_LEGACY_BITS))
     return true;
 #endif
 #if DECODE_DISH

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -125,9 +125,10 @@ class IRrecv {
   bool decodeRCMM(decode_results *results, uint16_t nbits = RCMM_BITS,
                   bool strict = false);
 #endif
-#if DECODE_PANASONIC
+#if (DECODE_PANASONIC || DECODE_DENON)
   bool decodePanasonic(decode_results *results, uint16_t nbits = PANASONIC_BITS,
-                       bool strict = false);
+                       bool strict = false,
+                       uint32_t manufacturer = PANASONIC_MANUFACTURER);
 #endif
 #if DECODE_LG
   bool decodeLG(decode_results *results, uint16_t nbits = LG_BITS,
@@ -157,9 +158,9 @@ class IRrecv {
   bool decodeDISH(decode_results *results, uint16_t nbits = DISH_BITS,
                   bool strict = true);
 #endif
-#if DECODE_SHARP
+#if (DECODE_SHARP || DECODE_DENON)
   bool decodeSharp(decode_results *results, uint16_t nbits = SHARP_BITS,
-                   bool strict = true);
+                   bool strict = true, bool expansion = true);
 #endif
 #if DECODE_AIWA_RC_T501
   bool decodeAiwaRCT501(decode_results *results,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -146,7 +146,9 @@ enum decode_type_t {
 #define COOLIX_BITS                 24U
 #define DAIKIN_BITS                 99U
 #define DAIKIN_COMMAND_LENGTH       27U
-#define DENON_BITS                  14U
+#define DENON_BITS                  SHARP_BITS
+#define DENON_48_BITS               PANASONIC_BITS
+#define DENON_LEGACY_BITS           14U
 #define DISH_BITS                   16U
 #define DISH_MIN_REPEAT              3U
 #define JVC_BITS                    16U
@@ -160,6 +162,7 @@ enum decode_type_t {
 #define MITSUBISHI_AC_MIN_REPEAT     1U
 #define NEC_BITS                    32U
 #define PANASONIC_BITS              48U
+#define PANASONIC_MANUFACTURER   0x4004ULL
 #define RC5_RAW_BITS                14U
 #define RC5_BITS      RC5_RAW_BITS - 2U
 #define RC5X_BITS     RC5_RAW_BITS - 1U

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -67,7 +67,7 @@ class IRsend {
   void sendLG(uint64_t data, uint16_t nbits = LG_BITS, uint16_t repeat = 0);
   uint32_t encodeLG(uint16_t address, uint16_t command);
 #endif
-#if SEND_SHARP
+#if (SEND_SHARP || SEND_DENON)
   uint32_t encodeSharp(uint16_t address, uint16_t command,
                        uint16_t expansion = 1, uint16_t check = 0,
                        bool MSBfirst = false);
@@ -97,7 +97,7 @@ class IRsend {
   void sendDISH(uint64_t data, uint16_t nbits = DISH_BITS,
                 uint16_t repeat = DISH_MIN_REPEAT);
 #endif
-#if SEND_PANASONIC
+#if (SEND_PANASONIC || SEND_DENON)
   void sendPanasonic64(uint64_t data, uint16_t nbits = PANASONIC_BITS,
                        uint16_t repeat = 0);
   void sendPanasonic(uint16_t address, uint32_t data,

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -29,9 +29,8 @@
     (PANASONIC_HDR_MARK + PANASONIC_HDR_SPACE + \
      PANASONIC_BITS * (PANASONIC_BIT_MARK + PANASONIC_ONE_SPACE) + \
      PANASONIC_BIT_MARK)))
-#define PANASONIC_MANUFACTURER       0x4004ULL
 
-#if SEND_PANASONIC
+#if (SEND_PANASONIC || SEND_DENON)
 // Send a Panasonic formatted message.
 //
 // Args:
@@ -108,9 +107,9 @@ uint64_t IRsend::encodePanasonic(uint16_t manufacturer,
           ((uint64_t) function << 8) |
           checksum);
 }
-#endif  // SEND_PANASONIC
+#endif  // (SEND_PANASONIC || SEND_DENON)
 
-#if DECODE_PANASONIC
+#if (DECODE_PANASONIC || DECODE_DENON)
 // Decode the supplied Panasonic message.
 //
 // Args:
@@ -127,7 +126,7 @@ uint64_t IRsend::encodePanasonic(uint16_t manufacturer,
 //   http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
 //   http://www.hifi-remote.com/wiki/index.php?title=Panasonic
 bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
-                             bool strict) {
+                             bool strict, uint32_t manufacturer) {
   if (results->rawlen < 2 * nbits + HEADER + FOOTER)
     return false;  // Not enough entries to be a Panasonic message.
   if (strict && nbits != PANASONIC_BITS)
@@ -161,7 +160,7 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   uint32_t address = data >> 32;
   uint32_t command = data & 0xFFFFFFFF;
   if (strict) {
-    if (address != PANASONIC_MANUFACTURER)  // Verify the Manufacturer code.
+    if (address != manufacturer)  // Verify the Manufacturer code.
       return false;
     // Verify the checksum.
     uint8_t checksumOrig = data & 0xFF;
@@ -178,4 +177,4 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   results->bits = nbits;
   return true;
 }
-#endif  // DECODE_PANASONIC
+#endif  // (DECODE_PANASONIC || DECODE_DENON)

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,7 +28,8 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
-        ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test
+        ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
+        ir_Denon_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -228,3 +229,11 @@ ir_Whynter_test.o : ir_Whynter_test.cpp $(USER_DIR)/IRremoteESP8266.h $(USER_DIR
 
 ir_Whynter_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Whynter_test.o ir_Whynter.o gtest_main.a
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+ir_Denon.o : $(USER_DIR)/ir_Denon.cpp $(GTEST_HEADERS)
+	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Denon.cpp
+
+ir_Denon_test.o : ir_Denon_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Denon_test.cpp
+
+ir_Denon_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Sharp.o ir_Panasonic.o ir_Denon_test.o ir_Denon.o gtest_main.a
+	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Denon_test.cpp
+++ b/test/ir_Denon_test.cpp
@@ -1,0 +1,272 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendDenon().
+
+// Test sending typical data only.
+TEST(TestSendDenon, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendDenon(0x2278);  // Denon AVR Power On. (Sharp)
+  EXPECT_EQ(
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605", irsend.outputStr());
+
+  irsend.reset();
+  // Denon Eco Mode On. (Panasonic/Kaseikyo)
+  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS);
+  EXPECT_EQ(
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000", irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestSendDenon, SendNormalWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendDenon(0x2278, DENON_BITS, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605", irsend.outputStr());
+  irsend.sendDenon(0x2278, DENON_BITS, 2);  // 2 repeats.
+  EXPECT_EQ(
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
+      "m260s1820m260s1820m260s1820m260s1820m260s780m260s780m260s780"
+      "m260s43605"
+      "m260s780m260s1820m260s780m260s780m260s780m260s780m260s1820m260s1820"
+      "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
+      "m260s43605", irsend.outputStr());
+}
+
+TEST(TestSendDenon, Send48BitWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000"
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000", irsend.outputStr());
+  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS, 2);  // 2 repeats.
+  EXPECT_EQ(
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000"
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000"
+      "m3456s1728"
+      "m432s432m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s432"
+      "m432s432m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s1296m432s432"
+      "m432s1296m432s432m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s432m432s1296m432s1296m432s432m432s1296m432s1296m432s432m432s432"
+      "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
+      "m432s130000", irsend.outputStr());
+}
+
+// Test sending an atypical data size.
+TEST(TestSendDenon, SendUnusualSize) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendDenon(0x12, 8);
+  EXPECT_EQ(
+      "m260s780m260s780m260s780m260s1820m260s780m260s780m260s1820m260s780"
+      "m260s43605"
+      "m260s1820m260s1820m260s1820m260s780m260s1820m260s1820m260s780m260s1820"
+      "m260s43605", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendDenon(0x1234567890ABCDEF, 64);
+  EXPECT_EQ(
+      "m3456s1728"
+      "m432s432m432s432m432s432m432s1296m432s432m432s432m432s1296m432s432"
+      "m432s432m432s432m432s1296m432s1296m432s432m432s1296m432s432m432s432"
+      "m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s1296m432s432"
+      "m432s432m432s1296m432s1296m432s1296m432s1296m432s432m432s432m432s432"
+      "m432s1296m432s432m432s432m432s1296m432s432m432s432m432s432m432s432"
+      "m432s1296m432s432m432s1296m432s432m432s1296m432s432m432s1296m432s1296"
+      "m432s1296m432s1296m432s432m432s432m432s1296m432s1296m432s432m432s1296"
+      "m432s1296m432s1296m432s1296m432s432m432s1296m432s1296m432s1296m432s1296"
+      "m432s130000", irsend.outputStr());
+}
+
+// Tests for decodeDenon().
+
+// Decode normal Denon messages.
+TEST(TestDecodeDenon, NormalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal Denon 15-bit message. (Sharp)
+  irsend.reset();
+  irsend.sendDenon(0x2278);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, true));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x2278, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);
+  EXPECT_EQ(0x79, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Legacy Denon 14-bit message.
+  irsend.reset();
+  irsend.sendDenon(0x1278, DENON_LEGACY_BITS);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_LEGACY_BITS, true));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(DENON_LEGACY_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x1278, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Normal Denon 48-bit message. (Panasonic/Kaseikyo)
+  irsend.reset();
+  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, true));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(DENON_48_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
+  EXPECT_EQ(0x2A4C, irsend.capture.address);
+  EXPECT_EQ(0x028D6CE3, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode a 'real' example via GlobalCache
+TEST(TestDecodeDenon, DecodeGlobalCacheExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Denon AVR series Power On code from Global Cache. (Sharp style)
+  uint16_t gc_test_power[67] = {38000, 1, 1,
+                                10, 30, 10, 70, 10, 30, 10, 30, 10, 30, 10, 70,
+                                10, 30, 10, 30, 10, 70, 10, 70, 10, 70, 10, 70,
+                                10, 30, 10, 30, 10, 30, 10, 1657,
+                                10, 30, 10, 70, 10, 30, 10, 30, 10, 30, 10, 30,
+                                10, 70, 10, 70, 10, 30, 10, 30, 10, 30, 10, 30,
+                                10, 70, 10, 70, 10, 70, 10, 1657};
+  irsend.sendGC(gc_test_power, 67);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, true));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x2278, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);
+  EXPECT_EQ(0x79, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Denon "Eco Mode Auto" code from Global Cache. (Panasonic style)
+  uint16_t gc_test_eco[103] = {37000, 1, 1, 128, 64, 16, 16, 16, 16, 16, 48,
+                               16, 16, 16, 48, 16, 16, 16, 48, 16, 16, 16, 16,
+                               16, 48, 16, 16, 16, 16, 16, 48, 16, 48, 16, 16,
+                               16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+                               16, 16, 16, 48, 16, 16, 16, 48, 16, 16, 16, 16,
+                               16, 16, 16, 48, 16, 48, 16, 16, 16, 48, 16, 16,
+                               16, 48, 16, 48, 16, 16, 16, 48, 16, 48, 16, 16,
+                               16, 16, 16, 48, 16, 48, 16, 48, 16, 16, 16, 16,
+                               16, 16, 16, 48, 16, 48, 16, 2766};
+  irsend.reset();
+  irsend.sendGC(gc_test_eco, 103);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, true));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(DENON_48_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
+  EXPECT_EQ(0x2A4C, irsend.capture.address);
+  EXPECT_EQ(0x028D6CE3, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Fail to decode a non-Denon example via GlobalCache
+TEST(TestDecodeDenon, FailToDecodeNonDenonExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 127, 20, 61, 9, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, DENON_LEGACY_BITS, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, false));
+}


### PR DESCRIPTION
- Unit tests for sendDenon & decodeDenon.
- Re-do sendDenon & decodeDenon to use Sharp & Panasonic protocols
  as that is what the Denon documentation indicates and GlobalCache data
  backs up. The previous Denon implementation was just a special case of
  the Sharp protocol, and only half of the protocol.
- Add a flag to decodeSharp() to set if we are checking for the expansion bit.
  This is something that differs between Denon and Sharp.
- Add setting the expected manufacturer to decodePanasonic()'s parameters.
  The manufacturer code differs between Denon and Panasonic protocols.
- Add support for sending & decoding Kaseikyo-like Denon messages.
- Add support for sending/decoding the legacy (poorly implemented) Denon
  implementation.