### PR TITLE
Unit tests for the Daikin A/C protocol and v2.0 upgrade.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
   - test/ir_Whynter_test
   - test/ir_Aiwa_test
   - test/ir_Denon_test
+  - test/ir_Daikin_test
 
 notifications:
   email:

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -149,7 +149,9 @@ class IRsend {
                       uint16_t repeat = 0);
 #endif
 #if SEND_DAIKIN
-  void sendDaikin(unsigned char data[]);
+  void sendDaikin(unsigned char data[],
+                  uint16_t nbytes = DAIKIN_COMMAND_LENGTH,
+                  uint16_t repeat = 0);
 #endif
 #if SEND_AIWA_RC_T501
   void sendAiwaRCT501(uint64_t data, uint16_t nbits = AIWA_RC_T501_BITS,

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -6,6 +6,7 @@ http://harizanov.com/2012/02/control-daikin-air-conditioner-over-the-internet/
 Copyright 2016 sillyfrog
 */
 
+#include <algorithm>
 #include "ir_Daikin.h"
 #include "IRutils.h"
 
@@ -37,33 +38,39 @@ Copyright 2016 sillyfrog
 // Ref:
 //   IRDaikinESP.cpp
 //   https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
-void IRsend::sendDaikin(unsigned char data[]) {
+void IRsend::sendDaikin(unsigned char data[], uint16_t nbytes,
+                        uint16_t repeat) {
+  if (nbytes < DAIKIN_COMMAND_LENGTH)
+    return;  // Not enough bytes to send a proper message.
   // Set IR carrier frequency
   enableIROut(38);
-  // Header #1
-  mark(DAIKIN_HDR_MARK);
-  space(DAIKIN_HDR_SPACE);
-  // Data #1
-  for (uint8_t i = 0; i < 8; i++)
-    sendData(DAIKIN_ONE_MARK, DAIKIN_ONE_SPACE, DAIKIN_ZERO_MARK,
-             DAIKIN_ZERO_SPACE, data[i], 8, false);
-  // Footer #1
-  mark(DAIKIN_ONE_MARK);
-  space(DAIKIN_ZERO_SPACE + 29000);
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header #1
+    mark(DAIKIN_HDR_MARK);
+    space(DAIKIN_HDR_SPACE);
+    // Data #1
+    for (uint16_t i = 0; i < 8 && i < nbytes; i++)
+      sendData(DAIKIN_ONE_MARK, DAIKIN_ONE_SPACE, DAIKIN_ZERO_MARK,
+               DAIKIN_ZERO_SPACE, data[i], 8, false);
+    // Footer #1
+    mark(DAIKIN_ONE_MARK);
+    space(DAIKIN_ZERO_SPACE + DAIKIN_GAP);
 
-  // Header #2
-  mark(DAIKIN_HDR_MARK);
-  space(DAIKIN_HDR_SPACE);
-  // Data #2
-  for (uint8_t i = 8; i < DAIKIN_COMMAND_LENGTH; i++)
-    sendData(DAIKIN_ONE_MARK, DAIKIN_ONE_SPACE, DAIKIN_ZERO_MARK,
-             DAIKIN_ZERO_SPACE, data[i], 8, false);
-  // Footer #2
-  mark(DAIKIN_ONE_MARK);
-  space(DAIKIN_ZERO_SPACE);
+    // Header #2
+    mark(DAIKIN_HDR_MARK);
+    space(DAIKIN_HDR_SPACE);
+    // Data #2
+    for (uint16_t i = 8; i < nbytes; i++)
+      sendData(DAIKIN_ONE_MARK, DAIKIN_ONE_SPACE, DAIKIN_ZERO_MARK,
+               DAIKIN_ZERO_SPACE, data[i], 8, false);
+    // Footer #2
+    mark(DAIKIN_ONE_MARK);
+    space(DAIKIN_ZERO_SPACE + DAIKIN_GAP);
+  }
 }
 
 IRDaikinESP::IRDaikinESP(uint16_t pin) : _irsend(pin) {
+  stateReset();
 }
 
 void IRDaikinESP::begin() {
@@ -88,6 +95,32 @@ void IRDaikinESP::checksum() {
   daikin[26] = sum & 0xFF;
 }
 
+
+void IRDaikinESP::stateReset() {
+  for (uint8_t i = 4; i < DAIKIN_COMMAND_LENGTH; i++)
+    daikin[i] = 0x0;
+
+  daikin[0] = 0x11;
+  daikin[1] = 0xDA;
+  daikin[2] = 0x27;
+  daikin[3] = 0xF0;
+  daikin[7] = 0x20;
+  daikin[8] = 0x11;
+  daikin[9] = 0xDA;
+  daikin[10] = 0x27;
+  daikin[13] = 0x41;
+  daikin[14] = 0x1E;
+  daikin[16] = 0xB0;
+  daikin[23] = 0xC0;
+  daikin[26] = 0xE3;
+  checksum();
+}
+
+uint8_t* IRDaikinESP::getRaw() {
+  checksum();   // Ensure correct settings before sending.
+  return daikin;
+}
+
 void IRDaikinESP::on() {
   // state = ON;
   daikin[13] |= 0x01;
@@ -98,6 +131,13 @@ void IRDaikinESP::off() {
   // state = OFF;
   daikin[13] &= 0xFE;
   checksum();
+}
+
+void IRDaikinESP::setPower(bool state) {
+  if (state)
+    on();
+  else
+    off();
 }
 
 uint8_t IRDaikinESP::getPower() {
@@ -114,13 +154,34 @@ uint8_t IRDaikinESP::getAux() {
   return daikin[21];
 }
 
+void IRDaikinESP::setQuiet(bool state) {
+  if (state)
+    setAux(DAIKIN_SILENT);
+  else
+    setAux(0x0);
+}
+
+bool IRDaikinESP::getQuiet() {
+  return (getAux() == DAIKIN_SILENT);
+}
+
+void IRDaikinESP::setPowerful(bool state) {
+  if (state)
+    setAux(DAIKIN_POWERFUL);
+  else
+    setAux(0x0);
+}
+
+bool IRDaikinESP::getPowerful() {
+  return (getAux() == DAIKIN_POWERFUL);
+}
 
 // Set the temp in deg C
 void IRDaikinESP::setTemp(uint8_t temp) {
-  if (temp < 18)
-    temp = 18;
-  else if (temp > 32)
-    temp = 32;
+  if (temp < DAIKIN_MIN_TEMP)
+    temp = DAIKIN_MIN_TEMP;
+  else if (temp > DAIKIN_MAX_TEMP)
+    temp = DAIKIN_MAX_TEMP;
   daikin[14] = temp * 2;
   checksum();
 }
@@ -134,10 +195,11 @@ void IRDaikinESP::setFan(uint8_t fan) {
   // Set the fan speed bits, leave low 4 bits alone
   uint8_t fanset;
   daikin[16] &= 0x0F;
-  if (fan >= 1 && fan <= 5)
-    fanset = 0x20 + (0x10 * fan);
-  else
+  fan = std::min(fan, DAIKIN_FAN_MAX);
+  if (fan == DAIKIN_FAN_AUTO)
     fanset = 0xA0;
+  else
+    fanset = 0x20 + (0x10 * fan);
   daikin[16] |= fanset;
   checksum();
 }
@@ -145,8 +207,8 @@ void IRDaikinESP::setFan(uint8_t fan) {
 uint8_t IRDaikinESP::getFan() {
   uint8_t fan = daikin[16] >> 4;
   fan -= 2;
-  if (fan > 5)
-    fan = 0;
+  if (fan > DAIKIN_FAN_MAX)
+    fan = DAIKIN_FAN_AUTO;
   return fan;
 }
 
@@ -162,34 +224,43 @@ uint8_t IRDaikinESP::getMode() {
 }
 
 void IRDaikinESP::setMode(uint8_t mode) {
+  switch (mode) {
+    case DAIKIN_COOL:
+    case DAIKIN_HEAT:
+    case DAIKIN_FAN:
+    case DAIKIN_DRY:
+      break;
+    default:
+      mode = DAIKIN_AUTO;
+  }
   daikin[13] = (mode << 4) | getPower();
   checksum();
 }
 
-void IRDaikinESP::setSwingVertical(uint8_t swing) {
-  if (swing)
+void IRDaikinESP::setSwingVertical(bool state) {
+  if (state)
     daikin[16] |= 0x0F;
   else
     daikin[16] &= 0xF0;
   checksum();
 }
 
-uint8_t IRDaikinESP::getSwingVertical() {
+bool IRDaikinESP::getSwingVertical() {
   return daikin[16] & 0x01;
 }
 
-void IRDaikinESP::setSwingHorizontal(uint8_t swing) {
-  if (swing)
+void IRDaikinESP::setSwingHorizontal(bool state) {
+  if (state)
     daikin[17] |= 0x0F;
   else
     daikin[17] &= 0xF0;
   checksum();
 }
 
-uint8_t IRDaikinESP::getSwingHorizontal() {
+bool IRDaikinESP::getSwingHorizontal() {
   return daikin[17] & 0x01;
 }
-#endif
+#endif  // SEND_DAIKIN
 
 #if DECODE_DAIKIN
 // TODO(crankyoldgit): NOT WORKING. This needs to be finished.
@@ -277,4 +348,4 @@ bool IRrecv::decodeDaikin(decode_results *results, uint16_t nbits,
   results->command = 0;
   return true;
 }
-#endif
+#endif  // DECODE_DAIKIN

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -60,6 +60,11 @@
 #define DAIKIN_DRY                 0b010
 #define DAIKIN_POWERFUL       0b00000010
 #define DAIKIN_SILENT         0b00100000
+#define DAIKIN_MIN_TEMP               18U  // Celsius
+#define DAIKIN_MAX_TEMP               32U  // Celsius
+#define DAIKIN_FAN_AUTO      (uint8_t) 0U
+#define DAIKIN_FAN_MIN       (uint8_t) 1U
+#define DAIKIN_FAN_MAX       (uint8_t) 5U
 
 #if SEND_DAIKIN
 class IRDaikinESP {
@@ -70,6 +75,7 @@ class IRDaikinESP {
   void begin();
   void on();
   void off();
+  void setPower(bool state);
   uint8_t getPower();
   void setAux(uint8_t aux);
   uint8_t getAux();
@@ -79,20 +85,20 @@ class IRDaikinESP {
   uint8_t getFan();
   uint8_t getMode();
   void setMode(uint8_t mode);
-  void setSwingVertical(uint8_t swing);
-  uint8_t getSwingVertical();
-  void setSwingHorizontal(uint8_t swing);
-  uint8_t getSwingHorizontal();
+  void setSwingVertical(bool state);
+  bool getSwingVertical();
+  void setSwingHorizontal(bool state);
+  bool getSwingHorizontal();
+  bool getQuiet();
+  void setQuiet(bool state);
+  bool getPowerful();
+  void setPowerful(bool state);
+  uint8_t* getRaw();
 
  private:
   // # of bytes per command
-  unsigned char daikin[DAIKIN_COMMAND_LENGTH] = {
-      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
-      // 0     1     2     3     4     5     6     7
-      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
-      // 8     9    10    11    12    13    14    15
-      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
-      // 16   17    18    19    20    21    22    23    24    25    26
+  uint8_t daikin[DAIKIN_COMMAND_LENGTH];
+  void stateReset();
   void checksum();
   IRsend _irsend;
 };

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
-				ir_Aiwa_test ir_Denon_test
+				ir_Aiwa_test ir_Denon_test ir_Daikin_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -247,3 +247,12 @@ ir_Denon_test.o : ir_Denon_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_H
 
 ir_Denon_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Sharp.o ir_Panasonic.o ir_Denon_test.o ir_Denon.o gtest_main.a
 	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Daikin.o : $(USER_DIR)/ir_Daikin.cpp $(USER_DIR)/ir_Daikin.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Daikin.cpp
+
+ir_Daikin_test.o : ir_Daikin_test.cpp $(USER_DIR)/ir_Daikin.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Daikin_test.cpp
+
+ir_Daikin_test : IRsend.o IRtimer.o IRutils.o ir_Daikin_test.o ir_Daikin.o gtest_main.a
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1,0 +1,419 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "ir_Daikin.h"
+#include "gtest/gtest.h"
+
+// Tests for sendDaikin().
+
+// Test sending typical data only.
+TEST(TestSendDaikin, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t daikin_code[DAIKIN_COMMAND_LENGTH] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
+      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
+
+  irsend.reset();
+  irsend.sendDaikin(daikin_code);
+  EXPECT_EQ(
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s1280m428s428m428s428"
+      "m428s29428"
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s1280m428s428m428s428m428s428m428s428m428s428m428s1280m428s428"
+      "m428s428m428s1280m428s1280m428s1280m428s1280m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s428m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s1280m428s1280m428s428m428s428m428s428m428s1280m428s1280m428s1280"
+      "m428s29428", irsend.outputStr());
+}
+
+// Test sending with repeats.
+TEST(TestSendDaikin, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  uint8_t daikin_code[DAIKIN_COMMAND_LENGTH] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
+      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
+  irsend.reset();
+
+  irsend.sendDaikin(daikin_code, DAIKIN_COMMAND_LENGTH, 1);
+  EXPECT_EQ(
+    "m3650s1623"
+    "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+    "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+    "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s1280m428s428m428s428"
+    "m428s29428"
+    "m3650s1623"
+    "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+    "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+    "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s1280m428s428m428s428m428s428m428s428m428s428m428s1280m428s428"
+    "m428s428m428s1280m428s1280m428s1280m428s1280m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s428m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s1280m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s1280m428s1280m428s428m428s428m428s428m428s1280m428s1280m428s1280"
+    "m428s29428"
+    "m3650s1623"
+    "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+    "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+    "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s1280m428s428m428s428"
+    "m428s29428"
+    "m3650s1623"
+    "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+    "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+    "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s1280m428s428m428s428m428s428m428s428m428s428m428s1280m428s428"
+    "m428s428m428s1280m428s1280m428s1280m428s1280m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s428m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s1280m428s1280"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+    "m428s1280m428s1280m428s428m428s428m428s428m428s1280m428s1280m428s1280"
+    "m428s29428", irsend.outputStr());
+}
+
+// Test sending atypical sizes.
+TEST(TestSendDaikin, SendUnexpectedSizes) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t daikin_short_code[DAIKIN_COMMAND_LENGTH - 1] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
+      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00};
+
+  irsend.reset();
+  irsend.sendDaikin(daikin_short_code, DAIKIN_COMMAND_LENGTH - 1);
+  ASSERT_EQ("", irsend.outputStr());
+
+  uint8_t daikin_long_code[DAIKIN_COMMAND_LENGTH + 1] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00,
+      0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3, 0x11};
+  irsend.reset();
+  irsend.sendDaikin(daikin_long_code, DAIKIN_COMMAND_LENGTH + 1);
+  ASSERT_EQ(
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s1280m428s428m428s428"
+      "m428s29428"
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s1280m428s428m428s428m428s428m428s428m428s428m428s1280m428s428"
+      "m428s428m428s1280m428s1280m428s1280m428s1280m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s428m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s1280m428s1280m428s428m428s428m428s428m428s1280m428s1280m428s1280"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s29428", irsend.outputStr());
+}
+
+// Tests for IRDaikinESP class.
+
+TEST(TestDaikinClass, Power) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.on();
+  EXPECT_TRUE(irdaikin.getPower());
+
+  irdaikin.off();
+  EXPECT_FALSE(irdaikin.getPower());
+
+  irdaikin.setPower(true);
+  EXPECT_TRUE(irdaikin.getPower());
+
+  irdaikin.setPower(false);
+  EXPECT_FALSE(irdaikin.getPower());
+}
+
+TEST(TestDaikinClass, Temperature) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setTemp(0);
+  EXPECT_EQ(DAIKIN_MIN_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(255);
+  EXPECT_EQ(DAIKIN_MAX_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(DAIKIN_MIN_TEMP);
+  EXPECT_EQ(DAIKIN_MIN_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(DAIKIN_MAX_TEMP);
+  EXPECT_EQ(DAIKIN_MAX_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(DAIKIN_MIN_TEMP - 1);
+  EXPECT_EQ(DAIKIN_MIN_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(DAIKIN_MAX_TEMP + 1);
+  EXPECT_EQ(DAIKIN_MAX_TEMP, irdaikin.getTemp());
+
+  irdaikin.setTemp(DAIKIN_MIN_TEMP + 1);
+  EXPECT_EQ(DAIKIN_MIN_TEMP + 1, irdaikin.getTemp());
+
+  irdaikin.setTemp(21);
+  EXPECT_EQ(21, irdaikin.getTemp());
+
+  irdaikin.setTemp(25);
+  EXPECT_EQ(25, irdaikin.getTemp());
+
+  irdaikin.setTemp(29);
+  EXPECT_EQ(29, irdaikin.getTemp());
+}
+
+TEST(TestDaikinClass, OperatingMode) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setMode(DAIKIN_AUTO);
+  EXPECT_EQ(DAIKIN_AUTO, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_COOL);
+  EXPECT_EQ(DAIKIN_COOL, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_HEAT);
+  EXPECT_EQ(DAIKIN_HEAT, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_DRY);
+  EXPECT_EQ(DAIKIN_DRY, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_FAN);
+  EXPECT_EQ(DAIKIN_FAN, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_FAN + 1);
+  EXPECT_EQ(DAIKIN_AUTO, irdaikin.getMode());
+
+  irdaikin.setMode(DAIKIN_AUTO + 1);
+  EXPECT_EQ(DAIKIN_AUTO, irdaikin.getMode());
+
+  irdaikin.setMode(255);
+  EXPECT_EQ(DAIKIN_AUTO, irdaikin.getMode());
+}
+
+TEST(TestDaikinClass, VaneSwing) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setSwingHorizontal(true);
+  irdaikin.setSwingVertical(false);
+
+  irdaikin.setSwingHorizontal(true);
+  EXPECT_TRUE(irdaikin.getSwingHorizontal());
+  EXPECT_FALSE(irdaikin.getSwingVertical());
+
+  irdaikin.setSwingVertical(true);
+  EXPECT_TRUE(irdaikin.getSwingHorizontal());
+  EXPECT_TRUE(irdaikin.getSwingVertical());
+
+  irdaikin.setSwingHorizontal(false);
+  EXPECT_FALSE(irdaikin.getSwingHorizontal());
+  EXPECT_TRUE(irdaikin.getSwingVertical());
+
+  irdaikin.setSwingVertical(false);
+  EXPECT_FALSE(irdaikin.getSwingHorizontal());
+  EXPECT_FALSE(irdaikin.getSwingVertical());
+}
+
+TEST(TestDaikinClass, QuietMode) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setQuiet(true);
+  EXPECT_TRUE(irdaikin.getQuiet());
+
+  irdaikin.setQuiet(false);
+  EXPECT_FALSE(irdaikin.getQuiet());
+
+  irdaikin.setQuiet(true);
+  EXPECT_TRUE(irdaikin.getQuiet());
+
+  irdaikin.setPowerful(true);
+  EXPECT_FALSE(irdaikin.getQuiet());
+}
+
+TEST(TestDaikinClass, PowerfulMode) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setPowerful(true);
+  EXPECT_TRUE(irdaikin.getPowerful());
+
+  irdaikin.setPowerful(false);
+  EXPECT_FALSE(irdaikin.getPowerful());
+
+  irdaikin.setPowerful(true);
+  EXPECT_TRUE(irdaikin.getPowerful());
+
+  irdaikin.setQuiet(true);
+  EXPECT_FALSE(irdaikin.getPowerful());
+}
+
+TEST(TestDaikinClass, FanSpeed) {
+  IRDaikinESP irdaikin(0);
+  irdaikin.begin();
+
+  irdaikin.setFan(0);
+  EXPECT_EQ(0, irdaikin.getFan());
+
+  irdaikin.setFan(255);
+  EXPECT_EQ(DAIKIN_FAN_MAX, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_MAX);
+  EXPECT_EQ(DAIKIN_FAN_MAX, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_MAX + 1);
+  EXPECT_EQ(DAIKIN_FAN_MAX, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_MAX - 1);
+  EXPECT_EQ(DAIKIN_FAN_MAX - 1, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_MIN);
+  EXPECT_EQ(DAIKIN_FAN_MIN, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_MIN + 1);
+  EXPECT_EQ(DAIKIN_FAN_MIN + 1, irdaikin.getFan());
+
+  irdaikin.setFan(3);
+  EXPECT_EQ(3, irdaikin.getFan());
+
+  irdaikin.setFan(DAIKIN_FAN_AUTO);
+  EXPECT_EQ(DAIKIN_FAN_AUTO, irdaikin.getFan());
+}
+
+TEST(TestDaikinClass, MessageConstuction) {
+  IRDaikinESP irdaikin(0);
+  IRsendTest irsend(4);
+  irdaikin.begin();
+  irsend.begin();
+
+  irdaikin.setFan(DAIKIN_FAN_MIN);
+  irdaikin.setMode(DAIKIN_COOL);
+  irdaikin.setTemp(27);
+  irdaikin.setSwingVertical(false);
+  irdaikin.setSwingHorizontal(true);
+  irdaikin.setQuiet(false);
+  irdaikin.setPower(true);
+
+  // Check everything for kicks.
+  EXPECT_EQ(DAIKIN_FAN_MIN, irdaikin.getFan());
+  EXPECT_EQ(DAIKIN_COOL, irdaikin.getMode());
+  EXPECT_EQ(27, irdaikin.getTemp());
+  EXPECT_FALSE(irdaikin.getSwingVertical());
+  EXPECT_TRUE(irdaikin.getSwingHorizontal());
+  EXPECT_FALSE(irdaikin.getQuiet());
+  EXPECT_TRUE(irdaikin.getPower());
+
+  irsend.reset();
+  irsend.sendDaikin(irdaikin.getRaw());
+  EXPECT_EQ(
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s29428"
+      "m3650s1623"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
+      "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
+      "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s1280m428s428m428s428m428s428m428s1280m428s1280m428s428m428s428"
+      "m428s428m428s1280m428s1280m428s428m428s1280m428s1280m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s1280m428s1280m428s428m428s428"
+      "m428s1280m428s1280m428s1280m428s1280m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s1280m428s1280"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
+      "m428s428m428s428m428s428m428s1280m428s1280m428s1280m428s1280m428s428"
+      "m428s29428", irsend.outputStr());
+}


### PR DESCRIPTION
- Add unit tests for sendDaikin() and the IRDaikinESP class.
- Add additional methods to the IRDaikinESP class to bring it inline with
  similar A/C classes.
- Add some useful defines/constants for users and code style.
- Re-work how mode and temp are set.
- Support sending longer byte lengths, and repeats to sendDaikin().
  i.e. v2.0 spec.