### PR TITLE
Better conversions of uint64_t's to strings. 

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -107,6 +107,7 @@
 #include <ESP8266mDNS.h>
 #include <IRremoteESP8266.h>
 #include <IRsend.h>
+#include <IRutils.h>
 #ifdef MQTT_ENABLE
 // --------------------------------------------------------------------
 // * * * IMPORTANT * * *
@@ -129,7 +130,7 @@
 // Set if your MQTT server requires a Username & Password to connect.
 const char* mqtt_user = "";
 const char* mqtt_password = "";
-#define MQTT_RECONNECT_TIME 5000  // Delay between reconnect tries.
+#define MQTT_RECONNECT_TIME 5000  // Delay(ms) between reconnect tries.
 
 #define MQTTprefix "ir_server"
 #define MQTTack MQTTprefix "/sent"  // Topic we send back acknowledgements on
@@ -710,24 +711,15 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
   #endif
       break;
     default:
-      debug("Code: 0x" +
-            String((uint32_t) (code >> 32), 16) +
-            String((uint32_t) (code & UINT32_MAX), 16));
+      debug("Code: 0x" + uint64ToString(code, 16));
       debug("Bits: " + String(bits));
       debug("Repeats: " + String(repeat));
 
 #ifdef MQTT_ENABLE
-      if (code >> 32)  // Are we dealing with a value larger than UINT32_MAX?
-        mqtt_client.publish(MQTTack, (String(ir_type) + "," +
-                                      String((uint32_t) (code >> 32), 16) +
-                                      String((uint32_t) (code & UINT32_MAX), 16)
-                                      + "," + String(bits) + "," +
-                                      String(repeat)).c_str());
-      else
-        mqtt_client.publish(MQTTack, (String(ir_type) + "," +
-                                      String((uint32_t) (code & UINT32_MAX), 16)
-                                      + "," + String(bits) + "," +
-                                      String(repeat)).c_str());
+      mqtt_client.publish(MQTTack, (String(ir_type) + "," +
+                                    uint64ToString(code, 16)
+                                    + "," + String(bits) + "," +
+                                    String(repeat)).c_str());
 #endif
   }
 }

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -4,9 +4,11 @@
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
+
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <algorithm>
+#include <string>
 #include "IRrecv.h"
 
 // Reverse the order of the requested least significant nr. of bits.
@@ -30,30 +32,44 @@ uint64_t reverseBits(uint64_t input, uint16_t nbits) {
   return (input << nbits) | output;
 }
 
+// Convert a uint64_t (unsigned long long) to a string.
+// Arduino String/toInt/Serial.print() can't handle printing 64 bit values.
+//
+// Args:
+//   input: The value to print
+//   base:  The output base.
+// Returns:
+//   A std:string representation of the integer.
+// Note: Based on Arduino's Print::printNumber()
+std::string uint64ToString(uint64_t input, uint8_t base) {
+  std::string result = "";
+  // prevent issues if called with base <= 1
+  if (base < 2) base = 10;
+  // Check we have a base that we can actually print.
+  // i.e. [0-9A-Z] == 36
+  if (base > 36) base = 10;
+
+  do {
+    char c = input % base;
+    input /= base;
+
+    if (c < 10)
+      c +='0';
+    else
+      c += 'A' - 10;
+    result = c + result;
+  } while (input);
+  return result;
+}
+
+#ifdef ARDUINO
 // Print a uint64_t/unsigned long long to the Serial port
 // Serial.print() can't handle printing long longs. (uint64_t)
 //
 // Args:
 //   input: The value to print
 //   base: The output base.
-// Note: Based on Arduino's Print::printNumber()
 void serialPrintUint64(uint64_t input, uint8_t base) {
-  char buf[8 * sizeof(input) + 1];  // Assumes 8-bit chars plus zero byte.
-  char *str = &buf[sizeof(buf) - 1];
-
-  *str = '\0';
-
-  // prevent crash if called with base == 1
-  if (base < 2) base = 10;
-
-  do {
-    char c = input % base;
-    input /= base;
-
-    *--str = c < 10 ? c + '0' : c + 'A' - 10;
-  } while (input);
-
-#ifndef UNIT_TEST
-  Serial.print(str);
-#endif
+  Serial.print(uint63ToString(input, base));
 }
+#endif

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -8,7 +8,9 @@
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <algorithm>
+#ifndef ARDUINO
 #include <string>
+#endif
 #include "IRrecv.h"
 
 // Reverse the order of the requested least significant nr. of bits.
@@ -39,10 +41,15 @@ uint64_t reverseBits(uint64_t input, uint16_t nbits) {
 //   input: The value to print
 //   base:  The output base.
 // Returns:
-//   A std:string representation of the integer.
+//   A string representation of the integer.
 // Note: Based on Arduino's Print::printNumber()
+#ifdef ARDUINO  // Arduino's & C++'s string implementations can't co-exist.
+String uint64ToString(uint64_t input, uint8_t base) {
+  String result = "";
+#else
 std::string uint64ToString(uint64_t input, uint8_t base) {
   std::string result = "";
+#endif
   // prevent issues if called with base <= 1
   if (base < 2) base = 10;
   // Check we have a base that we can actually print.
@@ -70,6 +77,6 @@ std::string uint64ToString(uint64_t input, uint8_t base) {
 //   input: The value to print
 //   base: The output base.
 void serialPrintUint64(uint64_t input, uint8_t base) {
-  Serial.print(uint63ToString(input, base));
+  Serial.print(uint64ToString(input, base));
 }
 #endif

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -3,12 +3,21 @@
 
 // Copyright 2017 David Conran
 
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
+#ifndef ARDUINO
 #include <string>
+#endif
 
 uint64_t reverseBits(uint64_t input, uint16_t nbits);
+#ifdef ARDUINO  // Arduino's & C++'s string implementations can't co-exist.
+String uint64ToString(uint64_t input, uint8_t base = 10);
+#else
 std::string uint64ToString(uint64_t input, uint8_t base = 10);
+#endif
 void serialPrintUint64(uint64_t input, uint8_t base = 10);
 
 #endif  // IRUTILS_H_

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -5,8 +5,10 @@
 
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
+#include <string>
 
 uint64_t reverseBits(uint64_t input, uint16_t nbits);
-void serialPrintUint64(uint64_t input, uint8_t base);
+std::string uint64ToString(uint64_t input, uint8_t base = 10);
+void serialPrintUint64(uint64_t input, uint8_t base = 10);
 
 #endif  // IRUTILS_H_

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -1,8 +1,8 @@
 // Copyright 2017 David Conran
 
 #include "IRutils.h"
-#include "gtest/gtest.h"
 #include <stdint.h>
+#include "gtest/gtest.h"
 
 // Tests reverseBits().
 
@@ -43,7 +43,7 @@ TEST(TestUint64ToString, TrivialCases) {
   EXPECT_EQ("0", uint64ToString(0, 8));  // Base-8
   EXPECT_EQ("0", uint64ToString(0, 10));  // Base-10
   EXPECT_EQ("0", uint64ToString(0, 16));  // Base-16
-  
+
   EXPECT_EQ("1", uint64ToString(1, 2));  // Base-2
   EXPECT_EQ("2", uint64ToString(2, 8));  // Base-8
   EXPECT_EQ("3", uint64ToString(3, 10));  // Base-10
@@ -52,7 +52,7 @@ TEST(TestUint64ToString, TrivialCases) {
 
 TEST(TestUint64ToString, NormalUse) {
   EXPECT_EQ("12345", uint64ToString(12345));
-  EXPECT_EQ("100", uint64ToString(4,2));
+  EXPECT_EQ("100", uint64ToString(4, 2));
   EXPECT_EQ("3039", uint64ToString(12345, 16));
   EXPECT_EQ("123456", uint64ToString(123456));
   EXPECT_EQ("1E240", uint64ToString(123456, 16));

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -2,6 +2,7 @@
 
 #include "IRutils.h"
 #include "gtest/gtest.h"
+#include <stdint.h>
 
 // Tests reverseBits().
 
@@ -32,4 +33,59 @@ TEST(ReverseBitsTest, LessBitsReversedThanInputHasSet) {
   EXPECT_EQ(0xF8, reverseBits(0xF1, 4));
   EXPECT_EQ(0xF5, reverseBits(0xFA, 4));
   EXPECT_EQ(0x12345678FFFF0000, reverseBits(0x123456780000FFFF, 32));
+}
+
+// Tests for uint64ToString()
+
+TEST(TestUint64ToString, TrivialCases) {
+  EXPECT_EQ("0", uint64ToString(0));  // Default base (10)
+  EXPECT_EQ("0", uint64ToString(0, 2));  // Base-2
+  EXPECT_EQ("0", uint64ToString(0, 8));  // Base-8
+  EXPECT_EQ("0", uint64ToString(0, 10));  // Base-10
+  EXPECT_EQ("0", uint64ToString(0, 16));  // Base-16
+  
+  EXPECT_EQ("1", uint64ToString(1, 2));  // Base-2
+  EXPECT_EQ("2", uint64ToString(2, 8));  // Base-8
+  EXPECT_EQ("3", uint64ToString(3, 10));  // Base-10
+  EXPECT_EQ("4", uint64ToString(4, 16));  // Base-16
+}
+
+TEST(TestUint64ToString, NormalUse) {
+  EXPECT_EQ("12345", uint64ToString(12345));
+  EXPECT_EQ("100", uint64ToString(4,2));
+  EXPECT_EQ("3039", uint64ToString(12345, 16));
+  EXPECT_EQ("123456", uint64ToString(123456));
+  EXPECT_EQ("1E240", uint64ToString(123456, 16));
+  EXPECT_EQ("FEEDDEADBEEF", uint64ToString(0xfeeddeadbeef, 16));
+}
+
+TEST(TestUint64ToString, Max64Bit) {
+  EXPECT_EQ("18446744073709551615", uint64ToString(UINT64_MAX));  // Default
+  EXPECT_EQ("1111111111111111111111111111111111111111111111111111111111111111",
+            uint64ToString(UINT64_MAX, 2));  // Base-2
+  EXPECT_EQ("1777777777777777777777", uint64ToString(UINT64_MAX, 8));  // Base-8
+  EXPECT_EQ("18446744073709551615", uint64ToString(UINT64_MAX, 10));  // Base-10
+  EXPECT_EQ("FFFFFFFFFFFFFFFF", uint64ToString(UINT64_MAX, 16));  // Base-16
+}
+
+TEST(TestUint64ToString, Max32Bit) {
+  EXPECT_EQ("4294967295", uint64ToString(UINT32_MAX));  // Default
+  EXPECT_EQ("37777777777", uint64ToString(UINT32_MAX, 8));  // Base-8
+  EXPECT_EQ("4294967295", uint64ToString(UINT32_MAX, 10));  // Base-10
+  EXPECT_EQ("FFFFFFFF", uint64ToString(UINT32_MAX, 16));  // Base-16
+}
+
+TEST(TestUint64ToString, InterestingCases) {
+  // Previous hacky-code didn't handle leading zeros in the lower 32 bits.
+  EXPECT_EQ("100000000", uint64ToString(0x100000000, 16));
+  EXPECT_EQ("100000001", uint64ToString(0x100000001, 16));
+}
+
+TEST(TestUint64ToString, SillyBases) {
+  // If we are given a silly base, we should defer to Base-10.
+  EXPECT_EQ("12345", uint64ToString(12345, 0));  // Super silly, makes no sense.
+  EXPECT_EQ("12345", uint64ToString(12345, 1));  // We don't do unary.
+  EXPECT_EQ("12345", uint64ToString(12345, 100));  // We can't print base-100.
+  EXPECT_EQ("12345", uint64ToString(12345, 37));  // Base-37 is one to far.
+  EXPECT_EQ("9IX", uint64ToString(12345, 36));  // But we *can* do base-36.
 }


### PR DESCRIPTION
- Add a function that returns a string for uint64_t's.
- Unit tests coverage.
- Make it cross platform.
- [Bug] Update MQTT example to fix poor quality hexidecimal output.