### PR TITLE
Support reporting of 'NEC'-like 32-bit protocols. e.g. Apple TV remote

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -39,6 +39,7 @@ void encoding(decode_results *results) {
     default:
     case UNKNOWN:      Serial.print("UNKNOWN");       break;
     case NEC:          Serial.print("NEC");           break;
+    case NEC_LIKE:     Serial.print("NEC (non-strict)");  break;
     case SONY:         Serial.print("SONY");          break;
     case RC5:          Serial.print("RC5");           break;
     case RC6:          Serial.print("RC6");           break;

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -297,6 +297,18 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
     return true;
 #endif
 */
+#if DECODE_NEC
+  // Some devices send NEC-like codes that don't follow the true NEC spec.
+  // This should detect those. e.g. Apple TV remote etc.
+  // This needs to be done after all other codes that use strict and some
+  // other protocols that are NEC-like as well, as turning off strict may
+  // cause this to match other valid protocols.
+  DPRINTLN("Attempting NEC (non-stict) decode");
+  if (decodeNEC(results, NEC_BITS, false)) {
+    results->decode_type = NEC_LIKE;
+    return true;
+  }
+#endif
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.
   // If you add any decodes, add them before this.

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -157,7 +157,8 @@ enum decode_type_t {
   SANYO_LC7461,
   RC5X,
   GREE,
-  PRONTO
+  PRONTO,
+  NEC_LIKE
 };
 
 // Message lengths & required repeat values


### PR DESCRIPTION
- Apple TV remotes use the NEC protocol, but don't follow the integrity checks.
  Decode these last and report them separately in the example code.
- Addresses Issue #264