### PR TITLE
Initial support of a "Lasertag" toy protocol

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -232,10 +232,10 @@ void handleRoot() {
         "<option value='13'>Dish</option>"
         "<option value='6'>JVC</option>"
         "<option value='10'>LG</option>"
+        "<option value='36'>Lasertag</option>"
         "<option value='35'>MagiQuest</option>"
         "<option value='34'>Midea</option>"
         "<option value='12'>Mitsubishi</option>"
-        "<option value='35'>Lasertag</option>"
         "<option selected='selected' value='3'>NEC</option>"  // Default
         "<option value='29'>Nikai</option>"
         "<option value='5'>Panasonic</option>"
@@ -1008,6 +1008,11 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
       if (bits == 0)
         bits = MAGIQUEST_BITS;
       irsend.sendMagiQuest(code, bits, repeat);
+      break;
+    case LASERTAG:  // 36
+      if (bits == 0)
+        bits = LASERTAG_BITS;
+      irsend.sendLasertag(code, bits, repeat);
       break;
   }
 

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -235,6 +235,7 @@ void handleRoot() {
         "<option value='35'>MagiQuest</option>"
         "<option value='34'>Midea</option>"
         "<option value='12'>Mitsubishi</option>"
+        "<option value='35'>Lasertag</option>"
         "<option selected='selected' value='3'>NEC</option>"  // Default
         "<option value='29'>Nikai</option>"
         "<option value='5'>Panasonic</option>"

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -426,6 +426,11 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
     return true;
   }
 #endif
+#if DECODE_LASERTAG
+  DPRINTLN("Attempting Lasertag decode");
+  if (decodeLasertag(results))
+    return true;
+#endif
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -122,7 +122,7 @@ class IRrecv {
   void setUnknownThreshold(uint16_t length);
 #endif
   static bool match(uint32_t measured, uint32_t desired,
-             uint8_t tolerance = TOLERANCE);
+             uint8_t tolerance = TOLERANCE, uint16_t delta = 0);
   static bool matchMark(uint32_t measured, uint32_t desired,
                  uint8_t tolerance = TOLERANCE, int16_t excess = MARK_EXCESS);
   static bool matchSpace(uint32_t measured, uint32_t desired,
@@ -138,10 +138,12 @@ class IRrecv {
   // These are called by decode
   void copyIrParams(volatile irparams_t *src, irparams_t *dst);
   int16_t compare(uint16_t oldval, uint16_t newval);
-  static uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = TOLERANCE);
-  static uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE);
+  static uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = TOLERANCE,
+                           uint16_t delta = 0);
+  static uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = TOLERANCE,
+                           uint16_t delta = 0);
   bool matchAtLeast(uint32_t measured, uint32_t desired,
-                    uint8_t tolerance = TOLERANCE);
+                    uint8_t tolerance = TOLERANCE, uint16_t delta = 0);
   match_result_t matchData(volatile uint16_t *data_ptr, const uint16_t nbits,
                            const uint16_t onemark, const uint32_t onespace,
                            const uint16_t zeromark, const uint32_t zerospace,
@@ -172,7 +174,7 @@ class IRrecv {
 #if (DECODE_RC5 || DECODE_R6 || DECODE_LASERTAG)
   int16_t getRClevel(decode_results *results, uint16_t *offset, uint16_t *used,
                      uint16_t bitTime, uint8_t tolerance = TOLERANCE,
-                     int16_t excess = MARK_EXCESS);
+                     int16_t excess = MARK_EXCESS, uint16_t delta = 0);
 #endif
 #if DECODE_RC5
   bool decodeRC5(decode_results *results, uint16_t nbits = RC5X_BITS,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -169,9 +169,10 @@ class IRrecv {
                         uint16_t nbits = MITSUBISHI_BITS,
                         bool strict = true);
 #endif
-#if (DECODE_RC5 || DECODE_R6)
+#if (DECODE_RC5 || DECODE_R6 || DECODE_LASERTAG)
   int16_t getRClevel(decode_results *results, uint16_t *offset, uint16_t *used,
-                     uint16_t bitTime);
+                     uint16_t bitTime, uint8_t tolerance = TOLERANCE,
+                     int16_t excess = MARK_EXCESS);
 #endif
 #if DECODE_RC5
   bool decodeRC5(decode_results *results, uint16_t nbits = RC5X_BITS,
@@ -256,6 +257,10 @@ class IRrecv {
   bool decodeFujitsuAC(decode_results *results,
                        uint16_t nbits = FUJITSU_AC_BITS,
                        bool strict = false);
+#endif
+#if DECODE_LASERTAG
+  bool decodeLasertag(decode_results *results, uint16_t nbits = LASERTAG_BITS,
+                      bool strict = true);
 #endif
 };
 

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -147,6 +147,9 @@
 #define DECODE_MIDEA         true
 #define SEND_MIDEA           true
 
+#define DECODE_LASERTAG      true
+#define SEND_LASERTAG        true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC)
@@ -197,7 +200,8 @@ enum decode_type_t {
   TOSHIBA_AC,
   FUJITSU_AC,
   MIDEA,
-  MAGIQUEST
+  MAGIQUEST,
+  LASERTAG
 };
 
 // Message lengths & required repeat values
@@ -266,6 +270,8 @@ enum decode_type_t {
 #define MAGIQUEST_BITS              56U
 #define MIDEA_BITS                  48U
 #define MIDEA_MIN_REPEAT             0U
+#define LASERTAG_BITS               13U
+#define LASERTAG_MIN_REPEAT          0U
 
 // Turn on Debugging information by uncommenting the following line.
 // #define DEBUG 1

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -199,6 +199,10 @@ class IRsend {
                      uint16_t repeat = 0);
   uint64_t encodeMagiQuest(uint32_t wand_id, uint16_t magnitude);
 #endif
+#if SEND_LASERTAG
+  void sendLasertag(uint64_t data, uint16_t nbits = LASERTAG_BITS,
+                    uint16_t repeat = LASERTAG_MIN_REPEAT);
+#endif
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -112,6 +112,7 @@ std::string typeToString(const decode_type_t protocol,
     case JVC:           result = "JVC";               break;
     case KELVINATOR:    result = "KELVINATOR";        break;
     case LG:            result = "LG";                break;
+    case LASERTAG:      result = "LASERTAG";          break;
     case MAGIQUEST:     result = "MAGIQUEST";         break;
     case MIDEA:         result = "MIDEA";             break;
     case MITSUBISHI:    result = "MITSUBISHI";        break;

--- a/src/ir_Lasertag.cpp
+++ b/src/ir_Lasertag.cpp
@@ -31,7 +31,7 @@ const int16_t kMARK = 0;
 //   nbits:   Bit size of the protocol you want to send.
 //   repeat:  Nr. of extra times the data will be sent.
 //
-// Status: Alpha / Untested.
+// Status: STABLE / Working.
 //
 
 void IRsend::sendLasertag(uint64_t data, uint16_t nbits, uint16_t repeat) {
@@ -69,7 +69,7 @@ void IRsend::sendLasertag(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: So Alpha, it hurts.
+// Status: BETA / Appears to be working 90% of the time.
 //
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/rc5.php

--- a/src/ir_Lasertag.cpp
+++ b/src/ir_Lasertag.cpp
@@ -16,8 +16,9 @@
 #define MIN_LASERTAG_SAMPLES       13U
 #define LASERTAG_TICK             333U
 #define LASERTAG_MIN_GAP       100000UL  // Completely made up amount.
-#define LASERTAG_TOLERANCE  TOLERANCE    // Percentage error margin
-#define LASERTAG_EXCESS            20U   // See MARK_EXCESS
+#define LASERTAG_TOLERANCE          0U   // Percentage error margin
+#define LASERTAG_EXCESS             0U   // See MARK_EXCESS
+#define LASERTAG_DELTA            150U   // Use instead of EXCESS and TOLERANCE.
 const int16_t kSPACE = 1;
 const int16_t kMARK = 0;
 
@@ -91,9 +92,11 @@ bool IRrecv::decodeLasertag(decode_results *results, uint16_t nbits,
   // Data
   for (; offset <= results->rawlen; actual_bits++) {
     int16_t levelA = getRClevel(results, &offset, &used, LASERTAG_TICK,
-                                LASERTAG_TOLERANCE, LASERTAG_EXCESS);
+                                LASERTAG_TOLERANCE, LASERTAG_EXCESS,
+                                LASERTAG_DELTA);
     int16_t levelB = getRClevel(results, &offset, &used, LASERTAG_TICK,
-                                LASERTAG_TOLERANCE, LASERTAG_EXCESS);
+                                LASERTAG_TOLERANCE, LASERTAG_EXCESS,
+                                LASERTAG_DELTA);
     if (levelA == kSPACE && levelB == kMARK) {
       data = (data << 1) | 1;  // 1
     } else {

--- a/src/ir_Lasertag.cpp
+++ b/src/ir_Lasertag.cpp
@@ -1,0 +1,122 @@
+// Copyright 2017 David Conran
+
+#include <algorithm>
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRtimer.h"
+#include "IRutils.h"
+
+//   LL        AAA    SSSSS  EEEEEEE RRRRRR  TTTTTTT   AAA     GGGG
+//   LL       AAAAA  SS      EE      RR   RR   TTT    AAAAA   GG  GG
+//   LL      AA   AA  SSSSS  EEEEE   RRRRRR    TTT   AA   AA GG
+//   LL      AAAAAAA      SS EE      RR  RR    TTT   AAAAAAA GG   GG
+//   LLLLLLL AA   AA  SSSSS  EEEEEEE RR   RR   TTT   AA   AA  GGGGGG
+
+// Constants
+#define MIN_LASERTAG_SAMPLES       13U
+#define LASERTAG_TICK             333U
+#define LASERTAG_MIN_GAP       100000UL  // Completely made up amount.
+#define LASERTAG_TOLERANCE  TOLERANCE    // Percentage error margin
+#define LASERTAG_EXCESS            20U   // See MARK_EXCESS
+const int16_t kSPACE = 1;
+const int16_t kMARK = 0;
+
+#if SEND_LASERTAG
+// Send a Lasertag packet.
+// This protocol is pretty much just raw Manchester encoding.
+//
+// Args:
+//   data:    The message you wish to send.
+//   nbits:   Bit size of the protocol you want to send.
+//   repeat:  Nr. of extra times the data will be sent.
+//
+// Status: Alpha / Untested.
+//
+
+void IRsend::sendLasertag(uint64_t data, uint16_t nbits, uint16_t repeat) {
+  if (nbits > sizeof(data) * 8)
+    return;  // We can't send something that big.
+
+  // Set 36kHz IR carrier frequency & a 1/4 (25%) duty cycle.
+  // NOTE: duty cycle is not confirmed. Just guessing based on RC5/6 protocols.
+  enableIROut(36, 25);
+
+  for (uint16_t i = 0; i <= repeat; i++) {
+    // Data
+    for (uint64_t mask = 1ULL << (nbits - 1); mask; mask >>= 1)
+      if (data & mask) {  // 1
+        space(LASERTAG_TICK);  // 1 is space, then mark.
+        mark(LASERTAG_TICK);
+      } else {  // 0
+        mark(LASERTAG_TICK);  // 0 is mark, then space.
+        space(LASERTAG_TICK);
+      }
+    // Footer
+    space(LASERTAG_MIN_GAP);
+  }
+}
+#endif  // SEND_LASERTAG
+
+#if DECODE_LASERTAG
+// Decode the supplied Lasertag message.
+// This protocol is pretty much just raw Manchester encoding.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: So Alpha, it hurts.
+//
+// Ref:
+//   http://www.sbprojects.com/knowledge/ir/rc5.php
+//   https://en.wikipedia.org/wiki/RC-5
+//   https://en.wikipedia.org/wiki/Manchester_code
+bool IRrecv::decodeLasertag(decode_results *results, uint16_t nbits,
+                            bool strict) {
+  if (results->rawlen < MIN_LASERTAG_SAMPLES) return false;
+
+  // Compliance
+  if (strict && nbits != LASERTAG_BITS) return false;
+
+  uint16_t offset = OFFSET_START;
+  uint16_t used = 0;
+  uint64_t data = 0;
+  uint16_t actual_bits = 0;
+
+  // No Header
+
+  // Data
+  for (; offset <= results->rawlen; actual_bits++) {
+    int16_t levelA = getRClevel(results, &offset, &used, LASERTAG_TICK,
+                                LASERTAG_TOLERANCE, LASERTAG_EXCESS);
+    int16_t levelB = getRClevel(results, &offset, &used, LASERTAG_TICK,
+                                LASERTAG_TOLERANCE, LASERTAG_EXCESS);
+    if (levelA == kSPACE && levelB == kMARK) {
+      data = (data << 1) | 1;  // 1
+    } else {
+      if (levelA == kMARK && levelB == kSPACE) {
+        data <<= 1;  // 0
+      } else {
+      break;
+      }
+    }
+  }
+  // Footer (None)
+
+  // Compliance
+  if (actual_bits < nbits) return false;  // Less data than we expected.
+  if (strict && actual_bits != LASERTAG_BITS) return false;
+
+  // Success
+  results->decode_type = LASERTAG;
+  results->value = data;
+  results->address = data & 0xF;  // Unit
+  results->command = data >> 4;   // Team
+  results->repeat = false;
+  results->bits = actual_bits;
+  return true;
+}
+#endif  // DECODE_LASERTAG

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -300,7 +300,7 @@ void IRsend::sendRC6(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   https://en.wikipedia.org/wiki/Manchester_code
 int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
                            uint16_t *used, uint16_t bitTime,
-                           uint8_t tolerance, int16_t excess) {
+                           uint8_t tolerance, int16_t excess, uint16_t delta) {
   DPRINT("DEBUG: getRClevel: offset = ");
   DPRINTLN(uint64ToString(*offset));
   if (*offset > results->rawlen) {
@@ -311,7 +311,7 @@ int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
   //  If the value of offset is odd, it's a MARK. Even, it's a SPACE.
   uint16_t val = ((*offset) % 2) ? kMARK : kSPACE;
   // Check to see if we have hit an inter-message gap (> 20ms).
-  if (val == kSPACE && width > 20000) {
+  if (val == kSPACE && width > 20000 - delta) {
     DPRINTLN("DEBUG: getRClevel: SPACE, hit end of mesg gap.");
     return kSPACE;
   }
@@ -322,11 +322,11 @@ int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
   // Note: We want to match in greedy order as the other way leads to
   //       mismatches due to overlaps induced by the correction and tolerance
   //       values.
-  if (match(width, 3 * bitTime + correction, tolerance)) {
+  if (match(width, 3 * bitTime + correction, tolerance, delta)) {
     avail = 3;
-  } else if (match(width, 2 * bitTime + correction, tolerance)) {
+  } else if (match(width, 2 * bitTime + correction, tolerance, delta)) {
     avail = 2;
-  } else if (match(width, bitTime + correction, tolerance)) {
+  } else if (match(width, bitTime + correction, tolerance, delta)) {
     avail = 1;
   } else {
     DPRINTLN("DEBUG: getRClevel: Unexpected width. Exiting.");

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -303,7 +303,7 @@ int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
                            uint8_t tolerance, int16_t excess, uint16_t delta) {
   DPRINT("DEBUG: getRClevel: offset = ");
   DPRINTLN(uint64ToString(*offset));
-  if (*offset > results->rawlen) {
+  if (*offset >= results->rawlen) {
     DPRINTLN("DEBUG: getRClevel: SPACE, past end of rawbuf");
     return kSPACE;  // After end of recorded buffer, assume SPACE.
   }

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -42,9 +42,8 @@
 #define RC6_36_TOGGLE_MASK     0x8000U  // (The 16th bit)
 
 // Common (getRClevel())
-#define MARK  0U
-#define SPACE 1U
-
+const int16_t kMARK = 0;
+const int16_t kSPACE = 1;
 
 #if SEND_RC5
 // Send a Philips RC-5/RC-5X packet.
@@ -282,7 +281,7 @@ void IRsend::sendRC6(uint64_t data, uint16_t nbits, uint16_t repeat) {
 }
 #endif  // SEND_RC6
 
-#if (DECODE_RC5 || DECODE_RC6)
+#if (DECODE_RC5 || DECODE_RC6 || DECODE_LASERTAG)
 // Gets one undecoded level at a time from the raw buffer.
 // The RC5/6 decoding is easier if the data is broken into time intervals.
 // E.g. if the buffer has MARK for 2 time intervals and SPACE for 1,
@@ -300,30 +299,39 @@ void IRsend::sendRC6(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Ref:
 //   https://en.wikipedia.org/wiki/Manchester_code
 int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
-                           uint16_t *used, uint16_t bitTime) {
-  if (*offset >= results->rawlen)
-    return SPACE;  // After end of recorded buffer, assume SPACE.
+                           uint16_t *used, uint16_t bitTime,
+                           uint8_t tolerance, int16_t excess) {
+  DPRINT("DEBUG: getRClevel: offset = ");
+  DPRINTLN(uint64ToString(*offset));
+  if (*offset > results->rawlen) {
+    DPRINTLN("DEBUG: getRClevel: SPACE, past end of rawbuf");
+    return kSPACE;  // After end of recorded buffer, assume SPACE.
+  }
   uint16_t width = results->rawbuf[*offset];
   //  If the value of offset is odd, it's a MARK. Even, it's a SPACE.
-  uint16_t val = ((*offset) % 2) ? MARK : SPACE;
+  uint16_t val = ((*offset) % 2) ? kMARK : kSPACE;
   // Check to see if we have hit an inter-message gap (> 20ms).
-  if (val == SPACE && width > 20000)
-    return SPACE;
-  int16_t correction = (val == MARK) ? MARK_EXCESS : -MARK_EXCESS;
+  if (val == kSPACE && width > 20000) {
+    DPRINTLN("DEBUG: getRClevel: SPACE, hit end of mesg gap.");
+    return kSPACE;
+  }
+  int16_t correction = (val == kMARK) ? excess : -excess;
 
   // Calculate the look-ahead for our current position in the buffer.
   uint16_t avail;
   // Note: We want to match in greedy order as the other way leads to
   //       mismatches due to overlaps induced by the correction and tolerance
   //       values.
-  if (match(width, 3 * bitTime + correction))
+  if (match(width, 3 * bitTime + correction, tolerance)) {
     avail = 3;
-  else if (match(width, 2 * bitTime + correction))
+  } else if (match(width, 2 * bitTime + correction, tolerance)) {
     avail = 2;
-  else if (match(width, bitTime + correction))
+  } else if (match(width, bitTime + correction, tolerance)) {
     avail = 1;
-  else
+  } else {
+    DPRINTLN("DEBUG: getRClevel: Unexpected width. Exiting.");
     return -1;  // The width is not what we expected.
+  }
 
   (*used)++;  // Count another one of the avail slots as used.
   if (*used >= avail) {  // Are we out of look-ahead/avail slots?
@@ -331,10 +339,15 @@ int16_t IRrecv::getRClevel(decode_results *results,  uint16_t *offset,
     *used = 0;
     (*offset)++;
   }
+  if (val == kMARK) {
+    DPRINTLN("DEBUG: getRClevel: MARK");
+  } else {
+    DPRINTLN("DEBUG: getRClevel: SPACE");
+  }
 
   return val;
 }
-#endif  // (DECODE_RC5 || DECODE_RC6)
+#endif  // (DECODE_RC5 || DECODE_RC6 || DECODE_LASERTAG)
 
 #if DECODE_RC5
 // Decode the supplied RC-5/RC5X message.
@@ -371,14 +384,14 @@ bool IRrecv::decodeRC5(decode_results *results, uint16_t nbits, bool strict) {
 
   // Header
   // Get start bit #1.
-  if (getRClevel(results, &offset, &used, RC5_T1) != MARK) return false;
+  if (getRClevel(results, &offset, &used, RC5_T1) != kMARK) return false;
   // Get field/start bit #2 (inverted bit-7 of the command if RC-5X protocol)
   uint16_t actual_bits = 1;
   int16_t levelA = getRClevel(results, &offset, &used, RC5_T1);
   int16_t levelB = getRClevel(results, &offset, &used, RC5_T1);
-  if (levelA == SPACE && levelB == MARK) {  // Matched a 1.
+  if (levelA == kSPACE && levelB == kMARK) {  // Matched a 1.
     is_rc5x = false;
-  } else if (levelA == MARK && levelB == SPACE) {  // Matched a 0.
+  } else if (levelA == kMARK && levelB == kSPACE) {  // Matched a 0.
     if (nbits <= RC5_BITS) return false;  // Field bit must be '1' for RC5.
     is_rc5x = true;
     data = 1;
@@ -390,9 +403,9 @@ bool IRrecv::decodeRC5(decode_results *results, uint16_t nbits, bool strict) {
   for (; offset < results->rawlen; actual_bits++) {
     int16_t levelA = getRClevel(results, &offset, &used, RC5_T1);
     int16_t levelB = getRClevel(results, &offset, &used, RC5_T1);
-    if (levelA == SPACE && levelB == MARK)
+    if (levelA == kSPACE && levelB == kMARK)
       data = (data << 1) | 1;  // 1
-    else if (levelA == MARK && levelB == SPACE)
+    else if (levelA == kMARK && levelB == kSPACE)
       data <<= 1;  // 0
     else
       break;
@@ -472,8 +485,8 @@ bool IRrecv::decodeRC6(decode_results *results, uint16_t nbits, bool strict) {
   uint16_t used = 0;
 
   // Get the start bit. e.g. 1.
-  if (getRClevel(results, &offset, &used, tick) != MARK) return false;
-  if (getRClevel(results, &offset, &used, tick) != SPACE) return false;
+  if (getRClevel(results, &offset, &used, tick) != kMARK) return false;
+  if (getRClevel(results, &offset, &used, tick) != kSPACE) return false;
 
   uint16_t actual_bits;
   uint64_t data = 0;
@@ -491,9 +504,9 @@ bool IRrecv::decodeRC6(decode_results *results, uint16_t nbits, bool strict) {
     if (actual_bits == 3 &&
         levelB != getRClevel(results, &offset, &used, tick))
       return false;
-    if (levelA == MARK && levelB == SPACE)  // reversed compared to RC5
+    if (levelA == kMARK && levelB == kSPACE)  // reversed compared to RC5
       data = (data << 1) | 1;  // 1
-    else if (levelA == SPACE && levelB == MARK)
+    else if (levelA == kSPACE && levelB == kMARK)
       data <<= 1;  // 0
     else
       break;

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_RC5_RC6_test ir_Panasonic_test ir_Dish_test ir_Whynter_test \
         ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
         ir_Gree_test IRrecv_test ir_Pronto_test ir_Fujitsu_test ir_Nikai_test \
-        ir_Toshiba_test ir_Midea_test ir_Magiquest_test
+        ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -73,7 +73,8 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
     ir_LG.o ir_Mitsubishi.o ir_Fujitsu.o ir_Sharp.o ir_Sanyo.o ir_Denon.o ir_Dish.o \
 		ir_Panasonic.o ir_Whynter.o ir_Coolix.o ir_Aiwa.o ir_Sherwood.o \
 		ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
-		ir_Midea.o ir_Magiquest.o
+		ir_Midea.o ir_Magiquest.o ir_Lasertag.o
+
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
              $(PROTOCOLS) gtest_main.a
@@ -376,4 +377,13 @@ ir_Magiquest_test.o : ir_Magiquest_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Magiquest_test.cpp
 
 ir_Magiquest_test : $(COMMON_OBJ) ir_Magiquest_test.o
+$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Lasertag.o : $(USER_DIR)/ir_Lasertag.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lasertag.cpp
+
+ir_Lasertag_test.o : ir_Lasertag_test.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Lasertag_test.cpp
+
+ir_Lasertag_test : $(COMMON_OBJ) ir_Lasertag_test.o ir_RC5_RC6.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -377,7 +377,7 @@ ir_Magiquest_test.o : ir_Magiquest_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Magiquest_test.cpp
 
 ir_Magiquest_test : $(COMMON_OBJ) ir_Magiquest_test.o
-$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Lasertag.o : $(USER_DIR)/ir_Lasertag.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lasertag.cpp

--- a/test/ir_Lasertag_test.cpp
+++ b/test/ir_Lasertag_test.cpp
@@ -260,4 +260,82 @@ TEST(TestDecodeLasertag, RealExamples) {
   EXPECT_EQ(0x02, irsend.capture.value);
   EXPECT_EQ(0x2, irsend.capture.address);  // Unit
   EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit1_1_issue532[25] = {
+      368, 352, 336, 308, 388, 276, 364, 356, 280, 360, 332, 336, 360, 360, 308,
+      300, 416, 280, 356, 360, 312, 328, 336, 636, 424};
+  irsend.sendRaw(red_unit1_1_issue532, 25, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x01, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit1_2_issue532[25] = {
+      328, 400, 272, 360, 388, 280, 360, 364, 272, 364, 332, 336, 332, 388, 304,
+      308, 388, 280, 356, 364, 272, 368, 384, 612, 408};
+  irsend.sendRaw(red_unit1_2_issue532, 25, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x01, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit1_3_issue532[25] = {
+      416, 284, 356, 336, 328, 336, 384, 308, 328, 368, 304, 308, 412, 280, 328,
+      368, 272, 368, 376, 312, 332, 392, 276, 700, 272};
+  irsend.sendRaw(red_unit1_3_issue532, 25, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x01, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_1_issue532[23] = {
+      308, 340, 408, 284, 332, 388, 276, 336, 356, 340, 332, 360, 300, 364, 360,
+      304, 280, 444, 276, 336, 384, 640, 696};
+  irsend.sendRaw(red_unit2_1_issue532, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_2_issue532[23] = {
+      332, 308, 388, 280, 328, 420, 308, 304, 384, 308, 332, 364, 272, 368, 384,
+      276, 364, 360, 308, 332, 384, 612, 696};
+  irsend.sendRaw(red_unit2_2_issue532, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_3_issue532[23] = {
+      392, 332, 340, 272, 448, 276, 364, 328, 340, 272, 396, 296, 340, 380, 312,
+      296, 400, 272, 364, 352, 284, 720, 672};
+  irsend.sendRaw(red_unit2_3_issue532, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
 }

--- a/test/ir_Lasertag_test.cpp
+++ b/test/ir_Lasertag_test.cpp
@@ -208,4 +208,56 @@ TEST(TestDecodeLasertag, RealExamples) {
   EXPECT_EQ(0x0F, irsend.capture.value);
   EXPECT_EQ(0xF, irsend.capture.address);  // Unit
   EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_1[23] = {
+      406, 262,  384, 374,  256, 354,  306, 366,  252, 442,  256, 374,
+      358, 336,  278, 438,  246, 340,  380, 292,  304, 688,  746};
+  irsend.sendRaw(red_unit2_1, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_2[23] = {
+      302, 306,  302, 392,  196, 476,  278, 352,  304, 348,  278, 438,
+      226, 382,  328, 366,  252, 458,  196, 392,  302, 688,  644};
+  irsend.sendRaw(red_unit2_2, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_3[23] = {
+      196, 432,  304, 348,  328, 386,  304, 326,  302, 370,  252, 442,
+      272, 356,  278, 374,  276, 438,  274, 352,  302, 668,  622};
+  irsend.sendRaw(red_unit2_3, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t red_unit2_4[23] = {
+      304, 390,  328, 324,  324, 346,  350, 364,  300, 330,  320, 310,
+      324, 388,  242, 366,  354, 318,  354, 340,  244, 726,  670};
+  irsend.sendRaw(red_unit2_4, 23, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
 }

--- a/test/ir_Lasertag_test.cpp
+++ b/test/ir_Lasertag_test.cpp
@@ -1,0 +1,211 @@
+// Copyright 2017 David Conran
+
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+//   LL        AAA    SSSSS  EEEEEEE RRRRRR  TTTTTTT   AAA     GGGG
+//   LL       AAAAA  SS      EE      RR   RR   TTT    AAAAA   GG  GG
+//   LL      AA   AA  SSSSS  EEEEE   RRRRRR    TTT   AA   AA GG
+//   LL      AAAAAAA      SS EE      RR  RR    TTT   AAAAAAA GG   GG
+//   LLLLLLL AA   AA  SSSSS  EEEEEEE RR   RR   TTT   AA   AA  GGGGGG
+
+
+// Tests for sendLasertag().
+
+// Test sending simplest case data only.
+TEST(TestSendLasertag, SendDataOnly) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLasertag(0x1);  // Red 1
+  EXPECT_EQ(
+      "m333s333m333s333m333s333m333s333m333s333m333s333m333s333m333s333m333"
+      "s333m333s333m333s333m333s666m333s100000", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendLasertag(0x2);  // Red 2
+  EXPECT_EQ(
+      "m333s333m333s333m333s333m333s333m333s333m333s333m333s333"
+      "m333s333m333s333m333s333m333s666m666s100333", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendLasertag(0x51);  // Green 1
+  // Raw: (21)
+  // m364s364m332s336m384s276m332s364m332s304m416s584m692s724m640s360m304s332m392s612m380,
+  EXPECT_EQ(
+    // m364s364m332s336m384s276m332s364m332s304m416s584
+    // m692s724m640s360m304s332m392s612m380
+      "m333s333m333s333m333s333m333s333m333s333m333s666"
+      "m666s666m666s333m333s333m333s666m333s100000", irsend.outputStr());
+
+  irsend.reset();
+  // Raw: (19)
+  // m332s308m412s280m360s336m332s304m444s248m332s644m744s612m696s692m668s636m360
+  irsend.sendLasertag(0x55);  // Green 5
+  EXPECT_EQ(
+    // m332s308m412s280m360s336m332s304m444s248m332s644
+    // m744s612m696s692m668s636m360
+      "m333s333m333s333m333s333m333s333m333s333m333s666"
+      "m666s666m666s666m666s666m333s100000",
+      irsend.outputStr());
+}
+
+TEST(TestSendLasertag, SendDataWithRepeat) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLasertag(0x1, LASERTAG_BITS, 1);  // Red 1, one repeat.
+  EXPECT_EQ(
+      "m333s333m333s333m333s333m333s333m333s333m333s333m333s333m333s333"
+      "m333s333m333s333m333s333m333s666m333s100000"
+      "m333s333m333s333m333s333m333s333m333s333m333s333m333s333m333s333"
+      "m333s333m333s333m333s333m333s666m333s100000", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendLasertag(0x52, LASERTAG_BITS, 2);  // Green 2, two repeats.
+  EXPECT_EQ(
+      "m333s333m333s333m333s333m333s333m333s333m333s666m666s666m666s333"
+      "m333s666m666s100333"
+      "m333s333m333s333m333s333m333s333m333s333m333s666m666s666m666s333"
+      "m333s666m666s100333"
+      "m333s333m333s333m333s333m333s333m333s333m333s666m666s666m666s333"
+      "m333s666m666s100333", irsend.outputStr());
+}
+
+TEST(TestSendLasertag, SmallestMessageSize) {
+  IRsendTest irsend(4);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLasertag(0x1555);  // Alternating bit pattern will be the smallest.
+  // i.e. 7 actual 'mark' pulses, which is a rawlen of 13.
+  EXPECT_EQ("m0s333m666s666m666s666m666s666m666s666m666s666m666s666m333s100000",
+            irsend.outputStr());
+}
+
+// Tests for decodeLasertag().
+
+// Decode normal Lasertag messages.
+TEST(TestDecodeLasertag, NormalSyntheticDecodeWithStrict) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  // Normal Lasertag 13-bit message.
+  irsend.reset();
+  irsend.sendLasertag(0x01);  // Red 1
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x01, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit 1
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team Red
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.reset();
+  irsend.sendLasertag(0x02);  // Red 2
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x02, irsend.capture.value);
+  EXPECT_EQ(0x2, irsend.capture.address);  // Unit 2
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team Red
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.reset();
+  irsend.sendLasertag(0x06);  // Red 6
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x06, irsend.capture.value);
+  EXPECT_EQ(0x6, irsend.capture.address);  // Unit 6
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team Red
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.reset();
+  irsend.sendLasertag(0x51);  // Green 1
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x51, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit 1
+  EXPECT_EQ(0x5, irsend.capture.command);  // Team Green
+  EXPECT_FALSE(irsend.capture.repeat);
+
+  irsend.reset();
+  irsend.sendLasertag(0x56);  // Green 6
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x56, irsend.capture.value);
+  EXPECT_EQ(0x6, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x5, irsend.capture.command);  // Team
+  EXPECT_FALSE(irsend.capture.repeat);
+}
+
+// Example data taken from: https://github.com/z3t0/Arduino-IRremote/issues/532
+TEST(TestDecodeLasertag, RealExamples) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  uint16_t green3[21] = {
+      360, 364, 272, 360, 420, 248, 360, 360, 332, 308, 388, 612, 692, 696,
+      636, 360, 332, 700, 300, 308, 416};
+  irsend.sendRaw(green3, 21, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x53, irsend.capture.value);
+  EXPECT_EQ(0x3, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x5, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t green1[21] = {
+      364, 364, 332, 336, 384, 276, 332, 364, 332, 304, 416, 584, 692, 724,
+      640, 360, 304, 332, 392, 612, 380};
+  irsend.sendRaw(green1, 21, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x51, irsend.capture.value);
+  EXPECT_EQ(0x1, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x5, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t green4[19] = {
+      336, 304, 412, 280, 360, 360, 304, 308, 420, 276, 332, 636, 744, 620,
+      688, 724, 640, 360, 304};
+  irsend.sendRaw(green4, 19, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x54, irsend.capture.value);
+  EXPECT_EQ(0x4, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x5, irsend.capture.command);  // Team
+
+  irsend.reset();
+  uint16_t unit15[25] = {
+      280, 360, 360, 308, 332, 388, 308, 332, 360, 308, 360, 360, 304, 304,
+      412, 284, 304, 692, 364, 360, 276, 336, 416, 276, 328};
+  irsend.sendRaw(unit15, 25, 36000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(LASERTAG_BITS, irsend.capture.bits);
+  EXPECT_EQ(0x0F, irsend.capture.value);
+  EXPECT_EQ(0xF, irsend.capture.address);  // Unit
+  EXPECT_EQ(0x0, irsend.capture.command);  // Team
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -34,7 +34,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Denon.o ir_Dish.o ir_Panasonic.o ir_Whynter.o ir_Coolix.o \
             ir_Aiwa.o ir_Sherwood.o ir_Kelvinator.o ir_Daikin.o ir_Gree.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
-            ir_Magiquest.o
+            ir_Magiquest.o ir_Lasertag.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -145,3 +145,6 @@ ir_Midea.o : $(USER_DIR)/ir_Midea.cpp $(COMMON_DEPS)
 
 ir_Magiquest.o : $(USER_DIR)/ir_Magiquest.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Magiquest.cpp
+
+ir_Lasertag.o : $(USER_DIR)/ir_Lasertag.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lasertag.cpp


### PR DESCRIPTION
* sendLasertag() & decodeLasertag() for issue #366
* Add an option of a fixed 'delta' to the core matching functions.
* Tweak getRClevel() to allow custom tolerances, excess levels, and fixed ranges.
* Unit tests for Lasertag etc.
* Update example code & tools for this protocol.