### PR TITLE
Clean up SEND_XYZ/DECODE_XYZ protocol disables.

### DIFF
--- a/examples/IRGCSendDemo/IRGCSendDemo.ino
+++ b/examples/IRGCSendDemo/IRGCSendDemo.ino
@@ -58,6 +58,10 @@ void setup() {
 
 void loop() {
   Serial.println("Toggling power");
+#if SEND_GLOBALCACHE
   irsend.sendGC(Samsung_power_toggle, 71);
+#else  // SEND_GLOBALCACHE
+  Serial.println("Can't send because SEND_GLOBALCACHE has been disabled.");
+#endif  // SEND_GLOBALCACHE
   delay(10000);
 }

--- a/examples/IRGCTCPServer/IRGCTCPServer.ino
+++ b/examples/IRGCTCPServer/IRGCTCPServer.ino
@@ -89,7 +89,9 @@ void sendGCString(String str) {
     count++;
   } while (index != -1);
 
+#if SEND_GLOBALCACHE
   irsend.sendGC(code_array, count);  // All done. Send it.
+#endif  // SEND_GLOBALCACHE
   free(code_array);  // Free up the memory allocated.
 }
 

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -453,30 +453,46 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
 
   // Make the appropriate call for the protocol type.
   switch (irType) {
+#if SEND_KELVINATOR
     case KELVINATOR:
       irsend.sendKelvinator(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_TOSHIBA_AC
     case TOSHIBA_AC:
       irsend.sendToshibaAC(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_DAIKIN
     case DAIKIN:
       irsend.sendDaikin(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if MITSUBISHI_AC
     case MITSUBISHI_AC:
       irsend.sendMitsubishiAC(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_TROTEC
     case TROTEC:
       irsend.sendTrotec(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_ARGO
     case ARGO:
       irsend.sendArgo(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_GREE
     case GREE:
       irsend.sendGree(reinterpret_cast<uint8_t *>(state));
       break;
+#endif
+#if SEND_FUJITSU_AC
     case FUJITSU_AC:
       irsend.sendFujitsuAC(reinterpret_cast<uint8_t *>(state), stateSize);
       break;
+#endif
   }
 }
 
@@ -517,6 +533,7 @@ uint16_t * newCodeArray(const uint16_t size) {
   return result;
 }
 
+#if SEND_GLOBALCACHE
 // Parse a GlobalCache String/code and send it.
 // Args:
 //   str: A GlobalCache formatted String of comma separated numbers.
@@ -556,7 +573,9 @@ void parseStringAndSendGC(const String str) {
   irsend.sendGC(code_array, count);  // All done. Send it.
   free(code_array);  // Free up the memory allocated.
 }
+#endif  // SEND_GLOBALCACHE
 
+#if SEND_PRONTO
 // Parse a Pronto Hex String/code and send it.
 // Args:
 //   str: A comma-separated String of nr. of repeats, then hexadecimal numbers.
@@ -609,7 +628,9 @@ void parseStringAndSendPronto(const String str, uint16_t repeats) {
   irsend.sendPronto(code_array, count, repeats);  // All done. Send it.
   free(code_array);  // Free up the memory allocated.
 }
+#endif  // SEND_PRONTO
 
+#if SEND_RAW
 // Parse an IRremote Raw Hex String/code and send it.
 // Args:
 //   str: A comma-separated String containing the freq and raw IR data.
@@ -649,6 +670,7 @@ void parseStringAndSendRaw(const String str) {
   irsend.sendRaw(raw_array, count, freq);  // All done. Send it.
   free(raw_array);  // Free up the memory allocated.
 }
+#endif  // SEND_RAW
 
 // Parse the URL args to find the IR code.
 void handleIr() {
@@ -876,80 +898,108 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
 
   // send the IR message.
   switch (ir_type) {
+#if SEND_RC5
     case RC5:  // 1
       if (bits == 0)
         bits = RC5_BITS;
       irsend.sendRC5(code, bits, repeat);
       break;
+#endif
+#if SEND_RC6
     case RC6:  // 2
       if (bits == 0)
         bits = RC6_MODE0_BITS;
       irsend.sendRC6(code, bits, repeat);
       break;
+#endif
+#if SEND_NEC
     case NEC:  // 3
       if (bits == 0)
         bits = NEC_BITS;
       irsend.sendNEC(code, bits, repeat);
       break;
+#endif
+#if SEND_SONY
     case SONY:  // 4
       if (bits == 0)
         bits = SONY_12_BITS;
       repeat = std::max(repeat, (uint16_t) SONY_MIN_REPEAT);
       irsend.sendSony(code, bits, repeat);
       break;
+#endif
+#if SEND_PANASONIC
     case PANASONIC:  // 5
       if (bits == 0)
         bits = PANASONIC_BITS;
       irsend.sendPanasonic64(code, bits, repeat);
       break;
+#endif
+#if SEND_JVC
     case JVC:  // 6
       if (bits == 0)
         bits = JVC_BITS;
       irsend.sendJVC(code, bits, repeat);
       break;
+#endif
+#if SEND_SAMSUNG
     case SAMSUNG:  // 7
       if (bits == 0)
         bits = SAMSUNG_BITS;
       irsend.sendSAMSUNG(code, bits, repeat);
       break;
+#endif
+#if SEND_WHYNTER
     case WHYNTER:  // 8
       if (bits == 0)
         bits = WHYNTER_BITS;
       irsend.sendWhynter(code, bits, repeat);
       break;
+#endif
+#if SEND_AIWA_RC_T501
     case AIWA_RC_T501:  // 9
       if (bits == 0)
         bits = AIWA_RC_T501_BITS;
       repeat = std::max(repeat, (uint16_t) AIWA_RC_T501_MIN_REPEAT);
       irsend.sendAiwaRCT501(code, bits, repeat);
       break;
+#endif
+#if SEND_LG
     case LG:  // 10
       if (bits == 0)
         bits = LG_BITS;
       irsend.sendLG(code, bits, repeat);
       break;
+#endif
+#if SEND_MITSUBISHI
     case MITSUBISHI:  // 12
       if (bits == 0)
         bits = MITSUBISHI_BITS;
       repeat = std::max(repeat, (uint16_t) MITSUBISHI_MIN_REPEAT);
       irsend.sendMitsubishi(code, bits, repeat);
       break;
+#endif
+#if SEND_DISH
     case DISH:  // 13
       if (bits == 0)
         bits = DISH_BITS;
       repeat = std::max(repeat, (uint16_t) DISH_MIN_REPEAT);
       irsend.sendDISH(code, bits, repeat);
       break;
+#endif
+#if SEND_SHARP
     case SHARP:  // 14
       if (bits == 0)
         bits = SHARP_BITS;
       irsend.sendSharpRaw(code, bits, repeat);
       break;
+#endif
+#if SEND_COOLIX
     case COOLIX:  // 15
       if (bits == 0)
         bits = COOLIX_BITS;
       irsend.sendCOOLIX(code, bits, repeat);
       break;
+#endif
     case DAIKIN:  // 16
     case KELVINATOR:  // 18
     case MITSUBISHI_AC:  // 20
@@ -960,60 +1010,85 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
     case FUJITSU_AC:  // 33
       parseStringAndSendAirCon(ir_type, code_str);
       break;
+#if SEND_DENON
     case DENON:  // 17
       if (bits == 0)
         bits = DENON_BITS;
       irsend.sendDenon(code, bits, repeat);
       break;
+#endif
+#if SEND_SHERWOOD
     case SHERWOOD:  // 19
       if (bits == 0)
         bits = SHERWOOD_BITS;
       repeat = std::max(repeat, (uint16_t) SHERWOOD_MIN_REPEAT);
       irsend.sendSherwood(code, bits, repeat);
       break;
+#endif
+#if SEND_RCMM
     case RCMM:  // 21
       if (bits == 0)
         bits == RCMM_BITS;
       irsend.sendRCMM(code, bits, repeat);
       break;
+#endif
+#if SEND_SANYO
     case SANYO_LC7461:  // 22
       if (bits == 0)
         bits = SANYO_LC7461_BITS;
       irsend.sendSanyoLC7461(code, bits, repeat);
       break;
+#endif
+#if SEND_RC5
     case RC5X:  // 23
       if (bits == 0)
         bits = RC5X_BITS;
       irsend.sendRC5(code, bits, repeat);
+      break;
+#endif
+#if SEND_PRONTO
     case PRONTO:  // 25
       parseStringAndSendPronto(code_str, repeat);
       break;
+#endif
+#if SEND_NIKAI
     case NIKAI:  // 29
       if (bits == 0)
         bits = NIKAI_BITS;
       irsend.sendNikai(code, bits, repeat);
       break;
+#endif
+#if SEND_RAW
     case RAW:  // 30
       parseStringAndSendRaw(code_str);
       break;
+#endif
+#if SEND_GLOBALCACHE
     case GLOBALCACHE:  // 31
       parseStringAndSendGC(code_str);
       break;
+#endif
+#if SEND_MIDEA
     case MIDEA:  // 34
       if (bits == 0)
         bits = MIDEA_BITS;
       irsend.sendMidea(code, bits, repeat);
       break;
+#endif
+#if SEND_MAGIQUEST
     case MAGIQUEST:  // 35
       if (bits == 0)
         bits = MAGIQUEST_BITS;
       irsend.sendMagiQuest(code, bits, repeat);
       break;
+#endif
+#if SEND_LASERTAG
     case LASERTAG:  // 36
       if (bits == 0)
         bits = LASERTAG_BITS;
       irsend.sendLasertag(code, bits, repeat);
       break;
+#endif
   }
 
   // Release the lock.

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -61,7 +61,9 @@ void handleIr() {
   for (uint8_t i = 0; i < server.args(); i++) {
     if (server.argName(i) == "code") {
       uint32_t code = strtoul(server.arg(i).c_str(), NULL, 10);
+#if SEND_NEC
       irsend.sendNEC(code, 32);
+#endif  // SEND_NEC
     }
   }
   handleRoot();

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -150,8 +150,10 @@ void setup() {
   Serial.begin(BAUD_RATE, SERIAL_8N1, SERIAL_TX_ONLY);
   delay(500);  // Wait a bit for the serial connection to be establised.
 
+#if DECODE_HASH
   // Ignore messages with less than minimum on or off pulses.
   irrecv.setUnknownThreshold(MIN_UNKNOWN_SIZE);
+#endif  // DECODE_HASH
   irrecv.enableIRIn();  // Start the receiver
 }
 

--- a/examples/IRsendDemo/IRsendDemo.ino
+++ b/examples/IRsendDemo/IRsendDemo.ino
@@ -50,13 +50,19 @@ void setup() {
 }
 
 void loop() {
+#if SEND_NEC
   Serial.println("NEC");
   irsend.sendNEC(0x00FFE01FUL, 32);
+#endif  // SEND_NEC
   delay(2000);
+#if SEND_SONY
   Serial.println("Sony");
   irsend.sendSony(0xa90, 12, 2);
+#endif  // SEND_SONY
   delay(2000);
+#if SEND_RAW
   Serial.println("a rawData capture from IRrecvDumpV2");
   irsend.sendRaw(rawData, 67, 38);  // Send a raw data capture at 38kHz.
+#endif  // SEND_RAW
   delay(2000);
 }

--- a/examples/IRsendProntoDemo/IRsendProntoDemo.ino
+++ b/examples/IRsendProntoDemo/IRsendProntoDemo.ino
@@ -96,10 +96,15 @@ void setup() {
 }
 
 void loop() {
+#if SEND_PRONTO
   Serial.println("Sending a Samsung TV 'on' command.");
   irsend.sendPronto(samsungProntoCode, 72);
   delay(2000);
   Serial.println("Sending a Panasonic Plasma TV 'on' command.");
   irsend.sendPronto(panasonicProntoCode, 104);
   delay(2000);
+#else  // SEND_PRONTO
+  Serial.println("Can't send because SEND_PRONTO has been disabled.");
+  delay(10000);
+#endif  // SEND_PRONTO
 }

--- a/examples/JVCPanasonicSendDemo/JVCPanasonicSendDemo.ino
+++ b/examples/JVCPanasonicSendDemo/JVCPanasonicSendDemo.ino
@@ -46,11 +46,19 @@ void setup() {
 
 void loop() {
   // This should turn your TV on and off
+#if SEND_PANASONIC
   irsend.sendPanasonic(PanasonicAddress, PanasonicPower);
+#else  // SEND_PANASONIC
+  Serial.println("Can't send because SEND_PANASONIC has been disabled.");
+#endif  // SEND_PANASONIC
 
+#if SEND_JVC
   irsend.sendJVC(JVCPower, 16, 0);  // hex value, 16 bits, no repeat
   // see http://www.sbprojects.com/knowledge/ir/jvc.php for information
   delayMicroseconds(50);
   irsend.sendJVC(JVCPower, 16, 1);  // hex value, 16 bits, repeat
   delayMicroseconds(50);
+#else  // SEND_JVC
+  Serial.println("Can't send because SEND_JVC has been disabled.");
+#endif  // SEND_JVC
 }

--- a/examples/LGACSend/LGACSend.ino
+++ b/examples/LGACSend/LGACSend.ino
@@ -45,7 +45,11 @@ void Ac_Send_Code(uint32_t code) {
   Serial.print(" : ");
   Serial.println(code, HEX);
 
+#if SEND_LG
   irsend.sendLG(code, 28);
+#else  // SEND_LG
+  Serial.println("Can't send because SEND_LG has been disabled.");
+#endif  // SEND_LG
 }
 
 void Ac_Activate(unsigned int temperature, unsigned int air_flow,
@@ -171,8 +175,8 @@ void loop() {
      # 4 : air_flow        0 ~ 3 : flow
      # + : temp + 1
      # - : temp - 1
-     # c : cooling         
-     # h : heating         
+     # c : cooling
+     # h : heating
      # m : change cooling to air clean, air clean to cooling
   */
   Serial.print("a : ");

--- a/examples/TurnOnArgoAC/TurnOnArgoAC.ino
+++ b/examples/TurnOnArgoAC/TurnOnArgoAC.ino
@@ -45,8 +45,12 @@ void loop() {
   argoir.setCoolMode(ARGO_COOL_AUTO);
   argoir.setTemp(25);
 
+#if SEND_ARGO
   // Now send the IR signal.
   argoir.send();
+#else  // SEND_ARGO
+  Serial.println("Can't send because SEND_ARGO has been disabled.");
+#endif  // SEND_ARGO
 
   delay(5000);
 }

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -59,7 +59,9 @@ void loop() {
   Serial.println(daikinir.toString());
 
   // Now send the IR signal.
+#if SEND_DAIKIN
   daikinir.send();
+#endif  // SEND_DAIKIN
 
   delay(15000);
 }

--- a/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
+++ b/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
@@ -24,7 +24,7 @@ void setup() {
   Serial.begin(115200);
   delay(200);
 
-  // Set up what we want to send. See ir_Mitsubishi.cpp for all the options.
+  // Set up what we want to send. See ir_Fujitsu.cpp for all the options.
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");
@@ -38,7 +38,11 @@ void setup() {
 void loop() {
   // Now send the IR signal.
   Serial.println("Sending IR command to A/C ...");
+#if SEND_FUJITSU_AC
   fujitsu.send();
+#else  // SEND_FUJITSU_AC
+  Serial.println("Can't send because SEND_FUJITSU_AC has been disabled.");
+#endif  // SEND_FUJITSU_AC
   printState();
   delay(5000);
 }

--- a/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
+++ b/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
@@ -73,8 +73,10 @@ void setup() {
 
 void loop() {
   // Now send the IR signal.
+#if SEND_KELVINATOR
   Serial.println("Sending IR command to A/C ...");
   kelvir.send();
+#endif  // SEND_KELVINATOR
   printState();
   delay(5000);
 }

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -64,8 +64,10 @@ void setup() {
 
 void loop() {
   // Now send the IR signal.
+#if SEND_MITSUBISHI_AC
   Serial.println("Sending IR command to A/C ...");
   mitsubir.send();
+#endif  // SEND_MITSUBISHI_AC
   printState();
   delay(5000);
 }

--- a/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
+++ b/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
@@ -62,8 +62,10 @@ void setup() {
 
 void loop() {
   // Now send the IR signal.
+#if SEND_TOSHIBA_AC
   Serial.println("Sending IR command to A/C ...");
   toshibair.send();
+#endif  // SEND_TOSHIBA_AC
   printState();
   delay(5000);
 }

--- a/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
+++ b/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
@@ -46,7 +46,11 @@ void loop() {
   trotecir.setTemp(25);
 
   // Now send the IR signal.
+#if SEND_TROTEC
   trotecir.send();
+#else  // SEND_TROTEC
+  Serial.println("Can't send because SEND_TROTEC has been disabled.");
+#endif  // SEND_TROTEC
 
   delay(5000);
 }

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -54,6 +54,8 @@
 //
 #define DECODE_HASH          true  // Semi-unique code for unknown messages
 
+#define SEND_RAW             true
+
 #define DECODE_NEC           true
 #define SEND_NEC             true
 

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -397,6 +397,7 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   }
 }
 
+#if SEND_RAW
 // Send a raw IRremote message.
 //
 // Args:
@@ -423,6 +424,7 @@ void IRsend::sendRaw(uint16_t buf[], uint16_t len, uint16_t hz) {
   }
   ledOff();  // We potentially have ended with a mark(), so turn of the LED.
 }
+#endif  // SEND_RAW
 
 #ifndef UNIT_TEST
 void IRsend::send(uint16_t type, uint64_t data, uint16_t nbits) {

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -35,6 +35,7 @@ void IRsend::sendArgo(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
               0, 0,  // No Footer.
               data, nbytes, 38, false, repeat, 50);
 }
+#endif  // SEND_ARGO
 
 IRArgoAC::IRArgoAC(uint16_t pin) : _irsend(pin) {
   stateReset();
@@ -44,11 +45,12 @@ void IRArgoAC::begin() {
   _irsend.begin();
 }
 
+#if SEND_ARGO
 void IRArgoAC::send() {
-  // Serial.println("Sending IR code"); // Only for Debug
   checksum();  // Create valid checksum before sending
   _irsend.sendArgo(argo);
 }
+#endif  // SEND_ARGO
 
 void IRArgoAC::checksum() {
   uint8_t sum = 2;  // Corresponds to byte 11 being constant 0b01
@@ -252,4 +254,3 @@ void IRArgoAC::setRoomTemp(uint8_t temp) {
   argo[3] += temp << 5;  // Append to bit 5,6,7
   argo[4] += temp >> 3;  // Remove lowest 3 bits and append in 0,1
 }
-#endif  // SEND_ARGO

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -57,12 +57,13 @@
 #define ARGO_FLAP_FULL            7U  // 0b111
 
 
-#if SEND_ARGO
 class IRArgoAC {
  public:
   explicit IRArgoAC(uint16_t pin);
 
+#if SEND_ARGO
   void send();
+#endif  // SEND_ARGO
   void begin();
   void on();
   void off();
@@ -119,6 +120,5 @@ class IRArgoAC {
   uint8_t max_mode;  // on/off
   uint8_t ifeel_mode;  // on/off
 };
-#endif  // SEND_ARGO
 
 #endif  // IR_ARGO_H_

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -85,7 +85,6 @@ void IRsend::sendDaikin(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_DAIKIN
 
-#if (SEND_DAIKIN || DECODE_DAIKIN)
 IRDaikinESP::IRDaikinESP(uint16_t pin) : _irsend(pin) {
   stateReset();
 }
@@ -94,10 +93,12 @@ void IRDaikinESP::begin() {
   _irsend.begin();
 }
 
+#if SEND_DAIKIN
 void IRDaikinESP::send() {
   checksum();
   _irsend.sendDaikin(daikin);
 }
+#endif  // SEND_DAIKIN
 
 // Calculate the checksum for a given data block.
 // Args:
@@ -641,7 +642,6 @@ void IRDaikinESP::setCommand(uint32_t value) {
   value >>= 20;
   setCurrentTime(value);
 }
-#endif  // (SEND_DAIKIN || DECODE_DAIKIN)
 
 #if DECODE_DAIKIN
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -128,12 +128,13 @@
 #define DAIKIN_FIRST_HEADER64 \
     0b1101011100000000000000001100010100000000001001111101101000010001
 
-#if SEND_DAIKIN
 class IRDaikinESP {
  public:
   explicit IRDaikinESP(uint16_t pin);
 
+#if SEND_DAIKIN
   void send();
+#endif
   void begin();
   void on();
   void off();
@@ -199,6 +200,5 @@ class IRDaikinESP {
   uint8_t getBit(uint8_t byte, uint8_t bitmask);
   IRsend _irsend;
 };
-#endif
 
 #endif  // IR_DAIKIN_H_

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -126,7 +126,6 @@ void IRsend::sendKelvinator(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_KELVINATOR
 
-#if (SEND_KELVINATOR || DECODE_KELVINATOR)
 IRKelvinatorAC::IRKelvinatorAC(uint16_t pin) : _irsend(pin) {
   stateReset();
 }
@@ -149,10 +148,12 @@ void IRKelvinatorAC::fixup() {
   checksum();  // Calculate the checksums
 }
 
+#if SEND_KELVINATOR
 void IRKelvinatorAC::send() {
   fixup();   // Ensure correct settings before sending.
   _irsend.sendKelvinator(remote_state);
 }
+#endif  // SEND_KELVINATOR
 
 uint8_t* IRKelvinatorAC::getRaw() {
   fixup();   // Ensure correct settings before sending.
@@ -437,7 +438,6 @@ std::string IRKelvinatorAC::toString() {
     result += "Off";
   return result;
 }
-#endif  // (SEND_KELVINATOR || DECODE_KELVINATOR)
 
 #if DECODE_KELVINATOR
 // Decode the supplied Kelvinator message.

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -110,15 +110,15 @@
     b7-4 = checksum of the previous bytes (8-14)
 */
 
-#if SEND_KELVINATOR
-
 // Classes
 class IRKelvinatorAC {
  public:
   explicit IRKelvinatorAC(uint16_t pin);
 
   void stateReset();
+#if SEND_KELVINATOR
   void send();
+#endif  // SEND_KELVINATOR
   void begin();
   void on();
   void off();
@@ -164,6 +164,5 @@ class IRKelvinatorAC {
   void fixup();
   IRsend _irsend;
 };
-#endif  // SEND_KELVINATOR
 
 #endif  // IR_KELVINATOR_H_

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -90,7 +90,6 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
 }
 #endif
 
-#if (SEND_MIDEA || DECODE_MIDEA)
 // Code to emulate Midea A/C IR remote control unit.
 // Warning: Consider this very alpha code.
 
@@ -110,11 +109,13 @@ void IRMideaAC::begin() {
     _irsend.begin();
 }
 
+#if SEND_MIDEA
 // Send the current desired state to the IR LED.
 void IRMideaAC::send() {
   checksum();   // Ensure correct checksum before sending.
   _irsend.sendMidea(remote_state);
 }
+#endif  // SEND_MIDEA
 
 // Return a pointer to the internal state date of the remote.
 uint64_t IRMideaAC::getRaw() {
@@ -333,8 +334,6 @@ std::string IRMideaAC::toString() {
   return result;
 }
 
-#endif  // SEND_MIDEA || DECODE_MIDEA
-
 #if DECODE_MIDEA
 // Decode the supplied Midea message.
 //
@@ -425,4 +424,4 @@ bool IRrecv::decodeMidea(decode_results *results, uint16_t nbits,
   results->command = 0;
   return true;
 }
-#endif
+#endif  // DECODE_MIDEA

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -44,13 +44,14 @@
 #define MIDEA_AC_MODE_MASK          0x0000FFF8FFFFFFFFULL
 #define MIDEA_AC_CHECKSUM_MASK      0x0000FFFFFFFFFF00ULL
 
-#if (SEND_MIDEA || DECODE_MIDEA)
 class IRMideaAC {
  public:
   explicit IRMideaAC(uint16_t pin);
 
   void stateReset();
+#if SEND_MIDEA
   void send();
+#endif  // SEND_MIDEA
   void begin();
   void on();
   void off();
@@ -82,6 +83,5 @@ class IRMideaAC {
   IRsend _irsend;
 };
 
-#endif  // (SEND_MIDEA || DECODE_MIDEA)
 
 #endif  // IR_MIDEA_H_

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -166,6 +166,7 @@ void IRsend::sendMitsubishiAC(unsigned char data[], uint16_t nbytes,
               MITSUBISHI_AC_RPT_MARK, MITSUBISHI_AC_RPT_SPACE,
               data, nbytes, 38, false, repeat, 50);
 }
+#endif  // SEND_MITSUBISHI_AC
 
 // Code to emulate Mitsubishi A/C IR remote control unit.
 // Inspired and derived from the work done at:
@@ -211,11 +212,13 @@ void IRMitsubishiAC::begin() {
     _irsend.begin();
 }
 
+#if SEND_MITSUBISHI_AC
 // Send the current desired state to the IR LED.
 void IRMitsubishiAC::send() {
   checksum();   // Ensure correct checksum before sending.
   _irsend.sendMitsubishiAC(remote_state);
 }
+#endif  // SEND_MITSUBISHI_AC
 
 // Return a pointer to the internal state date of the remote.
 uint8_t* IRMitsubishiAC::getRaw() {
@@ -325,4 +328,3 @@ void IRMitsubishiAC::setVane(uint8_t mode) {
 uint8_t IRMitsubishiAC::getVane() {
   return ((remote_state[9] & 0b00111000) >> 3);
 }
-#endif

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -32,13 +32,14 @@
 #define MITSUBISHI_AC_VANE_AUTO         0U
 #define MITSUBISHI_AC_VANE_AUTO_MOVE    7U
 
-#if SEND_MITSUBISHI_AC
 class IRMitsubishiAC {
  public:
   explicit IRMitsubishiAC(uint16_t pin);
 
   void stateReset();
+#if SEND_MITSUBISHI_AC
   void send();
+#endif  // SEND_MITSUBISHI_AC
   void begin();
   void on();
   void off();
@@ -60,6 +61,5 @@ class IRMitsubishiAC {
   IRsend _irsend;
 };
 
-#endif
 
 #endif  // IR_MITSUBISHI_H_

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -59,7 +59,6 @@ void IRsend::sendToshibaAC(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_TOSHIBA_AC
 
-#if (SEND_TOSHIBA_AC || DECODE_TOSHIBA_AC)
 // Code to emulate Toshiba A/C IR remote control unit.
 // Inspired and derived from the work done at:
 //   https://github.com/r45635/HVAC-IR-Control
@@ -95,11 +94,13 @@ void IRToshibaAC::begin() {
     _irsend.begin();
 }
 
+#if SEND_TOSHIBA_AC
 // Send the current desired state to the IR LED.
 void IRToshibaAC::send() {
   checksum();   // Ensure correct checksum before sending.
   _irsend.sendToshibaAC(remote_state);
 }
+#endif  // SEND_TOSHIBA_AC
 
 // Return a pointer to the internal state date of the remote.
 uint8_t* IRToshibaAC::getRaw() {
@@ -279,7 +280,6 @@ std::string IRToshibaAC::toString() {
   }
   return result;
 }
-#endif  // (SEND_TOSHIBA_AC || DECODE_TOSHIBA_AC)
 
 #if DECODE_TOSHIBA_AC
 // Decode a Toshiba AC IR message if possible.

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -31,13 +31,14 @@
 #define TOSHIBA_AC_MIN_TEMP         17U  // 17C
 #define TOSHIBA_AC_MAX_TEMP         30U  // 30C
 
-#if (SEND_TOSHIBA_AC || DECODE_TOSHIBA_AC)
 class IRToshibaAC {
  public:
   explicit IRToshibaAC(uint16_t pin);
 
   void stateReset();
+#if SEND_TOSHIBA_AC
   void send();
+#endif  // SEND_TOSHIBA_AC
   void begin();
   void on();
   void off();
@@ -69,7 +70,5 @@ class IRToshibaAC {
   uint8_t mode_state;
   IRsend _irsend;
 };
-
-#endif  // (SEND_TOSHIBA_AC || DECODE_TOSHIBA_AC)
 
 #endif  // IR_TOSHIBA_H_

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -34,6 +34,7 @@ void IRsend::sendTrotec(unsigned char data[], uint16_t nbytes,
     space(TROTEC_GAP_END);
   }
 }
+#endif  // SEND_TROTEC
 
 IRTrotecESP::IRTrotecESP(uint16_t pin) : _irsend(pin) {
   stateReset();
@@ -43,10 +44,12 @@ void IRTrotecESP::begin() {
   _irsend.begin();
 }
 
+#if SEND_TROTEC
 void IRTrotecESP::send() {
   checksum();
   _irsend.sendTrotec(trotec);
 }
+#endif  // SEND_TROTEC
 
 void IRTrotecESP::checksum() {
   uint8_t sum = 0;
@@ -141,5 +144,3 @@ void IRTrotecESP::setTimer(uint8_t timer) {
 uint8_t IRTrotecESP::getTimer() {
   return trotec[6];
 }
-
-#endif  // SEND_TROTEC

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -40,13 +40,14 @@
 #define TROTEC_MIN_TIMER      0
 #define TROTEC_MAX_TIMER     23
 
-#if SEND_TROTEC
 
 class IRTrotecESP {
  public:
   explicit IRTrotecESP(uint16_t pin);
 
+#if SEND_TROTEC
   void send();
+#endif  // SEND_TROTEC
   void begin();
 
   void setPower(bool state);
@@ -75,6 +76,5 @@ class IRTrotecESP {
   void checksum();
   IRsend _irsend;
 };
-#endif
 
 #endif  // IR_TROTEC_H_


### PR DESCRIPTION
- Add the ability to disable sendRaw() for consistency.
- Add a missing `break;` in IRMQTTServer example code.

Testing compiling most of the examples with:
* All SEND_XYZs set to false
* All DECODE_XYZs set to false
* All SEND_XYZs & DECODE_XYZs set to false

Note: Does not include SEND_FUJITSU_AC changes as they are in PR #375

Fixes issue #376