### PR TITLE
Update version to v2.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - arduino --install-boards esp8266:esp8266
   - arduino --board $BD --save-prefs
   - arduino --pref "compiler.warning_level=all" --save-prefs
+  - sudo apt-get install jq
 script:
   # Check that everything compiles.
   - arduino --verify --board $BD $PWD/examples/IRrecvDemo/IRrecvDemo.ino
@@ -35,6 +36,10 @@ script:
   - shopt -u nullglob
   # Build and run the unit tests.
   - (cd test; make run)
+  # Check the version numbers match.
+  - LIB_VERSION=$(egrep "^#define\s+_IRREMOTEESP8266_VERSION_\s+" src/IRremoteESP8266.h  | cut -d\" -f2)
+  - test ${LIB_VERSION} == "$(jq -r .version library.json)"
+  - grep -q "^version=${LIB_VERSION}$" library.properties
 
 notifications:
   email:

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.0.2
+version=2.0.3
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -43,6 +43,8 @@
 #include <iostream>
 #endif
 
+// Library Version
+#define _IRREMOTEESP8266_VERSION_ "2.0.3"
 // Supported IR protocols
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to false) all the protocols you do not need/want!


### PR DESCRIPTION
- Version bump due to Issue #246
- Add library version as a #define in src/IRremoteESP8266.h
- Add check to Travis config to ensure version numbers all match.