### PR TITLE
Add ability to invert the output of the GPIO.

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -20,10 +20,27 @@
 // sending IR code on ESP8266
 
 // IRsend ----------------------------------------------------------------------
-
-IRsend::IRsend(uint16_t IRsendPin) {
+// Create an IRsend object.
+//
+// Args:
+//   IRsendPin:  Which GPIO pin to use when sending an IR command.
+//   inverted:   *DANGER* Optional flag to invert the output. (default = false)
+//               e.g. LED is illuminated when GPIO is LOW rather than HIGH.
+//               Setting this to something other than the default could
+//               easily destroy your IR LED if you are overdriving it.
+//               Unless you *REALLY* know what you are doing, don't change this.
+// Returns:
+//   An IRsend object.
+IRsend::IRsend(uint16_t IRsendPin, bool inverted) {
   IRpin = IRsendPin;
   periodOffset = PERIOD_OFFSET;
+  if (inverted) {
+    outputOn = LOW;
+    outputOff = HIGH;
+  } else {
+    outputOn = HIGH;
+    outputOff = LOW;
+  }
 }
 
 // Enable the pin for output.
@@ -36,7 +53,7 @@ void IRsend::begin() {
 // Turn off the IR LED.
 void IRsend::ledOff() {
 #ifndef UNIT_TEST
-  digitalWrite(IRpin, LOW);
+  digitalWrite(IRpin, outputOff);
 #endif
 }
 
@@ -100,11 +117,11 @@ uint16_t IRsend::mark(uint16_t usec) {
 
   while (elapsed < usec) {  // Loop until we've met/exceeded our required time.
 #ifndef UNIT_TEST
-    digitalWrite(IRpin, HIGH);  // Turn the LED on.
+    digitalWrite(IRpin, outputOn);  // Turn the LED on.
     // Calculate how long we should pulse on for.
     // e.g. Are we to close to the end of our requested mark time (usec)?
     delayMicroseconds(std::min((uint32_t) onTimePeriod, usec - elapsed));
-    digitalWrite(IRpin, LOW);  // Turn the LED off.
+    digitalWrite(IRpin, outputOff);  // Turn the LED off.
 #endif
     counter++;
     if (elapsed + onTimePeriod >= usec)

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -28,7 +28,7 @@
 // Classes
 class IRsend {
  public:
-  explicit IRsend(uint16_t IRsendPin);
+  explicit IRsend(uint16_t IRsendPin, bool inverted = false);
   void begin();
   void enableIROut(uint32_t freq, uint8_t duty = DUTY_DEFAULT);
   VIRTUAL uint16_t mark(uint16_t usec);
@@ -157,6 +157,18 @@ class IRsend {
   void sendAiwaRCT501(uint64_t data, uint16_t nbits = AIWA_RC_T501_BITS,
                       uint16_t repeat = AIWA_RC_T501_MIN_REPEAT);
 #endif
+
+ protected:
+#ifdef UNIT_TEST
+#ifndef HIGH
+#define HIGH 0x1
+#endif
+#ifndef LOW
+#define LOW 0x0
+#endif
+#endif  // UNIT_TEST
+  uint8_t outputOn;
+  uint8_t outputOff;
 
  private:
   uint16_t onTimePeriod;

--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -63,3 +63,13 @@ TEST(TestSendData, SendOverLargeData) {
             "m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2m1s2",
             irsend.outputStr());
   }
+
+// Test inverting the output.
+TEST(TestIRSend, InvertedOutput) {
+  IRsendTest irsend(4, true);
+  irsend.begin();
+  irsend.sendData(1, 2, 3, 4, 0b1, 1, true);
+  EXPECT_EQ("s1m2", irsend.outputStr());
+  irsend.sendData(1, 2, 3, 4, 0b0, 1, true);
+  EXPECT_EQ("s3m4", irsend.outputStr());
+}

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -20,7 +20,7 @@ class IRsendTest: public IRsend {
   uint16_t rawbuf[RAW_BUF];
   decode_results capture;
 
-  explicit IRsendTest(uint16_t x) : IRsend(x) {
+  explicit IRsendTest(uint16_t x, bool i = false) : IRsend(x, i) {
     reset();
   }
 
@@ -34,7 +34,7 @@ class IRsendTest: public IRsend {
     if (last == 0 && output[0] == 0)
       return "";
     for (uint16_t i = 0; i <= last; i++) {
-      if (i & 1)  // Odd
+      if ((i & 1) != outputOff )  // Odd XOR outputOff
         result << "s";
       else
         result << "m";


### PR DESCRIPTION
i.e. IR LED off for mark signals, on for spaces.

Fixes issue #229 

@JZ-SmartThings, can please try this out on your hardware and let me know if it works as expected.