### PR TITLE
Fix a compile issue if SEND_FUJITSU_AC is false.

### DIFF
--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -86,11 +86,13 @@ void IRFujitsuAC::begin() {
   _irsend.begin();
 }
 
+#if SEND_FUJITSU_AC
 // Send the current desired state to the IR LED.
 void IRFujitsuAC::send() {
   getRaw();
   _irsend.sendFujitsuAC(remote_state, getStateLength());
 }
+#endif  // SEND_FUJITSU_AC
 
 void IRFujitsuAC::buildState() {
   remote_state[0] = 0x14;

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -45,7 +45,6 @@
 #define FUJITSU_AC_SWING_BOTH     0x03U
 
 
-#if SEND_FUJITSU_AC
 enum fujitsu_ac_remote_model_t {
   ARRAH2E = 1,
   ARDB1,
@@ -57,7 +56,9 @@ class IRFujitsuAC {
 
   void setModel(fujitsu_ac_remote_model_t model);
   void stateReset();
+#if SEND_FUJITSU_AC
   void send();
+#endif  // SEND_FUJITSU_AC
   void begin();
   void off();
   void stepHoriz();
@@ -97,6 +98,5 @@ class IRFujitsuAC {
   void buildState();
   void buildFromState(const uint16_t length);
 };
-#endif  // SEND_FUJITSU_AC
 
 #endif  // IR_FUJITSU_H_


### PR DESCRIPTION
Issue reported by @arendst in https://github.com/markszabo/IRremoteESP8266/pull/373#issuecomment-351414432

The IRFujistuAC class has a send() method that needs to be disabled if SEND_FUJITSU_AC is false.