### PR TITLE
Unit tests for and re-work of the Sanyo protocol(s).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ script:
   - test/ir_Whynter_test
   - test/ir_Aiwa_test
   - test/ir_Denon_test
+  - test/ir_Sanyo_test
 
 notifications:
   email:

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -306,6 +306,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   if (decodeCOOLIX(results))
     return true;
 #endif
+/* NOTE: Disabled due to poor quality.
 #if DECODE_SANYO
   // The Sanyo S866500B decoder is very poor quality & depricated.
   // *IF* you are going to enable it, do it near last to avoid false positive
@@ -316,6 +317,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   if (decodeSanyo(results))
     return true;
 #endif
+*/
 #endif  // UNIT_TEST
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -89,7 +89,7 @@ class IRrecv {
   bool matchSpace(uint32_t measured_ticks, uint32_t desired_us,
                   uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
   bool decodeHash(decode_results *results);
-#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501)
+#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || SEND_SANYO)
   bool decodeNEC(decode_results *results, uint16_t nbits = NEC_BITS,
                  bool strict = true);
 #endif
@@ -98,8 +98,10 @@ class IRrecv {
                   bool strict = false);
 #endif
 #if DECODE_SANYO
-  bool decodeSanyo(decode_results *results, uint16_t nbits = SANYO_SA8650B_BITS,
-                   bool strict = false);
+  // DISABLED due to poor quality.
+  // bool decodeSanyo(decode_results *results,
+  //                  uint16_t nbits = SANYO_SA8650B_BITS,
+  //                  bool strict = false);
   bool decodeSanyoLC7461(decode_results *results,
                          uint16_t nbits = SANYO_LC7461_BITS,
                          bool strict = true);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -78,7 +78,7 @@
 #define DECODE_LG            true
 #define SEND_LG              true
 
-#define DECODE_SANYO         false  // Broken.
+#define DECODE_SANYO         true
 #define SEND_SANYO           true
 
 #define DECODE_MITSUBISHI    true

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -39,7 +39,7 @@ class IRsend {
                 uint32_t zerospace, uint64_t data, uint16_t nbits,
                 bool MSBfirst = true);
   void send(uint16_t type, uint64_t data, uint16_t nbits);
-#if (SEND_NEC || SEND_SHERWOOD)
+#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = NEC_BITS, uint16_t repeat = 0);
   uint32_t encodeNEC(uint16_t address, uint16_t command);
 #endif
@@ -85,7 +85,7 @@ class IRsend {
                  uint16_t repeat = 0);
 #endif
 #if SEND_SANYO
-  uint64_t encodeSanyoLC7461(uint16_t address, uint16_t command);
+  uint64_t encodeSanyoLC7461(uint16_t address, uint8_t command);
   void sendSanyoLC7461(uint64_t data, uint16_t nbits = SANYO_LC7461_BITS,
                        uint16_t repeat = 0);
 #endif

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -32,7 +32,7 @@
     (NEC_HDR_MARK + NEC_HDR_SPACE + NEC_BITS * (NEC_BIT_MARK + NEC_ONE_SPACE) \
      + NEC_BIT_MARK)
 
-#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501)
+#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
 // Send a raw NEC(Renesas) formatted message.
 //
 // Args:
@@ -96,7 +96,7 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
 }
 #endif
 
-#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501)
+#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO)
 // Decode the supplied NEC message.
 //
 // Args:

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
-				ir_Aiwa_test ir_Denon_test
+				ir_Aiwa_test ir_Denon_test ir_Sanyo_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -247,3 +247,12 @@ ir_Denon_test.o : ir_Denon_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_H
 
 ir_Denon_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_Sharp.o ir_Panasonic.o ir_Denon_test.o ir_Denon.o gtest_main.a
 	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Sanyo.o : $(USER_DIR)/IRremoteESP8266.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h $(USER_DIR)/ir_Sanyo.cpp $(GTEST_HEADERS)
+	  $(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sanyo.cpp
+
+ir_Sanyo_test.o : ir_Sanyo_test.cpp $(USER_DIR)/IRremoteESP8266.h $(USER_DIR)/IRrecv.h $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sanyo_test.cpp
+
+ir_Sanyo_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_GlobalCache.o ir_NEC.o ir_Sanyo_test.o ir_Sanyo.o gtest_main.a
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Sanyo_test.cpp
+++ b/test/ir_Sanyo_test.cpp
@@ -1,0 +1,247 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+
+// Tests for encodeSanyoLC7461().
+
+TEST(TestEncodeSanyoLC7461, NormalEncoding) {
+  IRsendTest irsend(4);
+  EXPECT_EQ(0x1FFF00FF, irsend.encodeSanyoLC7461(0, 0));
+  EXPECT_EQ(0x3FFE01FE, irsend.encodeSanyoLC7461(1, 1));
+  EXPECT_EQ(0x3FFE02FD, irsend.encodeSanyoLC7461(1, 2));
+  EXPECT_EQ(0x3FFE000FF00, irsend.encodeSanyoLC7461(0x1FFF, 0xFF));
+  EXPECT_EQ(0x2AAAAAA55AA, irsend.encodeSanyoLC7461(0x1555, 0x55));
+  EXPECT_EQ(0x3FFE000FF00, irsend.encodeSanyoLC7461(0xFFFF, 0xFF));
+  EXPECT_EQ(0x1D8113F00FF, irsend.encodeSanyoLC7461(0xEC0, 0x0));
+}
+
+// Tests for sendSanyoLC7461().
+
+// Test sending typical data only.
+TEST(TestEncodeSanyoLC7461, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSanyoLC7461(0x1D8113F00FF);
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000", irsend.outputStr());
+}
+
+// Test sending with different repeats.
+TEST(TestEncodeSanyoLC7461, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSanyoLC7461(0x1D8113F00FF, SANYO_LC7461_BITS, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m9000s4500"
+      "m560s560m560s1690m560s1690m560s1690m560s560m560s1690m560s1690m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s1690m560s560m560s560"
+      "m560s560m560s1690m560s560m560s560m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s1690m560s1690m560s1690m560s1690m560s1690m560s1690"
+      "m560s1690m560s1690m560s108000"
+      "m9000s2250m560s108000", irsend.outputStr());
+}
+
+// Tests for decodeSanyoLC7461().
+
+// Decode normal Sanyo LC7461 messages.
+TEST(TestDecodeSanyoLC7461, NormalDecodeWithStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal Sanyo LC7461 42-bit message.
+  irsend.reset();
+  irsend.sendSanyoLC7461(0x1D8113F00FF);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                       true));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
+  EXPECT_EQ(0xEC0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Synthesised Normal Sanyo LC7461 42-bit message.
+  irsend.reset();
+  irsend.sendSanyoLC7461(irsend.encodeSanyoLC7461(0x1234, 0x56));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+              true));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x2468DCB56A9, irsend.capture.value);
+  EXPECT_EQ(0x1234, irsend.capture.address);
+  EXPECT_EQ(0x56, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  // Synthesised Normal Sanyo LC7461 42-bit message.
+  irsend.reset();
+  irsend.sendSanyoLC7461(irsend.encodeSanyoLC7461(0x1, 0x1));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                       true));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x3FFE01FE, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x1, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode normal repeated Sanyo LC7461 messages.
+TEST(TestDecodeSanyoLC7461, NormalDecodeWithRepeatAndStrict) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Normal Sanyo LC7461 16-bit message with 1 repeat.
+  irsend.reset();
+  irsend.sendSanyoLC7461(0x3FFE01FE, SANYO_LC7461_BITS, 1);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                       true));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x3FFE01FE, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x1, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Decode unsupported Sanyo LC7461 messages.
+TEST(TestDecodeSanyoLC7461, DecodeWithNonStrictValues) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSanyoLC7461(0x0);  // Illegal value Sanyo LC7461 message.
+  irsend.makeDecodeResult();
+  // Should fail with strict on.
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                        true));
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                       false));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x0, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  irsend.reset();
+  // Illegal value Sanyo LC7461 42-bit message.
+  irsend.sendSanyoLC7461(0x1234567890A);
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                        true));
+
+  // Should fail with strict when we ask for the wrong bit size.
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 32,
+                                        true));
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 64,
+                                        true));
+  // And should fail for a bad value.
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                        true));
+  // Should pass if strict off.
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+                                       false));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x1234567890A, irsend.capture.value);
+  EXPECT_EQ(0x91A, irsend.capture.address);
+  EXPECT_EQ(0x89, irsend.capture.command);
+
+  // Should pass if strict off and looking for a smaller size.
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, 34, false));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(34, irsend.capture.bits);
+  EXPECT_EQ(0x123456789, irsend.capture.value);
+  EXPECT_EQ(0x09, irsend.capture.address);
+  EXPECT_EQ(0x67, irsend.capture.command);
+}
+
+// Decode (non-standard) 64-bit messages.
+TEST(TestDecodeSanyoLC7461, Decode64BitMessages) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Illegal value & size Sanyo LC7461 64-bit message.
+  irsend.sendSanyoLC7461(0xFFFFFFFFFFFFFFFF, 64);
+  irsend.makeDecodeResult();
+  // Should work with a 'normal' match (not strict)
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, 64, false));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(64, irsend.capture.bits);
+  EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
+  EXPECT_EQ(0xFFFF, irsend.capture.address);
+  EXPECT_EQ(0xFF, irsend.capture.command);
+}
+
+// Decode a 'real' example via GlobalCache
+TEST(TestDecodeSanyoLC7461, DecodeGlobalCacheExample) {
+IRsendTest irsend(4);
+IRrecv irrecv(4);
+irsend.begin();
+
+irsend.reset();
+uint16_t gc_test[95] = {38000, 1, 89, 342, 171, 21, 21, 21, 64, 21, 64,
+                        21, 64, 21, 21, 21, 64, 21, 64, 21, 21, 21, 21,
+                        21, 21, 21, 21, 21, 21, 21, 21, 21, 64, 21, 21,
+                        21, 21, 21, 21, 21, 64, 21, 21, 21, 21, 21, 64,
+                        21, 64, 21, 64, 21, 64, 21, 64, 21, 64, 21, 21,
+                        21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
+                        21, 21, 21, 64, 21, 64, 21, 64, 21, 64, 21, 64,
+                        21, 64, 21, 64, 21, 64, 21, 875, 342, 171, 21, 3565};
+irsend.sendGC(gc_test, 95);
+irsend.makeDecodeResult();
+
+ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS, true));
+EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+EXPECT_EQ(SANYO_LC7461_BITS, irsend.capture.bits);
+EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
+EXPECT_EQ(0xEC0, irsend.capture.address);
+EXPECT_EQ(0x0, irsend.capture.command);
+EXPECT_FALSE(irsend.capture.repeat);
+
+// Confirm what the 42-bit NEC decode is.
+ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, 42, false));
+EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
+}
+
+// Fail to decode a non-Sanyo LC7461 example via GlobalCache
+TEST(TestDecodeSanyoLC7461, FailToDecodeNonSanyoLC7461Example) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+  // Modified a few entries to unexpected values, based on previous test case.
+  uint16_t gc_test[39] = {38000, 1, 1, 322, 162, 20, 61, 20, 61, 20, 20, 20, 20,
+                          20, 20, 20, 127, 20, 61, 9, 20, 20, 61, 20, 20, 20,
+                          61, 20, 61, 20, 61, 20, 20, 20, 20, 20, 20, 20, 884};
+  irsend.sendGC(gc_test, 39);
+  irsend.makeDecodeResult();
+
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture));
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, SANYO_LC7461_BITS,
+               false));
+}


### PR DESCRIPTION
- Unit tests for sendSanyoLC7461(), encodeSanyoLC7461, & decodeSanyoLC7461.
- As the protocol appears to be a NEC 42-bit varient, use send/decode NEC.
- Disable the dodgy decodeSanyo() until it gets fixed.