### PR TITLE
Gc decode improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ lib/googletest/**/*
 test/*.o
 test/*.a
 test/*_test
+
+# Tools builds
+tools/*.o
+tools/*.a
+tools/gc_decode
+
 .pioenvs
 .piolibdeps
 .clang_complete

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -64,16 +64,18 @@ class IRsendTest: public IRsend {
   }
 
   void dumpRawResult() {
-    std::cout << "uint16_t rawbuf["<< capture.rawlen << "] =\n";
-    for (uint16_t i = 0; i < capture.rawlen; i++) {
+    std::cout << std::dec;
+    if (capture.rawlen == 0) return;
+    std::cout << "uint16_t rawbuf["<< capture.rawlen - 1 << "] = {";
+    for (uint16_t i = 1; i < capture.rawlen; i++) {
+      if (i % 8 == 1)
+        std::cout << std::endl << "    ";
       std::cout << (capture.rawbuf[i] * RAWTICK);
-      std::cout << "(";
-      std::cout << capture.rawbuf[i];
-      std::cout << "), ";
-      if (i % 8 == 7)
-        std::cout << "\n";
+      // std::cout << "(" << capture.rawbuf[i] << ")";
+      if (i < capture.rawlen - 1)
+        std::cout << ", ";
     }
-    std::cout << "\n";
+    std::cout << "};" << std::endl;
   }
 
   void addGap(uint32_t usecs) {

--- a/tools/gc_decode.cpp
+++ b/tools/gc_decode.cpp
@@ -47,9 +47,25 @@ std::string encoding(decode_results *results) {
   }
 }
 
+void usage_error(char * name) {
+  std::cerr << "Usage: " << name << " [-raw] <global_code>" << std::endl;
+}
+
 int main(int argc, char * argv[]) {
-  if (argc != 2) {
-    std::cout << "Usage: gc_decode [global_code]" << std::endl;
+  int argv_offset = 1;
+  bool dumpraw = false;
+
+  // Check the invocation/calling usage.
+  if (argc < 2 || argc > 3) {
+    usage_error(argv[0]);
+    return 1;
+  }
+  if (strncmp("-raw", argv[argv_offset], 4) == 0) {
+    dumpraw = true;
+    argv_offset++;
+  }
+  if (argc - argv_offset != 1) {
+    usage_error(argv[0]);
     return 1;
   }
 
@@ -58,7 +74,7 @@ int main(int argc, char * argv[]) {
   char *pch;
   char *saveptr1;
 
-  pch = strtok_r(argv[1], ",", &saveptr1);
+  pch = strtok_r(argv[argv_offset], ",", &saveptr1);
   while (pch != NULL && index < MAX_GC_CODE_LENGHT) {
     str_to_uint16(pch, &gc_test[index]);
     pch = strtok_r(NULL, ",", &saveptr1);
@@ -76,11 +92,14 @@ int main(int argc, char * argv[]) {
 
   std::cout << "Code GC length " << index << std::endl
   << "Code type      " << irsend.capture.decode_type
-  << " " << encoding(&irsend.capture)  << std::endl
+  << " (" << encoding(&irsend.capture) << ")" << std::endl
   << "Code bits      " << irsend.capture.bits << std::endl
-  << "Code value     " << std::hex << irsend.capture.value << std::endl
-  << "Code address   " << std::hex << irsend.capture.address << std::endl
-  << "Code command   " << std::hex << irsend.capture.command << std::endl;
+  << "Code value     0x" << std::hex << irsend.capture.value << std::endl
+  << "Code address   0x" << std::hex << irsend.capture.address << std::endl
+  << "Code command   0x" << std::hex << irsend.capture.command << std::endl;
+
+  if (dumpraw || irsend.capture.decode_type == UNKNOWN)
+    irsend.dumpRawResult();
 
   return 0;
 }


### PR DESCRIPTION
* Ignore build files created by tools/Makefile.
* Better output of gc_decode.
* Make gc_decode to raw dump when decoding if it fails to decode, or the "-raw" flag is set.

FYI @jorgecis as the original author. 