### PR TITLE
Initial support for Haier A/Cs.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -325,6 +325,7 @@ void handleRoot() {
         "<option value='16'>Daikin</option>"
         "<option value='33'>Fujitsu</option>"
         "<option value='24'>Gree</option>"
+        "<option value='38'>Haier</option>"
         "<option selected='selected' value='18'>Kelvinator</option>"  // Default
         "<option value='20'>Mitsubishi</option>"
         "<option value='32'>Toshiba</option>"
@@ -420,6 +421,9 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
                              (uint16_t) (FUJITSU_AC_STATE_LENGTH - 1));
       // Lastly, it should never exceed the maximum "normal" size.
       stateSize = std::min(stateSize, (uint16_t) FUJITSU_AC_STATE_LENGTH);
+      break;
+    case HAIER_AC:
+      stateSize = HAIER_AC_STATE_LENGTH;
       break;
     default:  // Not a protocol we expected. Abort.
       debug("Unexpected AirCon protocol detected. Ignoring.");

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -27,6 +27,7 @@
 #include <ir_Daikin.h>
 #include <ir_Fujitsu.h>
 #include <ir_Gree.h>
+#include <ir_Haier.h>
 #include <ir_Kelvinator.h>
 #include <ir_Midea.h>
 #include <ir_Toshiba.h>
@@ -136,11 +137,11 @@ void dumpACInfo(decode_results *results) {
   }
 #endif  // DECODE_TOSHIBA_AC
 #if DECODE_GREE
-if (results->decode_type == GREE) {
-  IRGreeAC ac(0);
-  ac.setRaw(results->state);
-  description = ac.toString();
-}
+  if (results->decode_type == GREE) {
+    IRGreeAC ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
 #endif  // DECODE_GREE
 #if DECODE_MIDEA
   if (results->decode_type == MIDEA) {
@@ -149,6 +150,13 @@ if (results->decode_type == GREE) {
     description = ac.toString();
   }
 #endif  // DECODE_MIDEA
+#if DECODE_HAIER_AC
+  if (results->decode_type == HAIER_AC) {
+    IRHaierAC ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_HAIER_AC
   // If we got a human-readable description of the message, display it.
   if (description != "")  Serial.println("Mesg Desc.: " + description);
 }

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -449,6 +449,11 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   if (decodeGree(results))
     return true;
 #endif
+#if DECODE_HAIER_AC
+  DPRINTLN("Attempting Haier AC decode");
+  if (decodeHaierAC(results))
+    return true;
+#endif
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -47,16 +47,8 @@
 #define FNV_PRIME_32 16777619UL
 #define FNV_BASIS_32 2166136261UL
 
-#define MAX2(a, b) ((a > b)?(a):(b))
-#define MAX4(a, b, c, d) MAX2(MAX2(a, b), MAX2(c, d))
-#define STATE_SIZE_MAX MAX2(MAX4(ARGO_COMMAND_LENGTH, \
-                                 TROTEC_COMMAND_LENGTH, \
-                                 MITSUBISHI_AC_STATE_LENGTH, \
-                                 KELVINATOR_STATE_LENGTH), \
-                            MAX4(GREE_STATE_LENGTH, \
-                                 DAIKIN_COMMAND_LENGTH, \
-                                 TOSHIBA_AC_STATE_LENGTH, \
-                                 FUJITSU_AC_STATE_LENGTH))
+// Daikin is the current largest state size (by far).
+#define STATE_SIZE_MAX DAIKIN_COMMAND_LENGTH
 
 // Types
 // information for the interrupt handler
@@ -272,6 +264,10 @@ class IRrecv {
 #if DECODE_GREE
   bool decodeGree(decode_results *results,
                   uint16_t nbits = GREE_BITS, bool strict = true);
+#endif
+#if DECODE_HAIER_AC
+  bool decodeHaierAC(decode_results *results,
+                   uint16_t nbits = HAIER_AC_BITS, bool strict = true);
 #endif
 };
 

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -157,9 +157,12 @@
 #define DECODE_CARRIER_AC    true
 #define SEND_CARRIER_AC      true
 
+#define DECODE_HAIER_AC      true
+#define SEND_HAIER_AC        true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
-     DECODE_TROTEC)
+     DECODE_TROTEC || DECODE_HAIER_AC)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -209,7 +212,8 @@ enum decode_type_t {
   MIDEA,
   MAGIQUEST,
   LASERTAG,
-  CARRIER_AC
+  CARRIER_AC,
+  HAIER_AC
 };
 
 // Message lengths & required repeat values
@@ -229,6 +233,8 @@ enum decode_type_t {
 #define DISH_MIN_REPEAT              3U
 #define GREE_STATE_LENGTH            8U
 #define GREE_BITS                   (GREE_STATE_LENGTH * 8)
+#define HAIER_AC_STATE_LENGTH        9U
+#define HAIER_AC_BITS               (HAIER_AC_STATE_LENGTH * 8)
 #define JVC_BITS                    16U
 #define KELVINATOR_STATE_LENGTH     16U
 #define KELVINATOR_BITS             (KELVINATOR_STATE_LENGTH * 8)

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -229,6 +229,11 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
   void sendCarrierAC(uint64_t data, uint16_t nbits = CARRIER_AC_BITS,
                      uint16_t repeat = CARRIER_AC_MIN_REPEAT);
 #endif
+#if SEND_HAIER_AC
+  void sendHaierAC(unsigned char data[],
+                   uint16_t nbytes = HAIER_AC_STATE_LENGTH,
+                   uint16_t repeat = 0);
+#endif
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -110,6 +110,7 @@ std::string typeToString(const decode_type_t protocol,
     case FUJITSU_AC:    result = "FUJITSU_AC";        break;
     case GLOBALCACHE:   result = "GLOBALCACHE";       break;
     case GREE:          result = "GREE";              break;
+    case HAIER_AC:      result = "HAIER_AC";          break;
     case JVC:           result = "JVC";               break;
     case KELVINATOR:    result = "KELVINATOR";        break;
     case LG:            result = "LG";                break;
@@ -148,6 +149,7 @@ bool hasACState(const decode_type_t protocol) {
     case DAIKIN:
     case FUJITSU_AC:
     case GREE:
+    case HAIER_AC:
     case KELVINATOR:
     case TOSHIBA_AC:
       return true;

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -1,0 +1,497 @@
+// Copyright 2018 crankyoldgit
+// The specifics of reverse engineering the protocol details by kuzin2006
+
+#include "ir_Haier.h"
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRutils.h"
+
+//                      HH   HH   AAA   IIIII EEEEEEE RRRRRR
+//                      HH   HH  AAAAA   III  EE      RR   RR
+//                      HHHHHHH AA   AA  III  EEEEE   RRRRRR
+//                      HH   HH AAAAAAA  III  EE      RR  RR
+//                      HH   HH AA   AA IIIII EEEEEEE RR   RR
+
+// Supported devices:
+//   * Haier HSU07-HEA03 Remote control.
+
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/404
+//   https://www.dropbox.com/s/mecyib3lhdxc8c6/IR%20data%20reverse%20engineering.xlsx?dl=0
+
+// Constants
+#define HAIER_AC_HDR          3000U
+#define HAIER_AC_HDR_GAP      4300U
+
+#define HAIER_AC_BIT_MARK      520U
+#define HAIER_AC_ONE_SPACE    1650U
+#define HAIER_AC_ZERO_SPACE    650U
+#define HAIER_AC_MIN_GAP    150000U  // Completely made up value.
+
+#if SEND_HAIER_AC
+// Send a Haier A/C message.
+//
+// Args:
+//   data: An array of bytes containing the IR command.
+//   nbytes: Nr. of bytes of data in the array. (>=HAIER_AC_STATE_LENGTH)
+//   repeat: Nr. of times the message is to be repeated. (Default = 0).
+//
+// Status: Beta / Probably working.
+//
+void IRsend::sendHaierAC(unsigned char data[], uint16_t nbytes,
+                         uint16_t repeat) {
+  if (nbytes < HAIER_AC_STATE_LENGTH)
+    return;
+
+  for (uint16_t r = 0; r <= repeat; r++) {
+    enableIROut(38000);
+    mark(HAIER_AC_HDR);
+    space(HAIER_AC_HDR);
+    sendGeneric(HAIER_AC_HDR, HAIER_AC_HDR_GAP,
+                HAIER_AC_BIT_MARK, HAIER_AC_ONE_SPACE,
+                HAIER_AC_BIT_MARK, HAIER_AC_ZERO_SPACE,
+                HAIER_AC_BIT_MARK, HAIER_AC_MIN_GAP,
+                data, nbytes, 38, true, 0,  // Repeats handled elsewhere
+                50);
+  }
+}
+#endif  // SEND_HAIER_AC
+
+IRHaierAC::IRHaierAC(uint16_t pin) : _irsend(pin) {
+  stateReset();
+}
+
+void IRHaierAC::begin() {
+  _irsend.begin();
+}
+
+#if SEND_HAIER_AC
+void IRHaierAC::send() {
+  checksum();
+  _irsend.sendHaierAC(remote_state);
+}
+#endif  // SEND_HAIER_AC
+
+void IRHaierAC::checksum() {
+  remote_state[8] = sumBytes(remote_state, HAIER_AC_STATE_LENGTH - 1);
+}
+
+bool IRHaierAC::validChecksum(uint8_t state[], const uint16_t length) {
+  if (length < 2)  return false;  // 1 byte of data can't have a checksum.
+  return (state[length - 1] == sumBytes(state, length - 1));
+}
+
+void IRHaierAC::stateReset() {
+  for (uint8_t i = 1; i < HAIER_AC_STATE_LENGTH; i++)
+    remote_state[i] = 0x0;
+  remote_state[0] = HAIER_AC_PREFIX;
+  remote_state[2] = 0b00100000;
+
+  setTemp(HAIER_AC_DEF_TEMP);
+  setFan(HAIER_AC_FAN_AUTO);
+  setMode(HAIER_AC_AUTO);
+  setCommand(HAIER_AC_CMD_ON);
+}
+
+uint8_t* IRHaierAC::getRaw() {
+  checksum();
+  return remote_state;
+}
+
+void IRHaierAC::setRaw(uint8_t new_code[]) {
+  for (uint8_t i = 0; i < HAIER_AC_STATE_LENGTH; i++) {
+    remote_state[i] = new_code[i];
+  }
+}
+
+void IRHaierAC::setCommand(uint8_t state) {
+  remote_state[1] &= 0b11110000;
+  switch (state) {
+    case HAIER_AC_CMD_OFF:
+    case HAIER_AC_CMD_ON:
+    case HAIER_AC_CMD_MODE:
+    case HAIER_AC_CMD_FAN:
+    case HAIER_AC_CMD_TEMP_UP:
+    case HAIER_AC_CMD_TEMP_DOWN:
+    case HAIER_AC_CMD_SLEEP:
+    case HAIER_AC_CMD_TIMER_SET:
+    case HAIER_AC_CMD_TIMER_CANCEL:
+    case HAIER_AC_CMD_HEALTH:
+    case HAIER_AC_CMD_SWING:
+      remote_state[1] |= (state & 0b00001111);
+  }
+}
+
+uint8_t IRHaierAC::getCommand() {
+  return remote_state[1] & (0b00001111);
+}
+
+void IRHaierAC::setFan(uint8_t speed) {
+  uint8_t new_speed = HAIER_AC_FAN_AUTO;
+  switch (speed) {
+    case HAIER_AC_FAN_LOW:
+      new_speed = 3;
+      break;
+    case HAIER_AC_FAN_MED:
+      new_speed = 1;
+      break;
+    case HAIER_AC_FAN_HIGH:
+      new_speed = 2;
+      break;
+    default:
+      new_speed = HAIER_AC_FAN_AUTO;  // Default to auto for anything else.
+  }
+
+  if (speed != getFan())  setCommand(HAIER_AC_CMD_FAN);
+  remote_state[5] &= 0b11111100;
+  remote_state[5] |= new_speed;
+}
+
+uint8_t IRHaierAC::getFan() {
+  switch (remote_state[5] & 0b00000011) {
+    case 1:
+      return HAIER_AC_FAN_MED;
+    case 2:
+      return HAIER_AC_FAN_HIGH;
+    case 3:
+      return HAIER_AC_FAN_LOW;
+    default:
+      return HAIER_AC_FAN_AUTO;
+  }
+}
+
+void IRHaierAC::setMode(uint8_t mode) {
+  uint8_t new_mode = mode;
+  setCommand(HAIER_AC_CMD_MODE);
+  if (mode > HAIER_AC_FAN)  // If out of range, default to auto mode.
+    new_mode = HAIER_AC_AUTO;
+  remote_state[7] &= 0b00011111;
+  remote_state[7] |= (new_mode << 5);
+}
+
+uint8_t IRHaierAC::getMode() {
+  return (remote_state[7] & 0b11100000) >> 5;
+}
+
+void IRHaierAC::setTemp(const uint8_t celcius ) {
+  uint8_t temp = celcius;
+  if (temp < HAIER_AC_MIN_TEMP)
+    temp = HAIER_AC_MIN_TEMP;
+  else if (temp > HAIER_AC_MAX_TEMP)
+    temp = HAIER_AC_MAX_TEMP;
+
+  uint8_t old_temp = getTemp();
+  if (old_temp == temp)  return;
+  if (old_temp > temp)
+    setCommand(HAIER_AC_CMD_TEMP_DOWN);
+  else
+    setCommand(HAIER_AC_CMD_TEMP_UP);
+
+  remote_state[1] &= 0b00001111;  // Clear the previous temp.
+  remote_state[1] |= ((temp - HAIER_AC_MIN_TEMP) << 4);
+}
+
+uint8_t IRHaierAC::getTemp() {
+  return ((remote_state[1] & 0b11110000) >> 4) + HAIER_AC_MIN_TEMP;
+}
+
+void IRHaierAC::setHealth(bool state) {
+  setCommand(HAIER_AC_CMD_HEALTH);
+  remote_state[4] &= 0b11011111;
+  remote_state[4] |= (state << 5);
+}
+
+bool IRHaierAC::getHealth(void) {
+  return remote_state[4] & (1 << 5);
+}
+
+void IRHaierAC::setSleep(bool state) {
+  setCommand(HAIER_AC_CMD_SLEEP);
+  remote_state[7] &= 0b10111111;
+  remote_state[7] |= (state << 6);
+}
+
+bool IRHaierAC::getSleep(void) {
+  return remote_state[7] & 0b01000000;
+}
+
+uint16_t IRHaierAC::getTime(const uint8_t ptr[]) {
+  return (ptr[0] & 0b00011111) * 60 + (ptr[1] & 0b00111111);
+}
+
+int16_t IRHaierAC::getOnTimer() {
+  if (remote_state[3] & 0b10000000)  // Check if the timer is turned on.
+    return getTime(remote_state + 6);
+  else
+    return -1;
+}
+
+int16_t IRHaierAC::getOffTimer() {
+  if (remote_state[3] & 0b01000000)  // Check if the timer is turned on.
+    return getTime(remote_state + 4);
+  else
+    return -1;
+}
+
+uint16_t IRHaierAC::getCurrTime() {
+  return getTime(remote_state + 2);
+}
+
+void IRHaierAC::setTime(uint8_t ptr[], const uint16_t nr_mins) {
+  uint16_t mins = nr_mins;
+  if (nr_mins > HAIER_AC_MAX_TIME)
+    mins = HAIER_AC_MAX_TIME;
+
+    // Hours
+  ptr[0] &= 0b11100000;
+  ptr[0] |= (mins / 60);
+  // Minutes
+  ptr[1] &= 0b11000000;
+  ptr[1] |= (mins % 60);
+}
+
+void IRHaierAC::setOnTimer(const uint16_t nr_mins) {
+  setCommand(HAIER_AC_CMD_TIMER_SET);
+  remote_state[3] |= 0b10000000;
+  setTime(remote_state + 6, nr_mins);
+}
+
+void IRHaierAC::setOffTimer(const uint16_t nr_mins) {
+  setCommand(HAIER_AC_CMD_TIMER_SET);
+  remote_state[3] |= 0b01000000;
+  setTime(remote_state + 4, nr_mins);
+}
+
+void IRHaierAC::cancelTimers() {
+  setCommand(HAIER_AC_CMD_TIMER_CANCEL);
+  remote_state[3] &= 0b00111111;
+}
+
+void IRHaierAC::setCurrTime(const uint16_t nr_mins) {
+  setTime(remote_state + 2, nr_mins);
+}
+
+uint8_t IRHaierAC::getSwing() {
+  return (remote_state[2] & 0b11000000) >> 6;
+}
+
+void IRHaierAC::setSwing(const uint8_t state) {
+  if (state == getSwing())  return;  // Nothing to do.
+  setCommand(HAIER_AC_CMD_SWING);
+  switch (state) {
+    case HAIER_AC_SWING_OFF:
+    case HAIER_AC_SWING_UP:
+    case HAIER_AC_SWING_DOWN:
+    case HAIER_AC_SWING_CHG:
+      remote_state[2] &= 0b00111111;
+      remote_state[2] |= (state << 6);
+      break;
+  }
+}
+
+// Convert a Haier time into a human readable string.
+#ifdef ARDUINO
+String IRHaierAC::timeToString(const uint16_t nr_mins) {
+  String result = "";
+#else
+std::string IRHaierAC::timeToString(const uint16_t nr_mins) {
+  std::string result = "";
+#endif  // ARDUINO
+
+  if (nr_mins / 24 < 10)  result += "0";  // Zero pad.
+  result += uint64ToString(nr_mins / 60);
+  result += ":";
+  if (nr_mins % 60 < 10)  result += "0";  // Zero pad.
+  result += uint64ToString(nr_mins % 60);
+  return result;
+}
+
+// Convert the internal state into a human readable string.
+#ifdef ARDUINO
+String IRHaierAC::toString() {
+  String result = "";
+#else
+std::string IRHaierAC::toString() {
+  std::string result = "";
+#endif  // ARDUINO
+  uint8_t cmd = getCommand();
+  result += "Command: " + uint64ToString(cmd) +" (";
+  switch (cmd) {
+    case HAIER_AC_CMD_OFF:
+      result += "Off";
+      break;
+    case HAIER_AC_CMD_ON:
+      result += "On";
+      break;
+    case HAIER_AC_CMD_MODE:
+      result += "Mode";
+      break;
+    case HAIER_AC_CMD_FAN:
+      result += "Fan";
+      break;
+    case HAIER_AC_CMD_TEMP_UP:
+      result += "Temp Up";
+      break;
+    case HAIER_AC_CMD_TEMP_DOWN:
+      result += "Temp Down";
+      break;
+    case HAIER_AC_CMD_SLEEP:
+      result += "Sleep";
+      break;
+    case HAIER_AC_CMD_TIMER_SET:
+      result += "Timer Set";
+      break;
+    case HAIER_AC_CMD_TIMER_CANCEL:
+      result += "Timer Cancel";
+      break;
+    case HAIER_AC_CMD_HEALTH:
+      result += "Health";
+      break;
+    case HAIER_AC_CMD_SWING:
+      result += "Swing";
+      break;
+    default:
+      result += "Unknown";
+  }
+  result += ")";
+  result += ", Mode: " + uint64ToString(getMode());
+  switch (getMode()) {
+    case HAIER_AC_AUTO:
+      result += " (AUTO)";
+      break;
+    case HAIER_AC_COOL:
+      result += " (COOL)";
+      break;
+    case HAIER_AC_HEAT:
+      result += " (HEAT)";
+      break;
+    case HAIER_AC_DRY:
+      result += " (DRY)";
+      break;
+    case HAIER_AC_FAN:
+      result += " (FAN)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Temp: " + uint64ToString(getTemp()) + "C";
+  result += ", Fan: " + uint64ToString(getFan());
+  switch (getFan()) {
+    case HAIER_AC_FAN_AUTO:
+      result += " (AUTO)";
+      break;
+    case HAIER_AC_FAN_HIGH:
+      result += " (MAX)";
+      break;
+  }
+  result += ", Swing: " + uint64ToString(getSwing()) + " (";
+  switch (getSwing()) {
+    case HAIER_AC_SWING_OFF:
+      result += "Off";
+      break;
+    case HAIER_AC_SWING_UP:
+      result += "Up";
+      break;
+    case HAIER_AC_SWING_DOWN:
+      result += "Down";
+      break;
+    case HAIER_AC_SWING_CHG:
+      result += "Chg";
+      break;
+    default:
+      result += "Unknown";
+  }
+  result += ")";
+  result += ", Sleep: ";
+  if (getSleep())
+    result += "On";
+  else
+    result += "Off";
+  result += ", Health: ";
+  if (getHealth())
+    result += "On";
+  else
+    result += "Off";
+  result += ", Current Time: " + timeToString(getCurrTime());
+  result += ", On Timer: ";
+  if (getOnTimer() >= 0)
+    result += timeToString(getOnTimer());
+  else
+    result += "Off";
+  result += ", Off Timer: ";
+  if (getOffTimer() >= 0)
+    result += timeToString(getOffTimer());
+  else
+    result += "Off";
+
+  return result;
+}
+
+#if DECODE_HAIER_AC
+// Decode the supplied Haier message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically HAIER_AC_BITS.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: BETA / Appears to be working.
+//
+bool IRrecv::decodeHaierAC(decode_results *results, uint16_t nbits,
+                           bool strict) {
+  if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
+    return false;
+
+  if (strict) {
+    if (nbits != HAIER_AC_BITS)
+      return false;  // Not strictly a HAIER_AC message.
+  }
+
+  if (results->rawlen < (2 * nbits + HEADER) + FOOTER - 1)
+    return false;  // Can't possibly be a valid HAIER_AC message.
+
+  uint16_t offset = OFFSET_START;
+
+
+  // Header
+  if (!matchMark(results->rawbuf[offset++], HAIER_AC_HDR)) return false;
+  if (!matchSpace(results->rawbuf[offset++], HAIER_AC_HDR)) return false;
+  if (!matchMark(results->rawbuf[offset++], HAIER_AC_HDR)) return false;
+  if (!matchSpace(results->rawbuf[offset++], HAIER_AC_HDR_GAP)) return false;
+
+  // Data
+  for (uint16_t i = 0; i < nbits / 8; i++) {
+    match_result_t data_result = matchData(&(results->rawbuf[offset]), 8,
+                                           HAIER_AC_BIT_MARK,
+                                           HAIER_AC_ONE_SPACE,
+                                           HAIER_AC_BIT_MARK,
+                                           HAIER_AC_ZERO_SPACE);
+    if (data_result.success == false) return false;
+    offset += data_result.used;
+    results->state[i] = (uint8_t) data_result.data;
+  }
+
+  // Footer
+  if (!matchMark(results->rawbuf[offset++], HAIER_AC_BIT_MARK))  return false;
+  if (offset < results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset++], HAIER_AC_MIN_GAP))
+    return false;
+
+  // Compliance
+  if (strict) {
+    if (results->state[0] != HAIER_AC_PREFIX)  return false;
+    if (!IRHaierAC::validChecksum(results->state, nbits / 8))  return false;
+  }
+
+  // Success
+  results->decode_type = HAIER_AC;
+  results->bits = nbits;
+  return true;
+}
+#endif  // DECODE_HAIER_AC

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -1,0 +1,126 @@
+// Copyright 2018 crankyoldgit
+// The specifics of reverse engineering the protocol details by kuzin2006
+
+#ifndef IR_HAIER_H_
+#define IR_HAIER_H_
+
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+//                      HH   HH   AAA   IIIII EEEEEEE RRRRRR
+//                      HH   HH  AAAAA   III  EE      RR   RR
+//                      HHHHHHH AA   AA  III  EEEEE   RRRRRR
+//                      HH   HH AAAAAAA  III  EE      RR  RR
+//                      HH   HH AA   AA IIIII EEEEEEE RR   RR
+
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/404
+//   https://www.dropbox.com/s/mecyib3lhdxc8c6/IR%20data%20reverse%20engineering.xlsx?dl=0
+
+// Constants
+// Byte 0
+#define HAIER_AC_PREFIX      0b10100101
+
+// Byte 1
+#define HAIER_AC_MIN_TEMP      16
+#define HAIER_AC_MAX_TEMP      30
+#define HAIER_AC_DEF_TEMP      25
+
+#define HAIER_AC_CMD_OFF          0b00000000
+#define HAIER_AC_CMD_ON           0b00000001
+#define HAIER_AC_CMD_MODE         0b00000010
+#define HAIER_AC_CMD_FAN          0b00000011
+#define HAIER_AC_CMD_TEMP_UP      0b00000110
+#define HAIER_AC_CMD_TEMP_DOWN    0b00000111
+#define HAIER_AC_CMD_SLEEP        0b00001000
+#define HAIER_AC_CMD_TIMER_SET    0b00001001
+#define HAIER_AC_CMD_TIMER_CANCEL 0b00001010
+#define HAIER_AC_CMD_HEALTH       0b00001100
+#define HAIER_AC_CMD_SWING        0b00001101
+
+// Byte 2
+#define HAIER_AC_SWING_OFF        0b00000000
+#define HAIER_AC_SWING_UP         0b00000001
+#define HAIER_AC_SWING_DOWN       0b00000010
+#define HAIER_AC_SWING_CHG        0b00000011
+
+// Byte 6
+#define HAIER_AC_AUTO           0
+#define HAIER_AC_COOL           1
+#define HAIER_AC_DRY            2
+#define HAIER_AC_HEAT           3
+#define HAIER_AC_FAN            4
+
+#define HAIER_AC_FAN_AUTO       0
+#define HAIER_AC_FAN_LOW        1
+#define HAIER_AC_FAN_MED        2
+#define HAIER_AC_FAN_HIGH       3
+
+#define HAIER_AC_MAX_TIME      (23 * 60 + 59)
+
+
+class IRHaierAC {
+ public:
+  explicit IRHaierAC(uint16_t pin);
+
+#if SEND_HAIER_AC
+  void send();
+#endif  // SEND_HAIER_AC
+  void begin();
+
+  void setCommand(const uint8_t command);
+  uint8_t getCommand();
+
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+
+  void setFan(const uint8_t speed);
+  uint8_t getFan();
+
+  uint8_t getMode();
+  void setMode(const uint8_t mode);
+
+  bool getSleep();
+  void setSleep(const bool state);
+  bool getHealth();
+  void setHealth(const bool state);
+
+  int16_t getOnTimer();
+  void setOnTimer(const uint16_t mins);
+  int16_t getOffTimer();
+  void setOffTimer(const uint16_t mins);
+  void cancelTimers();
+
+  uint16_t getCurrTime();
+  void setCurrTime(const uint16_t mins);
+
+  uint8_t getSwing();
+  void setSwing(const uint8_t state);
+
+  uint8_t* getRaw();
+  void setRaw(uint8_t new_code[]);
+  static bool validChecksum(uint8_t state[],
+                            const uint16_t length = HAIER_AC_STATE_LENGTH);
+  #ifdef ARDUINO
+    String toString();
+    static String timeToString(const uint16_t nr_mins);
+  #else
+    std::string toString();
+    static std::string timeToString(const uint16_t nr_mins);
+  #endif
+
+ private:
+  uint8_t remote_state[HAIER_AC_STATE_LENGTH];
+  void stateReset();
+  void checksum();
+  static uint16_t getTime(const uint8_t ptr[]);
+  static void setTime(uint8_t ptr[], const uint16_t nr_mins);
+  IRsend _irsend;
+};
+
+#endif  // IR_HAIER_H_

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,7 +34,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Aiwa_test ir_Denon_test ir_Sanyo_test ir_Daikin_test ir_Coolix_test \
         ir_Gree_test IRrecv_test ir_Pronto_test ir_Fujitsu_test ir_Nikai_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
-				ir_Carrier_test
+				ir_Carrier_test ir_Haier_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -74,7 +74,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
     ir_LG.o ir_Mitsubishi.o ir_Fujitsu.o ir_Sharp.o ir_Sanyo.o ir_Denon.o ir_Dish.o \
 		ir_Panasonic.o ir_Whynter.o ir_Coolix.o ir_Aiwa.o ir_Sherwood.o \
 		ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
-		ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o
+		ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
@@ -396,4 +396,13 @@ ir_Carrier_test.o : ir_Carrier_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Carrier_test.cpp
 
 ir_Carrier_test : $(COMMON_OBJ) ir_Carrier_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(COMMON_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Haier.cpp
+
+ir_Haier_test.o : ir_Haier_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Haier_test.cpp
+
+ir_Haier_test : $(COMMON_OBJ) ir_Haier_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -1,0 +1,560 @@
+// Copyright 2018 David Conran
+
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "ir_Haier.h"
+#include "gtest/gtest.h"
+
+// Tests for sendHaierAC()
+
+// Test sending typical data only.
+TEST(TestSendHaierAC, SendDataOnly) {
+  IRsendTest irsend(0);
+  irsend.begin();
+  uint8_t haier_zero[HAIER_AC_STATE_LENGTH] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+  irsend.reset();
+  irsend.sendHaierAC(haier_zero);
+  EXPECT_EQ(
+      "m3000s3000m3000s4300"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s150000", irsend.outputStr());
+
+  uint8_t haier_test[HAIER_AC_STATE_LENGTH] = {
+    0xA5, 0x01, 0x20, 0x01, 0x00, 0xC0, 0x20, 0x00, 0xA7};
+  irsend.reset();
+  irsend.sendHaierAC(haier_test);
+  EXPECT_EQ(
+      "m3000s3000m3000s4300"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s1650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s1650m520s1650"
+      "m520s150000", irsend.outputStr());
+}
+
+// Test sending typical data with repeats.
+TEST(TestSendHaierAC, SendWithRepeats) {
+  IRsendTest irsend(0);
+  irsend.begin();
+
+  irsend.reset();
+  uint8_t haier_test[HAIER_AC_STATE_LENGTH] = {
+    0xA5, 0x01, 0x20, 0x01, 0x00, 0xC0, 0x20, 0x00, 0xA7};
+  irsend.reset();
+  irsend.sendHaierAC(haier_test, HAIER_AC_STATE_LENGTH, 2);  // two repeats.
+  EXPECT_EQ(
+      "m3000s3000m3000s4300"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s1650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s1650m520s1650"
+      "m520s150000"
+      "m3000s3000m3000s4300"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s1650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s1650m520s1650"
+      "m520s150000"
+      "m3000s3000m3000s4300"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s1650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s1650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s1650m520s650m520s650m520s650m520s650m520s650"
+      "m520s650m520s650m520s650m520s650m520s650m520s650m520s650m520s650"
+      "m520s1650m520s650m520s1650m520s650m520s650m520s1650m520s1650m520s1650"
+      "m520s150000", irsend.outputStr());
+}
+
+// Tests for IRHaierAC class.
+
+TEST(TestHaierACClass, Command) {
+  IRHaierAC haier(0);
+  haier.begin();
+
+  haier.setCommand(HAIER_AC_CMD_OFF);
+  EXPECT_EQ(HAIER_AC_CMD_OFF, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_ON);
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_MODE);
+  EXPECT_EQ(HAIER_AC_CMD_MODE, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_FAN);
+  EXPECT_EQ(HAIER_AC_CMD_FAN, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_TEMP_UP);
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_UP, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_TEMP_DOWN);
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_DOWN, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_SLEEP);
+  EXPECT_EQ(HAIER_AC_CMD_SLEEP, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_TIMER_SET);
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_SET, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_TIMER_CANCEL);
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_CANCEL, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_HEALTH);
+  EXPECT_EQ(HAIER_AC_CMD_HEALTH, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_SWING);
+  EXPECT_EQ(HAIER_AC_CMD_SWING, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_ON);
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+
+  // Test unexpected values.
+  haier.setCommand(0b00001110);
+  EXPECT_EQ(HAIER_AC_CMD_OFF, haier.getCommand());
+  haier.setCommand(0b00001111);
+  EXPECT_EQ(HAIER_AC_CMD_OFF, haier.getCommand());
+  haier.setCommand(0b00000100);
+  EXPECT_EQ(HAIER_AC_CMD_OFF, haier.getCommand());
+}
+
+TEST(TestHaierACClass, OperatingMode) {
+  IRHaierAC haier(0);
+  haier.begin();
+
+  haier.setMode(HAIER_AC_AUTO);
+  EXPECT_EQ(HAIER_AC_AUTO, haier.getMode());
+
+  haier.setMode(HAIER_AC_COOL);
+  EXPECT_EQ(HAIER_AC_COOL, haier.getMode());
+
+  haier.setMode(HAIER_AC_HEAT);
+  EXPECT_EQ(HAIER_AC_HEAT, haier.getMode());
+
+  haier.setMode(HAIER_AC_FAN);
+  EXPECT_EQ(HAIER_AC_FAN, haier.getMode());
+
+  haier.setMode(HAIER_AC_DRY);
+  EXPECT_EQ(HAIER_AC_DRY, haier.getMode());
+
+  haier.setMode(HAIER_AC_AUTO - 1);
+  EXPECT_EQ(HAIER_AC_AUTO, haier.getMode());
+
+  haier.setMode(HAIER_AC_COOL);
+  EXPECT_EQ(HAIER_AC_COOL, haier.getMode());
+
+  haier.setMode(HAIER_AC_FAN + 1);
+  EXPECT_EQ(HAIER_AC_AUTO, haier.getMode());
+
+  haier.setMode(255);
+  EXPECT_EQ(HAIER_AC_AUTO, haier.getMode());
+}
+
+TEST(TestHaierACClass, Temperature) {
+  IRHaierAC haier(0);
+  haier.begin();
+
+  haier.setTemp(HAIER_AC_MIN_TEMP);
+  EXPECT_EQ(HAIER_AC_MIN_TEMP, haier.getTemp());
+
+  haier.setCommand(HAIER_AC_CMD_ON);
+  haier.setTemp(HAIER_AC_MIN_TEMP + 1);
+  EXPECT_EQ(HAIER_AC_MIN_TEMP + 1, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_UP, haier.getCommand());
+
+  haier.setTemp(HAIER_AC_MAX_TEMP);
+  EXPECT_EQ(HAIER_AC_MAX_TEMP, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_UP, haier.getCommand());
+
+  haier.setTemp(HAIER_AC_MIN_TEMP - 1);
+  EXPECT_EQ(HAIER_AC_MIN_TEMP, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_DOWN, haier.getCommand());
+
+  haier.setTemp(HAIER_AC_MAX_TEMP + 1);
+  EXPECT_EQ(HAIER_AC_MAX_TEMP, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_UP, haier.getCommand());
+
+  haier.setTemp(23);
+  EXPECT_EQ(23, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_DOWN, haier.getCommand());
+  haier.setCommand(HAIER_AC_CMD_ON);
+  haier.setTemp(23);
+  EXPECT_EQ(23, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+
+  haier.setTemp(0);
+  EXPECT_EQ(HAIER_AC_MIN_TEMP, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_DOWN, haier.getCommand());
+
+  haier.setTemp(255);
+  EXPECT_EQ(HAIER_AC_MAX_TEMP, haier.getTemp());
+  EXPECT_EQ(HAIER_AC_CMD_TEMP_UP, haier.getCommand());
+}
+
+TEST(TestHaierACClass, FanSpeed) {
+  IRHaierAC haier(0);
+  haier.begin();
+  haier.setFan(HAIER_AC_FAN_LOW);
+  haier.setCommand(HAIER_AC_CMD_ON);
+
+  haier.setFan(HAIER_AC_FAN_AUTO);
+  EXPECT_EQ(HAIER_AC_FAN_AUTO, haier.getFan());
+  EXPECT_EQ(HAIER_AC_CMD_FAN, haier.getCommand());
+
+  haier.setFan(HAIER_AC_FAN_LOW);
+  EXPECT_EQ(HAIER_AC_FAN_LOW, haier.getFan());
+  haier.setFan(HAIER_AC_FAN_MED);
+  EXPECT_EQ(HAIER_AC_FAN_MED, haier.getFan());
+  haier.setFan(HAIER_AC_FAN_HIGH);
+  EXPECT_EQ(HAIER_AC_FAN_HIGH, haier.getFan());
+
+  haier.setCommand(HAIER_AC_CMD_ON);
+  haier.setFan(HAIER_AC_FAN_HIGH);
+  EXPECT_EQ(HAIER_AC_FAN_HIGH, haier.getFan());
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+}
+
+TEST(TestHaierACClass, Swing) {
+  IRHaierAC haier(0);
+  haier.begin();
+  haier.setFan(HAIER_AC_FAN_LOW);
+  haier.setCommand(HAIER_AC_CMD_ON);
+
+  haier.setSwing(HAIER_AC_SWING_OFF);
+  EXPECT_EQ(HAIER_AC_SWING_OFF, haier.getSwing());
+
+  haier.setSwing(HAIER_AC_SWING_UP);
+  EXPECT_EQ(HAIER_AC_SWING_UP, haier.getSwing());
+  EXPECT_EQ(HAIER_AC_CMD_SWING, haier.getCommand());
+
+  haier.setSwing(HAIER_AC_SWING_DOWN);
+  EXPECT_EQ(HAIER_AC_SWING_DOWN, haier.getSwing());
+  EXPECT_EQ(HAIER_AC_CMD_SWING, haier.getCommand());
+
+  haier.setSwing(HAIER_AC_SWING_CHG);
+  EXPECT_EQ(HAIER_AC_SWING_CHG, haier.getSwing());
+  EXPECT_EQ(HAIER_AC_CMD_SWING, haier.getCommand());
+}
+
+TEST(TestHaierACClass, CurrentTime) {
+  IRHaierAC haier(0);
+  haier.begin();
+  EXPECT_EQ(0, haier.getCurrTime());
+
+  haier.setCurrTime(1);
+  EXPECT_EQ(1, haier.getCurrTime());
+
+  haier.setCurrTime(60);
+  EXPECT_EQ(60, haier.getCurrTime());
+
+  haier.setCurrTime(61);
+  EXPECT_EQ(61, haier.getCurrTime());
+
+  haier.setCurrTime(18 * 60 + 34);  // 18:34
+  EXPECT_EQ(1114, haier.getCurrTime());
+
+  haier.setCurrTime(23 * 60 + 59);  // 23:59
+  EXPECT_EQ(HAIER_AC_MAX_TIME, haier.getCurrTime());  // 23:59
+
+  haier.setCurrTime(23 * 60 + 59 + 1);  // 24:00
+  EXPECT_EQ(HAIER_AC_MAX_TIME, haier.getCurrTime());  // 23:59
+
+  haier.setCurrTime(UINT16_MAX);
+  EXPECT_EQ(HAIER_AC_MAX_TIME, haier.getCurrTime());  // 23:59
+}
+
+TEST(TestHaierACClass, Timers) {
+  IRHaierAC haier(0);
+  haier.begin();
+
+  haier.setCommand(HAIER_AC_CMD_ON);
+
+  // Off by default.
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+
+  // On Timer.
+  haier.setOnTimer(6 * 60);  // 6am
+  EXPECT_EQ(6 * 60, haier.getOnTimer());  // 6am
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_SET, haier.getCommand());
+
+  haier.setCommand(HAIER_AC_CMD_ON);
+  EXPECT_EQ(6 * 60, haier.getOnTimer());  // 6am
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+
+  haier.cancelTimers();
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_CANCEL, haier.getCommand());
+
+  // Off Timer.
+  haier.setOffTimer(18 * 60 + 30);  // 6:30pm
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_EQ(18 * 60 + 30, haier.getOffTimer());  // 6:30pm
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_SET, haier.getCommand());
+
+  haier.setCommand(HAIER_AC_CMD_ON);
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_EQ(18 * 60 + 30, haier.getOffTimer());  // 6:30pm
+  EXPECT_EQ(HAIER_AC_CMD_ON, haier.getCommand());
+
+  haier.cancelTimers();
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_CANCEL, haier.getCommand());
+
+  // Both Timers.
+  haier.setOnTimer(6 * 60);  // 6am
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_SET, haier.getCommand());
+  haier.setOffTimer(18 * 60 + 30);  // 6:30pm
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_SET, haier.getCommand());
+  EXPECT_EQ(6 * 60, haier.getOnTimer());  // 6am
+  EXPECT_EQ(18 * 60 + 30, haier.getOffTimer());  // 6:30pm
+
+  haier.cancelTimers();
+  EXPECT_GT(0, haier.getOnTimer());
+  EXPECT_GT(0, haier.getOffTimer());
+  EXPECT_EQ(HAIER_AC_CMD_TIMER_CANCEL, haier.getCommand());
+}
+
+TEST(TestHaierACClass, TimeToString) {
+  EXPECT_EQ("00:00", IRHaierAC::timeToString(0));
+  EXPECT_EQ("00:01", IRHaierAC::timeToString(1));
+  EXPECT_EQ("00:10", IRHaierAC::timeToString(10));
+  EXPECT_EQ("00:59", IRHaierAC::timeToString(59));
+
+  EXPECT_EQ("01:00", IRHaierAC::timeToString(60));
+  EXPECT_EQ("01:01", IRHaierAC::timeToString(61));
+  EXPECT_EQ("01:59", IRHaierAC::timeToString(60 + 59));
+  EXPECT_EQ("18:59", IRHaierAC::timeToString(18 * 60 + 59));
+  EXPECT_EQ("23:59", IRHaierAC::timeToString(23 * 60 + 59));
+}
+
+TEST(TestHaierACClass, MessageConstuction) {
+  IRHaierAC haier(0);
+
+  EXPECT_EQ("Command: 1 (On), Mode: 0 (AUTO), Temp: 25C, Fan: 0 (AUTO), "
+            "Swing: 0 (Off), Sleep: Off, Health: Off, "
+            "Current Time: 00:00, On Timer: Off, Off Timer: Off",
+            haier.toString());
+  haier.setMode(HAIER_AC_COOL);
+  haier.setTemp(21);
+  haier.setFan(HAIER_AC_FAN_HIGH);
+  EXPECT_EQ("Command: 3 (Fan), Mode: 1 (COOL), Temp: 21C, Fan: 3 (MAX), "
+            "Swing: 0 (Off), Sleep: Off, Health: Off, "
+            "Current Time: 00:00, On Timer: Off, Off Timer: Off",
+            haier.toString());
+  haier.setSwing(HAIER_AC_SWING_CHG);
+  haier.setHealth(true);
+  haier.setSleep(true);
+  haier.setCurrTime(615);  // 10:15am
+  EXPECT_EQ("Command: 8 (Sleep), Mode: 3 (HEAT), Temp: 21C, Fan: 3 (MAX), "
+            "Swing: 3 (Chg), Sleep: On, Health: On, "
+            "Current Time: 10:15, On Timer: Off, Off Timer: Off",
+            haier.toString());
+  haier.setOnTimer(800);  // 1:20pm
+  haier.setOffTimer(1125);  // 6:45pm
+  haier.setCommand(HAIER_AC_CMD_ON);
+
+  EXPECT_EQ("Command: 1 (On), Mode: 2 (DRY), Temp: 21C, Fan: 2, "
+            "Swing: 3 (Chg), Sleep: On, Health: On, "
+            "Current Time: 10:15, On Timer: 13:20, Off Timer: 18:45",
+            haier.toString());
+
+  // Now change a few already set things.
+  haier.setMode(HAIER_AC_HEAT);
+  EXPECT_EQ("Command: 2 (Mode), Mode: 3 (HEAT), Temp: 21C, Fan: 2, "
+            "Swing: 3 (Chg), Sleep: On, Health: On, "
+            "Current Time: 10:15, On Timer: 13:52, Off Timer: 18:45",
+            haier.toString());
+
+  haier.setTemp(25);
+  EXPECT_EQ("Command: 6 (Temp Up), Mode: 3 (HEAT), Temp: 25C, Fan: 2, "
+            "Swing: 3 (Chg), Sleep: On, Health: On, "
+            "Current Time: 10:15, On Timer: 13:52, Off Timer: 18:45",
+            haier.toString());
+
+  uint8_t expectedState[HAIER_AC_STATE_LENGTH] = {
+    0xA5, 0x96, 0xEA, 0xCF, 0x32, 0x2D, 0x0D, 0x74, 0xD4};
+  EXPECT_STATE_EQ(expectedState, haier.getRaw(), HAIER_AC_BITS);
+
+  // Check that the checksum is valid.
+  EXPECT_TRUE(IRHaierAC::validChecksum(haier.getRaw()));
+
+  // Now load up some random data.
+  uint8_t randomState[HAIER_AC_STATE_LENGTH] = {
+      0x52, 0x49, 0x50, 0x20, 0x54, 0x61, 0x6C, 0x69, 0x61};
+  EXPECT_FALSE(IRHaierAC::validChecksum(randomState));
+  haier.setRaw(randomState);
+  EXPECT_EQ("Command: 9 (Timer Set), Mode: 3 (HEAT), Temp: 20C, Fan: 2, "
+            "Swing: 1 (Up), Sleep: On, Health: Off, "
+            "Current Time: 16:32, On Timer: Off, Off Timer: Off",
+            haier.toString());
+  // getRaw() should correct the checksum.
+  EXPECT_TRUE(IRHaierAC::validChecksum(haier.getRaw()));
+}
+
+// Tests for decodeHaierAC().
+
+// Decode normal "synthetic" messages.
+TEST(TestDecodeHaierAC, NormalDecodeWithStrict) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  uint8_t expectedState[HAIER_AC_STATE_LENGTH] = {
+      0xA5, 0x01, 0x20, 0x01, 0x00, 0xC0, 0x20, 0x00, 0xA7};
+  // With the specific decoder.
+  irsend.reset();
+  irsend.sendHaierAC(expectedState);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeHaierAC(&irsend.capture, HAIER_AC_BITS, true));
+  EXPECT_EQ(HAIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(HAIER_AC_BITS, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  // With the all the decoders.
+  irsend.reset();
+  irsend.sendHaierAC(expectedState);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(HAIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(HAIER_AC_BITS, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+// Decode a "real" example message.
+TEST(TestDecodeHaierAC, RealExample1) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Data from Issue #404 captured by kuzin2006
+  uint16_t rawData[149] = {3030, 3044, 3030, 4304, 576, 1694, 550, 582, 552,
+      1704, 552, 714, 550, 582, 550, 1706, 552, 582, 550, 1836, 552, 582, 578,
+      568, 550, 582, 550, 714, 550, 582, 550, 582, 552, 582, 550, 1836, 552,
+      582, 552, 580, 580, 1692, 550, 712, 552, 582, 550, 582, 552, 580, 550,
+      714, 552, 582, 550, 582, 552, 582, 578, 698, 552, 580, 552, 582, 552,
+      582, 552, 1836, 552, 580, 552, 582, 552, 582, 550, 714, 578, 568, 550,
+      582, 550, 582, 552, 714, 550, 1706, 550, 1706, 550, 582, 550, 714, 552,
+      582, 580, 566, 552, 582, 550, 714, 552, 580, 552, 580, 552, 1706, 550,
+      714, 550, 582, 552, 582, 578, 568, 552, 712, 552, 582, 550, 582, 550,
+      582, 550, 712, 552, 582, 550, 582, 552, 582, 578, 722, 552, 1704, 550,
+      582, 550, 1706, 550, 736, 550, 582, 550, 1706, 550, 1704, 552, 1704, 578};
+  uint8_t expectedState[HAIER_AC_STATE_LENGTH] = {
+      0xA5, 0x01, 0x20, 0x01, 0x00, 0xC0, 0x20, 0x00, 0xA7};
+
+  irsend.sendRaw(rawData, 149, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(HAIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(HAIER_AC_BITS, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  IRHaierAC haier(0);
+  haier.setRaw(irsend.capture.state);
+  EXPECT_EQ("Command: 1 (On), Mode: 0 (AUTO), Temp: 16C, Fan: 0 (AUTO), "
+            "Swing: 0 (Off), Sleep: Off, Health: Off, "
+            "Current Time: 00:01, On Timer: Off, Off Timer: Off",
+            haier.toString());
+}
+
+// Decode a "real" example message.
+TEST(TestDecodeHaierAC, RealExample2) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Data from Issue #404 captured by kuzin2006
+  uint16_t rawData[149] = {3028, 3046, 3028, 4304, 576, 1694, 552, 582, 550,
+      1704, 552, 714, 550, 582, 552, 1704, 550, 582, 550, 1836, 552, 582, 578,
+      1690, 552, 1704, 552, 712, 550, 582, 550, 1706, 550, 1706, 552, 712, 550,
+      582, 552, 582, 578, 1690, 552, 714, 552, 580, 552, 582, 552, 582, 550,
+      712, 552, 582, 550, 582, 550, 582, 578, 698, 552, 582, 550, 584, 550, 582,
+      552, 1836, 550, 582, 550, 582, 550, 582, 550, 712, 578, 568, 550, 582,
+      550, 582, 550, 714, 552, 1706, 550, 1706, 552, 580, 550, 714, 550, 582,
+      580, 568, 550, 582, 550, 714, 550, 582, 550, 582, 550, 1706, 552, 712,
+      550, 582, 550, 582, 580, 568, 552, 712, 550, 584, 550, 582, 550, 584, 550,
+      712, 550, 582, 550, 582, 550, 582, 578, 722, 550, 582, 552, 580, 552, 582,
+      550, 738, 550, 1706, 550, 1704, 552, 582, 550, 582, 578};
+  uint8_t expectedState[HAIER_AC_STATE_LENGTH] = {
+      0xA5, 0x66, 0x20, 0x01, 0x00, 0xC0, 0x20, 0x00, 0x0C};
+
+  irsend.sendRaw(rawData, 149, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(HAIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(HAIER_AC_BITS, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  IRHaierAC haier(0);
+  haier.setRaw(irsend.capture.state);
+  EXPECT_EQ("Command: 6 (Temp Up), Mode: 0 (AUTO), Temp: 22C, Fan: 0 (AUTO), "
+            "Swing: 0 (Off), Sleep: Off, Health: Off, "
+            "Current Time: 00:01, On Timer: Off, Off Timer: Off",
+            haier.toString());
+}
+
+// Decode a "real" example message.
+TEST(TestDecodeHaierAC, RealExample3) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Data from Issue #404 captured by kuzin2006
+  uint16_t rawData[149] = {3030, 3044, 3030, 4302, 578, 1692, 550, 582, 550,
+      1706, 550, 714, 550, 582, 552, 1706, 550, 582, 550, 1836, 552, 1706, 578,
+      1690, 552, 1704, 552, 714, 550, 1706, 552, 1706, 550, 582, 550, 714, 552,
+      582, 550, 582, 578, 1690, 550, 714, 552, 582, 552, 582, 550, 582, 550,
+      714, 550, 584, 550, 582, 550, 582, 578, 700, 552, 1706, 550, 582, 550,
+      582, 552, 1836, 550, 582, 550, 582, 552, 1706, 550, 714, 578, 568, 552,
+      582, 552, 582, 550, 714, 550, 1706, 550, 1706, 550, 582, 552, 712, 552,
+      582, 580, 568, 550, 582, 550, 714, 550, 582, 550, 582, 550, 1706, 550,
+      714, 550, 582, 550, 582, 578, 568, 552, 712, 552, 582, 550, 582, 550, 582,
+      550, 712, 550, 584, 550, 582, 552, 582, 578, 722, 552, 1704, 550, 582,
+      550, 1706, 550, 1862, 550, 1706, 550, 582, 550, 1704, 552, 582, 578};
+  uint8_t expectedState[HAIER_AC_STATE_LENGTH] = {
+      0xA5, 0xEC, 0x20, 0x09, 0x20, 0xC0, 0x20, 0x00, 0xBA};
+
+  irsend.sendRaw(rawData, 149, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(HAIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(HAIER_AC_BITS, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  IRHaierAC haier(0);
+  haier.setRaw(irsend.capture.state);
+  EXPECT_EQ("Command: 12 (Health), Mode: 0 (AUTO), Temp: 30C, Fan: 0 (AUTO), "
+            "Swing: 0 (Off), Sleep: Off, Health: On, "
+            "Current Time: 00:09, On Timer: Off, Off Timer: Off",
+            haier.toString());
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -34,7 +34,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Denon.o ir_Dish.o ir_Panasonic.o ir_Whynter.o ir_Coolix.o \
             ir_Aiwa.o ir_Sherwood.o ir_Kelvinator.o ir_Daikin.o ir_Gree.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
-            ir_Magiquest.o ir_Lasertag.o ir_Carrier.o
+            ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -151,3 +151,6 @@ ir_Lasertag.o : $(USER_DIR)/ir_Lasertag.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_
 
 ir_Carrier.o : $(USER_DIR)/ir_Carrier.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Carrier.cpp
+
+ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Haier.cpp


### PR DESCRIPTION
* Full send, decode, & message encoding support.
* Unit tests coverage for the above.
* Add Haier A/Cs to IRrecvDumpV2 and IRMQTTServer examples.
* Update tools/gc_decode tool.
* Based on the protocol reverse engineering done by @kuzin2006 (#404)

Note: Not yet tested against a real device.