### PR TITLE
Ensure IRsendTest::reset() does a better job of reseting.

### DIFF
--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -101,6 +101,10 @@ TEST(TestSendRaw, GeneralUse) {
   irsend.reset();
   irsend.sendRaw(rawData, 67, 38);
   irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, NEC_BITS, false));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(32, irsend.capture.bits);
+  EXPECT_EQ(0xC3E0E0E8, irsend.capture.value);
   EXPECT_EQ(
       "m8950s4500"
       "m550s1650m600s1650m550s550m600s500m600s550m550s550m600s1650m550s1650"
@@ -108,10 +112,6 @@ TEST(TestSendRaw, GeneralUse) {
       "m550s1650m600s1650m600s1650m550s550m600s500m600s500m600s550m550s550"
       "m600s1650m550s1650m600s1650m600s500m650s1600m600s500m600s550m550s550"
       "m600", irsend.outputStr());
-  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, NEC_BITS, false));
-  EXPECT_EQ(NEC, irsend.capture.decode_type);
-  EXPECT_EQ(32, irsend.capture.bits);
-  EXPECT_EQ(0xC3E0E0E8, irsend.capture.value);
 }
 
 // Incorrect handling of decodes from Raw. i.e. There is no gap recorded at

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -26,7 +26,10 @@ class IRsendTest: public IRsend {
 
   void reset() {
     last = 0;
-    output[last] = 0;
+    for (uint16_t i = 0; i < OUTPUT_BUF; i++)
+      output[i] = 0;
+    for (uint16_t i = 0; i < RAW_BUF; i++)
+        rawbuf[i] = 0;
   }
 
   std::string outputStr() {

--- a/test/ir_GlobalCache_test.cpp
+++ b/test/ir_GlobalCache_test.cpp
@@ -22,18 +22,18 @@ TEST(TestSendGlobalCache, NonRepeatingCode) {
                           21, 22, 21, 65, 21, 1519};
   irsend.sendGC(gc_test, 71);
   irsend.makeDecodeResult();
-  EXPECT_EQ("m8892s4472m546s572m546s546m546s1690m546s546m546s572m546s572"
-            "m546s546m546s572m546s1690m546s1690m546s572m546s1690m546s1690"
-            "m546s1690m546s1690m546s1690m546s1690m546s572m546s572m546s546"
-            "m546s572m546s572m546s1690m546s572m546s546m546s1690m546s1690"
-            "m546s1690m546s1664m572s1690m546s572m546s1690m546s39494",
-            irsend.outputStr());
   EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);
   EXPECT_EQ(0x20DF827D, irsend.capture.value);
   EXPECT_EQ(0x4, irsend.capture.address);
   EXPECT_EQ(0x41, irsend.capture.command);
+  EXPECT_EQ("m8892s4472m546s572m546s546m546s1690m546s546m546s572m546s572"
+            "m546s546m546s572m546s1690m546s1690m546s572m546s1690m546s1690"
+            "m546s1690m546s1690m546s1690m546s1690m546s572m546s572m546s546"
+            "m546s572m546s572m546s1690m546s572m546s546m546s1690m546s1690"
+            "m546s1690m546s1664m572s1690m546s572m546s1690m546s39494",
+            irsend.outputStr());
 }
 
 // Test sending typical command with repeats.
@@ -52,6 +52,12 @@ TEST(TestSendGlobalCache, RepeatCode) {
                           64, 21, 64, 21, 64, 21, 1600, 341, 85, 21, 3647};
   irsend.sendGC(gc_test, 75);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0xC1A28877, irsend.capture.value);
+  EXPECT_EQ(0x4583, irsend.capture.address);
+  EXPECT_EQ(0x11, irsend.capture.command);
   EXPECT_EQ("m8866s4446m546s1664m546s1664m546s546m546s546m546s546m546s546"
             "m546s546m546s1664m546s1664m546s546m546s1664m546s546m546s546"
             "m546s546m546s1664m546s546m546s1664m546s546m546s546m546s546"
@@ -59,10 +65,4 @@ TEST(TestSendGlobalCache, RepeatCode) {
             "m546s1664m546s546m546s1664m546s1664m546s1664m546s41600"
             "m8866s2210m546s94822"
             "m8866s2210m546s94822", irsend.outputStr());
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture));
-  EXPECT_EQ(NEC, irsend.capture.decode_type);
-  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
-  EXPECT_EQ(0xC1A28877, irsend.capture.value);
-  EXPECT_EQ(0x4583, irsend.capture.address);
-  EXPECT_EQ(0x11, irsend.capture.command);
 }

--- a/test/ir_Pronto_test.cpp
+++ b/test/ir_Pronto_test.cpp
@@ -129,6 +129,12 @@ TEST(TestSendPronto, NonRepeatingCode) {
   irsend.reset();
   irsend.sendPronto(pronto_test, 108);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x10, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
   EXPECT_EQ(
       "m2400s600"
       "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
@@ -142,18 +148,18 @@ TEST(TestSendPronto, NonRepeatingCode) {
       "m2400s600"
       "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
       "m600s600m600s600m600s600m600s600", irsend.outputStr());
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(SONY, irsend.capture.decode_type);
-  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x10, irsend.capture.value);
-  EXPECT_EQ(0x1, irsend.capture.address);
-  EXPECT_EQ(0x0, irsend.capture.command);
 
   // Now try repeating it.
   // As it has no repeat sequence, we shouldn't repeat it. (I think)
   irsend.reset();
   irsend.sendPronto(pronto_test, 108, 3);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x10, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
   EXPECT_EQ(
       "m2400s600"
       "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
@@ -167,12 +173,6 @@ TEST(TestSendPronto, NonRepeatingCode) {
       "m2400s600"
       "m600s600m600s600m600s600m600s600m600s600m600s600m600s600m1200s600"
       "m600s600m600s600m600s600m600s600", irsend.outputStr());
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(SONY, irsend.capture.decode_type);
-  EXPECT_EQ(SONY_12_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x10, irsend.capture.value);
-  EXPECT_EQ(0x1, irsend.capture.address);
-  EXPECT_EQ(0x0, irsend.capture.command);
 }
 
 // Test sending a Pronto code that only has a repeat sequence (Sony).
@@ -195,22 +195,28 @@ TEST(TestSendPronto, RepeatSequenceOnlyForSony) {
   irsend.reset();
   irsend.sendPronto(pronto_test, 46);
   irsend.makeDecodeResult();
-  EXPECT_EQ(
-      "m2400s600"
-      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
-      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
-      "m600s600m600s600m1200s600m600s25350", irsend.outputStr());
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
   EXPECT_EQ(0x74B92, irsend.capture.value);
   EXPECT_EQ(0x1A, irsend.capture.address);
   EXPECT_EQ(0x24AE, irsend.capture.command);
+  EXPECT_EQ(
+      "m2400s600"
+      "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
+      "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
+      "m600s600m600s600m1200s600m600s25350", irsend.outputStr());
 
   // Send the Pronto code with 2 repeats.
   irsend.reset();
   irsend.sendPronto(pronto_test, 46, SONY_MIN_REPEAT);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x74B92, irsend.capture.value);
+  EXPECT_EQ(0x1A, irsend.capture.address);
+  EXPECT_EQ(0x24AE, irsend.capture.command);
   EXPECT_EQ(
       "m2400s600"
       "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
@@ -224,13 +230,6 @@ TEST(TestSendPronto, RepeatSequenceOnlyForSony) {
       "m600s600m1200s600m1200s600m1200s600m600s600m1200s600m600s600m600s600"
       "m1200s600m600s600m1200s600m1200s600m1200s600m600s600m600s600m1200s600"
       "m600s600m600s600m1200s600m600s25350", irsend.outputStr());
-
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(SONY, irsend.capture.decode_type);
-  EXPECT_EQ(SONY_20_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x74B92, irsend.capture.value);
-  EXPECT_EQ(0x1A, irsend.capture.address);
-  EXPECT_EQ(0x24AE, irsend.capture.command);
 }
 
 // Test sending a Pronto code that only has a repeat sequence (Panasonic).
@@ -260,6 +259,12 @@ TEST(TestSendPronto, RepeatSequenceOnlyForPanasonic) {
   irsend.reset();
   irsend.sendPronto(pronto_test, 104);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
+  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x400401007C7D, irsend.capture.value);
+  EXPECT_EQ(0x4004, irsend.capture.address);
+  EXPECT_EQ(0x1007C7D, irsend.capture.command);
   EXPECT_EQ(
       "m3456s1701"
       "m432s432m432s1296m432s432m432s432m432s432m432s432m432s432m432s432"
@@ -269,13 +274,6 @@ TEST(TestSendPronto, RepeatSequenceOnlyForPanasonic) {
       "m432s432m432s1296m432s1296m432s1296m432s1296m432s1296m432s432m432s432"
       "m432s432m432s1296m432s1296m432s1296m432s1296m432s1296m432s432m432s1296"
       "m432s73224", irsend.outputStr());
-
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
-  EXPECT_EQ(PANASONIC_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x400401007C7D, irsend.capture.value);
-  EXPECT_EQ(0x4004, irsend.capture.address);
-  EXPECT_EQ(0x1007C7D, irsend.capture.command);
 }
 
 
@@ -303,6 +301,12 @@ TEST(TestSendPronto, NormalPlusRepeatSequence) {
   irsend.reset();
   irsend.sendPronto(pronto_test, 76);
   irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x18E710EF, irsend.capture.value);
+  EXPECT_EQ(0x18, irsend.capture.address);
+  EXPECT_EQ(0x8, irsend.capture.command);
   EXPECT_EQ(
       "m8892s4446"
       "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
@@ -310,17 +314,17 @@ TEST(TestSendPronto, NormalPlusRepeatSequence) {
       "m546s546m546s546m546s546m546s1664m546s546m546s546m546s546m546s546"
       "m546s1664m546s1664m546s1664m546s546m546s1664m546s1664m546s1664m546s1664"
       "m546s39858", irsend.outputStr());
+
+  // Send it again with a single repeat.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 76, 1);
+  irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);
   EXPECT_EQ(0x18E710EF, irsend.capture.value);
   EXPECT_EQ(0x18, irsend.capture.address);
   EXPECT_EQ(0x8, irsend.capture.command);
-
-  // Send it again with a single repeat.
-  irsend.reset();
-  irsend.sendPronto(pronto_test, 76, 1);
-  irsend.makeDecodeResult();
   EXPECT_EQ(
       "m8892s4446"
       "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
@@ -329,17 +333,17 @@ TEST(TestSendPronto, NormalPlusRepeatSequence) {
       "m546s1664m546s1664m546s1664m546s546m546s1664m546s1664m546s1664m546s1664"
       "m546s39858"
       "m8892s2210m546s95212", irsend.outputStr());
+
+  // Send it again with a two repeats.
+  irsend.reset();
+  irsend.sendPronto(pronto_test, 76, 2);
+  irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);
   EXPECT_EQ(0x18E710EF, irsend.capture.value);
   EXPECT_EQ(0x18, irsend.capture.address);
   EXPECT_EQ(0x8, irsend.capture.command);
-
-  // Send it again with a two repeats.
-  irsend.reset();
-  irsend.sendPronto(pronto_test, 76, 2);
-  irsend.makeDecodeResult();
   EXPECT_EQ(
       "m8892s4446"
       "m546s546m546s546m546s546m546s1664m546s1664m546s546m546s546m546s546"
@@ -349,10 +353,4 @@ TEST(TestSendPronto, NormalPlusRepeatSequence) {
       "m546s39858"
       "m8892s2210m546s95212"
       "m8892s2210m546s95212", irsend.outputStr());
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(NEC, irsend.capture.decode_type);
-  EXPECT_EQ(NEC_BITS, irsend.capture.bits);
-  EXPECT_EQ(0x18E710EF, irsend.capture.value);
-  EXPECT_EQ(0x18, irsend.capture.address);
-  EXPECT_EQ(0x8, irsend.capture.command);
 }


### PR DESCRIPTION
The unit test `reset()` function could allow data from previous
unit tests to leak through. So, don't use a short-cut, do a full
zero of the arrays.
This also exposed situations where a unit test `decode()` would still work after
a `reset()`, hence a need to re-order some of the unit tests as
`IRsendTest::outputStr()` does an implicit `reset()`.

Note: This doesn't affect real messages etc, this is just a _"unit test"_ bug/feature/fix only.