### PR TITLE
Unit tests and bug fix for the Aiwa protocol.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - test/ir_Panasonic_test
   - test/ir_Dish_test
   - test/ir_Whynter_test
+  - test/ir_Aiwa_test
 
 notifications:
   email:

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -143,6 +143,7 @@ enum decode_type_t {
 
 // Message lengths & required repeat values
 #define AIWA_RC_T501_BITS           15U
+#define AIWA_RC_T501_MIN_REPEAT      1U
 #define COOLIX_BITS                 24U
 #define DAIKIN_BITS                 99U
 #define DAIKIN_COMMAND_LENGTH       27U

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -153,7 +153,7 @@ class IRsend {
 #endif
 #if SEND_AIWA_RC_T501
   void sendAiwaRCT501(uint64_t data, uint16_t nbits = AIWA_RC_T501_BITS,
-                      uint16_t repeat = 0);
+                      uint16_t repeat = AIWA_RC_T501_MIN_REPEAT);
 #endif
 
  private:

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,7 +28,8 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
-        ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test
+        ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
+				ir_Aiwa_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -227,4 +228,13 @@ ir_Whynter_test.o : ir_Whynter_test.cpp $(USER_DIR)/IRremoteESP8266.h $(USER_DIR
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Whynter_test.cpp
 
 ir_Whynter_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Whynter_test.o ir_Whynter.o gtest_main.a
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Aiwa.o : $(USER_DIR)/IRremoteESP8266.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h $(USER_DIR)/ir_Aiwa.cpp $(GTEST_HEADERS)
+	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Aiwa.cpp
+
+ir_Aiwa_test.o : ir_Aiwa_test.cpp $(USER_DIR)/IRremoteESP8266.h $(USER_DIR)/IRrecv.h $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Aiwa_test.cpp
+
+ir_Aiwa_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_NEC.o ir_Aiwa_test.o ir_Aiwa.o gtest_main.a
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Aiwa_test.cpp
+++ b/test/ir_Aiwa_test.cpp
@@ -1,0 +1,338 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendAiwaRCT501().
+
+// Test sending typical data only.
+TEST(TestSendAiwa, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F);  // Aiwa Power Toggle.
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Test sending oversized data.
+TEST(TestSendAiwa, SendOversizedData) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F, 38);  // 38 bits is over the maximum. Should fail.
+  EXPECT_EQ("", irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestSendAiwa, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F, AIWA_RC_T501_BITS, 0);  // No repeats.
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000", irsend.outputStr());
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F, AIWA_RC_T501_BITS, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F, AIWA_RC_T501_BITS, 2);  // 2 repeats.
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000"
+      "m9000s2250m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Test sending an atypical data size.
+TEST(TestSendAiwa, SendUsualSize) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x12, 8);
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s1690m560s560m560s1690m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x1234567890, 37);
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s1690m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s1690m560s560m560s1690m560s560m560s560m560s560"
+      "m560s1690m560s560m560s1690m560s560m560s1690m560s1690m560s560m560s560"
+      "m560s1690m560s1690m560s1690m560s1690m560s560m560s560m560s560m560s1690"
+      "m560s560m560s560m560s1690m560s560m560s560m560s560m560s560m560s1690"
+      "m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Tests for decodeAiwaRCT501().
+
+// Decode normal Aiwa messages.
+TEST(TestDecodeAiwa, NormalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal Aiwa 16-bit message.
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      true));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(AIWA_RC_T501_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x7F, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Normal Aiwa 15-bit(42bit) message.
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x0);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      true));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(AIWA_RC_T501_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x0, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Normal Aiwa 15-bit(42bit) message.
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7FFF);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      true));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(AIWA_RC_T501_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x7FFF, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode normal repeated Aiwa messages.
+TEST(TestDecodeAiwa, NormalDecodeWithRepeatAndStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal Aiwa 15-bit(42bit) message with 2 repeats.
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x7F, AIWA_RC_T501_BITS, 2);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      true));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(AIWA_RC_T501_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x7F, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode unsupported Aiwa messages.
+TEST(TestDecodeAiwa, DecodeWithNonStrictValues) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Confirm using sendNEC(data, 42, 1) can make a legal Aiwa message.
+  irsend.sendNEC(0x1D8113F00FF, 42, AIWA_RC_T501_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  // MUST pass with strict on.
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       true));
+  ASSERT_EQ(0x7F, irsend.capture.value);
+
+  irsend.reset();
+  // Use sendNEC(data, 42) to make/send an illegal value Aiwa message.
+  // Value is illegal due to bad pre & post data.
+  irsend.sendNEC(0x1234567890A, 42, AIWA_RC_T501_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       true));
+  // Should fail if strict off too.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      false));
+
+  irsend.reset();
+  // Use sendNEC(data, 42) to make/send an illegal value Aiwa message.
+  // Value is illegal due to bad post data only.
+  irsend.sendNEC(0x1D8113F00FE, 42, AIWA_RC_T501_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       true));
+  // Should fail if strict off too.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      false));
+
+  irsend.reset();
+  // Use sendNEC(data, 42) to make/send an illegal value Aiwa message.
+  // Value is illegal due to bad pre data only.
+  irsend.sendNEC(0x0D8113F00FF, 42, AIWA_RC_T501_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       true));
+  // Should fail if strict off too.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      false));
+}
+
+// Decode unsupported Aiwa messages.
+TEST(TestDecodeAiwa, DecodeWithNonStrictSizes) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x0, 8);  // Illegal size Aiwa 8-bit message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       true));
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 8, false));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(8, irsend.capture.bits);
+  EXPECT_EQ(0x0, irsend.capture.value);
+
+  irsend.reset();
+  irsend.sendAiwaRCT501(0x12345678, 32);  // Illegal size Aiwa 32-bit message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                      true));
+  // Should fail with strict when we ask for the wrong bit size.
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, 32, true));
+
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 32, false));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(32, irsend.capture.bits);
+  EXPECT_EQ(0x12345678, irsend.capture.value);
+}
+
+// Decode (non-standard) 64-bit messages.
+TEST(TestDecodeAiwa, Decode64BitMessages) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Illegal value & size Aiwa 37(64)-bit message.
+  irsend.sendAiwaRCT501(0x1FFFFFFFFF, 37);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 37, false));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(37, irsend.capture.bits);
+  EXPECT_EQ(0x1FFFFFFFFF, irsend.capture.value);
+
+  // Reconfirm it by sending a true 64bit NEC message with the Aiwa prefix.
+  irsend.reset();
+  irsend.sendNEC(0x76044FFFFFFFFFFF, 64, AIWA_RC_T501_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 37, false));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(37, irsend.capture.bits);
+  EXPECT_EQ(0x1FFFFFFFFF, irsend.capture.value);
+}
+
+// Decode a 'real' example via GlobalCache
+TEST(TestDecodeAiwa, DecodeGlobalCacheExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Aiwa Power Toggle from Global Cache.
+  uint16_t gc_test[95] = {38000, 1, 89, 342, 171, 21, 21, 21, 64, 21, 64,
+                          21, 64, 21, 21, 21, 64, 21, 64, 21, 21, 21, 21,
+                          21, 21, 21, 21, 21, 21, 21, 21, 21, 64, 21, 21,
+                          21, 21, 21, 21, 21, 64, 21, 21, 21, 21, 21, 64,
+                          21, 64, 21, 64, 21, 64, 21, 64, 21, 64, 21, 21,
+                          21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
+                          21, 21, 21, 64, 21, 64, 21, 64, 21, 64, 21, 64,
+                          21, 64, 21, 64, 21, 64, 21, 875, 342, 171, 21, 3565};
+  irsend.sendGC(gc_test, 95);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(AIWA_RC_T501_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x7F, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Confirm what the 42-bit NEC decode is.
+  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, 42, false));
+  EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
+}
+
+// Fail to decode a non-Aiwa example via GlobalCache
+TEST(TestDecodeAiwa, FailToDecodeNonAiwaExample) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 127, 20, 61, 9, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, AIWA_RC_T501_BITS,
+                                       false));
+}


### PR DESCRIPTION
- Unit tests for send & decode.
- [bugfix] incorrect use of non-inverted LIRC values.
- GlobalCache data indicates there is always a repeat, so set the default appropriately.
- Fix a typo.
- Testing based on simulated data from known okay source (GlobalCache)
- Bump status to Beta for the methods.