### PR TITLE
Handle the end of a capture better, plus more debug code.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -358,6 +358,22 @@ bool IRrecv::match(uint32_t measured_ticks, uint32_t desired_us,
 //   Boolean: true if it matches, false if it doesn't.
 bool IRrecv::matchAtLeast(uint32_t measured_ticks, uint32_t desired_us,
                           uint8_t tolerance) {
+  DPRINT("Matching ATLEAST ");
+  DPRINT(measured_ticks * USECPERTICK);
+  DPRINT(" vs ");
+  DPRINT(desired_us);
+  DPRINT(". Matching: ");
+  DPRINT(measured_ticks);
+  DPRINT(" >= ");
+  DPRINT(ticksLow(std::min(desired_us, TIMEOUT_MS * 1000), tolerance));
+  DPRINT(" [min(");
+  DPRINT(ticksLow(desired_us, tolerance));
+  DPRINT(", ");
+  DPRINT(ticksLow(TIMEOUT_MS * 1000, tolerance));
+  DPRINTLN(")]");
+  // We really should never get a value of 0, except as the last value
+  // in the buffer. If that is the case, then assume infinity and return true.
+  if (measured_ticks == 0) return true;
   return measured_ticks >= ticksLow(std::min(desired_us, TIMEOUT_MS * 1000),
                                     tolerance);
 }

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -131,7 +131,7 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
   // Footer
   if (!matchMark(results->rawbuf[offset++], COOLIX_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], COOLIX_MIN_GAP))
     return false;
 

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -132,7 +132,7 @@ bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits,  bool strict) {
   // Footer
   if (!matchMark(results->rawbuf[offset++], JVC_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], JVC_MIN_GAP))
     return false;
 

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -168,7 +168,7 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
   // Footer
   if (!matchMark(results->rawbuf[offset++], LG_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], LG_MIN_GAP))
     return false;
 
@@ -191,7 +191,8 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
       return false;
     if (!matchMark(results->rawbuf[offset++], LG_BIT_MARK))
       return false;
-    if (!matchAtLeast(results->rawbuf[offset], LG_MIN_GAP))
+    if (offset < results->rawlen &&
+        !matchAtLeast(results->rawbuf[offset], LG_MIN_GAP))
       return false;
   }
 

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -119,7 +119,7 @@ bool IRrecv::decodeMitsubishi(decode_results *results, uint16_t nbits,
   // Footer
   if (!matchMark(results->rawbuf[offset++], MITSUBISHI_BIT_MARK, 30))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], MITSUBISHI_MIN_GAP))
     return false;
 

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -156,7 +156,7 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   // Footer
   if (!match(results->rawbuf[offset++], PANASONIC_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], PANASONIC_END_GAP))
     return false;
 

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -141,7 +141,7 @@ bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
   // Footer decode
   if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], RCMM_MIN_GAP))
     return false;
 

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -129,7 +129,7 @@ bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t nbits,
   // Footer
   if (!matchMark(results->rawbuf[offset++], SAMSUNG_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], SAMSUNG_MIN_GAP))
     return false;
 

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -209,7 +209,7 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
   // Footer
   if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], SHARP_GAP))
     return false;
 
@@ -245,7 +245,8 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
     // Footer
     if (!match(results->rawbuf[offset++], SHARP_BIT_MARK))
       return false;
-    if (!matchAtLeast(results->rawbuf[offset], SHARP_GAP))
+    if (offset < results->rawlen &&
+        !matchAtLeast(results->rawbuf[offset], SHARP_GAP))
       return false;
 
     // Check that second_data has been inverted correctly.

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -114,7 +114,7 @@ bool IRrecv::decodeWhynter(decode_results *results, uint16_t nbits,
   // Footer
   if (!matchMark(results->rawbuf[offset++], WHYNTER_BIT_MARK))
     return false;
-  if (offset <= results->rawlen &&
+  if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], WHYNTER_MIN_GAP))
     return false;
 

--- a/test/ir_NEC_test.cpp
+++ b/test/ir_NEC_test.cpp
@@ -248,4 +248,13 @@ TEST(TestDecodeNEC, NoTrailingGap_Issue243) {
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);
   EXPECT_EQ(0x4BB640BF, irsend.capture.value);
+
+  // Add a zero length space to the message to test how it handles that as
+  // a end of command gap.
+  irsend.addGap(0);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x4BB640BF, irsend.capture.value);
 }


### PR DESCRIPTION
- [bug] Issue #243 uncovered an odd case where a zero length end gap is encountered.
- Add unit test to cover zero length space at the end.
- Add more debugging code for matchAtLeast()
- [bug] fix incorrect end of buffer calculation in decodes