### PR TITLE
BUG: Integer underflow causes HUGE space() in sendGeneric()

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -340,7 +340,12 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
 
     // Footer
     if (footermark)  mark(footermark);
-    space(std::max(gap, mesgtime - usecs.elapsed()));
+    uint32_t elapsed = usecs.elapsed();
+    // Avoid potential unsigned integer underflow. e.g. when mesgtime is 0.
+    if (elapsed >= mesgtime)
+      space(gap);
+    else
+      space(std::max(gap, mesgtime - elapsed));
   }
 }
 


### PR DESCRIPTION
A mesgtime of zero (or less than the elapsed time to send a message) tickled
a bug in sendGeneric() due to the subtraction of two unsigned values.

This bug isn't catchable with our current unit test setup.
This was discovered by "on hardware" testing.

FYI @roidayan That elegant solution wasn't so elegant after all.