### PR TITLE
Fix and Deprecate IRrecvDump.ino example code.

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -1,9 +1,22 @@
 /*
  * IRremoteESP8266: IRrecvDump - dump details of IR codes with IRrecv
- * An IR detector/demodulator must be connected to the input RECV_PIN.
- * Version 0.1 Sept, 2015
- * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
  * Copyright 2009 Ken Shirriff, http://arcfn.com
+ *
+ ***** DEPRECATED - DO NOT USE *****
+ * Unless you know what you are doing, you should be using the
+ * IRrecvDumpV2.ino sketch/example instead for capturing & decoding IR messages.
+ * In almost ALL ways it is BETTER, FASTER, and MORE DETAILED.
+ *
+ * This code is left only for legacy reasons, and as another simple example of
+ * how to use the IRremoteESP8266 library.
+ *
+ * As of November 2017 it will no longer be updated or supported.
+ * You have been warned.
+ ***** DEPRECATED - DO NOT USE *****
+ *
+ * An IR detector/demodulator must be connected to the input RECV_PIN.
+ * Version 0.2 Oct 2017
+ * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
  * JVC and Panasonic protocol added by Kristian Lauszus
  *   (Thanks to zenwheel and other people at the original blog post)
  * LG added by Darryl Smith (based on the JVC protocol)
@@ -67,7 +80,7 @@ void dump(decode_results *results) {
   Serial.println(" bits)");
   Serial.print("Raw (");
   Serial.print(count, DEC);
-  Serial.print("): ");
+  Serial.print("): {");
 
   for (uint16_t i = 1; i < count; i++) {
     if (i % 100 == 0)
@@ -75,18 +88,17 @@ void dump(decode_results *results) {
     if (i & 1) {
       Serial.print(results->rawbuf[i] * RAWTICK, DEC);
     } else {
-      Serial.write('-');
+      Serial.print(", ");
       Serial.print((uint32_t) results->rawbuf[i] * RAWTICK, DEC);
     }
-    Serial.print(" ");
   }
-  Serial.println();
+  Serial.println("};")
 }
 
 void loop() {
   if (irrecv.decode(&results)) {
-    serialPrintUint64(results.value, 16);
     dump(&results);
+    Serial.println("DEPRECATED: Please use IRrecvDumpV2.ino instead!");
     irrecv.resume();  // Receive the next value
   }
 }


### PR DESCRIPTION
- Place plenty of deprecation notices in the code and output.
- Strongly suggest people use IRrecvDumpV2.ino instead.
- Clean up some output issue which caused some confusion for new users
  of the library.
- Add a notice that this code is unsupport as of next month.