### PR TITLE
Add missing sendHaierAC() to MQTT example code.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -500,6 +500,11 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
       irsend.sendFujitsuAC(reinterpret_cast<uint8_t *>(state), stateSize);
       break;
 #endif
+#if SEND_HAIER_AC
+    case HAIER_AC:
+      irsend.sendHaierAC(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif
   }
 }
 


### PR DESCRIPTION
Forgot to add the actual sending part for HaierAC part of the IRMQTTServer
example code.