### PR TITLE
Fix copying to a second capture buffer.

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -32,6 +32,16 @@ irparams_t save;         // A place to copy the interrupt state while decoding.
 void setup() {
   // Status message will be sent to the PC at 115200 baud
   Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
+  delay(500);  // Wait a bit for the serial connection to be establised.
+  // Give the 'save' copy the same sized buffer.
+  save.rawbuf = new uint16_t[irrecv.getBufSize()];
+  if (save.rawbuf == NULL) {  // Check we allocated the memory successfully.
+    Serial.printf("Could not allocate a %d buffer size for the save buffer.\n"
+                  "Try a smaller size for CAPTURE_BUFFER_SIZE.\nRebooting!",
+                  irrecv.getBufSize());
+    ESP.restart();
+  }
+
   irrecv.enableIRIn();  // Start the receiver
 }
 

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -82,13 +82,14 @@ class IRrecv {
   void enableIRIn();
   void disableIRIn();
   void resume();
+  uint16_t getBufSize();
 
 #ifndef UNIT_TEST
 
  private:
 #endif
   // These are called by decode
-  void copyIrParams(irparams_t *dest);
+  void copyIrParams(volatile irparams_t *src, irparams_t *dst);
   int16_t compare(uint16_t oldval, uint16_t newval);
   uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = TOLERANCE);
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE);


### PR DESCRIPTION
- The recent change to run-time selectable buffer sizes changed
they way that the copy routine needed to work, and to how the save
object needed to be setup prior to use.

- Add unit tests for copyIrParams and make it more testable by allowing a src arg.