### PR TITLE
Ensure the IR LED is off before we start.

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -47,6 +47,7 @@ void IRsend::begin() {
 #ifndef UNIT_TEST
   pinMode(IRpin, OUTPUT);
 #endif
+  ledOff();  // Ensure the LED is in a known safe state when we start.
 }
 
 // Turn off the IR LED.


### PR DESCRIPTION
`pinMode(XX, OUTPUT);` defaults (arduino) to pulling the gpio LOW by default.
If we have been set up to transmit in `inverted` mode, we want the gpio pulled HIGH initially. i.e. the physical IR LED will be off.
`ledOff()` understands this, and will do the right thing.