### PR TITLE
Allow disabling the use of delay() calls.

### DIFF
--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -174,6 +174,12 @@
 #define DECODE_AC false   // We don't need that infrastructure.
 #endif
 
+// Use millisecond 'delay()' calls where we can to avoid tripping the WDT.
+// Note: If you plan to send IR messages in the callbacks of the AsyncWebserver
+//       library, you need to set PREFER_DELAY to false.
+//       Ref: https://github.com/markszabo/IRremoteESP8266/issues/430
+#define PREFER_DELAY true
+
 /*
  * Always add to the end of the list and should never remove entries
  * or change order. Projects may save the type number for later usage

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -176,9 +176,9 @@
 
 // Use millisecond 'delay()' calls where we can to avoid tripping the WDT.
 // Note: If you plan to send IR messages in the callbacks of the AsyncWebserver
-//       library, you need to set PREFER_DELAY to false.
+//       library, you need to set ALLOW_DELAY_CALLS to false.
 //       Ref: https://github.com/markszabo/IRremoteESP8266/issues/430
-#define PREFER_DELAY true
+#define ALLOW_DELAY_CALLS true
 
 /*
  * Always add to the end of the list and should never remove entries

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -117,7 +117,7 @@ void IRsend::enableIROut(uint32_t freq, uint8_t duty) {
   offTimePeriod = period - onTimePeriod;
 }
 
-#if PREFER_DELAY
+#if ALLOW_DELAY_CALLS
 // An ESP8266 RTOS watch-dog timer friendly version of delayMicroseconds().
 // Args:
 //   usec: Nr. of uSeconds to delay for.
@@ -137,7 +137,7 @@ void IRsend::_delayMicroseconds(uint32_t usec) {
 #endif
   }
 }
-#else  // PREFER_DELAY
+#else  // ALLOW_DELAY_CALLS
 // A version of delayMicroseconds() that handles large values and does NOT use
 // the watch-dog friendly delay() calls where appropriate.
 // Args:
@@ -152,7 +152,7 @@ void IRsend::_delayMicroseconds(uint32_t usec) {
   delayMicroseconds(static_cast<uint16_t>(usec));
 #endif  // UNIT_TEST
 }
-#endif  // PREFER_DELAY
+#endif  // ALLOW_DELAY_CALLS
 
 // Modulate the IR LED for the given period (usec) and at the duty cycle set.
 //

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -117,13 +117,14 @@ void IRsend::enableIROut(uint32_t freq, uint8_t duty) {
   offTimePeriod = period - onTimePeriod;
 }
 
+#if PREFER_DELAY
 // An ESP8266 RTOS watch-dog timer friendly version of delayMicroseconds().
 // Args:
 //   usec: Nr. of uSeconds to delay for.
 void IRsend::_delayMicroseconds(uint32_t usec) {
-  // delayMicroseconds is only accurate to 16383us.
+  // delayMicroseconds() is only accurate to 16383us.
   // Ref: https://www.arduino.cc/en/Reference/delayMicroseconds
-  if (usec <= 16383) {
+  if (usec <= MAX_ACCURATE_USEC_DELAY) {
 #ifndef UNIT_TEST
     delayMicroseconds(usec);
 #endif
@@ -136,6 +137,22 @@ void IRsend::_delayMicroseconds(uint32_t usec) {
 #endif
   }
 }
+#else  // PREFER_DELAY
+// A version of delayMicroseconds() that handles large values and does NOT use
+// the watch-dog friendly delay() calls where appropriate.
+// Args:
+//   usec: Nr. of uSeconds to delay for.
+//
+// NOTE: Use this only if you know what you are doing as it may cause the WDT
+//       to reset the ESP8266.
+void IRsend::_delayMicroseconds(uint32_t usec) {
+  for (; usec > MAX_ACCURATE_USEC_DELAY; usec -= MAX_ACCURATE_USEC_DELAY)
+#ifndef UNIT_TEST
+    delayMicroseconds(MAX_ACCURATE_USEC_DELAY);
+  delayMicroseconds(static_cast<uint16_t>(usec));
+#endif  // UNIT_TEST
+}
+#endif  // PREFER_DELAY
 
 // Modulate the IR LED for the given period (usec) and at the duty cycle set.
 //

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -25,6 +25,9 @@
 #define PERIOD_OFFSET -3
 #define DUTY_DEFAULT 50
 #define DUTY_MAX 100  // Percentage
+// delayMicroseconds() is only accurate to 16383us.
+// Ref: https://www.arduino.cc/en/Reference/delayMicroseconds
+#define MAX_ACCURATE_USEC_DELAY 16383U
 
 // Classes
 class IRsend {


### PR DESCRIPTION
Per Issue #430, the use of delay() calls is incompatible with the AsyncWebserver
library. Give users of the library a way to send IR messages without the delay()
calls which cause it to break the callbacks of AsyncWebserver. This is not
without risk as the delay() calls feed the WDT.

No delay() calls means the user can easily cause the WDT to reset the ESP8266.
Thus the default is to use delay() calls where possible, and make this a
compile-time option to try to limit people shooting themselves in the foot.