### PR TITLE
Add matching of an expected minimum gap at the end of a message.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -75,7 +75,7 @@ static void ICACHE_RAM_ATTR gpio_intr() {
 
   start = now;
   #define ONCE 0
-  os_timer_arm(&timer, 15, ONCE);
+  os_timer_arm(&timer, TIMEOUT_MS, ONCE);
 }
 #endif  // UNIT_TEST
 
@@ -343,6 +343,23 @@ bool IRrecv::match(uint32_t measured_ticks, uint32_t desired_us,
   DPRINTLN(ticksHigh(desired_us, tolerance));
   return (measured_ticks >= ticksLow(desired_us, tolerance) &&
           measured_ticks <= ticksHigh(desired_us, tolerance));
+}
+
+
+// Check if we match a pulse(measured_ticks) of at least desired_us within
+// +/-tolerance percent.
+//
+// Args:
+//   measured_ticks:  The recorded period of the signal pulse.
+//   desired_us:  The expected period (in useconds) we are matching against.
+//   tolerance:  A percentage expressed as an integer. e.g. 10 is 10%.
+//
+// Returns:
+//   Boolean: true if it matches, false if it doesn't.
+bool IRrecv::matchAtLeast(uint32_t measured_ticks, uint32_t desired_us,
+                          uint8_t tolerance) {
+  return measured_ticks >= ticksLow(std::min(desired_us, TIMEOUT_MS * 1000),
+                                    tolerance);
 }
 
 // Check if we match a mark signal(measured_ticks) with the desired_us within

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -30,6 +30,7 @@
 #define STATE_STOP     5U
 #define TOLERANCE     25U  // default percent tolerance in measurements
 #define USECPERTICK   50U  // microseconds per clock interrupt tick
+#define TIMEOUT_MS    15U  // How long before we give up wait for more data.
 
 // Use FNV hash algorithm: http://isthe.com/chongo/tech/comp/fnv/#FNV-param
 #define FNV_PRIME_32 16777619UL
@@ -84,6 +85,8 @@ class IRrecv {
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE);
   bool match(uint32_t measured_ticks, uint32_t desired_us,
              uint8_t tolerance = TOLERANCE);
+  bool matchAtLeast(uint32_t measured_ticks, uint32_t desired_us,
+                    uint8_t tolerance = TOLERANCE);
   bool matchMark(uint32_t measured_ticks, uint32_t desired_us,
                  uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
   bool matchSpace(uint32_t measured_ticks, uint32_t desired_us,

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -129,8 +129,10 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
   }
 
   // Footer
-  if (!matchMark(results->rawbuf[offset], COOLIX_BIT_MARK))
-      return false;
+  if (!matchMark(results->rawbuf[offset++], COOLIX_BIT_MARK))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], COOLIX_MIN_GAP))
+    return false;
 
   // Compliance
   uint64_t orig = data;  // Save a copy of the data.

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -130,7 +130,9 @@ bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits,  bool strict) {
   }
 
   // Footer
-  if (!matchMark(results->rawbuf[offset], JVC_BIT_MARK))
+  if (!matchMark(results->rawbuf[offset++], JVC_BIT_MARK))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], JVC_MIN_GAP))
     return false;
 
   // Success

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -168,6 +168,8 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
   // Footer
   if (!matchMark(results->rawbuf[offset++], LG_BIT_MARK))
     return false;
+  if (!matchAtLeast(results->rawbuf[offset], LG_MIN_GAP))
+    return false;
 
   // Repeat
   if (nbits >= LG32_BITS) {
@@ -187,6 +189,8 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
     if (!matchSpace(results->rawbuf[offset++], LG_RPT_SPACE))
       return false;
     if (!matchMark(results->rawbuf[offset++], LG_BIT_MARK))
+      return false;
+    if (!matchAtLeast(results->rawbuf[offset], LG_MIN_GAP))
       return false;
   }
 

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -105,7 +105,7 @@ bool IRrecv::decodeMitsubishi(decode_results *results, uint16_t nbits,
 
   // Data
   uint16_t actualBits;
-  for (actualBits = 0; offset < results->rawlen - 1; actualBits++, offset++) {
+  for (actualBits = 0; actualBits < nbits; actualBits++, offset++) {
     if (!matchMark(results->rawbuf[offset++], MITSUBISHI_BIT_MARK, 30))
       return false;
     if (matchSpace(results->rawbuf[offset], MITSUBISHI_ONE_SPACE))
@@ -116,7 +116,11 @@ bool IRrecv::decodeMitsubishi(decode_results *results, uint16_t nbits,
       break;
   }
 
-  // Footer is matched by the last iteration of the data loop.
+  // Footer
+  if (!matchMark(results->rawbuf[offset++], MITSUBISHI_BIT_MARK, 30))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], MITSUBISHI_MIN_GAP))
+    return false;
 
   // Compliance
   if (actualBits < nbits)

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -159,8 +159,10 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
       return false;
   }
   // Footer
-  if (!matchMark(results->rawbuf[offset], NEC_BIT_MARK))
+  if (!matchMark(results->rawbuf[offset++], NEC_BIT_MARK))
       return false;
+  if (!matchAtLeast(results->rawbuf[offset], NEC_MIN_GAP))
+    return false;
 
   // Compliance
   // Calculate command and optionally enforce integrity checking.

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -153,7 +153,9 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
       return false;
   }
   // Footer
-  if (!match(results->rawbuf[offset], PANASONIC_BIT_MARK))
+  if (!match(results->rawbuf[offset++], PANASONIC_BIT_MARK))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], PANASONIC_MIN_GAP))
     return false;
 
   // Compliance

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -139,7 +139,9 @@ bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
       return false;
   }
   // Footer decode
-  if (!matchMark(results->rawbuf[offset], RCMM_BIT_MARK))
+  if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], RCMM_MIN_GAP))
     return false;
 
   // Compliance

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -129,6 +129,8 @@ bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t nbits,
   // Footer
   if (!matchMark(results->rawbuf[offset++], SAMSUNG_BIT_MARK))
     return false;
+  if (!matchAtLeast(results->rawbuf[offset], SAMSUNG_MIN_GAP))
+    return false;
 
   // Compliance
 

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -209,6 +209,8 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
   // Footer
   if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
     return false;
+  if (!matchAtLeast(results->rawbuf[offset], SHARP_GAP))
+    return false;
 
   // Compliance
   if (strict) {
@@ -241,6 +243,8 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
     }
     // Footer
     if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
+      return false;
+    if (!matchAtLeast(results->rawbuf[offset], SHARP_GAP))
       return false;
 
     // Check that second_data has been inverted correctly.

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -112,7 +112,9 @@ bool IRrecv::decodeWhynter(decode_results *results, uint16_t nbits,
   }
 
   // Footer
-  if (!matchMark(results->rawbuf[offset], WHYNTER_BIT_MARK))
+  if (!matchMark(results->rawbuf[offset++], WHYNTER_BIT_MARK))
+    return false;
+  if (!matchAtLeast(results->rawbuf[offset], WHYNTER_MIN_GAP))
     return false;
 
   // Success

--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -101,7 +101,7 @@ TEST(TestSendRaw, GeneralUse) {
   irsend.reset();
   irsend.sendRaw(rawData, 67, 38);
   // Add some extra space at the end of the command to allow it to match.
-  irsend.addGap(10000);
+  irsend.addGap(22000);
   irsend.makeDecodeResult();
   EXPECT_EQ(
       "m8950s4500"
@@ -109,7 +109,7 @@ TEST(TestSendRaw, GeneralUse) {
       "m600s1650m600s1650m550s1700m550s550m600s550m550s550m600s500m600s550"
       "m550s1650m600s1650m600s1650m550s550m600s500m600s500m600s550m550s550"
       "m600s1650m550s1650m600s1650m600s500m650s1600m600s500m600s550m550s550"
-      "m600s10000", irsend.outputStr());
+      "m600s22000", irsend.outputStr());
   ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, NEC_BITS, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -235,8 +235,8 @@ TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
   irsend.reset();
   irsend.sendCOOLIX(0x12345678, 32);  // Illegal value Coolix 32-bit message.
   irsend.makeDecodeResult();
-  // Should pass with strict when we ask for less bits than we got.
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, COOLIX_BITS, true));
+  // Shouldn't pass with strict when we ask for less bits than we got.
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, COOLIX_BITS, true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.

--- a/test/ir_JVC_test.cpp
+++ b/test/ir_JVC_test.cpp
@@ -205,8 +205,8 @@ TEST(TestDecodeJVC, DecodeWithNonStrictValues) {
   irsend.reset();
   irsend.sendJVC(0x12345678, 32);  // Illegal value JVC 32-bit message.
   irsend.makeDecodeResult();
-  // Should pass with strict when we ask for less bits than we got.
-  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
+  // Should not pass with strict when we ask for less bits than we got.
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
@@ -224,13 +224,9 @@ TEST(TestDecodeJVC, DecodeWithNonStrictValues) {
   irsend.sendJVC(irsend.encodeJVC(2, 3), 36);
   irsend.makeDecodeResult();
 
-  // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, false));
-  EXPECT_EQ(JVC, irsend.capture.decode_type);
-  EXPECT_EQ(JVC_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x0, irsend.capture.value);  // We told it to expect 20 bits less.
-  EXPECT_EQ(0x00, irsend.capture.address);
-  EXPECT_EQ(0x00, irsend.capture.command);
+  // Shouldn't pass if strict off and the wrong expected bits.
+  ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, JVC_BITS, false));
+
   // Re-decode with correct bit size.
   ASSERT_FALSE(irrecv.decodeJVC(&irsend.capture, 36, true));
   ASSERT_TRUE(irrecv.decodeJVC(&irsend.capture, 36, false));

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -244,13 +244,7 @@ TEST(TestDecodeLG, DecodeWithNonStrictValues) {
   irsend.reset();
   irsend.sendLG(0x1111111, LG32_BITS);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, LG_BITS, false));
-  EXPECT_EQ(LG, irsend.capture.decode_type);
-  EXPECT_EQ(LG_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x111111, irsend.capture.value);
-  EXPECT_EQ(0x1, irsend.capture.address);
-  EXPECT_EQ(0x1111, irsend.capture.command);
-  EXPECT_FALSE(irsend.capture.repeat);
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, LG_BITS, false));
 }
 
 // Decode unsupported LG message sizes.
@@ -284,16 +278,9 @@ TEST(TestDecodeLG, DecodeWithNonStrictSizes) {
   irsend.makeDecodeResult();
   // Should fail when unexpected against different bit sizes.
   ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, LG_BITS, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, LG_BITS, false));
   ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, LG32_BITS, true));
   ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, LG32_BITS, false));
-
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, LG_BITS, false));
-  EXPECT_EQ(LG, irsend.capture.decode_type);
-  EXPECT_EQ(LG_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x1234567, irsend.capture.value);
-  EXPECT_EQ(0x12, irsend.capture.address);
-  EXPECT_EQ(0x3456, irsend.capture.command);
-  EXPECT_FALSE(irsend.capture.repeat);
 
   ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, 36, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -235,13 +235,8 @@ TEST(TestDecodeMitsubishi, DecodeWithNonStrictValues) {
   EXPECT_EQ(0xFEDCBA9876543210, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, 8, false));
-  EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
-  EXPECT_EQ(64, irsend.capture.bits);
-  EXPECT_EQ(0xFEDCBA9876543210, irsend.capture.value);
-  EXPECT_EQ(0x0, irsend.capture.address);
-  EXPECT_EQ(0x0, irsend.capture.command);
+  // Should fail when we are after a shorter message than we got.
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 8, false));
 }
 
 // Decode a 'real' example via GlobalCache

--- a/test/ir_NEC_test.cpp
+++ b/test/ir_NEC_test.cpp
@@ -178,16 +178,11 @@ TEST(TestDecodeNEC, ShortNECDecodeWithoutStrict) {
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 
-  // Expecting less than what was sent is valid.
+  // Expecting less than what was sent is not valid.
   irsend.reset();
   irsend.sendNEC(0x0, 32);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, 16, false));
-  EXPECT_EQ(NEC, irsend.capture.decode_type);
-  EXPECT_EQ(16, irsend.capture.bits);
-  EXPECT_EQ(0, irsend.capture.value);
-  EXPECT_EQ(0, irsend.capture.address);
-  EXPECT_EQ(0, irsend.capture.command);
+  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, 16, false));
 
   // Send 16 bits of data, but fail because we are expecting 17.
   irsend.reset();

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -327,13 +327,8 @@ TEST(TestDecodePanasonic, DecodeWithNonStrictSize) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, PANASONIC_BITS, true));
-  // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, PANASONIC_BITS, false));
-  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
-  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x4004010203, irsend.capture.value);
-  EXPECT_EQ(0x40, irsend.capture.address);
-  EXPECT_EQ(0x04010203, irsend.capture.command);
+  // Shouldn't pass if strict off and wrong bit size.
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, PANASONIC_BITS, false));
   // Re-decode with correct bit size.
   ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, 56, true));
   ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, 56, false));

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -176,13 +176,8 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   irsend.makeDecodeResult();
   // Should fail with strict on.
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, SAMSUNG_BITS, true));
-  // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, SAMSUNG_BITS, false));
-  EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
-  EXPECT_EQ(SAMSUNG_BITS, irsend.capture.bits);
-  EXPECT_EQ(0xF, irsend.capture.value);  // We told it to expect 4 bits less.
-  EXPECT_EQ(0x00, irsend.capture.address);
-  EXPECT_EQ(0x00, irsend.capture.command);
+  // Shouldn't pass if strict off and wrong expected bit size.
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, SAMSUNG_BITS, false));
   // Re-decode with correct bit size.
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, 36, true));
   ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 36, false));
@@ -201,7 +196,7 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   // And it should fail when we expect more bits.
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, SAMSUNG_BITS, false));
 
-  // Should pass if strict off if we ask for <= nr. of bits sent.
+  // Should pass if strict off if we ask for correct nr. of bits sent.
   ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 16, false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(16, irsend.capture.bits);
@@ -209,12 +204,8 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   EXPECT_EQ(0x00, irsend.capture.address);
   EXPECT_EQ(0x00, irsend.capture.command);
 
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 12, false));
-  EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
-  EXPECT_EQ(12, irsend.capture.bits);
-  EXPECT_EQ(0xF, irsend.capture.value);  // We told it to expect 8 bits less.
-  EXPECT_EQ(0x00, irsend.capture.address);
-  EXPECT_EQ(0x00, irsend.capture.command);
+  // Should fail as we are expecting less bits than there are.
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, 12, false));
 }
 
 // Decode (non-standard) 64-bit messages.

--- a/test/ir_Sanyo_test.cpp
+++ b/test/ir_Sanyo_test.cpp
@@ -168,13 +168,8 @@ TEST(TestDecodeSanyoLC7461, DecodeWithNonStrictValues) {
   EXPECT_EQ(0x91A, irsend.capture.address);
   EXPECT_EQ(0x89, irsend.capture.command);
 
-  // Should pass if strict off and looking for a smaller size.
-  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, 34, false));
-  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
-  EXPECT_EQ(34, irsend.capture.bits);
-  EXPECT_EQ(0x123456789, irsend.capture.value);
-  EXPECT_EQ(0x09, irsend.capture.address);
-  EXPECT_EQ(0x67, irsend.capture.command);
+  // Shouldn't pass if strict off and looking for a smaller size.
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 34, false));
 }
 
 // Decode (non-standard) 64-bit messages.

--- a/test/ir_Whynter_test.cpp
+++ b/test/ir_Whynter_test.cpp
@@ -194,8 +194,8 @@ TEST(TestDecodeWhynter, DecodeWithNonStrictSizes) {
   irsend.reset();
   irsend.sendWhynter(0x1234567890, 40);  // Illegal size Whynter 40-bit message.
   irsend.makeDecodeResult();
-  // Should pass with strict when we ask for less bits than we got.
-  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, WHYNTER_BITS, true));
+  // Shouldn't pass with strict when we ask for less bits than we got.
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, WHYNTER_BITS, true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.


### PR DESCRIPTION
Makes decoding more strict and should reduce the number of false positive
matches and wrong decodes.

Address some Issues found in #204