### PR TITLE
Allow the capture buffer to be set during run-time.

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -20,8 +20,11 @@
 // An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU
 // board).
 uint16_t RECV_PIN = 14;
+// As this program is a special purpose capture/decoder, let us use a larger
+// than normal buffer so we can handle Air Conditioner remote codes.
+uint16_t CAPTURE_BUFFER_SIZE = 1024;
 
-IRrecv irrecv(RECV_PIN);
+IRrecv irrecv(RECV_PIN, CAPTURE_BUFFER_SIZE);
 
 decode_results results;  // Somewhere to store the results
 irparams_t save;         // A place to copy the interrupt state while decoding.
@@ -64,8 +67,10 @@ void encoding(decode_results *results) {
 //
 void dumpInfo(decode_results *results) {
   if (results->overflow)
-    Serial.println("WARNING: IR code too long."
-                   "Edit IRrecv.h and increase RAWBUF");
+    Serial.printf("WARNING: IR code too big for buffer (>= %d). "
+                  "These results shouldn't be trusted until this is resolved. "
+                  "Edit & increase CAPTURE_BUFFER_SIZE.\n",
+                  CAPTURE_BUFFER_SIZE);
 
   // Show Encoding standard
   Serial.print("Encoding  : ");

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -54,7 +54,7 @@ static void ICACHE_RAM_ATTR gpio_intr() {
   // N.B. It saves about 13 bytes of IRAM.
   uint16_t rawlen = irparams.rawlen;
 
-  if (rawlen >= RAWBUF) {
+  if (rawlen >= irparams.bufsize) {
     irparams.overflow = true;
     irparams.rcvstate = STATE_STOP;
   }
@@ -80,8 +80,27 @@ static void ICACHE_RAM_ATTR gpio_intr() {
 #endif  // UNIT_TEST
 
 // Start of IRrecv class -------------------
-IRrecv::IRrecv(uint16_t recvpin) {
+
+// Class constructor
+// Args:
+//   recvpin: GPIO pin the IR receiver module's data pin is connected to.
+//   bufsize: Nr. of entries to have in the capture buffer. (Default: RAWBUF)
+// Returns:
+//   A IRrecv class object.
+IRrecv::IRrecv(uint16_t recvpin, uint16_t bufsize) {
   irparams.recvpin = recvpin;
+  irparams.bufsize = bufsize;
+  irparams.rawbuf = new uint16_t[bufsize];
+  if (irparams.rawbuf == NULL) {
+#ifndef UNIT_TEST
+    ESP.restart();  // Mem alloc failure. Reboot.
+#endif
+  }
+}
+
+// Class destructor
+IRrecv::~IRrecv(void) {
+  delete [] irparams.rawbuf;
 }
 
 // initialization

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -21,7 +21,7 @@
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.
 #define MARK_EXCESS  100U
-#define RAWBUF       100U  // Length of raw duration buffer
+#define RAWBUF       100U  // Default length of raw capture buffer
 #define REPEAT UINT64_MAX
 // receiver states
 #define STATE_IDLE     2U
@@ -42,7 +42,8 @@ typedef struct {
   uint8_t recvpin;              // pin for IR data from detector
   uint8_t rcvstate;             // state machine
   uint16_t timer;               // state timer, counts 50uS ticks.
-  uint16_t rawbuf[RAWBUF];      // raw data
+  uint16_t bufsize;             // max. nr. of entries in the capture buffer.
+  uint16_t *rawbuf;             // raw data
   // uint16_t is used for rawlen as it saves 3 bytes of iram in the interrupt
   // handler. Don't ask why, I don't know. It just does.
   uint16_t rawlen;              // counter of entries in rawbuf.
@@ -75,7 +76,8 @@ class decode_results {
 // main class for receiving IR
 class IRrecv {
  public:
-  explicit IRrecv(uint16_t recvpin);
+  explicit IRrecv(uint16_t recvpin, uint16_t bufsize = RAWBUF);  // Constructor
+  ~IRrecv();  // Destructor
   bool decode(decode_results *results, irparams_t *save = NULL);
   void enableIRIn();
   void disableIRIn();


### PR DESCRIPTION
- Allow the buffer size to be set in the class constructor.
- Delete the buffer in the class destructor.
- Update the IRrecvDumpV2 example to have a much bigger capture buffer (1024) & warning message.