### PR TITLE
Add Fujitsu A/C to library

### DIFF
--- a/.github/Contributors.md
+++ b/.github/Contributors.md
@@ -7,6 +7,7 @@
 - [Marcos de Alcântara Marinho](https://github.com/marcosamarinho/)
 - [Massimiliano Pinto](https://github.com/pintomax/)
 - [Darsh Patel](https://github.com/darshkpatel/)
+- [Jonny Graham](https://github.com/jonnygraham/)
 
 All contributors can be found on the [contributors site](https://github.com/markszabo/IRremoteESP8266/graphs/contributors). 
 

--- a/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
+++ b/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
@@ -1,0 +1,44 @@
+// Copyright 2017 Jonny Graham
+#include <IRsend.h>
+#include <ir_Fujitsu.h>
+
+IRFujitsuAC fujitsu(5);  // IR led controlled by Pin D1.
+
+void printState() {
+  // Display the settings.
+  Serial.println("Fujitsu A/C remote is in the following state:");
+  Serial.printf("  Command:%d,  Mode: %d, Temp: %dC, Fan Speed: %d," \
+                    " Swing Mode: %d\n",
+                fujitsu.getCmd(), fujitsu.getMode(), fujitsu.getTemp(),
+                fujitsu.getFanSpeed(), fujitsu.getSwing());
+  // Display the encoded IR sequence.
+  unsigned char* ir_code = fujitsu.getRaw();
+  Serial.print("IR Code: 0x");
+  for (uint8_t i = 0; i < FUJITSU_AC_STATE_LENGTH; i++)
+    Serial.printf("%02X", ir_code[i]);
+  Serial.println();
+}
+
+void setup() {
+  fujitsu.begin();
+  Serial.begin(115200);
+  delay(200);
+
+  // Set up what we want to send. See ir_Mitsubishi.cpp for all the options.
+  Serial.println("Default state of the remote.");
+  printState();
+  Serial.println("Setting desired state for A/C.");
+  fujitsu.setCmd(FUJITSU_AC_CMD_TURN_ON);
+  fujitsu.setSwing(FUJITSU_AC_SWING_BOTH);
+  fujitsu.setMode(FUJITSU_AC_MODE_COOL);
+  fujitsu.setFanSpeed(FUJITSU_AC_FAN_HIGH);
+  fujitsu.setTemp(24);
+}
+
+void loop() {
+  // Now send the IR signal.
+  Serial.println("Sending IR command to A/C ...");
+  fujitsu.send();
+  printState();
+  delay(5000);
+}

--- a/examples/TurnOnFujitsuAC/platformio.ini
+++ b/examples/TurnOnFujitsuAC/platformio.ini
@@ -1,0 +1,17 @@
+[platformio]
+lib_extra_dirs = ../../
+src_dir=.
+
+[common]
+build_flags =
+lib_deps_builtin =
+lib_deps_external =
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -31,7 +31,7 @@
  *
  *  Updated by sillyfrog for Daikin, adopted from
  * (https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/)
- *
+ * Fujitsu A/C code added by jonnygraham
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -107,6 +107,9 @@
 #define DECODE_MITSUBISHI_AC false  // Not written.
 #define SEND_MITSUBISHI_AC   true
 
+#define DECODE_FUJITSU_AC false  // Not written.
+#define SEND_FUJITSU_AC   true
+
 #define DECODE_DAIKIN        false  // Not finished.
 #define SEND_DAIKIN          true
 
@@ -179,6 +182,7 @@ enum decode_type_t {
 #define MITSUBISHI_MIN_REPEAT        1U  // Based on marcosamarinho's code.
 #define MITSUBISHI_AC_STATE_LENGTH  18U
 #define MITSUBISHI_AC_MIN_REPEAT     1U
+#define FUJITSU_AC_MIN_REPEAT        0U
 #define NEC_BITS                    32U
 #define PANASONIC_BITS              48U
 #define PANASONIC_MANUFACTURER   0x4004ULL

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -140,6 +140,11 @@ class IRsend {
                         uint16_t nbytes = MITSUBISHI_AC_STATE_LENGTH,
                         uint16_t repeat = MITSUBISHI_AC_MIN_REPEAT);
 #endif
+#if SEND_FUJITSU_AC
+  void sendFujitsuAC(unsigned char data[],
+                     uint16_t nbytes,
+                     uint16_t repeat = FUJITSU_AC_MIN_REPEAT);
+#endif
 #if SEND_GLOBALCACHE
   void sendGC(uint16_t buf[], uint16_t len);
 #endif

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -1,0 +1,221 @@
+// Copyright 2017 Jonny Graham
+#include "ir_Fujitsu.h"
+#include <algorithm>
+#include "IRsend.h"
+
+
+// Fujitsu A/C support added by Jonny Graham
+
+
+// Fujitsu A/C
+// Ref:
+// These values are based on averages of measurements
+#define FUJITSU_AC_HDR_MARK    3224U
+#define FUJITSU_AC_HDR_SPACE   1574U
+#define FUJITSU_AC_BIT_MARK    448U
+#define FUJITSU_AC_ONE_SPACE   1182U
+#define FUJITSU_AC_ZERO_SPACE  367U
+#define FUJITSU_AC_TRL_MARK    448U
+#define FUJITSU_AC_TRL_SPACE   8100U
+
+#if SEND_FUJITSU_AC
+// Send a Fujitsu A/C message.
+//
+// Args:
+//   data: An array of bytes containing the IR command.
+//   nbytes: Nr. of bytes of data in the array. (typically either
+//           FUJITSU_AC_STATE_LENGTH or FUJITSU_AC_STATE_LENGTH_SHORT)
+//   repeat: Nr. of times the message is to be repeated.
+//          (Default = FUJITSU_AC_MIN_REPEAT).
+//
+// Status: BETA / Appears to be working.
+//
+void IRsend::sendFujitsuAC(unsigned char data[], uint16_t nbytes,
+                           uint16_t repeat) {
+  // Set IR carrier frequency
+  enableIROut(38);
+  for (uint16_t r = 0; r <= repeat; ++r) {
+    // Header
+    mark(FUJITSU_AC_HDR_MARK);
+    space(FUJITSU_AC_HDR_SPACE);
+    // Data
+    for (uint16_t i = 0; i < nbytes; i++)
+      sendData(FUJITSU_AC_BIT_MARK, FUJITSU_AC_ONE_SPACE,
+               FUJITSU_AC_BIT_MARK, FUJITSU_AC_ZERO_SPACE,
+               data[i], 8, false);
+    // Footer
+    mark(FUJITSU_AC_TRL_MARK);
+    space(FUJITSU_AC_TRL_SPACE);
+  }
+}
+
+// Code to emulate Fujitsu A/C IR remote control unit.
+
+// Warning: Consider this very alpha code. Seems to work, but not validated.
+//
+// Equipment it seems compatible with:
+//  * Fujitsu ASYG30LFCA with remote AR-RAH2E
+//  * <Add models (A/C & remotes) you've gotten it working with here>
+// Initialise the object.
+IRFujitsuAC::IRFujitsuAC(uint16_t pin) : _irsend(pin) {
+  stateReset();
+}
+
+// Reset the state of the remote to a known good state/sequence.
+void IRFujitsuAC::stateReset() {
+  _temp = 24;
+  _fanSpeed = FUJITSU_AC_FAN_HIGH;
+  _mode = FUJITSU_AC_MODE_COOL;
+  _swingMode = FUJITSU_AC_SWING_BOTH;
+  _cmd = FUJITSU_AC_CMD_TURN_ON;
+}
+
+// Configure the pin for output.
+void IRFujitsuAC::begin() {
+    _irsend.begin();
+}
+
+// Send the current desired state to the IR LED.
+void IRFujitsuAC::send() {
+  getRaw();
+  uint8_t len = getCommandLength();
+  _irsend.sendFujitsuAC(remote_state, len);
+}
+
+uint8_t IRFujitsuAC::getCommandLength() {
+  if (remote_state[5] != 0xFE)
+    return FUJITSU_AC_STATE_LENGTH_SHORT;
+  else
+    return FUJITSU_AC_STATE_LENGTH;
+}
+
+// Return a pointer to the internal state date of the remote.
+uint8_t* IRFujitsuAC::getRaw() {
+  remote_state[0] = 0x14;
+  remote_state[1] = 0x63;
+  remote_state[2] = 0x00;
+  remote_state[3] = 0x10;
+  remote_state[4] = 0x10;
+  bool fullCmd = false;
+  switch (_cmd) {
+    case FUJITSU_AC_CMD_TURN_OFF:
+      remote_state[5] = 0x02;
+      break;
+    case FUJITSU_AC_CMD_STEP_HORIZ:
+      remote_state[5] = 0x79;
+      break;
+    case FUJITSU_AC_CMD_STEP_VERT:
+      remote_state[5] = 0x6C;
+      break;
+    default:
+      remote_state[5] = 0xFE;
+      fullCmd = true;
+      break;
+  }
+  if (fullCmd) {
+    remote_state[6] = 0x09;
+    remote_state[7] = 0x30;
+    uint8_t tempByte = _temp - FUJITSU_AC_MIN_TEMP;
+    remote_state[8] = (_cmd == FUJITSU_AC_CMD_TURN_ON) | (tempByte << 4);
+    remote_state[9] = _mode | 0 << 4;  // timer off
+    remote_state[10] = _fanSpeed | _swingMode << 4;
+    remote_state[11] = 0;  // timerOff values
+    remote_state[12] = 0;  // timerOff/on values
+    remote_state[13] = 0;  // timerOn values
+    remote_state[14] = 0x20;
+    // Checksum is the sum of the 8th to 16th bytes (ie remote_state[7]
+    // thru remote_state[15]).
+    // The checksum itself is stored in the 16th byte (ie remote_state[15]).
+    // So we sum bytes 8th-15th...
+    uint8_t checksum = 0;
+    for (uint8_t i = 7 ; i < 15; ++i) {
+      checksum += remote_state[i];
+    }
+    // and then do 0 - sum and store it in 16th.
+    remote_state[15] = 0 - checksum;
+  } else {
+    // For the short codes, byte 7 is the inverse of byte 6
+    remote_state[6] = ~remote_state[5];
+    for (uint8_t i = 7; i < FUJITSU_AC_STATE_LENGTH; ++i) {
+      remote_state[i] = 0;
+    }
+  }
+  return remote_state;
+}
+
+// Set the requested power state of the A/C to off.
+void IRFujitsuAC::off() {
+  _cmd = FUJITSU_AC_CMD_TURN_OFF;
+}
+
+void IRFujitsuAC::stepHoriz() {
+  _cmd = FUJITSU_AC_CMD_STEP_HORIZ;
+}
+
+void IRFujitsuAC::stepVert() {
+  _cmd = FUJITSU_AC_CMD_STEP_VERT;
+}
+
+// Set the requested command of the A/C.
+void IRFujitsuAC::setCmd(uint8_t cmd) {
+  switch (cmd) {
+    case FUJITSU_AC_CMD_TURN_OFF:
+    case FUJITSU_AC_CMD_TURN_ON:
+    case FUJITSU_AC_CMD_STAY_ON:
+    case FUJITSU_AC_CMD_STEP_HORIZ:
+    case FUJITSU_AC_CMD_STEP_VERT:
+      break;
+    default:
+      cmd = FUJITSU_AC_CMD_STAY_ON;
+      break;
+  }
+  _cmd = cmd;
+}
+
+uint8_t IRFujitsuAC::getCmd() {
+  return _cmd;
+}
+
+// Set the temp. in deg C
+void IRFujitsuAC::setTemp(uint8_t temp) {
+  temp = std::max((uint8_t) FUJITSU_AC_MIN_TEMP, temp);
+  temp = std::min((uint8_t) FUJITSU_AC_MAX_TEMP, temp);
+  _temp = temp;
+}
+
+uint8_t IRFujitsuAC::getTemp() {
+  return _temp;
+}
+
+// Set the speed of the fan
+void IRFujitsuAC::setFanSpeed(uint8_t fanSpeed) {
+  if (fanSpeed > FUJITSU_AC_FAN_QUIET)
+    fanSpeed = FUJITSU_AC_FAN_HIGH;  // Set the fan to maximum if out of range.
+  _fanSpeed = fanSpeed;
+}
+uint8_t IRFujitsuAC::getFanSpeed() {
+  return _fanSpeed;
+}
+
+// Set the requested climate operation mode of the a/c unit.
+void IRFujitsuAC::setMode(uint8_t mode) {
+  if (mode > FUJITSU_AC_MODE_HEAT)
+    mode = FUJITSU_AC_MODE_HEAT;  // Set the mode to maximum if out of range.
+  _mode = mode;
+}
+
+uint8_t IRFujitsuAC::getMode() {
+  return _mode;
+}
+// Set the requested swing operation mode of the a/c unit.
+void IRFujitsuAC::setSwing(uint8_t swingMode) {
+  if (swingMode > FUJITSU_AC_SWING_BOTH)
+    swingMode = FUJITSU_AC_SWING_BOTH;  // Set the mode to max if out of range
+  _swingMode = swingMode;
+}
+
+uint8_t IRFujitsuAC::getSwing() {
+  return _swingMode;
+}
+
+#endif

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -1,0 +1,80 @@
+// Copyright 2017 Jonny Graham
+#ifndef IR_FUJITSU_H_
+#define IR_FUJITSU_H_
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+
+// FUJITSU A/C support added by Jonny Graham
+
+// Constants
+
+#define FUJITSU_AC_MODE_AUTO      0x00U
+#define FUJITSU_AC_MODE_COOL      0x01U
+#define FUJITSU_AC_MODE_DRY       0x02U
+#define FUJITSU_AC_MODE_FAN       0x03U
+#define FUJITSU_AC_MODE_HEAT      0x04U
+
+#define FUJITSU_AC_CMD_STAY_ON    0x00U
+#define FUJITSU_AC_CMD_TURN_ON    0x01U
+#define FUJITSU_AC_CMD_TURN_OFF   0x02U
+#define FUJITSU_AC_CMD_STEP_HORIZ 0x79U
+#define FUJITSU_AC_CMD_STEP_VERT  0x6CU
+
+#define FUJITSU_AC_FAN_AUTO       0x00U
+#define FUJITSU_AC_FAN_HIGH       0x01U
+#define FUJITSU_AC_FAN_MED        0x02U
+#define FUJITSU_AC_FAN_LOW        0x03U
+#define FUJITSU_AC_FAN_QUIET      0x04U
+
+#define FUJITSU_AC_MIN_TEMP         16U  // 16C
+#define FUJITSU_AC_MAX_TEMP         30U  // 30C
+
+#define FUJITSU_AC_SWING_OFF      0x00U
+#define FUJITSU_AC_SWING_VERT     0x01U
+#define FUJITSU_AC_SWING_HORIZ    0x02U
+#define FUJITSU_AC_SWING_BOTH     0x03U
+
+#define FUJITSU_AC_STATE_LENGTH      16
+#define FUJITSU_AC_STATE_LENGTH_SHORT 7
+
+#if SEND_FUJITSU_AC
+class IRFujitsuAC {
+ public:
+  explicit IRFujitsuAC(uint16_t pin);
+
+  void stateReset();
+  void send();
+  void begin();
+  void off();
+  void stepHoriz();
+  void stepVert();
+  void setCmd(uint8_t cmd);
+  uint8_t getCmd();
+  void setTemp(uint8_t temp);
+  uint8_t getTemp();
+  void setFanSpeed(uint8_t fan);
+  uint8_t getFanSpeed();
+  void setMode(uint8_t mode);
+  uint8_t getMode();
+  void setSwing(uint8_t mode);
+  uint8_t getSwing();
+  uint8_t* getRaw();
+
+ private:
+  uint8_t remote_state[FUJITSU_AC_STATE_LENGTH];
+  uint8_t getCommandLength();
+  IRsend _irsend;
+  uint8_t _temp;
+  uint8_t _fanSpeed;
+  uint8_t _mode;
+  uint8_t _swingMode;
+  uint8_t _cmd;
+};
+
+#endif
+
+#endif  // IR_FUJITSU_H_

--- a/test/Makefile
+++ b/test/Makefile
@@ -29,8 +29,8 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Sherwood_test ir_Sony_test ir_Samsung_test ir_Kelvinator_test \
         ir_JVC_test ir_RCMM_test ir_LG_test ir_Mitsubishi_test ir_Sharp_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
-				ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
-				ir_Gree_test IRrecv_test ir_Pronto_test
+        ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
+        ir_Gree_test IRrecv_test ir_Pronto_test ir_Fujitsu_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -64,7 +64,7 @@ GTEST_SRCS_ = $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
 
 # All the IR protocol object files.
 PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
-            ir_LG.o ir_Mitsubishi.o ir_Sharp.o ir_Sanyo.o ir_Denon.o ir_Dish.o \
+            ir_LG.o ir_Mitsubishi.o ir_Fujitsu.o ir_Sharp.o ir_Sanyo.o ir_Denon.o ir_Dish.o \
 					  ir_Panasonic.o ir_Whynter.o ir_Coolix.o ir_Aiwa.o ir_Sherwood.o \
 						ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o
 # Common object files
@@ -216,6 +216,15 @@ ir_Mitsubishi_test.o : ir_Mitsubishi_test.cpp $(USER_DIR)/ir_Mitsubishi.h $(COMM
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Mitsubishi_test.cpp
 
 ir_Mitsubishi_test : $(COMMON_OBJ) ir_Mitsubishi_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Fujitsu.cpp
+
+ir_Fujitsu_test.o : ir_Fujitsu_test.cpp $(USER_DIR)/ir_Fujitsu.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Fujitsu_test.cpp
+
+ir_Fujitsu_test : $(COMMON_OBJ) ir_Fujitsu_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Sharp.o : $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -1,0 +1,141 @@
+// Copyright 2017 Jonny Graham
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "ir_Fujitsu.h"
+#include "gtest/gtest.h"
+
+template<typename T, size_t size>
+::testing::AssertionResult ArraysMatch(const T (&expected)[size],
+                                       const T* actual) {
+  for (size_t i(0); i < size; ++i) {
+    if (expected[i] != actual[i]) {
+      int e = expected[i];
+      int a = actual[i];
+      return ::testing::AssertionFailure() << "array[" << i
+        << "] (" << std::hex << a << std::dec << ") != expected[" << i
+        << "] (" << std::hex << e << std::dec << ")";
+    }
+  }
+
+  return ::testing::AssertionSuccess();
+}
+// Tests for Mitsubishi A/C methods.
+
+// Test sending typical data only.
+TEST(TestSendFujitsuAC, GetRawDefault) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.setCmd(FUJITSU_AC_CMD_TURN_ON);
+  fujitsuACSender.setSwing(FUJITSU_AC_SWING_BOTH);
+  fujitsuACSender.setMode(FUJITSU_AC_MODE_COOL);
+  fujitsuACSender.setFanSpeed(FUJITSU_AC_FAN_HIGH);
+  fujitsuACSender.setTemp(24);
+  uint8_t expected[16] = {0x14, 0x63, 0x0, 0x10, 0x10, 0xFE, 0x9, 0x30,
+                          0x81, 0x1, 0x31, 0x0, 0x0, 0x0, 0x20, 0xFD};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+
+TEST(TestSendFujitsuAC, GetRawTurnOff) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.off();
+  uint8_t expected[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02, 0xFD};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+TEST(TestSendFujitsuAC, GetRawStepHoriz) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.stepHoriz();
+  uint8_t expected[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x79, 0x86};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+TEST(TestSendFujitsuAC, GetRawStepVert) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.stepVert();
+  uint8_t expected[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x6C, 0x93};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+
+TEST(TestSendFujitsuAC, GetRawWithSwingHoriz) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.setCmd(FUJITSU_AC_CMD_STAY_ON);
+  fujitsuACSender.setSwing(FUJITSU_AC_SWING_HORIZ);
+  fujitsuACSender.setMode(FUJITSU_AC_MODE_COOL);
+  fujitsuACSender.setFanSpeed(FUJITSU_AC_FAN_QUIET);
+  fujitsuACSender.setTemp(25);
+  uint8_t expected[16] = {0x14, 0x63, 0x0, 0x10, 0x10, 0xFE, 0x9, 0x30,
+                          0x90, 0x1, 0x24, 0x0, 0x0, 0x0, 0x20, 0xFB};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+
+TEST(TestSendFujitsuAC, GetRawWithFan) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  fujitsuACSender.setCmd(FUJITSU_AC_CMD_STAY_ON);
+  fujitsuACSender.setSwing(FUJITSU_AC_SWING_HORIZ);
+  fujitsuACSender.setMode(FUJITSU_AC_MODE_FAN);
+  fujitsuACSender.setFanSpeed(FUJITSU_AC_FAN_MED);
+  fujitsuACSender.setTemp(20);  // temp doesn't matter for fan
+                                // but it is sent by the RC anyway
+  uint8_t expected[16] = {0x14, 0x63, 0x0, 0x10, 0x10, 0xFE, 0x9, 0x30,
+                          0x40, 0x3, 0x22, 0x0, 0x0, 0x0, 0x20, 0x4B};
+  EXPECT_TRUE(ArraysMatch(expected, fujitsuACSender.getRaw()));
+}
+
+TEST(TestSendFujitsuAC, GenerateMessage) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  IRsendTest irsend(4);
+  fujitsuACSender.begin();
+  irsend.begin();
+
+  fujitsuACSender.setCmd(FUJITSU_AC_CMD_STAY_ON);
+  fujitsuACSender.setSwing(FUJITSU_AC_SWING_BOTH);
+  fujitsuACSender.setMode(FUJITSU_AC_MODE_COOL);
+  fujitsuACSender.setFanSpeed(FUJITSU_AC_FAN_HIGH);
+  fujitsuACSender.setTemp(24);
+
+  EXPECT_EQ(FUJITSU_AC_FAN_HIGH, fujitsuACSender.getFanSpeed());
+  EXPECT_EQ(FUJITSU_AC_MODE_COOL, fujitsuACSender.getMode());
+  EXPECT_EQ(24, fujitsuACSender.getTemp());
+  EXPECT_EQ(FUJITSU_AC_SWING_BOTH, fujitsuACSender.getSwing());
+  EXPECT_EQ(FUJITSU_AC_CMD_STAY_ON, fujitsuACSender.getCmd());
+
+  irsend.reset();
+  irsend.sendFujitsuAC(fujitsuACSender.getRaw(), FUJITSU_AC_STATE_LENGTH);
+  EXPECT_EQ(
+  "m3224s1574m448s367m448s367m448s1182m448s367m448s1182m448s367m448s367m448"
+  "s367m448s1182m448s1182m448s367m448s367m448s367m448s1182m448s1182m448s367"
+  "m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s367m448s1182m448s367m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s1182m448s367m448s367m448s367m448s367m448s1182"
+  "m448s1182m448s1182m448s1182m448s1182m448s1182m448s1182m448s1182m448s367"
+  "m448s367m448s1182m448s367m448s367m448s367m448s367m448s367m448s367m448s367"
+  "m448s367m448s1182m448s1182m448s367m448s367m448s367m448s367m448s367m448s367"
+  "m448s367m448s367m448s367m448s1182m448s1182m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s367m448s1182m448s367m448s367m448s367m448s1182m448"
+  "s1182m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448"
+  "s367m448s367m448s367m448s367m448s367m448s1182m448s367m448s367m448s367m448"
+  "s1182m448s1182m448s1182m448s1182m448s1182m448s1182m448s1182m448s8100",
+  irsend.outputStr());
+}
+TEST(TestSendFujitsuAC, GenerateShortMessage) {
+  IRFujitsuAC fujitsuACSender = IRFujitsuAC(4);
+  IRsendTest irsend(4);
+  fujitsuACSender.begin();
+  irsend.begin();
+
+  fujitsuACSender.off();
+
+  EXPECT_EQ(FUJITSU_AC_CMD_TURN_OFF, fujitsuACSender.getCmd());
+
+  irsend.reset();
+  irsend.sendFujitsuAC(fujitsuACSender.getRaw(), FUJITSU_AC_STATE_LENGTH_SHORT);
+  EXPECT_EQ(
+  "m3224s1574m448s367m448s367m448s1182m448s367m448s1182m448s367m448s367m448"
+  "s367m448s1182m448s1182m448s367m448s367m448s367m448s1182m448s1182m448s367"
+  "m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367m448s367"
+  "m448s367m448s367m448s367m448s1182m448s367m448s367m448s367m448s367m448s367"
+  "m448s367m448s367m448s1182m448s367m448s367m448s367m448s367m448s1182m448s367"
+  "m448s367m448s367m448s367m448s367m448s367m448s1182m448s367m448s1182m448"
+  "s1182m448s1182m448s1182m448s1182m448s1182m448s8100",
+  irsend.outputStr());
+}


### PR DESCRIPTION
I've added code to generate and send Fujitsu A/C remote control IR codes.
I based it off the Mitsubishi code, although I changed it so that the actual byte array is only created when you send() the code because it got messy since there are two different lengths of codes on Fujitsu (turn off and step horizontal/vertical are short codes). I think it makes the code neater anyway, since the getters just return state rather than having to decode from the byte array.

