### PR TITLE
Bump default raw capture buffer length to 150

### DIFF
--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -22,7 +22,7 @@
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.
 #define MARK_EXCESS   50U
-#define RAWBUF       100U  // Default length of raw capture buffer
+#define RAWBUF       150U  // Default length of raw capture buffer
 #define REPEAT UINT64_MAX
 #define UNKNOWN_THRESHOLD 6U  // Default min size of reported UNKNOWN messages.
 // receiver states


### PR DESCRIPTION
Tested capturing some long codes with [1], ran into issues which were
resolved by increasing RAWBUF according to its helpful advice.

[1] https://github.com/mdhiggins/ESP8266-HTTP-IR-Blaster