### PR TITLE
Add sendGeneric() routines to reduce overall code size.

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -356,6 +356,59 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   }
 }
 
+// Generic method for sending simple protocol messages.
+//
+// Args:
+//   headermark:  Nr. of usecs for the led to be pulsed for the header mark.
+//                A value of 0 means no header mark.
+//   headerspace: Nr. of usecs for the led to be off after the header mark.
+//                A value of 0 means no header space.
+//   onemark:     Nr. of usecs for the led to be pulsed for a '1' bit.
+//   onespace:    Nr. of usecs for the led to be fully off for a '1' bit.
+//   zeromark:    Nr. of usecs for the led to be pulsed for a '0' bit.
+//   zerospace:   Nr. of usecs for the led to be fully off for a '0' bit.
+//   footermark:  Nr. of usecs for the led to be pulsed for the footer mark.
+//                A value of 0 means no footer mark.
+//   gap:         Nr. of usecs for the led to be off after the footer mark.
+//                This is effectively the gap between messages.
+//                A value of 0 means no gap space.
+//   dataptr:     Pointer to the data to be transmitted.
+//   nbytes:      Nr. of bytes of data to be sent.
+//   frequency:   The frequency we want to modulate at.
+//                Assumes < 1000 means kHz otherwise it is in Hz.
+//                Most common value is 38000 or 38, for 38kHz.
+//   MSBfirst:    Flag for bit transmission order. Defaults to MSB->LSB order.
+//   repeat:      Nr. of extra times the message will be sent.
+//                e.g. 0 = 1 message sent, 1 = 1 initial + 1 repeat = 2 messages
+//   dutycycle:   Percentage duty cycle of the LED.
+//                e.g. 25 = 25% = 1/4 on, 3/4 off.
+//                If you are not sure, try 50 percent.
+void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                         const uint16_t onemark, const uint32_t onespace,
+                         const uint16_t zeromark, const uint32_t zerospace,
+                         const uint16_t footermark, const uint32_t gap,
+                         const uint8_t *dataptr, const uint16_t nbytes,
+                         const uint16_t frequency, const bool MSBfirst,
+                         const uint16_t repeat, const uint8_t dutycycle) {
+  // Setup
+  enableIROut(frequency, dutycycle);
+  // We always send a message, even for repeat=0, hence '<= repeat'.
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header
+    if (headermark > 0)  mark(headermark);
+    if (headerspace > 0)  space(headerspace);
+
+    // Data
+    for (uint16_t i = 0; i < nbytes; i++)
+      sendData(onemark, onespace, zeromark, zerospace,
+               *(dataptr + i), 8, MSBfirst);
+
+    // Footer
+    if (footermark > 0)  mark(footermark);
+    space(gap);
+  }
+}
+
 // Send a raw IRremote message.
 //
 // Args:

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -280,21 +280,9 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
                          const uint64_t data, const uint16_t nbits,
                          const uint16_t frequency, const bool MSBfirst,
                          const uint16_t repeat, const uint8_t dutycycle) {
-  // Setup
-  enableIROut(frequency, dutycycle);
-  // We always send a message, even for repeat=0, hence '<= repeat'.
-  for (uint16_t r = 0; r <= repeat; r++) {
-    // Header
-    if (headermark)  mark(headermark);
-    if (headerspace)  space(headerspace);
-
-    // Data
-    sendData(onemark, onespace, zeromark, zerospace, data, nbits, MSBfirst);
-
-    // Footer
-    if (footermark)  mark(footermark);
-    space(gap);
-  }
+  sendGeneric(headermark, headerspace, onemark, onespace, zeromark, zerospace,
+              footermark, gap, 0U, data, nbits, frequency, MSBfirst, repeat,
+              dutycycle);
 }
 
 // Generic method for sending simple protocol messages.

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -285,14 +285,14 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   // We always send a message, even for repeat=0, hence '<= repeat'.
   for (uint16_t r = 0; r <= repeat; r++) {
     // Header
-    if (headermark > 0)  mark(headermark);
-    if (headerspace > 0)  space(headerspace);
+    if (headermark)  mark(headermark);
+    if (headerspace)  space(headerspace);
 
     // Data
     sendData(onemark, onespace, zeromark, zerospace, data, nbits, MSBfirst);
 
     // Footer
-    if (footermark > 0)  mark(footermark);
+    if (footermark)  mark(footermark);
     space(gap);
   }
 }
@@ -344,14 +344,14 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
     usecs.reset();
 
     // Header
-    if (headermark > 0)  mark(headermark);
-    if (headerspace > 0)  space(headerspace);
+    if (headermark)  mark(headermark);
+    if (headerspace)  space(headerspace);
 
     // Data
     sendData(onemark, onespace, zeromark, zerospace, data, nbits, MSBfirst);
 
     // Footer
-    if (footermark > 0)  mark(footermark);
+    if (footermark)  mark(footermark);
     space(std::max(gap, mesgtime - usecs.elapsed()));
   }
 }
@@ -395,8 +395,8 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   // We always send a message, even for repeat=0, hence '<= repeat'.
   for (uint16_t r = 0; r <= repeat; r++) {
     // Header
-    if (headermark > 0)  mark(headermark);
-    if (headerspace > 0)  space(headerspace);
+    if (headermark)  mark(headermark);
+    if (headerspace)  space(headerspace);
 
     // Data
     for (uint16_t i = 0; i < nbytes; i++)
@@ -404,7 +404,7 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
                *(dataptr + i), 8, MSBfirst);
 
     // Footer
-    if (footermark > 0)  mark(footermark);
+    if (footermark)  mark(footermark);
     space(gap);
   }
 }

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -244,6 +244,118 @@ void IRsend::sendData(uint16_t onemark, uint32_t onespace,
   }
 }
 
+// Generic method for sending simple protocol messages.
+// Will send leading or trailing 0's if the nbits is larger than the number
+// of bits in data.
+//
+// Args:
+//   headermark:  Nr. of usecs for the led to be pulsed for the header mark.
+//                A value of 0 means no header mark.
+//   headerspace: Nr. of usecs for the led to be off after the header mark.
+//                A value of 0 means no header space.
+//   onemark:     Nr. of usecs for the led to be pulsed for a '1' bit.
+//   onespace:    Nr. of usecs for the led to be fully off for a '1' bit.
+//   zeromark:    Nr. of usecs for the led to be pulsed for a '0' bit.
+//   zerospace:   Nr. of usecs for the led to be fully off for a '0' bit.
+//   footermark:  Nr. of usecs for the led to be pulsed for the footer mark.
+//                A value of 0 means no footer mark.
+//   gap:         Nr. of usecs for the led to be off after the footer mark.
+//                This is effectively the gap between messages.
+//                A value of 0 means no gap space.
+//   data:        The data to be transmitted.
+//   nbits:       Nr. of bits of data to be sent.
+//   frequency:   The frequency we want to modulate at.
+//                Assumes < 1000 means kHz otherwise it is in Hz.
+//                Most common value is 38000 or 38, for 38kHz.
+//   MSBfirst:    Flag for bit transmission order. Defaults to MSB->LSB order.
+//   repeat:      Nr. of extra times the message will be sent.
+//                e.g. 0 = 1 message sent, 1 = 1 initial + 1 repeat = 2 messages
+//   dutycycle:   Percentage duty cycle of the LED.
+//                e.g. 25 = 25% = 1/4 on, 3/4 off.
+//                If you are not sure, try 50 percent.
+void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                         const uint16_t onemark, const uint32_t onespace,
+                         const uint16_t zeromark, const uint32_t zerospace,
+                         const uint16_t footermark, const uint32_t gap,
+                         const uint64_t data, const uint16_t nbits,
+                         const uint16_t frequency, const bool MSBfirst,
+                         const uint16_t repeat, const uint8_t dutycycle) {
+  // Setup
+  enableIROut(frequency, dutycycle);
+  // We always send a message, even for repeat=0, hence '<= repeat'.
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Header
+    if (headermark > 0)  mark(headermark);
+    if (headerspace > 0)  space(headerspace);
+
+    // Data
+    sendData(onemark, onespace, zeromark, zerospace, data, nbits, MSBfirst);
+
+    // Footer
+    if (footermark > 0)  mark(footermark);
+    space(gap);
+  }
+}
+
+// Generic method for sending simple protocol messages.
+// Will send leading or trailing 0's if the nbits is larger than the number
+// of bits in data.
+//
+// Args:
+//   headermark:  Nr. of usecs for the led to be pulsed for the header mark.
+//                A value of 0 means no header mark.
+//   headerspace: Nr. of usecs for the led to be off after the header mark.
+//                A value of 0 means no header space.
+//   onemark:     Nr. of usecs for the led to be pulsed for a '1' bit.
+//   onespace:    Nr. of usecs for the led to be fully off for a '1' bit.
+//   zeromark:    Nr. of usecs for the led to be pulsed for a '0' bit.
+//   zerospace:   Nr. of usecs for the led to be fully off for a '0' bit.
+//   footermark:  Nr. of usecs for the led to be pulsed for the footer mark.
+//                A value of 0 means no footer mark.
+//   gap:         Min. nr. of usecs for the led to be off after the footer mark.
+//                This is effectively the absolute minimum gap between messages.
+//   mesgtime:    Min. nr. of usecs a single message needs to be.
+//                This is effectively the min. total length of a single message.
+//   data:        The data to be transmitted.
+//   nbits:       Nr. of bits of data to be sent.
+//   frequency:   The frequency we want to modulate at.
+//                Assumes < 1000 means kHz otherwise it is in Hz.
+//                Most common value is 38000 or 38, for 38kHz.
+//   MSBfirst:    Flag for bit transmission order. Defaults to MSB->LSB order.
+//   repeat:      Nr. of extra times the message will be sent.
+//                e.g. 0 = 1 message sent, 1 = 1 initial + 1 repeat = 2 messages
+//   dutycycle:   Percentage duty cycle of the LED.
+//                e.g. 25 = 25% = 1/4 on, 3/4 off.
+//                If you are not sure, try 50 percent.
+void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                         const uint16_t onemark, const uint32_t onespace,
+                         const uint16_t zeromark, const uint32_t zerospace,
+                         const uint16_t footermark, const uint32_t gap,
+                         const uint32_t mesgtime,
+                         const uint64_t data, const uint16_t nbits,
+                         const uint16_t frequency, const bool MSBfirst,
+                         const uint16_t repeat, const uint8_t dutycycle) {
+  // Setup
+  enableIROut(frequency, dutycycle);
+  IRtimer usecs = IRtimer();
+
+  // We always send a message, even for repeat=0, hence '<= repeat'.
+  for (uint16_t r = 0; r <= repeat; r++) {
+    usecs.reset();
+
+    // Header
+    if (headermark > 0)  mark(headermark);
+    if (headerspace > 0)  space(headerspace);
+
+    // Data
+    sendData(onemark, onespace, zeromark, zerospace, data, nbits, MSBfirst);
+
+    // Footer
+    if (footermark > 0)  mark(footermark);
+    space(std::max(gap, mesgtime - usecs.elapsed()));
+  }
+}
+
 // Send a raw IRremote message.
 //
 // Args:

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -38,6 +38,21 @@ class IRsend {
   void sendData(uint16_t onemark, uint32_t onespace, uint16_t zeromark,
                 uint32_t zerospace, uint64_t data, uint16_t nbits,
                 bool MSBfirst = true);
+  void sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                   const uint16_t onemark, const uint32_t onespace,
+                   const uint16_t zeromark, const uint32_t zerospace,
+                   const uint16_t footermark, const uint32_t gap,
+                   const uint64_t data, const uint16_t nbits,
+                   const uint16_t frequency, const bool MSBfirst,
+                   const uint16_t repeat, const uint8_t dutycycle);
+  void sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                   const uint16_t onemark, const uint32_t onespace,
+                   const uint16_t zeromark, const uint32_t zerospace,
+                   const uint16_t footermark, const uint32_t gap,
+                   const uint32_t mesgtime,
+                   const uint64_t data, const uint16_t nbits,
+                   const uint16_t frequency, const bool MSBfirst,
+                   const uint16_t repeat, const uint8_t dutycycle);
   void send(uint16_t type, uint64_t data, uint16_t nbits);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = NEC_BITS, uint16_t repeat = 0);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -53,7 +53,14 @@ class IRsend {
                    const uint64_t data, const uint16_t nbits,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
-  void send(uint16_t type, uint64_t data, uint16_t nbits);
+  void sendGeneric(const uint16_t headermark, const uint32_t headerspace,
+                   const uint16_t onemark, const uint32_t onespace,
+                   const uint16_t zeromark, const uint32_t zerospace,
+                   const uint16_t footermark, const uint32_t gap,
+                   const uint8_t *dataptr, const uint16_t nbytes,
+                   const uint16_t frequency, const bool MSBfirst,
+                   const uint16_t repeat, const uint8_t dutycycle);
+void send(uint16_t type, uint64_t data, uint16_t nbits);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = NEC_BITS, uint16_t repeat = 0);
   uint32_t encodeNEC(uint16_t address, uint16_t command);

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -11,9 +11,9 @@ Copyright 2017 Schmolders
 
 // Constants
 // using SPACE modulation. MARK is always const 400u
-#define ARGO_PREAMBLE_1           6400U  // Mark
-#define ARGO_PREAMBLE_2           3300U  // Space
-#define ARGO_MARK                  400U
+#define ARGO_HDR_MARK             6400U  // Mark
+#define ARGO_HDR_SPACE            3300U  // Space
+#define ARGO_BIT_MARK              400U
 #define ARGO_ONE_SPACE            2200U
 #define ARGO_ZERO_SPACE            900U
 
@@ -24,25 +24,16 @@ Copyright 2017 Schmolders
 //   data: An array of ARGO_COMMAND_LENGTH bytes containing the IR command.
 //
 // Status: ALPHA / Untested.
-//
-// Overloading the IRSend Function
 
 void IRsend::sendArgo(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
   // Check if we have enough bytes to send a proper message.
   if (nbytes < ARGO_COMMAND_LENGTH) return;
-  // Set IR carrier frequency
-  enableIROut(38);
-  for (uint16_t r = 0; r <= repeat; r++) {
-    // Header
-    // TODO(kaschmo): validate
-    mark(ARGO_PREAMBLE_1);
-    space(ARGO_PREAMBLE_2);
-    // send data, defined in IRSend.cpp
-    for (uint16_t i = 0; i < nbytes; i++)
-      sendData(ARGO_MARK, ARGO_ONE_SPACE, ARGO_MARK,
-               ARGO_ZERO_SPACE, data[i], 8, false);
-               // send LSB first reverses the bit order in array for sending.
-  }
+  // TODO(kaschmo): validate
+  sendGeneric(ARGO_HDR_MARK, ARGO_HDR_SPACE,
+              ARGO_BIT_MARK, ARGO_ONE_SPACE,
+              ARGO_BIT_MARK, ARGO_ZERO_SPACE,
+              0, 0,  // No Footer.
+              data, nbytes, 38, false, repeat, 50);
 }
 
 IRArgoAC::IRArgoAC(uint16_t pin) : _irsend(pin) {

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -54,38 +54,34 @@ void IRsend::sendDaikin(unsigned char data[], uint16_t nbytes,
                         uint16_t repeat) {
   if (nbytes < DAIKIN_COMMAND_LENGTH)
     return;  // Not enough bytes to send a proper message.
-  // Set IR carrier frequency
-  enableIROut(38);
+
   for (uint16_t r = 0; r <= repeat; r++) {
     // Send the header, 0b00000
-    sendData(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE, DAIKIN_BIT_MARK,
-             DAIKIN_ZERO_SPACE, 0, 5, false);
-    sendDaikinGapHeader();
+    sendGeneric(0, 0,  // No header for the header
+                DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE + DAIKIN_GAP,
+                (uint64_t) 0b00000, 5, 38, false, 0, 50);
     // Leading header
     // Do this as a constant to save RAM and keep in flash memory
-    sendData(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE, DAIKIN_BIT_MARK,
-             DAIKIN_ZERO_SPACE, DAIKIN_FIRST_HEADER64, 64, false);
-    sendDaikinGapHeader();
+    sendGeneric(DAIKIN_HDR_MARK, DAIKIN_HDR_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE + DAIKIN_GAP,
+                DAIKIN_FIRST_HEADER64, 64, 38, false, 0, 50);
     // Data #1
-    for (uint16_t i = 0; i < 8 && i < nbytes; i++)
-      sendData(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE, DAIKIN_BIT_MARK,
-               DAIKIN_ZERO_SPACE, data[i], 8, false);
-    sendDaikinGapHeader();
+    sendGeneric(DAIKIN_HDR_MARK, DAIKIN_HDR_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE + DAIKIN_GAP,
+                data, 8, 38, false, 0, 50);
     // Data #2
-    for (uint16_t i = 8; i < nbytes; i++)
-      sendData(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE, DAIKIN_BIT_MARK,
-               DAIKIN_ZERO_SPACE, data[i], 8, false);
-    // Footer #2
-    mark(DAIKIN_BIT_MARK);
-    space(DAIKIN_ZERO_SPACE + DAIKIN_GAP);
+    sendGeneric(DAIKIN_HDR_MARK, DAIKIN_HDR_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE,
+                DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE + DAIKIN_GAP,
+                data + 8, nbytes - 8, 38, false, 0, 50);
   }
-}
-
-void IRsend::sendDaikinGapHeader() {
-  mark(DAIKIN_BIT_MARK);
-  space(DAIKIN_ZERO_SPACE + DAIKIN_GAP);
-  mark(DAIKIN_HDR_MARK);
-  space(DAIKIN_HDR_SPACE);
 }
 #endif  // SEND_DAIKIN
 

--- a/src/ir_Dish.cpp
+++ b/src/ir_Dish.cpp
@@ -56,20 +56,16 @@
 // Ref:
 //   http://www.hifi-remote.com/wiki/index.php?title=Dish
 void IRsend::sendDISH(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set 57.6kHz IR carrier frequency, duty cycle is unknown.
-  enableIROut(57600);
-  // Header
+  enableIROut(57600);  // Set modulation freq. to 57.6kHz.
+  // Header is only ever sent once.
   mark(DISH_HDR_MARK);
   space(DISH_HDR_SPACE);
-  // We always send a command, even for repeat=0, hence '<= repeat'.
-  for (uint16_t i = 0; i <= repeat; i++) {
-    // Data
-    sendData(DISH_BIT_MARK, DISH_ONE_SPACE, DISH_BIT_MARK, DISH_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(DISH_BIT_MARK);
-    space(DISH_RPT_SPACE);
-  }
+
+  sendGeneric(0, 0,  // No headers from here on in.
+              DISH_BIT_MARK, DISH_ONE_SPACE,
+              DISH_BIT_MARK, DISH_ZERO_SPACE,
+              DISH_BIT_MARK, DISH_RPT_SPACE,
+              data, nbits, 57600, true, repeat, 50);
 }
 #endif
 

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -41,21 +41,11 @@
 //
 void IRsend::sendFujitsuAC(unsigned char data[], uint16_t nbytes,
                            uint16_t repeat) {
-  // Set IR carrier frequency
-  enableIROut(38);
-  for (uint16_t r = 0; r <= repeat; ++r) {
-    // Header
-    mark(FUJITSU_AC_HDR_MARK);
-    space(FUJITSU_AC_HDR_SPACE);
-    // Data
-    for (uint16_t i = 0; i < nbytes; i++)
-      sendData(FUJITSU_AC_BIT_MARK, FUJITSU_AC_ONE_SPACE,
-               FUJITSU_AC_BIT_MARK, FUJITSU_AC_ZERO_SPACE,
-               data[i], 8, false);
-    // Footer
-    mark(FUJITSU_AC_BIT_MARK);
-    space(FUJITSU_AC_MIN_GAP);
-  }
+  sendGeneric(FUJITSU_AC_HDR_MARK, FUJITSU_AC_HDR_SPACE,
+              FUJITSU_AC_BIT_MARK, FUJITSU_AC_ONE_SPACE,
+              FUJITSU_AC_BIT_MARK, FUJITSU_AC_ZERO_SPACE,
+              FUJITSU_AC_BIT_MARK, FUJITSU_AC_MIN_GAP,
+              data, nbytes, 38, false, repeat, 50);
 }
 #endif  // SEND_FUJITSU_AC
 

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -38,36 +38,26 @@ void IRsend::sendGree(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
   if (nbytes < GREE_STATE_LENGTH)
     return;  // Not enough bytes to send a proper message.
 
-  // Set IR carrier frequency
-  enableIROut(38);
-
   for (uint16_t r = 0; r <= repeat; r++) {
-    // Header #1
-    mark(GREE_HDR_MARK);
-    space(GREE_HDR_SPACE);
+    // Block #1
+    sendGeneric(GREE_HDR_MARK, GREE_HDR_SPACE,
+                GREE_BIT_MARK, GREE_ONE_SPACE,
+                GREE_BIT_MARK, GREE_ZERO_SPACE,
+                0, 0,  // No Footer.
+                data, 4, 38, false, 0, 50);
+    // Footer #1
+    sendGeneric(0, 0,  // No Header
+                GREE_BIT_MARK, GREE_ONE_SPACE,
+                GREE_BIT_MARK, GREE_ZERO_SPACE,
+                GREE_BIT_MARK, GREE_MSG_SPACE,
+                0b010, 3, 38, true, 0, false);
 
-    // Data #1
-    uint16_t i;
-    for (i = 0; i < 4 && i < nbytes; i++)
-      sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
-               data[i], 8, false);
-
-    // Footer #1 (010)
-    sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
-             0b010, 3);
-
-    // Header #2
-    mark(GREE_BIT_MARK);
-    space(GREE_MSG_SPACE);
-
-    // Data #2
-    for (; i < nbytes; i++)
-      sendData(GREE_BIT_MARK, GREE_ONE_SPACE, GREE_BIT_MARK, GREE_ZERO_SPACE,
-               data[i], 8, false);
-
-    // Footer #2
-    mark(GREE_BIT_MARK);
-    space(GREE_MSG_SPACE);
+    // Block #2
+    sendGeneric(0, 0,  // No Header for Block #2
+                GREE_BIT_MARK, GREE_ONE_SPACE,
+                GREE_BIT_MARK, GREE_ZERO_SPACE,
+                GREE_BIT_MARK, GREE_MSG_SPACE,
+                data + 4, nbytes - 4, 38, false, 0, 50);
   }
 }
 

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -62,13 +62,14 @@ void IRsend::sendJVC(uint64_t data, uint16_t nbits, uint16_t repeat) {
 
   // We always send the data & footer at least once, hence '<= repeat'.
   for (uint16_t i = 0; i <= repeat; i++) {
-    // Data
-    sendData(JVC_BIT_MARK, JVC_ONE_SPACE, JVC_BIT_MARK, JVC_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(JVC_BIT_MARK);
+    sendGeneric(0, 0,  // No Header
+                JVC_BIT_MARK, JVC_ONE_SPACE,
+                JVC_BIT_MARK, JVC_ZERO_SPACE,
+                JVC_BIT_MARK, JVC_MIN_GAP,
+                data, nbits, 38, true, 0,  // Repeats are handles elsewhere.
+                33);
     // Wait till the end of the repeat time window before we send another code.
-    space(std::max(JVC_MIN_GAP, JVC_RPT_LENGTH - usecs.elapsed()));
+    space(std::max(JVC_RPT_LENGTH - JVC_MIN_GAP - usecs.elapsed(), 0U));
     usecs.reset();
   }
 }

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -83,59 +83,45 @@ void IRsend::sendKelvinator(unsigned char data[], uint16_t nbytes,
   if (nbytes < KELVINATOR_STATE_LENGTH)
     return;  // Not enough bytes to send a proper message.
 
-  // Set IR carrier frequency
-  enableIROut(38);
-
   for (uint16_t r = 0; r <= repeat; r++) {
-    // Header #1
-    mark(KELVINATOR_HDR_MARK);
-    space(KELVINATOR_HDR_SPACE);
-    // Data (command)
-    // Send the first command data (4 bytes)
-    uint8_t i;
-    for (i = 0; i < 4; i++)
-      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-               KELVINATOR_ZERO_SPACE, data[i], 8, false);
-    // Send Footer for the command data (3 bits (0b010))
-    sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER,
-             KELVINATOR_CMD_FOOTER_BITS, false);
-    // Send an interdata gap.
-    mark(KELVINATOR_BIT_MARK);
-    space(KELVINATOR_GAP_SPACE);
-    // Data (options)
-    // Send the 1st option chunk of data (4 bytes).
-    for (; i < 8; i++)
-      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-               KELVINATOR_ZERO_SPACE, data[i], 8, false);
-    // Send a double data gap to signify we are starting a new command sequence.
-    mark(KELVINATOR_BIT_MARK);
-    space(KELVINATOR_GAP_SPACE * 2);
-    // Header #2
-    mark(KELVINATOR_HDR_MARK);
-    space(KELVINATOR_HDR_SPACE);
-    // Data (command)
-    // Send the 2nd command data (4 bytes).
-    // Basically an almost identical repeat of the earlier command data.
-    for (; i < 12; i++)
-      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-               KELVINATOR_ZERO_SPACE, data[i], 8, false);
-    // Send Footer for the command data (3 bits (B010))
-    sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-             KELVINATOR_ZERO_SPACE, KELVINATOR_CMD_FOOTER,
-             KELVINATOR_CMD_FOOTER_BITS, false);
-    // Send an interdata gap.
-    mark(KELVINATOR_BIT_MARK);
-    space(KELVINATOR_GAP_SPACE);
-    // Data (options)
-    // Send the 2nd option chunk of data (4 bytes).
-    // Unlike the commands, definitely not a repeat of the earlier option data.
-    for (; i < KELVINATOR_STATE_LENGTH; i++)
-      sendData(KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE, KELVINATOR_BIT_MARK,
-               KELVINATOR_ZERO_SPACE, data[i], 8, false);
-    // Footer
-    mark(KELVINATOR_BIT_MARK);
-    space(KELVINATOR_GAP_SPACE * 2);
+    // Command Block #1 (4 bytes)
+    sendGeneric(KELVINATOR_HDR_MARK, KELVINATOR_HDR_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                0, 0,  // No Footer yet.
+                data, 4, 38, false, 0, 50);
+    // Send Footer for the command block (3 bits (B010))
+    sendGeneric(0, 0,  // No Header
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_GAP_SPACE,
+                KELVINATOR_CMD_FOOTER, KELVINATOR_CMD_FOOTER_BITS,
+                38, false, 0, 50);
+    // Data Block #1 (4 bytes)
+    sendGeneric(0, 0,  // No header
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_GAP_SPACE * 2,
+                data + 4, 4, 38, false, 0, 50);
+    // Command Block #2 (4 bytes)
+    sendGeneric(KELVINATOR_HDR_MARK, KELVINATOR_HDR_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                0, 0,  // No Footer yet.
+                data + 8, 4, 38, false, 0, 50);
+    // Send Footer for the command block (3 bits (B010))
+    sendGeneric(0, 0,  // No Header
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_GAP_SPACE,
+                KELVINATOR_CMD_FOOTER, KELVINATOR_CMD_FOOTER_BITS,
+                38, false, 0, 50);
+    // Data Block #2 (4 bytes)
+    sendGeneric(0, 0,  // No header
+                KELVINATOR_BIT_MARK, KELVINATOR_ONE_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_ZERO_SPACE,
+                KELVINATOR_BIT_MARK, KELVINATOR_GAP_SPACE * 2,
+                data + 12, 4, 38, false, 0, 50);
   }
 }
 #endif  // SEND_KELVINATOR

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -88,20 +88,14 @@ void IRsend::sendLG(uint64_t data, uint16_t nbits, uint16_t repeat) {
                 50);
   }
 
-  // Set IR carrier frequency
-  enableIROut(38);
-  IRtimer usecTimer = IRtimer();
-
   // Repeat
   // Protocol has a mandatory repeat-specific code sent after every command.
-  for (uint16_t i = 0; i < repeat; i++) {
-    usecTimer.reset();
-    mark(repeatHeaderMark);
-    space(LG_RPT_SPACE);
-    mark(LG_BIT_MARK);
-    space(std::max((uint32_t) LG_MIN_MESSAGE_LENGTH - usecTimer.elapsed(),
-                   (uint32_t) LG_MIN_GAP));
-  }
+  if (repeat)
+    sendGeneric(repeatHeaderMark, LG_RPT_SPACE,
+                0, 0, 0, 0,  // No data is sent.
+                LG_BIT_MARK, LG_MIN_GAP, LG_MIN_MESSAGE_LENGTH,
+                0, 0,  // No data.
+                38, true, repeat - 1, 50);
 }
 
 // Construct a raw 28-bit LG message from the supplied address & command.

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -69,11 +69,7 @@ uint8_t calcLGChecksum(uint16_t data) {
 // Notes:
 //   LG has a separate message to indicate a repeat, like NEC does.
 void IRsend::sendLG(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set IR carrier frequency
-  enableIROut(38);
-
   uint16_t repeatHeaderMark = 0;
-  IRtimer usecTimer = IRtimer();
 
   if (nbits >= LG32_BITS) {
     // LG 32bit protocol is near identical to Samsung except for repeats.
@@ -83,18 +79,18 @@ void IRsend::sendLG(uint64_t data, uint16_t nbits, uint16_t repeat) {
   } else {
     // LG (28-bit) protocol.
     repeatHeaderMark = LG_HDR_MARK;
-    // Header
-    usecTimer.reset();
-    mark(LG_HDR_MARK);
-    space(LG_HDR_SPACE);
-    // Data
-    sendData(LG_BIT_MARK, LG_ONE_SPACE, LG_BIT_MARK, LG_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(LG_BIT_MARK);
-    space(std::max((uint32_t) (LG_MIN_MESSAGE_LENGTH - usecTimer.elapsed()),
-                   (uint32_t) LG_MIN_GAP));
+    sendGeneric(LG_HDR_MARK, LG_HDR_SPACE,
+                LG_BIT_MARK, LG_ONE_SPACE,
+                LG_BIT_MARK, LG_ZERO_SPACE,
+                LG_BIT_MARK,
+                LG_MIN_GAP, LG_MIN_MESSAGE_LENGTH,
+                data, nbits, 38, true, 0,  // Repeats are handled later.
+                50);
   }
+
+  // Set IR carrier frequency
+  enableIROut(38);
+  IRtimer usecTimer = IRtimer();
 
   // Repeat
   // Protocol has a mandatory repeat-specific code sent after every command.

--- a/src/ir_Magiquest.cpp
+++ b/src/ir_Magiquest.cpp
@@ -31,16 +31,13 @@
 // Status: Alpha / Should be working.
 //
 void IRsend::sendMagiQuest(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  enableIROut(36);
-  for (uint16_t r = 0; r <= repeat; r++) {
-    // No Headers - Technically it's included in the data. i.e. 8 zeros.
-
-    // Data
-    sendData(MAGIQUEST_MARK_ONE, MAGIQUEST_SPACE_ONE, MAGIQUEST_MARK_ZERO,
-             MAGIQUEST_SPACE_ZERO, data, nbits, true);
-    // Footer
-    space(MAGIQUEST_GAP);
-  }
+  sendGeneric(0, 0,  // No Headers - Technically it's included in the data.
+                     // i.e. 8 zeros.
+              MAGIQUEST_MARK_ONE, MAGIQUEST_SPACE_ONE,
+              MAGIQUEST_MARK_ZERO, MAGIQUEST_SPACE_ZERO,
+              0,  // No footer mark.
+              MAGIQUEST_GAP,
+              data, nbits, 36, true, repeat, 50);
 }
 
 // Encode a MagiQuest wand_id, and a magnitude into a single 64bit value.

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -160,22 +160,11 @@ void IRsend::sendMitsubishiAC(unsigned char data[], uint16_t nbytes,
   if (nbytes < MITSUBISHI_AC_STATE_LENGTH)
     return;  // Not enough bytes to send a proper message.
 
-  // Set IR carrier frequency
-  enableIROut(38);
-  // Mitsubishi AC remote sends the packet twice.
-  for (uint16_t r = 0; r <= repeat; r++) {
-    // Header
-    mark(MITSUBISHI_AC_HDR_MARK);
-    space(MITSUBISHI_AC_HDR_SPACE);
-    // Data
-    for (uint16_t i = 0; i < nbytes; i++)
-      sendData(MITSUBISHI_AC_BIT_MARK, MITSUBISHI_AC_ONE_SPACE,
-               MITSUBISHI_AC_BIT_MARK, MITSUBISHI_AC_ZERO_SPACE,
-               data[i], 8, false);
-    // Footer
-    mark(MITSUBISHI_AC_RPT_MARK);
-    space(MITSUBISHI_AC_RPT_SPACE);
-  }
+  sendGeneric(MITSUBISHI_AC_HDR_MARK, MITSUBISHI_AC_HDR_SPACE,
+              MITSUBISHI_AC_BIT_MARK, MITSUBISHI_AC_ONE_SPACE,
+              MITSUBISHI_AC_BIT_MARK, MITSUBISHI_AC_ZERO_SPACE,
+              MITSUBISHI_AC_RPT_MARK, MITSUBISHI_AC_RPT_SPACE,
+              data, nbytes, 38, false, repeat, 50);
 }
 
 // Code to emulate Mitsubishi A/C IR remote control unit.

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -67,22 +67,12 @@
 //   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Mitsubishi.cpp
 //   GlobalCache's Control Tower's Mitsubishi TV data.
 void IRsend::sendMitsubishi(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  enableIROut(33);  // Set IR carrier frequency
-  IRtimer usecTimer = IRtimer();
-
-  for (uint16_t i = 0; i <= repeat; i++) {
-    usecTimer.reset();
-    // No header
-
-    // Data
-    sendData(MITSUBISHI_BIT_MARK, MITSUBISHI_ONE_SPACE,
-             MITSUBISHI_BIT_MARK, MITSUBISHI_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(MITSUBISHI_BIT_MARK);
-    space(std::max(MITSUBISHI_MIN_COMMAND_LENGTH - usecTimer.elapsed(),
-                   MITSUBISHI_MIN_GAP));
-  }
+  sendGeneric(0, 0,  // No Header
+              MITSUBISHI_BIT_MARK, MITSUBISHI_ONE_SPACE,
+              MITSUBISHI_BIT_MARK, MITSUBISHI_ZERO_SPACE,
+              MITSUBISHI_BIT_MARK, MITSUBISHI_MIN_GAP,
+              MITSUBISHI_MIN_COMMAND_LENGTH,
+              data, nbits, 33, true, repeat, 50);
 }
 #endif
 

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -64,7 +64,7 @@ void IRsend::sendNEC(uint64_t data, uint16_t nbits, uint16_t repeat) {
               data, nbits, 38, true, 0,  // Repeats are handled later.
               33);
   // Optional command repeat sequence.
-  if (repeat > 0)
+  if (repeat)
     sendGeneric(NEC_HDR_MARK, NEC_RPT_SPACE,
                 0, 0, 0, 0,  // No actual data sent.
                 NEC_BIT_MARK, NEC_MIN_GAP, NEC_MIN_COMMAND_LENGTH,

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -57,29 +57,20 @@
 // Ref:
 //  http://www.sbprojects.com/knowledge/ir/nec.php
 void IRsend::sendNEC(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set 38kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(38, 33);
-  IRtimer usecs = IRtimer();
-  // Header
-  mark(NEC_HDR_MARK);
-  space(NEC_HDR_SPACE);
-  // Data
-  sendData(NEC_BIT_MARK, NEC_ONE_SPACE, NEC_BIT_MARK, NEC_ZERO_SPACE,
-           data, nbits, true);
-  // Footer
-  mark(NEC_BIT_MARK);
-  // Gap to next command.
-  space(std::max(NEC_MIN_GAP, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
-
+  sendGeneric(NEC_HDR_MARK, NEC_HDR_SPACE,
+              NEC_BIT_MARK, NEC_ONE_SPACE,
+              NEC_BIT_MARK, NEC_ZERO_SPACE,
+              NEC_BIT_MARK, NEC_MIN_GAP, NEC_MIN_COMMAND_LENGTH,
+              data, nbits, 38, true, 0,  // Repeats are handled later.
+              33);
   // Optional command repeat sequence.
-  for (uint16_t i = 0; i < repeat; i++) {
-    usecs.reset();
-    mark(NEC_HDR_MARK);
-    space(NEC_RPT_SPACE);
-    mark(NEC_BIT_MARK);
-    // Gap till next command.
-    space(std::max(NEC_MIN_GAP, NEC_MIN_COMMAND_LENGTH - usecs.elapsed()));
-  }
+  if (repeat > 0)
+    sendGeneric(NEC_HDR_MARK, NEC_RPT_SPACE,
+                0, 0, 0, 0,  // No actual data sent.
+                NEC_BIT_MARK, NEC_MIN_GAP, NEC_MIN_COMMAND_LENGTH,
+                0, 0,  // No data to be sent.
+                38, true, repeat - 1,  // We've already sent a one message.
+                33);
 }
 
 // Calculate the raw NEC data based on address and command.

--- a/src/ir_Nikai.cpp
+++ b/src/ir_Nikai.cpp
@@ -43,20 +43,11 @@
 //
 // Ref: https://github.com/markszabo/IRremoteESP8266/issues/309
 void IRsend::sendNikai(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set 38kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(38, 33);
-  // We always send a message, even for repeat=0, hence '<= repeat'.
-  for (uint16_t i=0; i <= repeat; i++) {
-    // Header
-    mark(NIKAI_HDR_MARK);
-    space(NIKAI_HDR_SPACE);
-    // Data
-    sendData(NIKAI_BIT_MARK, NIKAI_ONE_SPACE, NIKAI_BIT_MARK,
-             NIKAI_ZERO_SPACE, data, nbits, true);
-    // Footer
-    mark(NIKAI_BIT_MARK);
-    space(NIKAI_MIN_GAP);
-  }
+  sendGeneric(NIKAI_HDR_MARK, NIKAI_HDR_SPACE,
+              NIKAI_BIT_MARK, NIKAI_ONE_SPACE,
+              NIKAI_BIT_MARK, NIKAI_ZERO_SPACE,
+              NIKAI_BIT_MARK, NIKAI_MIN_GAP,
+              data, nbits, 38, true, repeat, 33);
 }
 #endif
 

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -53,24 +53,12 @@
 // Note:
 //   This protocol is a modified version of Kaseikyo.
 void IRsend::sendPanasonic64(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  enableIROut(36700U);  // Set IR carrier frequency of 36.7kHz.
-  IRtimer usecTimer = IRtimer();
-
-  for (uint16_t i = 0; i <= repeat; i++) {
-    usecTimer.reset();
-    // Header
-    mark(PANASONIC_HDR_MARK);
-    space(PANASONIC_HDR_SPACE);
-    // Data
-    sendData(PANASONIC_BIT_MARK, PANASONIC_ONE_SPACE,
-             PANASONIC_BIT_MARK, PANASONIC_ZERO_SPACE,
-             data, nbits, true);
-    // Footer
-    mark(PANASONIC_BIT_MARK);
-    space(std::max((uint32_t) PANASONIC_MIN_COMMAND_LENGTH -
-                       usecTimer.elapsed(),
-                   PANASONIC_MIN_GAP));
-  }
+  sendGeneric(PANASONIC_HDR_MARK, PANASONIC_HDR_SPACE,
+              PANASONIC_BIT_MARK, PANASONIC_ONE_SPACE,
+              PANASONIC_BIT_MARK, PANASONIC_ZERO_SPACE,
+              PANASONIC_BIT_MARK,
+              PANASONIC_MIN_GAP, PANASONIC_MIN_COMMAND_LENGTH,
+              data, nbits, 36700U, true, repeat, 50);
 }
 
 // Send a Panasonic formatted message.

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -57,24 +57,12 @@
 //
 // Ref: http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
 void IRsend::sendSAMSUNG(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set 38kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(38, 33);
-  IRtimer usecTimer = IRtimer();
-  // We always send a message, even for repeat=0, hence '<= repeat'.
-  for (uint16_t i=0; i <= repeat; i++) {
-    usecTimer.reset();
-    // Header
-    mark(SAMSUNG_HDR_MARK);
-    space(SAMSUNG_HDR_SPACE);
-    // Data
-    sendData(SAMSUNG_BIT_MARK, SAMSUNG_ONE_SPACE, SAMSUNG_BIT_MARK,
-             SAMSUNG_ZERO_SPACE, data, nbits, true);
-    // Footer
-    mark(SAMSUNG_BIT_MARK);
-    space(std::max((uint32_t) SAMSUNG_MIN_GAP,
-                   (uint32_t) (SAMSUNG_MIN_MESSAGE_LENGTH -
-                               usecTimer.elapsed())));
-  }
+  sendGeneric(SAMSUNG_HDR_MARK, SAMSUNG_HDR_SPACE,
+              SAMSUNG_BIT_MARK, SAMSUNG_ONE_SPACE,
+              SAMSUNG_BIT_MARK, SAMSUNG_ZERO_SPACE,
+              SAMSUNG_BIT_MARK,
+              SAMSUNG_MIN_GAP, SAMSUNG_MIN_MESSAGE_LENGTH,
+              data, nbits, 38, true, repeat, 33);
 }
 
 // Construct a raw Samsung message from the supplied customer(address) &

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -61,25 +61,18 @@
 //   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
 //   http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
 void IRsend::sendSharpRaw(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Set 38kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(38, 33);
-
   for (uint16_t i = 0; i <= repeat; i++) {
     // Protocol demands that the data be sent twice; once normally,
     // then with all but the address bits inverted.
     // Note: Previously this used to be performed 3 times (normal, inverted,
     //       normal), however all data points to that being incorrect.
     for (uint8_t n = 0; n < 2; n++) {
-      // No Header
-
-      // Data
-      sendData(SHARP_BIT_MARK, SHARP_ONE_SPACE,
-               SHARP_BIT_MARK, SHARP_ZERO_SPACE,
-               data, nbits, true);
-      // Footer
-      mark(SHARP_BIT_MARK);
-      space(SHARP_GAP);
-
+      sendGeneric(0, 0,  // No Header
+                  SHARP_BIT_MARK, SHARP_ONE_SPACE,
+                  SHARP_BIT_MARK, SHARP_ZERO_SPACE,
+                  SHARP_BIT_MARK, SHARP_GAP,
+                  data, nbits, 38, true, 0,  // Repeats are handled already.
+                  33);
       // Invert the data per protocol. This is always called twice, so it's
       // retured to original upon exiting the inner loop.
       data ^= SHARP_TOGGLE_MASK;

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -51,24 +51,12 @@
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/sirc.php
 void IRsend::sendSony(uint64_t data, uint16_t nbits, uint16_t repeat) {
-  // Sony devices use a 40kHz IR carrier frequency & a 1/3 (33%) duty cycle.
-  enableIROut(40, 33);
-  IRtimer usecs = IRtimer();
-
-  for (uint16_t i = 0; i <= repeat; i++) {  // Typically loop 3 or more times.
-    usecs.reset();
-    // Header
-    mark(SONY_HDR_MARK);
-    space(SONY_SPACE);
-    // Data
-    sendData(SONY_ONE_MARK, SONY_SPACE, SONY_ZERO_MARK, SONY_SPACE,
-             data, nbits, true);
-    // Footer
-    // The Sony protocol requires us to wait 45ms from start of a code to the
-    // start of the next one. A 10ms minimum gap is also required.
-    space(std::max(SONY_MIN_GAP, SONY_RPT_LENGTH - usecs.elapsed()));
-  }
-  // A space() is always performed last, so no need to turn off the LED.
+  sendGeneric(SONY_HDR_MARK, SONY_SPACE,
+              SONY_ONE_MARK, SONY_SPACE,
+              SONY_ZERO_MARK, SONY_SPACE,
+              0,  // No Footer mark.
+              SONY_MIN_GAP, SONY_RPT_LENGTH,
+              data, nbits, 40, true, repeat, 33);
 }
 
 // Convert Sony/SIRC command, address, & extended bits into sendSony format.

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -51,23 +51,11 @@ void IRsend::sendToshibaAC(unsigned char data[], uint16_t nbytes,
                               uint16_t repeat) {
   if (nbytes < TOSHIBA_AC_STATE_LENGTH)
     return;  // Not enough bytes to send a proper message.
-
-  // Set IR carrier frequency
-  enableIROut(38);
-  // Repeat the message if requested.
-  for (uint16_t r = 0; r <= repeat; r++) {
-    // Header
-    mark(TOSHIBA_AC_HDR_MARK);
-    space(TOSHIBA_AC_HDR_SPACE);
-    // Data
-    for (uint16_t i = 0; i < nbytes; i++)
-      sendData(TOSHIBA_AC_BIT_MARK, TOSHIBA_AC_ONE_SPACE,
-               TOSHIBA_AC_BIT_MARK, TOSHIBA_AC_ZERO_SPACE,
-               data[i], 8, true);
-    // Footer
-    mark(TOSHIBA_AC_BIT_MARK);
-    space(TOSHIBA_AC_MIN_GAP);
-  }
+  sendGeneric(TOSHIBA_AC_HDR_MARK, TOSHIBA_AC_HDR_SPACE,
+              TOSHIBA_AC_BIT_MARK, TOSHIBA_AC_ONE_SPACE,
+              TOSHIBA_AC_BIT_MARK, TOSHIBA_AC_ZERO_SPACE,
+              TOSHIBA_AC_BIT_MARK, TOSHIBA_AC_MIN_GAP,
+              data, nbytes, 38, true, repeat, 50);
 }
 #endif  // SEND_TOSHIBA_AC
 

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -21,21 +21,15 @@ void IRsend::sendTrotec(unsigned char data[], uint16_t nbytes,
   if (nbytes < TROTEC_COMMAND_LENGTH)
     return;
 
-  enableIROut(36);
-
   for (uint16_t r = 0; r <= repeat; r++) {
-    // Header
-    mark(TROTEC_HDR_MARK);
-    space(TROTEC_HDR_SPACE);
-
-    // Data
-    for (uint16_t i = 0; i < nbytes; i++)
-      sendData(TROTEC_ONE_MARK, TROTEC_ONE_SPACE, TROTEC_ZERO_MARK,
-               TROTEC_ZERO_SPACE, data[i], 8, false);
-
-    // Footer
-    mark(TROTEC_ONE_MARK);
-    space(TROTEC_GAP);
+    sendGeneric(TROTEC_HDR_MARK, TROTEC_HDR_SPACE,
+                TROTEC_ONE_MARK, TROTEC_ONE_SPACE,
+                TROTEC_ZERO_MARK, TROTEC_ZERO_SPACE,
+                TROTEC_ONE_MARK, TROTEC_GAP,
+                data, nbytes, 36, false, 0,  // Repeats handled elsewhere
+                50);
+    // More footer
+    enableIROut(36);
     mark(TROTEC_ONE_MARK);
     space(TROTEC_GAP_END);
   }

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -58,18 +58,17 @@ void IRsend::sendWhynter(uint64_t data, uint16_t nbits, uint16_t repeat) {
 
   for (uint16_t i = 0; i <= repeat; i++) {
     usecTimer.reset();
-    // Header
+    // (Pre-)Header
     mark(WHYNTER_BIT_MARK);
     space(WHYNTER_ZERO_SPACE);
-    mark(WHYNTER_HDR_MARK);
-    space(WHYNTER_HDR_SPACE);
-    // Data
-    sendData(WHYNTER_BIT_MARK, WHYNTER_ONE_SPACE, WHYNTER_BIT_MARK,
-             WHYNTER_ZERO_SPACE, data, nbits, true);
-    // Footer
-    mark(WHYNTER_BIT_MARK);
-    space(std::max(WHYNTER_MIN_COMMAND_LENGTH - usecTimer.elapsed(),
-                   WHYNTER_MIN_GAP));
+    sendGeneric(WHYNTER_HDR_MARK, WHYNTER_HDR_SPACE,
+                WHYNTER_BIT_MARK, WHYNTER_ONE_SPACE,
+                WHYNTER_BIT_MARK, WHYNTER_ZERO_SPACE,
+                WHYNTER_BIT_MARK, WHYNTER_MIN_GAP,
+                data, nbits, 38, true, 0,  // Repeats are already handled.
+                50);
+    space(std::max(WHYNTER_MIN_COMMAND_LENGTH - WHYNTER_MIN_GAP -
+                   usecTimer.elapsed(), 0U));
   }
 }
 #endif


### PR DESCRIPTION
* sendGeneric() supports the basics need by most simple message protocols
* Refactor compatible sendXYZ() routines to use sendGeneric to reduce overall code size.

Huzzah for Unit Tests! So we know nothing broke in this refactor process.

Data savings example:
_Before_ using `sendGeneric()`, IRMQTTServer.ino compiled to **347424** bytes.
_After_ using `sendGeneric()`, IRMQTTServer.ino compiled to **347072** bytes.

Thus, this saves about **352** bytes when _all_  of the send routines are linked in. This might help with some projects that are really tight on space and support lots of IRsend routines. e.g. https://github.com/arendst/Sonoff-Tasmota (FYI @arendst )