### PR TITLE
Freq. override; Freq. definitions for "1" (mark), "0"(space);  Long delay critical fix 

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -37,7 +37,7 @@
 
 // Returns:
 //   An IRsend object.
-IRsend::IRsend(uint16_t IRsendPin, bool inverted int32_t mark_freq, int32_t space_freq) : IRpin(IRsendPin),
+IRsend::IRsend(uint16_t IRsendPin, bool inverted int32_t, mark_freq, int32_t space_freq) : IRpin(IRsendPin),
     periodOffset(PERIOD_OFFSET) {
   if (inverted) {
     outputOn = LOW;
@@ -105,7 +105,7 @@ uint32_t IRsend::calcUSecPeriod(uint32_t hz, bool use_offset) {
 //   microseconds timing. Thus minor changes to the freq & duty values may have
 //   limited effect. You've been warned.
 void IRsend::enableIROut(uint32_t freq, uint8_t duty, uint32_t space_freq) {
-  if (marqFreq!=-1)  freq=marqFreq;
+  if (markFreq!=-1)  freq=marqFreq;
   if (spaceFreq!=-1) space_freq=spaceFreq;
   
   // Can't have more than 100% duty cycle.

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -37,7 +37,7 @@
 
 // Returns:
 //   An IRsend object.
-IRsend::IRsend(uint16_t IRsendPin, bool inverted int32_t, mark_freq, int32_t space_freq) : IRpin(IRsendPin),
+IRsend::IRsend(uint16_t IRsendPin, bool inverted, int32_t mark_freq, int32_t space_freq) : IRpin(IRsendPin),
     periodOffset(PERIOD_OFFSET) {
   if (inverted) {
     outputOn = LOW;
@@ -105,7 +105,7 @@ uint32_t IRsend::calcUSecPeriod(uint32_t hz, bool use_offset) {
 //   microseconds timing. Thus minor changes to the freq & duty values may have
 //   limited effect. You've been warned.
 void IRsend::enableIROut(uint32_t freq, uint8_t duty, uint32_t space_freq) {
-  if (markFreq!=-1)  freq=marqFreq;
+  if (markFreq!=-1)  freq=markFreq;
   if (spaceFreq!=-1) space_freq=spaceFreq;
   
   // Can't have more than 100% duty cycle.

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -32,7 +32,7 @@ class IRsend {
   void begin();
   void enableIROut(uint32_t mark_freq=0, uint8_t duty = DUTY_DEFAULT, uint32_t space_freq=0);
   void overrideFreqs(int32_t mark_freq=-1, int32_t space_freq=-1);
-  VIRTUAL uint16_t mark(uint16_t usec);
+  VIRTUAL uint16_t mark(uint32_t usec);
   VIRTUAL void space(uint32_t usec);
   void calibrate(uint16_t hz = 38000U);
   void sendRaw(uint16_t buf[], uint16_t len, uint16_t hz);
@@ -249,10 +249,10 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
   uint8_t outputOff;
 
  private:
-  uint16_t onTimePeriod;
-  uint16_t offTimePeriod;
-  uint16_t spaceOnTimePeriod;
-  uint16_t spaceOffTimePeriod; 
+  uint32_t onTimePeriod;
+  uint32_t offTimePeriod;
+  uint32_t spaceOnTimePeriod;
+  uint32_t spaceOffTimePeriod; 
   int32_t  markFreq;
   int32_t  spaceFreq;
   uint16_t IRpin;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -28,9 +28,10 @@
 // Classes
 class IRsend {
  public:
-  explicit IRsend(uint16_t IRsendPin, bool inverted = false);
+  explicit IRsend(uint16_t IRsendPin, bool inverted = false, int32_t mark_freq=-1, int32_t space_freq=0);
   void begin();
-  void enableIROut(uint32_t freq, uint8_t duty = DUTY_DEFAULT);
+  void enableIROut(uint32_t mark_freq=0, uint8_t duty = DUTY_DEFAULT, uint32_t space_freq=0);
+  void overrideFreqs(int32_t mark_freq=-1, int32_t space_freq=-1);
   VIRTUAL uint16_t mark(uint16_t usec);
   VIRTUAL void space(uint32_t usec);
   void calibrate(uint16_t hz = 38000U);
@@ -250,6 +251,10 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
  private:
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
+  uint16_t spaceOnTimePeriod;
+  uint16_t spaceOffTimePeriod; 
+  int32_t  markFreq;
+  int32_t  spaceFreq;
   uint16_t IRpin;
   int8_t periodOffset;
   void ledOff();


### PR DESCRIPTION
overrideFreqs (freqMark, freqSpace) function added
-1 - no override(default)
0   - no modulation (to allow direct connection output to low-freq IR input)
>0 -  forced frequency set-up

if freqSpace >0 - filling space period by particular frequency (default=0 - no filling)

Long delay issue fixed both, for mark and space
Ref: https://www.arduino.cc/en/Reference/delayMicroseconds

Tested