### PR TITLE
Remove the use of USECPERTICKs from the library.

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -71,10 +71,10 @@ void dump(decode_results *results) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
     if (i & 1) {
-      Serial.print(results->rawbuf[i] * USECPERTICK, DEC);
+      Serial.print(results->rawbuf[i], DEC);
     } else {
       Serial.write('-');
-      Serial.print((uint32_t) results->rawbuf[i] * USECPERTICK, DEC);
+      Serial.print((uint32_t) results->rawbuf[i], DEC);
     }
     Serial.print(" ");
   }

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -71,10 +71,10 @@ void dump(decode_results *results) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
     if (i & 1) {
-      Serial.print(results->rawbuf[i], DEC);
+      Serial.print(results->rawbuf[i] * RAWTICK, DEC);
     } else {
       Serial.write('-');
-      Serial.print((uint32_t) results->rawbuf[i], DEC);
+      Serial.print((uint32_t) results->rawbuf[i] * RAWTICK, DEC);
     }
     Serial.print(" ");
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -108,7 +108,7 @@ void dumpRaw(decode_results *results) {
   for (uint16_t i = 1;  i < results->rawlen;  i++) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
-    uint32_t x = results->rawbuf[i] * USECPERTICK;
+    uint32_t x = results->rawbuf[i];
     if (!(i & 1)) {  // even
       Serial.print("-");
       if (x < 1000) Serial.print(" ");
@@ -139,7 +139,7 @@ void dumpCode(decode_results *results) {
 
   // Dump data
   for (uint16_t i = 1; i < results->rawlen; i++) {
-    Serial.print(results->rawbuf[i] * USECPERTICK, DEC);
+    Serial.print(results->rawbuf[i], DEC);
     if (i < results->rawlen - 1)
       Serial.print(",");  // ',' not needed on last one
     if (!(i & 1)) Serial.print(" ");

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -97,6 +97,16 @@ void dumpInfo(decode_results *results) {
   Serial.println(" bits)");
 }
 
+uint16_t getCookedLength(decode_results *results) {
+  uint16_t length = results->rawlen - 1;
+  for (uint16_t i = 0; i < results->rawlen - 1; i++) {
+    uint32_t usecs = results->rawbuf[i] * RAWTICK;
+    // Add two extra entries for multiple larger than UINT16_MAX it is.
+    length += (usecs / UINT16_MAX) * 2;
+  }
+  return length;
+}
+
 // Dump out the decode_results structure.
 //
 void dumpRaw(decode_results *results) {
@@ -105,24 +115,17 @@ void dumpRaw(decode_results *results) {
   Serial.print(results->rawlen - 1, DEC);
   Serial.println("]: ");
 
-  for (uint16_t i = 1;  i < results->rawlen;  i++) {
+  for (uint16_t i = 1; i < results->rawlen; i++) {
     if (i % 100 == 0)
       yield();  // Preemptive yield every 100th entry to feed the WDT.
-    uint32_t x = results->rawbuf[i];
-    if (!(i & 1)) {  // even
+    if (i % 2 == 0) {  // even
       Serial.print("-");
-      if (x < 1000) Serial.print(" ");
-      if (x < 100) Serial.print(" ");
-      Serial.print(x, DEC);
     } else {  // odd
-      Serial.print("     ");
-      Serial.print("+");
-      if (x < 1000) Serial.print(" ");
-      if (x < 100) Serial.print(" ");
-      Serial.print(x, DEC);
-      if (i < results->rawlen - 1)
-        Serial.print(", ");  // ',' not needed for last one
+      Serial.print("   +");
     }
+    Serial.printf("%6d", results->rawbuf[i] * RAWTICK);
+    if (i < results->rawlen - 1)
+      Serial.print(", ");  // ',' not needed for last one
     if (!(i % 8)) Serial.println("");
   }
   Serial.println("");  // Newline
@@ -132,17 +135,22 @@ void dumpRaw(decode_results *results) {
 //
 void dumpCode(decode_results *results) {
   // Start declaration
-  Serial.print("uint16_t  ");              // variable type
+  Serial.print("uint16_t ");               // variable type
   Serial.print("rawData[");                // array name
-  Serial.print(results->rawlen - 1, DEC);  // array size
+  Serial.print(getCookedLength(results), DEC);  // array size
   Serial.print("] = {");                   // Start declaration
 
   // Dump data
   for (uint16_t i = 1; i < results->rawlen; i++) {
-    Serial.print(results->rawbuf[i], DEC);
+    uint32_t usecs;
+    for (usecs = results->rawbuf[i] * RAWTICK;
+         usecs > UINT16_MAX;
+         usecs -= UINT16_MAX)
+      Serial.printf("%d, 0", UINT16_MAX);
+    Serial.print(usecs, DEC);
     if (i < results->rawlen - 1)
-      Serial.print(",");  // ',' not needed on last one
-    if (!(i & 1)) Serial.print(" ");
+      Serial.print(", ");  // ',' not needed on last one
+    if (i % 2 == 0) Serial.print(" ");  // Extra if it was even.
   }
 
   // End declaration
@@ -152,7 +160,7 @@ void dumpCode(decode_results *results) {
   Serial.print("  // ");
   encoding(results);
   Serial.print(" ");
-  serialPrintUint64(results->value, 16);
+  serialPrintUint64(results->value, HEX);
 
   // Newline
   Serial.println("");
@@ -163,16 +171,16 @@ void dumpCode(decode_results *results) {
     // NOTE: It will ignore the atypical case when a message has been decoded
     // but the address & the command are both 0.
     if (results->address > 0 || results->command > 0) {
-      Serial.print("uint32_t  address = 0x");
+      Serial.print("uint32_t address = 0x");
       Serial.print(results->address, HEX);
       Serial.println(";");
-      Serial.print("uint32_t  command = 0x");
+      Serial.print("uint32_t command = 0x");
       Serial.print(results->command, HEX);
       Serial.println(";");
     }
 
     // All protocols have data
-    Serial.print("uint64_t  data = 0x");
+    Serial.print("uint64_t data = 0x");
     serialPrintUint64(results->value, 16);
     Serial.println(";");
   }

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -67,9 +67,9 @@ static void ICACHE_RAM_ATTR gpio_intr() {
     irparams.rawbuf[rawlen] = 1;
   } else {
     if (now < start)
-      irparams.rawbuf[rawlen] = 0xFFFFFFFF - start + now;
+      irparams.rawbuf[rawlen] = (UINT32_MAX - start + now) / RAWTICK;
     else
-      irparams.rawbuf[rawlen] = now - start;
+      irparams.rawbuf[rawlen] = (now - start) / RAWTICK;
   }
   irparams.rawlen++;
 
@@ -395,6 +395,7 @@ uint32_t IRrecv::ticksHigh(uint32_t usecs, uint8_t tolerance) {
 //   Boolean: true if it matches, false if it doesn't.
 bool IRrecv::match(uint32_t measured, uint32_t desired,
                    uint8_t tolerance) {
+  measured *= RAWTICK;  // Convert to uSecs.
   DPRINT("Matching: ");
   DPRINT(ticksLow(desired, tolerance));
   DPRINT(" <= ");
@@ -418,6 +419,7 @@ bool IRrecv::match(uint32_t measured, uint32_t desired,
 //   Boolean: true if it matches, false if it doesn't.
 bool IRrecv::matchAtLeast(uint32_t measured, uint32_t desired,
                           uint8_t tolerance) {
+  measured *= RAWTICK;  // Convert to uSecs.
   DPRINT("Matching ATLEAST ");
   DPRINT(measured);
   DPRINT(" vs ");
@@ -452,7 +454,7 @@ bool IRrecv::matchAtLeast(uint32_t measured, uint32_t desired,
 bool IRrecv::matchMark(uint32_t measured, uint32_t desired,
                        uint8_t tolerance, int16_t excess) {
   DPRINT("Matching MARK ");
-  DPRINT(measured);
+  DPRINT(measured * RAWTICK);
   DPRINT(" vs ");
   DPRINT(desired);
   DPRINT(" + ");
@@ -475,7 +477,7 @@ bool IRrecv::matchMark(uint32_t measured, uint32_t desired,
 bool IRrecv::matchSpace(uint32_t measured, uint32_t desired,
                         uint8_t tolerance, int16_t excess) {
   DPRINT("Matching SPACE ");
-  DPRINT(measured);
+  DPRINT(measured * RAWTICK);
   DPRINT(" vs ");
   DPRINT(desired);
   DPRINT(" - ");

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -20,7 +20,7 @@
 #define OFFSET_START   1U  // Usual rawbuf entry to start processing from.
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.
-#define MARK_EXCESS  100U
+#define MARK_EXCESS   50U
 #define RAWBUF       100U  // Default length of raw capture buffer
 #define REPEAT UINT64_MAX
 // receiver states
@@ -29,8 +29,10 @@
 #define STATE_SPACE    4U
 #define STATE_STOP     5U
 #define TOLERANCE     25U  // default percent tolerance in measurements
-#define USECPERTICK   50U  // microseconds per clock interrupt tick
-#define TIMEOUT_MS    15U  // How long before we give up wait for more data.
+// How long (ms) before we give up wait for more data?
+// Don't exceed 65ms without a good reason.
+// That is the capture buffers maximum value size. (uint16_t)
+#define TIMEOUT_MS    15U
 
 // Use FNV hash algorithm: http://isthe.com/chongo/tech/comp/fnv/#FNV-param
 #define FNV_PRIME_32 16777619UL
@@ -93,13 +95,13 @@ class IRrecv {
   int16_t compare(uint16_t oldval, uint16_t newval);
   uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = TOLERANCE);
   uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE);
-  bool match(uint32_t measured_ticks, uint32_t desired_us,
+  bool match(uint32_t measured, uint32_t desired,
              uint8_t tolerance = TOLERANCE);
-  bool matchAtLeast(uint32_t measured_ticks, uint32_t desired_us,
+  bool matchAtLeast(uint32_t measured, uint32_t desired,
                     uint8_t tolerance = TOLERANCE);
-  bool matchMark(uint32_t measured_ticks, uint32_t desired_us,
+  bool matchMark(uint32_t measured, uint32_t desired,
                  uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
-  bool matchSpace(uint32_t measured_ticks, uint32_t desired_us,
+  bool matchSpace(uint32_t measured, uint32_t desired,
                   uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
   match_result_t matchData(volatile uint16_t *data_ptr, uint16_t nbits,
                            uint16_t onemark, uint32_t onespace,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -29,10 +29,14 @@
 #define STATE_SPACE    4U
 #define STATE_STOP     5U
 #define TOLERANCE     25U  // default percent tolerance in measurements
+#define RAWTICK        2U  // Capture tick to uSec factor.
 // How long (ms) before we give up wait for more data?
-// Don't exceed 65ms without a good reason.
-// That is the capture buffers maximum value size. (uint16_t)
-#define TIMEOUT_MS    15U
+// Don't exceed 130ms (RAWTICK * UINT16_MAX uSeconds) without a good reason.
+// That is the capture buffers maximum value size. (UINT16_MAX / RAWTICK)
+// Typically messages/protocols tend to repeat around the 100ms timeframe,
+// thus we should timeout before that to give us some time to try to decode
+// before we need to start capturing a possible new message.
+#define TIMEOUT_MS    90U  // In MilliSeconds. (Historic default was 15ms)
 
 // Use FNV hash algorithm: http://isthe.com/chongo/tech/comp/fnv/#FNV-param
 #define FNV_PRIME_32 16777619UL

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -57,14 +57,3 @@ void serialPrintUint64(uint64_t input, uint8_t base) {
   Serial.print(str);
 #endif
 }
-
-// Calculate the tick time in uSeconds based on the input time & factor.
-//
-// Args:
-//   input: Nr. of capture ticks.
-//   factor: Nr. of multiples of the common tick divisor the input should be.
-// Returns:
-//   A uint32_t containing the common tick time in uSeconds.
-uint32_t calcTickTime(uint16_t input, uint16_t factor) {
-  return (input * USECPERTICK) / factor;
-}

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -8,6 +8,5 @@
 
 uint64_t reverseBits(uint64_t input, uint16_t nbits);
 void serialPrintUint64(uint64_t input, uint8_t base);
-uint32_t calcTickTime(uint16_t input, uint16_t factor);
 
 #endif  // IRUTILS_H_

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -113,12 +113,10 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], COOLIX_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 COOLIX_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / COOLIX_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], COOLIX_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 COOLIX_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / COOLIX_HDR_SPACE_TICKS;
 
   // Data
   // Twice as many bits as there are normal plus inverted bits.

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -113,10 +113,11 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], COOLIX_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / COOLIX_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK / COOLIX_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], COOLIX_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / COOLIX_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK /
+      COOLIX_HDR_SPACE_TICKS;
 
   // Data
   // Twice as many bits as there are normal plus inverted bits.

--- a/src/ir_Denon.cpp
+++ b/src/ir_Denon.cpp
@@ -116,11 +116,9 @@ bool IRrecv::decodeDenon(decode_results *results, uint16_t nbits, bool strict) {
     // Header
     if (!matchMark(results->rawbuf[offset], DENON_HDR_MARK)) return false;
     // Calculate how long the common tick time is based on the header mark.
-    uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                   DENON_HDR_MARK_TICKS);
+    uint32_t m_tick = results->rawbuf[offset++] / DENON_HDR_MARK_TICKS;
     if (!matchSpace(results->rawbuf[offset], DENON_HDR_SPACE)) return false;
-    uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                   DENON_HDR_SPACE_TICKS);
+    uint32_t s_tick = results->rawbuf[offset++] / DENON_HDR_SPACE_TICKS;
 
     // Data
     match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Denon.cpp
+++ b/src/ir_Denon.cpp
@@ -116,9 +116,11 @@ bool IRrecv::decodeDenon(decode_results *results, uint16_t nbits, bool strict) {
     // Header
     if (!matchMark(results->rawbuf[offset], DENON_HDR_MARK)) return false;
     // Calculate how long the common tick time is based on the header mark.
-    uint32_t m_tick = results->rawbuf[offset++] / DENON_HDR_MARK_TICKS;
+    uint32_t m_tick = results->rawbuf[offset++] * RAWTICK /
+        DENON_HDR_MARK_TICKS;
     if (!matchSpace(results->rawbuf[offset], DENON_HDR_SPACE)) return false;
-    uint32_t s_tick = results->rawbuf[offset++] / DENON_HDR_SPACE_TICKS;
+    uint32_t s_tick = results->rawbuf[offset++] * RAWTICK /
+        DENON_HDR_SPACE_TICKS;
 
     // Data
     match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Dish.cpp
+++ b/src/ir_Dish.cpp
@@ -105,12 +105,10 @@ bool IRrecv::decodeDISH(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!match(results->rawbuf[offset], DISH_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 DISH_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / DISH_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], DISH_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 DISH_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / DISH_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Dish.cpp
+++ b/src/ir_Dish.cpp
@@ -105,10 +105,10 @@ bool IRrecv::decodeDISH(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!match(results->rawbuf[offset], DISH_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / DISH_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK / DISH_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], DISH_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / DISH_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK / DISH_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -122,12 +122,12 @@ bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits,  bool strict) {
   // (Optional as repeat codes don't have the header)
   if (matchMark(results->rawbuf[offset], JVC_HDR_MARK)) {
     isRepeat = false;
-    m_tick = calcTickTime(results->rawbuf[offset++], JVC_HDR_MARK_TICKS);
+    m_tick = results->rawbuf[offset++] / JVC_HDR_MARK_TICKS;
     if (results->rawlen < 2 * nbits + 4)
       return false;  // Can't possibly be a valid JVC message with a header.
     if (!matchSpace(results->rawbuf[offset], JVC_HDR_SPACE))
       return false;
-    s_tick = calcTickTime(results->rawbuf[offset++], JVC_HDR_SPACE_TICKS);
+    s_tick = results->rawbuf[offset++] / JVC_HDR_SPACE_TICKS;
   } else {
     // We can't easily auto-calibrate as there is no header, so assume
     // the default tick time.

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -122,12 +122,12 @@ bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits,  bool strict) {
   // (Optional as repeat codes don't have the header)
   if (matchMark(results->rawbuf[offset], JVC_HDR_MARK)) {
     isRepeat = false;
-    m_tick = results->rawbuf[offset++] / JVC_HDR_MARK_TICKS;
+    m_tick = results->rawbuf[offset++] * RAWTICK / JVC_HDR_MARK_TICKS;
     if (results->rawlen < 2 * nbits + 4)
       return false;  // Can't possibly be a valid JVC message with a header.
     if (!matchSpace(results->rawbuf[offset], JVC_HDR_SPACE))
       return false;
-    s_tick = results->rawbuf[offset++] / JVC_HDR_SPACE_TICKS;
+    s_tick = results->rawbuf[offset++] * RAWTICK / JVC_HDR_SPACE_TICKS;
   } else {
     // We can't easily auto-calibrate as there is no header, so assume
     // the default tick time.

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -163,16 +163,16 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
       !matchMark(results->rawbuf[offset], LG32_HDR_MARK)) return false;
   uint32_t m_tick;
   if (matchMark(results->rawbuf[offset], LG_HDR_MARK))
-    m_tick = calcTickTime(results->rawbuf[offset++], LG_HDR_MARK_TICKS);
+    m_tick = results->rawbuf[offset++] / LG_HDR_MARK_TICKS;
   else
-    m_tick = calcTickTime(results->rawbuf[offset++], LG32_HDR_MARK_TICKS);
+    m_tick = results->rawbuf[offset++] / LG32_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], LG_HDR_SPACE) &&
       !matchSpace(results->rawbuf[offset], LG32_HDR_SPACE)) return false;
   uint32_t s_tick;
   if (matchSpace(results->rawbuf[offset], LG_HDR_SPACE))
-    s_tick = calcTickTime(results->rawbuf[offset++], LG_HDR_SPACE_TICKS);
+    s_tick = results->rawbuf[offset++] / LG_HDR_SPACE_TICKS;
   else
-    s_tick = calcTickTime(results->rawbuf[offset++], LG32_HDR_SPACE_TICKS);
+    s_tick = results->rawbuf[offset++] / LG32_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -163,16 +163,16 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
       !matchMark(results->rawbuf[offset], LG32_HDR_MARK)) return false;
   uint32_t m_tick;
   if (matchMark(results->rawbuf[offset], LG_HDR_MARK))
-    m_tick = results->rawbuf[offset++] / LG_HDR_MARK_TICKS;
+    m_tick = results->rawbuf[offset++] * RAWTICK / LG_HDR_MARK_TICKS;
   else
-    m_tick = results->rawbuf[offset++] / LG32_HDR_MARK_TICKS;
+    m_tick = results->rawbuf[offset++] * RAWTICK / LG32_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], LG_HDR_SPACE) &&
       !matchSpace(results->rawbuf[offset], LG32_HDR_SPACE)) return false;
   uint32_t s_tick;
   if (matchSpace(results->rawbuf[offset], LG_HDR_SPACE))
-    s_tick = results->rawbuf[offset++] / LG_HDR_SPACE_TICKS;
+    s_tick = results->rawbuf[offset++] * RAWTICK / LG_HDR_SPACE_TICKS;
   else
-    s_tick = results->rawbuf[offset++] / LG32_HDR_SPACE_TICKS;
+    s_tick = results->rawbuf[offset++] * RAWTICK / LG32_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -118,7 +118,7 @@ bool IRrecv::decodeMitsubishi(decode_results *results, uint16_t nbits,
   if (!matchMark(results->rawbuf[offset], MITSUBISHI_BIT_MARK, 30))
     return false;
   // Calculate how long the common tick time is based on the initial mark.
-  uint32_t tick = results->rawbuf[offset] / MITSUBISHI_BIT_MARK_TICKS;
+  uint32_t tick = results->rawbuf[offset] * RAWTICK / MITSUBISHI_BIT_MARK_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -118,8 +118,7 @@ bool IRrecv::decodeMitsubishi(decode_results *results, uint16_t nbits,
   if (!matchMark(results->rawbuf[offset], MITSUBISHI_BIT_MARK, 30))
     return false;
   // Calculate how long the common tick time is based on the initial mark.
-  uint32_t tick = calcTickTime(results->rawbuf[offset],
-                               MITSUBISHI_BIT_MARK_TICKS);
+  uint32_t tick = results->rawbuf[offset] / MITSUBISHI_BIT_MARK_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -143,7 +143,8 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!matchMark(results->rawbuf[offset], NEC_HDR_MARK)) return false;
   // Calculate how long the lowest tick time is based on the header mark.
-  uint32_t mark_tick = results->rawbuf[offset++] / NEC_HDR_MARK_TICKS;
+  uint32_t mark_tick = results->rawbuf[offset++] * RAWTICK /
+      NEC_HDR_MARK_TICKS;
   // Check if it is a repeat code.
   if (results->rawlen == NEC_RPT_LENGTH &&
       matchSpace(results->rawbuf[offset], NEC_RPT_SPACE) &&
@@ -160,7 +161,8 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
   // Header (cont.)
   if (!matchSpace(results->rawbuf[offset], NEC_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t space_tick = results->rawbuf[offset++] / NEC_HDR_SPACE_TICKS;
+  uint32_t space_tick = results->rawbuf[offset++] * RAWTICK /
+      NEC_HDR_SPACE_TICKS;
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,
                                          NEC_BIT_MARK_TICKS * mark_tick,

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -143,8 +143,7 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!matchMark(results->rawbuf[offset], NEC_HDR_MARK)) return false;
   // Calculate how long the lowest tick time is based on the header mark.
-  uint32_t mark_tick = calcTickTime(results->rawbuf[offset++],
-                                    NEC_HDR_MARK_TICKS);
+  uint32_t mark_tick = results->rawbuf[offset++] / NEC_HDR_MARK_TICKS;
   // Check if it is a repeat code.
   if (results->rawlen == NEC_RPT_LENGTH &&
       matchSpace(results->rawbuf[offset], NEC_RPT_SPACE) &&
@@ -161,8 +160,7 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
   // Header (cont.)
   if (!matchSpace(results->rawbuf[offset], NEC_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t space_tick = calcTickTime(results->rawbuf[offset++],
-                                     NEC_HDR_SPACE_TICKS);
+  uint32_t space_tick = results->rawbuf[offset++] / NEC_HDR_SPACE_TICKS;
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,
                                          NEC_BIT_MARK_TICKS * mark_tick,

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -148,12 +148,10 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], PANASONIC_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 PANASONIC_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / PANASONIC_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], PANASONIC_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 PANASONIC_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / PANASONIC_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -148,10 +148,12 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], PANASONIC_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / PANASONIC_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK /
+      PANASONIC_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], PANASONIC_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / PANASONIC_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK /
+      PANASONIC_HDR_SPACE_TICKS;
 
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -307,7 +307,7 @@ int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
   //  If the value of offset is odd, it's a MARK. Even, it's a SPACE.
   uint16_t val = ((*offset) % 2) ? MARK : SPACE;
   // Check to see if we have hit an inter-message gap (> 20ms).
-  if (val == SPACE && width * USECPERTICK > 20000)
+  if (val == SPACE && width > 20000)
     return SPACE;
   int16_t correction = (val == MARK) ? MARK_EXCESS : -MARK_EXCESS;
 
@@ -465,8 +465,7 @@ bool IRrecv::decodeRC6(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!matchMark(results->rawbuf[offset], RC6_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = calcTickTime(results->rawbuf[offset++],
-                               RC6_HDR_MARK_TICKS);
+  uint32_t tick = results->rawbuf[offset++] / RC6_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset++], RC6_HDR_SPACE_TICKS * tick))
     return false;
 

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -465,7 +465,7 @@ bool IRrecv::decodeRC6(decode_results *results, uint16_t nbits, bool strict) {
   // Header
   if (!matchMark(results->rawbuf[offset], RC6_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = results->rawbuf[offset++] / RC6_HDR_MARK_TICKS;
+  uint32_t tick = results->rawbuf[offset++] * RAWTICK / RC6_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset++], RC6_HDR_SPACE_TICKS * tick))
     return false;
 

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -122,43 +122,38 @@ bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
   // Header decode
   if (!matchMark(results->rawbuf[offset], RCMM_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 RCMM_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / RCMM_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], RCMM_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 RCMM_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / RCMM_HDR_SPACE_TICKS;
 
   // Data decode
   // RC-MM has two bits of data per mark/space pair.
   uint16_t actualBits;
   for (actualBits = 0; actualBits < maxBitSize; actualBits += 2, offset++) {
-    if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK_TICKS * m_tick))
+    if (!match(results->rawbuf[offset++], RCMM_BIT_MARK_TICKS * m_tick))
       return false;
 
     data <<= 2;
     // Use non-default tolerance & excess for matching some of the spaces as the
     // defaults are too generous and causes mis-matches in some cases.
-    if (matchSpace(results->rawbuf[offset],
-                   RCMM_BIT_SPACE_0_TICKS * s_tick, TOLERANCE, RCMM_EXCESS))
+    if (match(results->rawbuf[offset], RCMM_BIT_SPACE_0_TICKS * s_tick,
+              TOLERANCE))
       data += 0;
-    else if (matchSpace(results->rawbuf[offset],
-                        RCMM_BIT_SPACE_1_TICKS * s_tick, TOLERANCE,
-                        RCMM_EXCESS))
+    else if (match(results->rawbuf[offset], RCMM_BIT_SPACE_1_TICKS * s_tick,
+                   TOLERANCE))
       data += 1;
-    else if (matchSpace(results->rawbuf[offset],
-                        RCMM_BIT_SPACE_2_TICKS * s_tick, RCMM_TOLERANCE,
-                        RCMM_EXCESS))
+    else if (match(results->rawbuf[offset], RCMM_BIT_SPACE_2_TICKS * s_tick,
+                   RCMM_TOLERANCE))
       data += 2;
-    else if (matchSpace(results->rawbuf[offset],
-                        RCMM_BIT_SPACE_3_TICKS * s_tick, RCMM_TOLERANCE,
-                        RCMM_EXCESS))
+    else if (match(results->rawbuf[offset], RCMM_BIT_SPACE_3_TICKS * s_tick,
+                   RCMM_TOLERANCE))
       data += 3;
     else
       return false;
   }
   // Footer decode
-  if (!matchMark(results->rawbuf[offset++], RCMM_BIT_MARK_TICKS * m_tick))
+  if (!match(results->rawbuf[offset++], RCMM_BIT_MARK_TICKS * m_tick))
     return false;
   if (offset < results->rawlen &&
       !matchAtLeast(results->rawbuf[offset], RCMM_MIN_GAP_TICKS * s_tick))

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -122,10 +122,10 @@ bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
   // Header decode
   if (!matchMark(results->rawbuf[offset], RCMM_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / RCMM_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK / RCMM_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], RCMM_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / RCMM_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK / RCMM_HDR_SPACE_TICKS;
 
   // Data decode
   // RC-MM has two bits of data per mark/space pair.

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -128,12 +128,10 @@ bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], SAMSUNG_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 SAMSUNG_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / SAMSUNG_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], SAMSUNG_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 SAMSUNG_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / SAMSUNG_HDR_SPACE_TICKS;
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,
                                          SAMSUNG_BIT_MARK_TICKS * m_tick,

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -128,10 +128,12 @@ bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t nbits,
   // Header
   if (!matchMark(results->rawbuf[offset], SAMSUNG_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / SAMSUNG_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK /
+      SAMSUNG_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], SAMSUNG_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / SAMSUNG_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK /
+      SAMSUNG_HDR_SPACE_TICKS;
   // Data
   match_result_t data_result = matchData(&(results->rawbuf[offset]), nbits,
                                          SAMSUNG_BIT_MARK_TICKS * m_tick,

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -200,8 +200,7 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
   // But try to auto-calibrate off the initial mark signal.
   if (!matchMark(results->rawbuf[offset], SHARP_BIT_MARK, 35)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = calcTickTime(results->rawbuf[offset],
-                               SHARP_BIT_MARK_TICKS);
+  uint32_t tick = results->rawbuf[offset] / SHARP_BIT_MARK_TICKS;
   // Data
   for (uint16_t i = 0; i < nbits; i++, offset++) {
     // Use a higher tolerance value for SHARP_BIT_MARK as it is quite small.

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -200,7 +200,7 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
   // But try to auto-calibrate off the initial mark signal.
   if (!matchMark(results->rawbuf[offset], SHARP_BIT_MARK, 35)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = results->rawbuf[offset] / SHARP_BIT_MARK_TICKS;
+  uint32_t tick = results->rawbuf[offset] * RAWTICK / SHARP_BIT_MARK_TICKS;
   // Data
   for (uint16_t i = 0; i < nbits; i++, offset++) {
     // Use a higher tolerance value for SHARP_BIT_MARK as it is quite small.

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -141,11 +141,11 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
   uint32_t timeSoFar = 0;  // Time in uSecs of the message length.
 
   // Header
-  timeSoFar += results->rawbuf[offset];
+  timeSoFar += results->rawbuf[offset] * RAWTICK;
   if (!matchMark(results->rawbuf[offset], SONY_HDR_MARK))
     return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = results->rawbuf[offset++] / SONY_HDR_MARK_TICKS;
+  uint32_t tick = results->rawbuf[offset++] * RAWTICK / SONY_HDR_MARK_TICKS;
 
   // Data
   for (actualBits = 0; offset < results->rawlen - 1; actualBits++, offset++) {
@@ -154,10 +154,10 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
     if (matchSpace(results->rawbuf[offset], SONY_MIN_GAP_TICKS * tick) ||
         matchAtLeast(results->rawbuf[offset], SONY_RPT_LENGTH - timeSoFar))
       break;  // Found a repeat space.
-    timeSoFar += results->rawbuf[offset];
+    timeSoFar += results->rawbuf[offset] * RAWTICK;
     if (!matchSpace(results->rawbuf[offset++], SONY_SPACE_TICKS * tick))
       return false;
-    timeSoFar += results->rawbuf[offset];
+    timeSoFar += results->rawbuf[offset] * RAWTICK;
     if (matchMark(results->rawbuf[offset], SONY_ONE_MARK_TICKS * tick))
       data = (data << 1) | 1;
     else if (matchMark(results->rawbuf[offset], SONY_ZERO_MARK_TICKS * tick))

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -141,12 +141,11 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
   uint32_t timeSoFar = 0;  // Time in uSecs of the message length.
 
   // Header
-  timeSoFar += results->rawbuf[offset] * USECPERTICK;
+  timeSoFar += results->rawbuf[offset];
   if (!matchMark(results->rawbuf[offset], SONY_HDR_MARK))
     return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t tick = calcTickTime(results->rawbuf[offset++],
-                               SONY_HDR_MARK_TICKS);
+  uint32_t tick = results->rawbuf[offset++] / SONY_HDR_MARK_TICKS;
 
   // Data
   for (actualBits = 0; offset < results->rawlen - 1; actualBits++, offset++) {
@@ -155,10 +154,10 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
     if (matchSpace(results->rawbuf[offset], SONY_MIN_GAP_TICKS * tick) ||
         matchAtLeast(results->rawbuf[offset], SONY_RPT_LENGTH - timeSoFar))
       break;  // Found a repeat space.
-    timeSoFar += results->rawbuf[offset] * USECPERTICK;
+    timeSoFar += results->rawbuf[offset];
     if (!matchSpace(results->rawbuf[offset++], SONY_SPACE_TICKS * tick))
       return false;
-    timeSoFar += results->rawbuf[offset] * USECPERTICK;
+    timeSoFar += results->rawbuf[offset];
     if (matchMark(results->rawbuf[offset], SONY_ONE_MARK_TICKS * tick))
       data = (data << 1) | 1;
     else if (matchMark(results->rawbuf[offset], SONY_ZERO_MARK_TICKS * tick))

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -108,10 +108,12 @@ bool IRrecv::decodeWhynter(decode_results *results, uint16_t nbits,
   // Main header mark and space
   if (!matchMark(results->rawbuf[offset], WHYNTER_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = results->rawbuf[offset++] / WHYNTER_HDR_MARK_TICKS;
+  uint32_t m_tick = results->rawbuf[offset++] * RAWTICK /
+      WHYNTER_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], WHYNTER_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = results->rawbuf[offset++] / WHYNTER_HDR_SPACE_TICKS;
+  uint32_t s_tick = results->rawbuf[offset++] * RAWTICK /
+      WHYNTER_HDR_SPACE_TICKS;
 
   // Data
   uint64_t data = 0;

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -108,12 +108,10 @@ bool IRrecv::decodeWhynter(decode_results *results, uint16_t nbits,
   // Main header mark and space
   if (!matchMark(results->rawbuf[offset], WHYNTER_HDR_MARK)) return false;
   // Calculate how long the common tick time is based on the header mark.
-  uint32_t m_tick = calcTickTime(results->rawbuf[offset++],
-                                 WHYNTER_HDR_MARK_TICKS);
+  uint32_t m_tick = results->rawbuf[offset++] / WHYNTER_HDR_MARK_TICKS;
   if (!matchSpace(results->rawbuf[offset], WHYNTER_HDR_SPACE)) return false;
   // Calculate how long the common tick time is based on the header space.
-  uint32_t s_tick = calcTickTime(results->rawbuf[offset++],
-                                 WHYNTER_HDR_SPACE_TICKS);
+  uint32_t s_tick = results->rawbuf[offset++] / WHYNTER_HDR_SPACE_TICKS;
 
   // Data
   uint64_t data = 0;

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -58,9 +58,9 @@ class IRsendTest: public IRsend {
          (i < RAW_BUF - 1) && (offset < OUTPUT_BUF);
          i++, offset++)
       if (output[offset] > UINT16_MAX)
-        rawbuf[i + 1] = UINT16_MAX / USECPERTICK;
+        rawbuf[i + 1] = UINT16_MAX;
       else
-        rawbuf[i + 1] = output[offset] / USECPERTICK;
+        rawbuf[i + 1] = output[offset];
   }
 
   void dumpRawResult() {
@@ -68,7 +68,7 @@ class IRsendTest: public IRsend {
     for (uint16_t i = 0; i < capture.rawlen; i++) {
       std::cout << capture.rawbuf[i];
       std::cout << "(";
-      std::cout << capture.rawbuf[i] * USECPERTICK;
+      std::cout << capture.rawbuf[i];
       std::cout << "), ";
       if (i % 8 == 7)
         std::cout << "\n";

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -57,16 +57,16 @@ class IRsendTest: public IRsend {
     for (uint16_t i = 0;
          (i < RAW_BUF - 1) && (offset < OUTPUT_BUF);
          i++, offset++)
-      if (output[offset] > UINT16_MAX)
+      if (output[offset] / RAWTICK > UINT16_MAX)
         rawbuf[i + 1] = UINT16_MAX;
       else
-        rawbuf[i + 1] = output[offset];
+        rawbuf[i + 1] = output[offset] / RAWTICK;
   }
 
   void dumpRawResult() {
     std::cout << "uint16_t rawbuf["<< capture.rawlen << "] =\n";
     for (uint16_t i = 0; i < capture.rawlen; i++) {
-      std::cout << capture.rawbuf[i];
+      std::cout << (capture.rawbuf[i] * RAWTICK);
       std::cout << "(";
       std::cout << capture.rawbuf[i];
       std::cout << "), ";


### PR DESCRIPTION
Store and measure everything in usecs to similify things and improve timing accuracy.
Reduce excess to 50us from 100us.
Adjustments to RC-MM decoding to handle small measurements better.
Remove calcTick(s) as it is pretty redundant now.