### PR TITLE
[bugfix] GlobalCache incorrectly using hardware offset for period calc.

### DIFF
--- a/src/ir_GlobalCache.cpp
+++ b/src/ir_GlobalCache.cpp
@@ -43,7 +43,7 @@
 void IRsend::sendGC(uint16_t buf[], uint16_t len) {
   uint16_t hz = buf[GLOBALCACHE_FREQ_INDEX];  // GC frequency is in Hz.
   enableIROut(hz);
-  uint32_t periodic_time = calcUSecPeriod(hz);
+  uint32_t periodic_time = calcUSecPeriod(hz, false);
   uint8_t emits = std::min(buf[GLOBALCACHE_RPT_INDEX],
                            (uint16_t) GLOBALCACHE_MAX_REPEAT);
   // Repeat

--- a/test/ir_GlobalCache_test.cpp
+++ b/test/ir_GlobalCache_test.cpp
@@ -22,11 +22,11 @@ TEST(TestSendGlobalCache, NonRepeatingCode) {
                           21, 22, 21, 65, 21, 1519};
   irsend.sendGC(gc_test, 71);
   irsend.makeDecodeResult();
-  EXPECT_EQ("m7866s3956m483s506m483s483m483s1495m483s483m483s506m483s506"
-            "m483s483m483s506m483s1495m483s1495m483s506m483s1495m483s1495"
-            "m483s1495m483s1495m483s1495m483s1495m483s506m483s506m483s483"
-            "m483s506m483s506m483s1495m483s506m483s483m483s1495m483s1495"
-            "m483s1495m483s1472m506s1495m483s506m483s1495m483s34937",
+  EXPECT_EQ("m8892s4472m546s572m546s546m546s1690m546s546m546s572m546s572"
+            "m546s546m546s572m546s1690m546s1690m546s572m546s1690m546s1690"
+            "m546s1690m546s1690m546s1690m546s1690m546s572m546s572m546s546"
+            "m546s572m546s572m546s1690m546s572m546s546m546s1690m546s1690"
+            "m546s1690m546s1664m572s1690m546s572m546s1690m546s39494",
             irsend.outputStr());
   EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
@@ -52,13 +52,13 @@ TEST(TestSendGlobalCache, RepeatCode) {
                           64, 21, 64, 21, 64, 21, 1600, 341, 85, 21, 3647};
   irsend.sendGC(gc_test, 75);
   irsend.makeDecodeResult();
-  EXPECT_EQ("m7843s3933m483s1472m483s1472m483s483m483s483m483s483m483s483"
-            "m483s483m483s1472m483s1472m483s483m483s1472m483s483m483s483"
-            "m483s483m483s1472m483s483m483s1472m483s483m483s483m483s483"
-            "m483s1472m483s483m483s483m483s483m483s483m483s1472m483s1472"
-            "m483s1472m483s483m483s1472m483s1472m483s1472m483s36800"
-            "m7843s1955m483s83881"
-            "m7843s1955m483s83881", irsend.outputStr());
+  EXPECT_EQ("m8866s4446m546s1664m546s1664m546s546m546s546m546s546m546s546"
+            "m546s546m546s1664m546s1664m546s546m546s1664m546s546m546s546"
+            "m546s546m546s1664m546s546m546s1664m546s546m546s546m546s546"
+            "m546s1664m546s546m546s546m546s546m546s546m546s1664m546s1664"
+            "m546s1664m546s546m546s1664m546s1664m546s1664m546s41600"
+            "m8866s2210m546s94822"
+            "m8866s2210m546s94822", irsend.outputStr());
   EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);


### PR DESCRIPTION
GlobalCache was using the calc period time function incorrectly causing
all mark & spaces it issued to be approx 10% too short.

Fixes #266