### PR TITLE
Initial support for sending Pronto IR codes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - arduino --verify --board $BD $PWD/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+  - arduino --verify --board $BD $PWD/examples/IRsendProntoDemo/IRsendProntoDemo.ino
   # Check for lint issues.
   - shopt -s nullglob
   - python cpplint.py --extensions=c,cc,cpp,ino --headers=h,hpp {src,test}/*.{h,c,cc,cpp,hpp,ino} examples/*/*.{h,c,cc,cpp,hpp,ino}

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
   - test/ir_Daikin_test
   - test/ir_Gree_test
   - test/IRrecv_test
+  - test/ir_Pronto_test
 
 notifications:
   email:

--- a/examples/IRsendProntoDemo/IRsendProntoDemo.ino
+++ b/examples/IRsendProntoDemo/IRsendProntoDemo.ino
@@ -1,0 +1,101 @@
+/* IRremoteESP8266: IRsendProntoDemo
+ * Copyright 2017 David Conran
+ *
+ * Demonstrates sending Pronto codes with IRsend.
+ *
+ * Version 1.0 June, 2017
+ *
+ * An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2), unless you
+ * change the irsend() value below.
+ *
+ * TL;DR: The IR LED needs to be driven by a transistor for a good result.
+ *
+ * Suggested circuit:
+ *     https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
+ *
+ * Common mistakes & tips:
+ *   * Don't just connect the IR LED directly to the pin, it won't
+ *     have enough current to drive the IR LED effectively.
+ *   * Make sure you have the IR LED polarity correct.
+ *     See: https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity
+ *   * Typical digital camera/phones can be used to see if the IR LED is flashed.
+ *     Replace the IR LED with a normal LED if you don't have a digital camera
+ *     when debugging.
+ *   * Avoid using the following pins unless you really know what you are doing:
+ *     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
+ *     * Pin 1/TX/TXD0: Any serial transmissions from the ESP8266 will interfere.
+ *     * Pin 3/RX/RXD0: Any serial transmissions to the ESP8266 will interfere.
+ *   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
+ *     for your first time. e.g. ESP-12 etc.
+ */
+#include <IRremoteESP8266.h>
+#include <IRsend.h>
+
+IRsend irsend(4);  // an IR led is connected to GPIO pin 4 (D2)
+
+// Panasonic Plasma TV Descrete code (Power On).
+// Acquired from:
+//   https://irdb.globalcache.com/
+// e.g.
+// 0000 006D 0000 0022 00ac 00ac 0016 0040 0016 0040 0016 0040 0016 0015 0016
+// 0015 0016 0015 0016 0015 0016 0015 0016 0040 0016 0040 0016 0040 0016 0015
+// 0016 0015 0016 0015 0016 0015 0016 0015 0016 0040 0016 0015 0016 0015 0016
+// 0040 0016 0040 0016 0015 0016 0015 0016 0040 0016 0015 0016 0040 0016 0040
+// 0016 0015 0016 0015 0016 0040 0016 0040 0016 0015 0016 071c
+//
+// Or the equiv. of sendSamsung(0xE0E09966);
+uint16_t samsungProntoCode[72] = {
+    0x0000, 0x006D, 0x0000, 0x0022,
+    0x00ac, 0x00ac, 0x0016, 0x0040, 0x0016, 0x0040, 0x0016, 0x0040,
+    0x0016, 0x0015, 0x0016, 0x0015, 0x0016, 0x0015, 0x0016, 0x0015,
+    0x0016, 0x0015, 0x0016, 0x0040, 0x0016, 0x0040, 0x0016, 0x0040,
+    0x0016, 0x0015, 0x0016, 0x0015, 0x0016, 0x0015, 0x0016, 0x0015,
+    0x0016, 0x0015, 0x0016, 0x0040, 0x0016, 0x0015, 0x0016, 0x0015,
+    0x0016, 0x0040, 0x0016, 0x0040, 0x0016, 0x0015, 0x0016, 0x0015,
+    0x0016, 0x0040, 0x0016, 0x0015, 0x0016, 0x0040, 0x0016, 0x0040,
+    0x0016, 0x0015, 0x0016, 0x0015, 0x0016, 0x0040, 0x0016, 0x0040,
+    0x0016, 0x0015, 0x0016, 0x071c
+};
+
+// Panasonic Plasma TV Descrete code (Power On).
+// Acquired from:
+//   ftp://ftp.panasonic.com/pub/panasonic/drivers/monitors/Discrete-remote-control-codesProntoCCFformat.pdf
+// e.g.
+// 0000 0071 0000 0032 0080 003F 0010 0010 0010 0030 0010 0010 0010 0010 0010
+// 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010
+// 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010
+// 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010
+// 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010
+// 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0010 0010 0010 0010 0030
+// 0010 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0030 0010 0A98
+//
+// Or the equiv. of sendPanasonic64(0x400401007C7D);
+uint16_t panasonicProntoCode[104] = {
+    0x0000, 0x0071, 0x0000, 0x0032,
+    0x0080, 0x003F, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0030, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0030,
+    0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0010,
+    0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0030,
+    0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0010,
+    0x0010, 0x0030, 0x0010, 0x0A98};
+
+void setup() {
+  irsend.begin();
+  Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
+}
+
+void loop() {
+  Serial.println("Sending a Samsung TV 'on' command.");
+  irsend.sendPronto(samsungProntoCode, 72);
+  delay(2000);
+  Serial.println("Sending a Panasonic Plasma TV 'on' command.");
+  irsend.sendPronto(panasonicProntoCode, 104);
+  delay(2000);
+}

--- a/examples/IRsendProntoDemo/platformio.ini
+++ b/examples/IRsendProntoDemo/platformio.ini
@@ -1,0 +1,17 @@
+[platformio]
+lib_extra_dirs = ../../
+src_dir=.
+
+[common]
+build_flags =
+lib_deps_builtin =
+lib_deps_external =
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -20,6 +20,7 @@
           (from https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp)
  * Kelvinator A/C and Sherwood added by crankyoldgit
  * Mitsubishi (TV) sending added by crankyoldgit
+ * Pronto code sending added by crankyoldgit
  * Mitsubishi A/C added by crankyoldgit
  *     (derived from https://github.com/r45635/HVAC-IR-Control)
  * DISH decode by marcosamarinho
@@ -115,6 +116,10 @@
 
 #define DECODE_GREE          false  // Not written.
 #define SEND_GREE            true
+
+#define DECODE_PRONTO        false  // Not written.
+#define SEND_PRONTO          true
+
 /*
  * Always add to the end of the list and should never remove entries
  * or change order. Projects may save the type number for later usage
@@ -146,7 +151,8 @@ enum decode_type_t {
   RCMM,
   SANYO_LC7461,
   RC5X,
-  GREE
+  GREE,
+  PRONTO
 };
 
 // Message lengths & required repeat values
@@ -174,6 +180,7 @@ enum decode_type_t {
 #define NEC_BITS                    32U
 #define PANASONIC_BITS              48U
 #define PANASONIC_MANUFACTURER   0x4004ULL
+#define PRONTO_MIN_LENGTH            6U
 #define RC5_RAW_BITS                14U
 #define RC5_BITS      RC5_RAW_BITS - 2U
 #define RC5X_BITS     RC5_RAW_BITS - 1U

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -60,13 +60,17 @@ void IRsend::ledOff() {
 //
 // Args:
 //   freq: Frequency in Hz.
+//   use_offset: Should we use the calculated offset or not?
 // Returns:
 //   nr. of uSeconds.
-uint32_t IRsend::calcUSecPeriod(uint32_t hz) {
+uint32_t IRsend::calcUSecPeriod(uint32_t hz, bool use_offset) {
   if (hz == 0) hz = 1;  // Avoid Zero hz. Divide by Zero is nasty.
   uint32_t period = (1000000UL + hz/2) / hz;  // The equiv of round(1000000/hz).
   // Apply the offset and ensure we don't result in a <= 0 value.
-  return std::max((uint32_t) 1, period + periodOffset);
+  if (use_offset)
+    return std::max((uint32_t) 1, period + periodOffset);
+  else
+    return std::max((uint32_t) 1, period);
 }
 
 // Set the output frequency modulation and duty cycle.

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -162,6 +162,9 @@ class IRsend {
   void sendGree(uint8_t data[], uint16_t nbytes = GREE_STATE_LENGTH,
                 uint16_t repeat = 0);
 #endif
+#if SEND_PRONTO
+  void sendPronto(uint16_t data[], uint16_t len, uint16_t repeat = 0);
+#endif
 
  protected:
 #ifdef UNIT_TEST
@@ -181,7 +184,7 @@ class IRsend {
   uint16_t IRpin;
   int8_t periodOffset;
   void ledOff();
-  uint32_t calcUSecPeriod(uint32_t hz);
+  uint32_t calcUSecPeriod(uint32_t hz, bool use_offset = true);
 };
 
 #endif  // IRSEND_H_

--- a/src/ir_Pronto.cpp
+++ b/src/ir_Pronto.cpp
@@ -1,0 +1,109 @@
+// Copyright 2017 David Conran
+
+#include <algorithm>
+#include "IRsend.h"
+#include "IRtimer.h"
+
+//                PPPPPP                        tt
+//                PP   PP rr rr   oooo  nn nnn  tt     oooo
+//                PPPPPP  rrr  r oo  oo nnn  nn tttt  oo  oo
+//                PP      rr     oo  oo nn   nn tt    oo  oo
+//                PP      rr      oooo  nn   nn  tttt  oooo
+
+// Constants
+#define PRONTO_FREQ_FACTOR      0.241246
+#define PRONTO_TYPE_OFFSET             0U
+#define PRONTO_FREQ_OFFSET             1U
+#define PRONTO_SEQ_1_LEN_OFFSET        2U
+#define PRONTO_SEQ_2_LEN_OFFSET        3U
+#define PRONTO_DATA_OFFSET             4U
+
+#if SEND_PRONTO
+// Send a Pronto Code formatted message.
+//
+// Args:
+//   data: An array of uint16_t containing the pronto codes.
+//   len: Nr. of entries in the data[] array.
+//   repeat: Nr. of times to repeat the message.
+//
+// Status: ALPHA / Not tested in the real world.
+//
+// Note:
+//   Pronto codes are typically represented in hexidecimal.
+//   You will need to convert the code to an array of integers, and calculate
+//   it's length.
+//   e.g.
+//      A Sony 20 bit DVD remote command.
+//      "0000 0067 0000 0015 0060 0018 0018 0018 0030 0018 0030 0018 0030 0018
+//       0018 0018 0030 0018 0018 0018 0018 0018 0030 0018 0018 0018 0030 0018
+//       0030 0018 0030 0018 0018 0018 0018 0018 0030 0018 0018 0018 0018 0018
+//       0030 0018 0018 03f6"
+//
+//   converts to:
+//
+//       uint16_t prontoCode[46] = {
+//           0x0000, 0x0067, 0x0000, 0x0015,
+//           0x0060, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018, 0x0030, 0x0018,
+//           0x0030, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018,
+//           0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018,
+//           0x0030, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+//           0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018,
+//           0x0018, 0x03f6};
+//       // Send the Pronto(Sony) code. Repeat twice as Sony's require that.
+//       sendPronto(prontoCode, 46, SONY_MIN_REPEAT);
+//
+// Ref:
+//   http://www.etcwiki.org/wiki/Pronto_Infrared_Format
+//   http://www.remotecentral.com/features/irdisp2.htm
+void IRsend::sendPronto(uint16_t data[], uint16_t len, uint16_t repeat) {
+  // Check we have enough data to work out what to send.
+  if (len < PRONTO_MIN_LENGTH) return;
+
+  // We only know how to deal with 'raw' pronto codes types. Reject all others.
+  if (data[PRONTO_TYPE_OFFSET] != 0) return;
+
+  // Pronto frequency is in Hz.
+  uint16_t hz = (uint16_t) (1000000U / (data[PRONTO_FREQ_OFFSET] *
+                                        PRONTO_FREQ_FACTOR));
+  enableIROut(hz);
+
+  // Grab the length of the two sequences.
+  uint16_t seq_1_len = data[PRONTO_SEQ_1_LEN_OFFSET] * 2;
+  uint16_t seq_2_len = data[PRONTO_SEQ_2_LEN_OFFSET] * 2;
+  // Calculate where each sequence starts in the buffer.
+  uint16_t seq_1_start = PRONTO_DATA_OFFSET;
+  uint16_t seq_2_start = PRONTO_DATA_OFFSET + seq_1_len;
+
+  uint32_t periodic_time = calcUSecPeriod(hz, false);
+
+  // Normal (1st sequence) case.
+  // Is there a first (normal) sequence to send?
+  if (seq_1_len > 0) {
+    // Check we have enough data to send the complete first sequence.
+    if (seq_1_len + seq_1_start > len) return;
+    // Send the contents of the 1st sequence.
+    for (uint16_t i = seq_1_start; i < seq_1_start + seq_1_len; i += 2) {
+      mark(data[i] * periodic_time);
+      space(data[i + 1] * periodic_time);
+    }
+  } else {
+    // There was no first sequence to send, it is implied that we have to send
+    // the 2nd/repeat sequence an additional time. i.e. At least once.
+    repeat++;
+  }
+
+  // Repeat (2nd sequence) case.
+  // Is there a second (repeat) sequence to be sent?
+  if (seq_2_len > 0) {
+    // Check we have enough data to send the complete second sequence.
+    if (seq_2_len + seq_2_start > len) return;
+
+    // Send the contents of the 2nd sequence.
+    for (uint16_t r = 0; r < repeat; r++)
+      for (uint16_t i = seq_2_start; i < seq_2_start + seq_2_len; i += 2) {
+        mark(data[i] * periodic_time);
+        space(data[i + 1] * periodic_time);
+      }
+  }
+}
+#endif

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -142,10 +142,7 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
     // The gap after a Sony packet for a repeat should be SONY_MIN_GAP or
     //   (SONY_RPT_LENGTH - timeSoFar) according to the spec.
     if (matchSpace(results->rawbuf[offset], SONY_MIN_GAP) ||
-  #ifdef UNIT_TEST
-        matchSpace(results->rawbuf[offset], SONY_RPT_LENGTH) ||
-  #endif
-        matchSpace(results->rawbuf[offset], SONY_RPT_LENGTH - timeSoFar))
+        matchAtLeast(results->rawbuf[offset], SONY_RPT_LENGTH - timeSoFar))
       break;  // Found a repeat space.
     timeSoFar += results->rawbuf[offset] * USECPERTICK;
     if (!matchSpace(results->rawbuf[offset++], SONY_SPACE))

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
 				ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
-				ir_Gree_test IRrecv_test
+				ir_Gree_test IRrecv_test ir_Pronto_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -54,7 +54,7 @@ GTEST_SRCS_ = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_LG.o ir_Mitsubishi.o ir_Sharp.o ir_Sanyo.o ir_Denon.o ir_Dish.o \
 					  ir_Panasonic.o ir_Whynter.o ir_Coolix.o ir_Aiwa.o ir_Sherwood.o \
-						ir_Kelvinator.o ir_Daikin.o ir_Gree.o
+						ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
              $(PROTOCOLS) gtest_main.a
@@ -303,4 +303,13 @@ ir_Gree_test.o : ir_Gree_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Gree_test.cpp
 
 ir_Gree_test : $(COMMON_OBJ) ir_Gree_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Pronto.o : $(USER_DIR)/ir_Pronto.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Pronto.cpp
+
+ir_Pronto_test.o : ir_Pronto_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Pronto_test.cpp
+
+ir_Pronto_test : $(COMMON_OBJ) ir_Pronto_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Pronto_test.cpp
+++ b/test/ir_Pronto_test.cpp
@@ -1,0 +1,358 @@
+// Copyright 2017 David Conran
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendPronto().
+
+TEST(TestSendPronto, CodeTooShort) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // Less entries than the smallest possible (practical) Pronto code.
+  uint16_t pronto_test[5] = {0x0000, 0x0067, 0x0034, 0x0000, 0x0000};
+  irsend.sendPronto(pronto_test, 5);
+  EXPECT_EQ("", irsend.outputStr());  // Should do nothing.
+}
+
+TEST(TestSendPronto, NormalSequenceTooLong) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // The First 'Normal' sequence is declared to be longer than the data we have.
+  uint16_t pronto_test[6] = {0x0000, 0x0067, 0x0010, 0x0000, 0x0000, 0x0000};
+  irsend.sendPronto(pronto_test, 6);
+  EXPECT_EQ("", irsend.outputStr());  // Should do nothing.
+}
+
+TEST(TestSendPronto, RepeatSequenceTooLong) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // The 2nd 'Repeat' sequence is declared to be longer than the data we have.
+  uint16_t pronto_test[6] = {0x0000, 0x0067, 0x0000, 0x0010, 0x0000, 0x0000};
+  irsend.sendPronto(pronto_test, 6);
+  EXPECT_EQ("", irsend.outputStr());  // Should do nothing.
+}
+
+TEST(TestSendPronto, BothSequencesTooLong) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // All sequences are declared to be longer than the data we have.
+  uint16_t pronto_test[6] = {0x0000, 0x0067, 0x0010, 0x0010, 0x0000, 0x0000};
+  irsend.sendPronto(pronto_test, 6);
+  EXPECT_EQ("", irsend.outputStr());  // Should do nothing.
+}
+
+TEST(TestSendPronto, MoreDataThanNeededInNormal) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // We should handle when we are given more data than needed. (normal seq.)
+  uint16_t pronto_test[8] = {0x0000, 0x0067, 0x0001, 0x0000,
+                             0x0001, 0x0002, 0x0003, 0x0004};
+  irsend.sendPronto(pronto_test, 8);
+  EXPECT_EQ("m25s50", irsend.outputStr());  // Only send the data required.
+}
+
+TEST(TestSendPronto, MoreDataThanNeededInRepeat) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // We should handle when we are given more data than needed. (repeat seq.)
+  uint16_t pronto_test[8] = {0x0000, 0x0067, 0x0000, 0x0001,
+                             0x0001, 0x0002, 0x0003, 0x0004};
+  irsend.sendPronto(pronto_test, 8);
+  EXPECT_EQ("m25s50", irsend.outputStr());  // Only send the data required.
+}
+
+TEST(TestSendPronto, MoreDataThanNeededInBoth) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  // We should handle when we are given more data than needed. (repeat seq.)
+  uint16_t pronto_test[10] = {0x0000, 0x0067, 0x0001, 0x0001,
+                              0x0001, 0x0002, 0x0003, 0x0004, 0x5, 0x6};
+  irsend.sendPronto(pronto_test, 10);
+  EXPECT_EQ("m25s50", irsend.outputStr());  // Only send the data required.
+  irsend.sendPronto(pronto_test, 10, 1);
+  EXPECT_EQ("m25s50m75s100", irsend.outputStr());  // Only the data required.
+}
+
+TEST(TestSendPronto, ShortestValidCodeThatSendsNothing) {
+  IRsendTest irsend(4);
+  irsend.begin();
+  irsend.reset();
+
+  uint16_t pronto_test[6] = {0x0000, 0x0067, 0x0000, 0x0000, 0x0001, 0x0002};
+  irsend.sendPronto(pronto_test, 6);
+  EXPECT_EQ("", irsend.outputStr());  // Nothing Happens.
+  irsend.sendPronto(pronto_test, 6, 1);
+  EXPECT_EQ("", irsend.outputStr());  // Twice as much Nothing Happens. ;-)
+}
+
+// Test sending a Pronto code that only has a normal (first) sequence.
+// i.e. No Pronto repeat sequence.
+TEST(TestSendPronto, NonRepeatingCode) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // A random Pronto code I found on the Internet that has no repeat sequence.
+  // It was an example of a poor Pronto code.
+  // It turned out to be a 4 copies of a Sony 12-bit code. Who knew!?!
+  uint16_t pronto_test[108] = {
+      0x0000, 0x0067, 0x0034, 0x0000,
+      0x0060, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0452, 0x0060, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0452, 0x0060, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0452, 0x0060, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018,
+      0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018};
+
+  // Send the Pronto code without any repeats set.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 108);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s600", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x10, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+
+  // Now try repeating it.
+  // As it has no repeat sequence, we shouldn't repeat it. (I think)
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 108, 3);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s27650"
+      "m2400s600"
+      "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
+      "m600s600m600s600m600s600m600s600", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x10, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
+}
+
+// Test sending a Pronto code that only has a repeat sequence (Sony).
+TEST(TestSendPronto, RepeatSequenceOnlyForSony) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Sony 20-bit command.
+  uint16_t pronto_test[46] = {
+      0x0000, 0x0067, 0x0000, 0x0015,
+      0x0060, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018, 0x0030, 0x0018,
+      0x0030, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018,
+      0x0018, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018,
+      0x0030, 0x0018, 0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018,
+      0x0030, 0x0018, 0x0018, 0x0018, 0x0018, 0x0018, 0x0030, 0x0018,
+      0x0018, 0x03f6};
+
+  // Send the Pronto code without any repeats set.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 46);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m2400s600"
+      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
+      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
+      "m600s600m600s600m1200s600m600s25350", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x74B92, irsend.capture.value);
+  EXPECT_EQ(0x1A, irsend.capture.address);
+  EXPECT_EQ(0x24AE, irsend.capture.command);
+
+  // Send the Pronto code with 2 repeats.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 46, SONY_MIN_REPEAT);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m2400s600"
+      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
+      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
+      "m600s600m600s600m1200s600m600s25350"
+      "m2400s600"
+      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
+      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
+      "m600s600m600s600m1200s600m600s25350"
+      "m2400s600"
+      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
+      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
+      "m600s600m600s600m1200s600m600s25350", irsend.outputStr());
+
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x74B92, irsend.capture.value);
+  EXPECT_EQ(0x1A, irsend.capture.address);
+  EXPECT_EQ(0x24AE, irsend.capture.command);
+}
+
+// Test sending a Pronto code that only has a repeat sequence (Panasonic).
+TEST(TestSendPronto, RepeatSequenceOnlyForPanasonic) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // Panasonic Plasma TV Descrete code (Power On).
+  uint16_t pronto_test[104] = {
+      0x0000, 0x0071, 0x0000, 0x0032,
+      0x0080, 0x003F, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0030, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0030,
+      0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0010,
+      0x0010, 0x0010, 0x0010, 0x0010, 0x0010, 0x0030, 0x0010, 0x0030,
+      0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0030, 0x0010, 0x0010,
+      0x0010, 0x0030, 0x0010, 0x0A98};
+
+  // Send the Pronto code without any repeats set.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 104);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m3456s1701"
+      "m432s432m432s1296m432s432m432s432m432s432m432s432m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s1296m432s432m432s432"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s432m432s1296"
+      "m432s432m432s432m432s432m432s432m432s432m432s432m432s432m432s432"
+      "m432s432m432s1296m432s1296m432s1296m432s1296m432s1296m432s432m432s432"
+      "m432s432m432s1296m432s1296m432s1296m432s1296m432s1296m432s432m432s1296"
+      "m432s73224", irsend.outputStr());
+
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
+  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x400401007C7D, irsend.capture.value);
+  EXPECT_EQ(0x4004, irsend.capture.address);
+  EXPECT_EQ(0x1007C7D, irsend.capture.command);
+}
+
+
+// Test sending a Pronto code that has a normal & arepeat sequence (NEC).
+TEST(TestSendPronto, NormalPlusRepeatSequence) {
+  IRsendTest irsend(4);
+  IRrecv irrecv(4);
+  irsend.begin();
+
+  // NEC 32 bit power on command.
+  uint16_t pronto_test[76] = {
+      0x0000, 0x006D, 0x0022, 0x0002,
+      0x0156, 0x00AB, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015,
+      0x0015, 0x0040, 0x0015, 0x0040, 0x0015, 0x0015, 0x0015, 0x0015,
+      0x0015, 0x0015, 0x0015, 0x0040, 0x0015, 0x0040, 0x0015, 0x0040,
+      0x0015, 0x0015, 0x0015, 0x0015, 0x0015, 0x0040, 0x0015, 0x0040,
+      0x0015, 0x0040, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015,
+      0x0015, 0x0040, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015, 0x0015,
+      0x0015, 0x0015, 0x0015, 0x0040, 0x0015, 0x0040, 0x0015, 0x0040,
+      0x0015, 0x0015, 0x0015, 0x0040, 0x0015, 0x0040, 0x0015, 0x0040,
+      0x0015, 0x0040, 0x0015, 0x05FD,
+      0x0156, 0x0055, 0x0015, 0x0E4E};
+
+  // Send the Pronto code without any repeats set.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 76);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m8892s4446"
+      "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s546m546s1664m546s1664m546s1664"
+      "m546s546m546s546m546s546m546s1664m546s546m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s1664m546s1664m546s1664m546s1664"
+      "m546s39858", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x18E710EF, irsend.capture.value);
+  EXPECT_EQ(0x18, irsend.capture.address);
+  EXPECT_EQ(0x8, irsend.capture.command);
+
+  // Send it again with a single repeat.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 76, 1);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m8892s4446"
+      "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s546m546s1664m546s1664m546s1664"
+      "m546s546m546s546m546s546m546s1664m546s546m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s1664m546s1664m546s1664m546s1664"
+      "m546s39858"
+      "m8892s2210m546s95212", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x18E710EF, irsend.capture.value);
+  EXPECT_EQ(0x18, irsend.capture.address);
+  EXPECT_EQ(0x8, irsend.capture.command);
+
+  // Send it again with a two repeats.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 76, 2);
+  irsend.makeDecodeResult();
+  EXPECT_EQ(
+      "m8892s4446"
+      "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s546m546s1664m546s1664m546s1664"
+      "m546s546m546s546m546s546m546s1664m546s546m546s546m546s546m546s546"
+      "m546s1664m546s1664m546s1664m546s546m546s1664m546s1664m546s1664m546s1664"
+      "m546s39858"
+      "m8892s2210m546s95212"
+      "m8892s2210m546s95212", irsend.outputStr());
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x18E710EF, irsend.capture.value);
+  EXPECT_EQ(0x18, irsend.capture.address);
+  EXPECT_EQ(0x8, irsend.capture.command);
+}


### PR DESCRIPTION
* Code for sendPronto().
* Enable it in the default build.
* Tweak calculating the period of the modulation frequency to be able to ignore the preset
offset.
* Unit tests for sendPronto().
* Tweak decodeSony() to use matchAtLeast, and thus remove some unit test-only code.
* Add example code for using sendPronto().
* Fix Issue #248