### PR TITLE
Add send support for Gree Heat Pumps to v2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
   - test/ir_Denon_test
   - test/ir_Sanyo_test
   - test/ir_Daikin_test
+  - test/ir_Gree_test
 
 notifications:
   email:

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -23,6 +23,8 @@
  * Mitsubishi A/C added by crankyoldgit
  *     (derived from https://github.com/r45635/HVAC-IR-Control)
  * DISH decode by marcosamarinho
+ * Gree Heatpump sending added by Ville Skyttä (scop)
+ *     (derived from https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp)
  * Updated by markszabo (https://github.com/markszabo/IRremoteESP8266) for sending IR code on ESP8266
  * Updated by Sebastien Warin (http://sebastien.warin.fr) for receiving IR code on ESP8266
  *
@@ -108,6 +110,8 @@
 #define DECODE_GLOBALCACHE   false  // Not written.
 #define SEND_GLOBALCACHE     true
 
+#define DECODE_GREE          false  // Not written.
+#define SEND_GREE            true
 /*
  * Always add to the end of the list and should never remove entries
  * or change order. Projects may save the type number for later usage
@@ -138,7 +142,8 @@ enum decode_type_t {
   MITSUBISHI_AC,
   RCMM,
   SANYO_LC7461,
-  RC5X
+  RC5X,
+  GREE
 };
 
 // Message lengths & required repeat values
@@ -152,6 +157,8 @@ enum decode_type_t {
 #define DENON_LEGACY_BITS           14U
 #define DISH_BITS                   16U
 #define DISH_MIN_REPEAT              3U
+#define GREE_STATE_LENGTH            8U
+#define GREE_BITS                   (GREE_STATE_LENGTH * 8)
 #define JVC_BITS                    16U
 #define KELVINATOR_STATE_LENGTH     16U
 #define LG_BITS                     28U

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -157,6 +157,11 @@ class IRsend {
   void sendAiwaRCT501(uint64_t data, uint16_t nbits = AIWA_RC_T501_BITS,
                       uint16_t repeat = AIWA_RC_T501_MIN_REPEAT);
 #endif
+#if SEND_GREE
+  void sendGree(uint64_t data, uint16_t nbits = GREE_BITS, uint16_t repeat = 0);
+  void sendGree(uint8_t data[], uint16_t nbytes = GREE_STATE_LENGTH,
+                uint16_t repeat = 0);
+#endif
 
  private:
   uint16_t onTimePeriod;

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -1,0 +1,113 @@
+// Copyright 2017 Ville Skyttä (scop)
+// Copyright 2017 David Conran
+//
+//  Gree protocol compatible heat pump carrying the "Ultimate" brand name.
+//
+
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+//                      GGGG  RRRRRR  EEEEEEE EEEEEEE
+//                     GG  GG RR   RR EE      EE
+//                    GG      RRRRRR  EEEEE   EEEEE
+//                    GG   GG RR  RR  EE      EE
+//                     GGGGGG RR   RR EEEEEEE EEEEEEE
+
+// Constants
+// Ref: https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.h
+#define GREE_HDR_MARK      9000U
+#define GREE_HDR_SPACE     4000U
+#define GREE_BIT_MARK       620U
+#define GREE_ONE_SPACE     1600U
+#define GREE_ZERO_SPACE     540U
+#define GREE_MSG_SPACE    19000U
+
+#if SEND_GREE
+// Send a Gree Heat Pump message.
+//
+// Args:
+//   data: An array of bytes containing the IR command.
+//   nbytes: Nr. of bytes of data in the array. (>=GREE_STATE_LENGTH)
+//   repeat: Nr. of times the message is to be repeated. (Default = 0).
+//
+// Status: ALPHA / Untested.
+//
+// Ref:
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp
+void IRsend::sendGree(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
+  if (nbytes < GREE_STATE_LENGTH)
+    return;  // Not enough bytes to send a proper message.
+
+  // Set IR carrier frequency
+  enableIROut(38);
+
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header #1
+    mark(GREE_HDR_MARK);
+    space(GREE_HDR_SPACE);
+
+    // Data #1
+    uint16_t i;
+    for (i = 0; i < 4 && i < nbytes; i++)
+      sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
+               data[i], 8, false);
+
+    // Footer #1 (010)
+    sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
+             0b010, 3);
+
+    // Header #2
+    mark(GREE_BIT_MARK);
+    space(GREE_MSG_SPACE);
+
+    // Data #2
+    for (; i < nbytes; i++)
+      sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
+               data[i], 8, false);
+
+    // Footer #2
+    mark(GREE_BIT_MARK);
+    space(GREE_MSG_SPACE);
+  }
+}
+
+// Send a Gree Heat Pump message.
+//
+// Args:
+//   data: The raw message to be sent.
+//   nbits: Nr. of bits of data in the message. (Default is GREE_BITS)
+//   repeat: Nr. of times the message is to be repeated. (Default = 0).
+//
+// Status: ALPHA / Untested.
+//
+// Ref:
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp
+void IRsend::sendGree(uint64_t data, uint16_t nbits, uint16_t repeat) {
+  if (nbits != GREE_BITS)
+    return;  // Wrong nr. of bits to send a proper message.
+  // Set IR carrier frequency
+  enableIROut(38);
+
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header
+    mark(GREE_HDR_MARK);
+    space(GREE_HDR_SPACE);
+
+    // Data
+    for (int16_t i = 8; i <= nbits; i += 8) {
+      sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
+               (data >> (nbits - i)) & 0xFF, 8, false);
+      if (i == nbits / 2) {
+        // Send the mid-message Footer.
+        sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
+                 0b010, 3);
+        mark(GREE_BIT_MARK);
+        space(GREE_MSG_SPACE);
+      }
+    }
+    // Footer
+    mark(GREE_BIT_MARK);
+    space(GREE_MSG_SPACE);
+  }
+}
+#endif  // SEND_GREE

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,7 +29,8 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
-				ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test
+				ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
+				ir_Gree_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -274,3 +275,12 @@ ir_Daikin_test.o : ir_Daikin_test.cpp $(USER_DIR)/ir_Daikin.h $(USER_DIR)/IRsend
 
 ir_Daikin_test : IRsend.o IRtimer.o IRutils.o ir_Daikin_test.o ir_Daikin.o gtest_main.a
 		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Gree.o : $(USER_DIR)/ir_Gree.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Gree.cpp
+
+ir_Gree_test.o : ir_Gree_test.cpp $(USER_DIR)/IRsend.h IRsend_test.h $(GTEST_HEADERS)
+		$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Gree_test.cpp
+
+ir_Gree_test : IRrecv.o IRsend.o IRtimer.o IRutils.o ir_Gree_test.o ir_Gree.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Gree_test.cpp
+++ b/test/ir_Gree_test.cpp
@@ -1,0 +1,192 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendGree().
+
+// Test sending typical data only.
+TEST(TestSendGreeChars, SendData) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t gree_code[GREE_STATE_LENGTH] = {
+      0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF};
+  irsend.reset();
+  irsend.sendGree(gree_code);
+  EXPECT_EQ(
+      "m9000s4000"
+      "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+      "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+      "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+      "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+      "m620s540m620s1600m620s540"
+      "m620s19000"
+      "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+      "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+      "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+      "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+      "m620s19000", irsend.outputStr());
+}
+
+TEST(TestSendGreeUint64, SendData) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendGree(0x1234567890ABCDEF);
+  EXPECT_EQ(
+      "m9000s4000"
+      "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+      "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+      "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+      "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+      "m620s540m620s1600m620s540"
+      "m620s19000"
+      "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+      "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+      "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+      "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+      "m620s19000", irsend.outputStr());
+}
+
+// Test sending with repeats.
+TEST(TestSendGreeChars, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  uint8_t gree_code[GREE_STATE_LENGTH] = {
+      0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF};
+  irsend.reset();
+
+  irsend.sendGree(gree_code, GREE_STATE_LENGTH, 1);
+  EXPECT_EQ(
+    "m9000s4000"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+    "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+    "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+    "m620s540m620s1600m620s540"
+    "m620s19000"
+    "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+    "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+    "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+    "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+    "m620s19000"
+    "m9000s4000"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+    "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+    "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+    "m620s540m620s1600m620s540"
+    "m620s19000"
+    "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+    "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+    "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+    "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+    "m620s19000", irsend.outputStr());
+}
+
+TEST(TestSendGreeUint64, SendWithRepeats) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendGree(0x1234567890ABCDEF, GREE_BITS, 1);
+  EXPECT_EQ(
+    "m9000s4000"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+    "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+    "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+    "m620s540m620s1600m620s540"
+    "m620s19000"
+    "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+    "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+    "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+    "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+    "m620s19000"
+    "m9000s4000"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+    "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+    "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+    "m620s540m620s1600m620s540"
+    "m620s19000"
+    "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+    "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+    "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+    "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+    "m620s19000", irsend.outputStr());
+}
+
+// Test sending atypical sizes.
+TEST(TestSendGreeChars, SendUnexpectedSizes) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  uint8_t gree_short_code[GREE_STATE_LENGTH - 1] = {
+      0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD};
+  uint8_t gree_long_code[GREE_STATE_LENGTH + 1] = {
+      0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF, 0x12};
+  irsend.reset();
+  irsend.sendGree(gree_short_code, GREE_STATE_LENGTH - 1);
+  ASSERT_EQ("", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendGree(gree_long_code, GREE_STATE_LENGTH + 1);
+  ASSERT_EQ(
+    "m9000s4000"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s540m620s540m620s1600m620s540m620s1600m620s1600m620s540m620s540"
+    "m620s540m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540"
+    "m620s540m620s540m620s540m620s1600m620s1600m620s1600m620s1600m620s540"
+    "m620s540m620s1600m620s540"
+    "m620s19000"
+    "m620s540m620s540m620s540m620s540m620s1600m620s540m620s540m620s1600"
+    "m620s1600m620s1600m620s540m620s1600m620s540m620s1600m620s540m620s1600"
+    "m620s1600m620s540m620s1600m620s1600m620s540m620s540m620s1600m620s1600"
+    "m620s1600m620s1600m620s1600m620s1600m620s540m620s1600m620s1600m620s1600"
+    "m620s540m620s1600m620s540m620s540m620s1600m620s540m620s540m620s540"
+    "m620s19000", irsend.outputStr());
+}
+
+TEST(TestSendGreeUint64, SendUnexpectedSizes) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendGree(0x1234567890ABCDEF, GREE_BITS - 1);
+  ASSERT_EQ("", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendGree(0x1234567890ABCDEF, GREE_BITS + 1);
+  ASSERT_EQ("", irsend.outputStr());
+}
+
+TEST(TestSendGree, CompareUint64ToCharResults) {
+  IRsendTest irsend_chars(4);
+  IRsendTest irsend_uint64(0);
+
+  uint8_t gree_code[GREE_STATE_LENGTH] = {
+      0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF};
+
+  irsend_chars.begin();
+  irsend_uint64.begin();
+
+  irsend_chars.reset();
+  irsend_uint64.reset();
+  irsend_chars.sendGree(gree_code);
+  irsend_uint64.sendGree(0x1234567890ABCDEF);
+  ASSERT_EQ(irsend_chars.outputStr(), irsend_uint64.outputStr());
+
+  uint8_t gree_zero_code[GREE_STATE_LENGTH] = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  irsend_chars.reset();
+  irsend_uint64.reset();
+  irsend_chars.sendGree(gree_zero_code);
+  irsend_uint64.sendGree((uint64_t) 0x0);
+  ASSERT_EQ(irsend_chars.outputStr(), irsend_uint64.outputStr());
+}


### PR DESCRIPTION
- Merge PR #226 (@scop) upstream to the v2.0 branch.
- v2.0-ify sendGree() by adding repeat and different bit/byte size support.
- Unit tests for sendGree().
- As char[8] fits into a uint64, make a version of sendGree() that
  supports being called with a uint64 rather than a char array. This gives
  users a more traditional interface if desired.