### PR TITLE
Fix pin number in Daikin example

### DIFF
--- a/examples/TurnOnArgoAC/TurnOnArgoAC.ino
+++ b/examples/TurnOnArgoAC/TurnOnArgoAC.ino
@@ -1,5 +1,5 @@
 /* Copyright 2017 crankyoldgit
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -29,7 +29,7 @@
 #include <IRsend.h>
 #include <ir_Argo.h>
 
-IRArgoAC argoir(4);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRArgoAC argoir(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void setup() {
   argoir.begin();

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -1,6 +1,6 @@
 /* Copyright 2017 sillyfrog
 *
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -30,7 +30,7 @@
 #include <IRsend.h>
 #include <ir_Daikin.h>
 
-IRDaikinESP daikinir(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRDaikinESP daikinir(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void setup() {
   daikinir.begin();

--- a/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
+++ b/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
@@ -1,6 +1,6 @@
 /* Copyright 2016 David Conran
 *
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -29,7 +29,7 @@
 #include <IRsend.h>
 #include <ir_Kelvinator.h>
 
-IRKelvinatorAC kelvir(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRKelvinatorAC kelvir(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void printState() {
   // Display the settings.

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -1,6 +1,6 @@
 /* Copyright 2017 David Conran
 *
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -29,7 +29,7 @@
 #include <IRsend.h>
 #include <ir_Mitsubishi.h>
 
-IRMitsubishiAC mitsubir(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRMitsubishiAC mitsubir(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void printState() {
   // Display the settings.

--- a/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
+++ b/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
@@ -1,6 +1,6 @@
 /* Copyright 2017 David Conran
 *
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -29,7 +29,7 @@
 #include <IRsend.h>
 #include <ir_Toshiba.h>
 
-IRToshibaAC toshibair(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRToshibaAC toshibair(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void printState() {
   // Display the settings.

--- a/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
+++ b/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
@@ -1,5 +1,5 @@
 /* Copyright 2017 stufisher
-* An IR LED circuit *MUST* be connected to ESP8266 pin 4 (D2).
+* An IR LED circuit *MUST* be connected to ESP8266 GPIO4.
 *
 * TL;DR: The IR LED needs to be driven by a transistor for a good result.
 *
@@ -29,7 +29,7 @@
 #include <IRsend.h>
 #include <ir_Trotec.h>
 
-IRTrotecESP trotecir(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
+IRTrotecESP trotecir(4);  // An IR LED is controlled by GPIO4, NodeMCU D2
 
 void setup() {
   trotecir.begin();


### PR DESCRIPTION
```
src/main.cpp:33:22: error: 'D2' was not declared in this scope
IRDaikinESP daikinir(D2);  // An IR LED is controlled by GPIO pin 4 (D2)
                     ^
```

Compiled on PlatformIO 3.4.1, tested on an Adafruit Feather Huzzah, with correct response from a Daikin A/C.

Note: also occurs in `TurnOnKelvinatorAC.ino`, `TurnOnMitsubishiAC.ino`, `TurnOnToshibaAC.ino`, and `TurnOnTrotecAC.ino` but I'm unable to test them. :grin: Is the change correct, and shall I widen the change to cover these?