### PR TITLE
Improve transmission pulse modulation support.

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -24,13 +24,16 @@
 // Value determined in https://github.com/markszabo/IRremoteESP8266/issues/62
 #define PERIOD_OFFSET -3
 #define DUTY_DEFAULT 50
+#define DUTY_MAX 100  // Percentage
 
 // Classes
 class IRsend {
  public:
-  explicit IRsend(uint16_t IRsendPin, bool inverted = false);
+  explicit IRsend(uint16_t IRsendPin, bool inverted = false,
+                  bool use_modulation = true);
   void begin();
   void enableIROut(uint32_t freq, uint8_t duty = DUTY_DEFAULT);
+  VIRTUAL void _delayMicroseconds(uint32_t usec);
   VIRTUAL uint16_t mark(uint16_t usec);
   VIRTUAL void space(uint32_t usec);
   void calibrate(uint16_t hz = 38000U);
@@ -246,13 +249,16 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
 #endif  // UNIT_TEST
   uint8_t outputOn;
   uint8_t outputOff;
+  VIRTUAL void ledOff();
+  VIRTUAL void ledOn();
 
  private:
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
   uint16_t IRpin;
   int8_t periodOffset;
-  void ledOff();
+  uint8_t _dutycycle;
+  bool modulation;
   uint32_t calcUSecPeriod(uint32_t hz, bool use_offset = true);
 };
 

--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -137,3 +137,145 @@ TEST(TestSendRaw, NoTrailingGap) {
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(NEC_BITS, irsend.capture.bits);
 }
+
+TEST(TestLowLevelSend, MarkFrequencyModulationAt38kHz) {
+  IRsendLowLevelTest irsend(0);
+
+  irsend.begin();
+
+  irsend.reset();
+  irsend.enableIROut(38000, 50);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]11usecs[Off]12usecs[On]11usecs[Off]12usecs[On]11usecs[Off]12usecs"
+      "[On]11usecs[Off]12usecs[On]8usecs[Off]", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(38000, 33);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]7usecs[Off]16usecs[On]7usecs[Off]16usecs[On]7usecs[Off]16usecs"
+      "[On]7usecs[Off]16usecs[On]7usecs[Off]1usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(38000, 100);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+}
+
+TEST(TestLowLevelSend, MarkFrequencyModulationAt36_7kHz) {
+  IRsendLowLevelTest irsend(0);
+
+  irsend.begin();
+
+  irsend.reset();
+  irsend.enableIROut(36700, 50);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]12usecs[Off]12usecs[On]12usecs[Off]12usecs[On]12usecs[Off]12usecs"
+      "[On]12usecs[Off]12usecs[On]4usecs[Off]", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(36700, 33);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]7usecs[Off]17usecs[On]7usecs[Off]17usecs[On]7usecs[Off]17usecs"
+      "[On]7usecs[Off]17usecs[On]4usecs[Off]", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(36700, 100);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+}
+
+TEST(TestLowLevelSend, MarkFrequencyModulationAt40kHz) {
+  IRsendLowLevelTest irsend(0);
+
+  irsend.begin();
+
+  irsend.reset();
+  irsend.enableIROut(40000, 50);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]11usecs[Off]11usecs[On]11usecs[Off]11usecs[On]11usecs[Off]11usecs"
+      "[On]11usecs[Off]11usecs[On]11usecs[Off]1usecs",
+      irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(40000, 33);
+  EXPECT_EQ(5, irsend.mark(100));
+  EXPECT_EQ(
+      "[On]7usecs[Off]15usecs[On]7usecs[Off]15usecs[On]7usecs[Off]15usecs"
+      "[On]7usecs[Off]15usecs[On]7usecs[Off]5usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(40000, 100);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+}
+
+TEST(TestLowLevelSend, MarkNoModulation) {
+  IRsendLowLevelTest irsend(0, false, false);
+
+  irsend.begin();
+
+  irsend.reset();
+  irsend.enableIROut(38000, 50);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(36700, 25);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(40000, 75);
+  EXPECT_EQ(1, irsend.mark(1000));
+  EXPECT_EQ("[On]1000usecs[Off]", irsend.low_level_sequence);
+}
+
+TEST(TestLowLevelSend, SpaceFrequencyModulation) {
+  IRsendLowLevelTest irsend(0);
+
+  irsend.reset();
+  irsend.enableIROut(38000);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(40000, 75);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(38000, 100);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(38000, 33);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+}
+
+TEST(TestLowLevelSend, SpaceNoModulation) {
+  IRsendLowLevelTest irsend(0, false, false);
+
+  irsend.begin();
+
+  irsend.reset();
+  irsend.enableIROut(38000, 50);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(36700, 25);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+
+  irsend.reset();
+  irsend.enableIROut(40000, 75);
+  irsend.space(1000);
+  EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+}

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -27,7 +27,8 @@ class IRsendTest: public IRsend {
   uint16_t rawbuf[RAW_BUF];
   decode_results capture;
 
-  explicit IRsendTest(uint16_t x, bool i = false) : IRsend(x, i) {
+  explicit IRsendTest(uint16_t x, bool i = false, bool j = true) :
+      IRsend(x, i, j) {
     reset();
   }
 
@@ -115,4 +116,37 @@ class IRsendTest: public IRsend {
     }
   }
 };
+
+#ifdef UNIT_TEST
+class IRsendLowLevelTest: public IRsend {
+ public:
+  std::string low_level_sequence;
+
+  explicit IRsendLowLevelTest(uint16_t x, bool i = false, bool j = true) :
+      IRsend(x, i, j) {
+    reset();
+  }
+
+  void reset() {
+    low_level_sequence = "";
+  }
+
+ protected:
+  void _delayMicroseconds(uint32_t usec) {
+    _IRtimer_unittest_now += usec;
+    std::ostringstream Convert;
+    Convert << usec;
+    low_level_sequence += Convert.str() + "usecs";
+  }
+
+  void ledOff() {
+    low_level_sequence += "[Off]";
+  }
+
+  void ledOn() {
+    low_level_sequence += "[On]";
+  }
+};
+#endif  // UNIT_TEST
+
 #endif  // TEST_IRSEND_TEST_H_


### PR DESCRIPTION
- Allow transmission frequency modulation to be turned off.
- Better handle the case when a 100% duty cycle has been selected.
- Slight refactor of mark() & space().
- Create & use our own delayMicroseconds() function.
- Introduce an ledOn() function.
- Create a new low-level unit test class for IRsend to allow low-level
  testing of mark() & space(). i.e. The software PWM emulation.
- Unit test coverage for most of the above.
- Based on discussions around/in PR #438 (FYI @anklimov)