### PR TITLE
Fix decoding of real Panasonic codes.

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -10,6 +10,7 @@
  */
 
 #include <IRrecv.h>
+#include <IRutils.h>
 
 // an IR detector/demodulator is connected to GPIO pin 2
 uint16_t RECV_PIN = 2;
@@ -21,14 +22,6 @@ decode_results results;
 void setup() {
   Serial.begin(115200);
   irrecv.enableIRIn();  // Start the receiver
-}
-
-void serialPrintUint64Hex(uint64_t value) {
-  // Serial.print() can't handle printing long longs. (uint64_t)
-  // So we have to print the top and bottom halves separately.
-  if (value >> 32)
-    Serial.print((uint32_t) (value >> 32), HEX);
-  Serial.print((uint32_t) (value & 0xFFFFFFFF), HEX);
 }
 
 void dump(decode_results *results) {
@@ -60,7 +53,7 @@ void dump(decode_results *results) {
   } else if (results->decode_type == WHYNTER) {
     Serial.print("Decoded Whynter: ");
   }
-  serialPrintUint64Hex(results->value);
+  serialPrintUint64(results->value, 16);
   Serial.print(" (");
   Serial.print(results->bits, DEC);
   Serial.println(" bits)");
@@ -84,7 +77,7 @@ void dump(decode_results *results) {
 
 void loop() {
   if (irrecv.decode(&results)) {
-    serialPrintUint64Hex(results.value);
+    serialPrintUint64(results.value, 16);
     dump(&results);
     irrecv.resume();  // Receive the next value
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -58,10 +58,9 @@ void encoding(decode_results *results) {
 // Dump out the decode_results structure.
 //
 void dumpInfo(decode_results *results) {
-  if (results->overflow) {
-    Serial.println("IR code too long. Edit IRremoteInt.h and increase RAWBUF");
-    return;
-  }
+  if (results->overflow)
+    Serial.println("WARNING: IR code too long."
+                   "Edit IRrecv.h and increase RAWBUF");
 
   // Show Encoding standard
   Serial.print("Encoding  : ");

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -11,6 +11,7 @@
  */
 
 #include <IRrecv.h>
+#include <IRutils.h>
 
 // An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU
 // board).
@@ -25,16 +26,6 @@ void setup() {
   // Status message will be sent to the PC at 115200 baud
   Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
   irrecv.enableIRIn();  // Start the receiver
-}
-
-// Print a uint64_t in Hex, to the Serial interface.
-//
-void serialPrintUint64Hex(uint64_t value) {
-  // Serial.print() can't handle printing long longs. (uint64_t)
-  // So we have to print the top and bottom halves separately.
-  if (value >> 32)
-    Serial.print((uint32_t) (value >> 32), HEX);
-  Serial.print((uint32_t) (value & 0xFFFFFFFF), HEX);
 }
 
 // Display encoding type
@@ -79,7 +70,7 @@ void dumpInfo(decode_results *results) {
 
   // Show Code & length
   Serial.print("Code      : ");
-  serialPrintUint64Hex(results->value);
+  serialPrintUint64(results->value, 16);
   Serial.print(" (");
   Serial.print(results->bits, DEC);
   Serial.println(" bits)");
@@ -140,7 +131,7 @@ void dumpCode(decode_results *results) {
   Serial.print("  // ");
   encoding(results);
   Serial.print(" ");
-  serialPrintUint64Hex(results->value);
+  serialPrintUint64(results->value, 16);
 
   // Newline
   Serial.println("");
@@ -161,7 +152,7 @@ void dumpCode(decode_results *results) {
 
     // All protocols have data
     Serial.print("uint64_t  data = 0x");
-    serialPrintUint64Hex(results->value);
+    serialPrintUint64(results->value, 16);
     Serial.println(";");
   }
 }

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -28,3 +28,31 @@ uint64_t reverseBits(uint64_t input, uint16_t nbits) {
   // Merge any remaining unreversed bits back to the top of the reversed bits.
   return (input << nbits) | output;
 }
+
+// Print a uint64_t/unsigned long long to the Serial port
+// Serial.print() can't handle printing long longs. (uint64_t)
+//
+// Args:
+//   input: The value to print
+//   base: The output base.
+// Note: Based on Arduino's Print::printNumber()
+void serialPrintUint64(uint64_t input, uint8_t base) {
+  char buf[8 * sizeof(input) + 1];  // Assumes 8-bit chars plus zero byte.
+  char *str = &buf[sizeof(buf) - 1];
+
+  *str = '\0';
+
+  // prevent crash if called with base == 1
+  if (base < 2) base = 10;
+
+  do {
+    char c = input % base;
+    input /= base;
+
+    *--str = c < 10 ? c + '0' : c + 'A' - 10;
+  } while (input);
+
+#ifndef UNIT_TEST
+  Serial.print(str);
+#endif
+}

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -7,5 +7,6 @@
 #include <stdint.h>
 
 uint64_t reverseBits(uint64_t input, uint16_t nbits);
+void serialPrintUint64(uint64_t input, uint8_t base);
 
 #endif  // IRUTILS_H_

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -25,6 +25,7 @@
 #define PANASONIC_ONE_SPACE            1296U
 #define PANASONIC_ZERO_SPACE            432U
 #define PANASONIC_MIN_COMMAND_LENGTH 130000UL
+#define PANASONIC_END_GAP              5000U  // See issue #245
 #define PANASONIC_MIN_GAP ((uint32_t)(PANASONIC_MIN_COMMAND_LENGTH - \
     (PANASONIC_HDR_MARK + PANASONIC_HDR_SPACE + \
      PANASONIC_BITS * (PANASONIC_BIT_MARK + PANASONIC_ONE_SPACE) + \
@@ -156,7 +157,7 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   if (!match(results->rawbuf[offset++], PANASONIC_BIT_MARK))
     return false;
   if (offset <= results->rawlen &&
-      !matchAtLeast(results->rawbuf[offset], PANASONIC_MIN_GAP))
+      !matchAtLeast(results->rawbuf[offset], PANASONIC_END_GAP))
     return false;
 
   // Compliance

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -412,3 +412,46 @@ TEST(TestDecodePanasonic, FailToDecodeNonPanasonicExample) {
   ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture));
   ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, PANASONIC_BITS, false));
 }
+
+// Failing to decode Panasonic in Issue #245
+TEST(TestDecodePanasonic, DecodeIssue245) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  irsend.reset();
+
+  uint16_t rawData[100] = {3550, 1750, 500, 450, 500, 1300, 500, 450, 500, 450,
+                          500, 450, 500, 450, 500, 450, 500, 450, 500, 450,
+                          500, 450, 500, 450, 500, 450, 500, 450, 500, 1300,
+                          500, 450, 500, 450, 500, 450, 500, 450, 500, 450,
+                          500, 450, 500, 450, 500, 450, 500, 450, 500, 1300,
+                          500, 450, 500, 450, 500, 450, 500, 450, 500, 450,
+                          500, 450, 500, 450, 500, 450, 500, 1300, 500, 450,
+                          500, 1300, 500, 1300, 500, 1300, 500, 1300, 500, 450,
+                          500, 450, 500, 1300, 500, 450, 500, 1300, 500, 1300,
+                          500, 1300, 500, 1300, 500, 450, 500, 1300, 500, 5000};
+
+  irsend.sendRaw(rawData, 100, 37);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture));
+  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
+  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x40040100BCBD, irsend.capture.value);
+  EXPECT_EQ(0x4004, irsend.capture.address);
+  EXPECT_EQ(0x100BCBD, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.reset();
+  irsend.sendRaw(rawData, 99, 37);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
+  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x40040100BCBD, irsend.capture.value);
+  EXPECT_EQ(0x4004, irsend.capture.address);
+  EXPECT_EQ(0x100BCBD, irsend.capture.command);
+  EXPECT_FALSE(irsend.capture.repeat);
+}


### PR DESCRIPTION
- Should fix Issue #245
- Add tests to cover the issue found.
- [bugfix] Add real-life values for the gap at the end of a panasonic command when decoding.
- [bugfix] uint64 print routine in the examples was subtly broken. Implement new version.
- Adjust overflow warning in IRrecvDumpV2. Make it a warning and no longer fatal.