### PR TITLE
Ensure WiFi.localIP() is converted to a string when needed.

### DIFF
--- a/examples/IRGCTCPServer/IRGCTCPServer.ino
+++ b/examples/IRGCTCPServer/IRGCTCPServer.ino
@@ -111,7 +111,7 @@ void setup() {
 
   server.begin();
   IPAddress myAddress = WiFi.localIP();
-  Serial.println(myAddress);
+  Serial.println(myAddress.toString());
   irsend.begin();
 }
 

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -804,7 +804,7 @@ void setup_wifi() {
     delay(5000);
   }
 
-  debug("WiFi connected. IP address: " + WiFi.localIP());
+  debug("WiFi connected. IP address: " + WiFi.localIP().toString());
 }
 
 void setup(void) {

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -102,7 +102,7 @@ void setup(void) {
   Serial.print("Connected to ");
   Serial.println(ssid);
   Serial.print("IP address: ");
-  Serial.println(WiFi.localIP());
+  Serial.println(WiFi.localIP().toString());
 
   if (mdns.begin("esp8266", WiFi.localIP())) {
     Serial.println("MDNS responder started");


### PR DESCRIPTION
Due to a potential compiler difference (e.g. Platformio vs. Arduino IDE) it
seems that `WiFi.localIP()` wasn't being automatically associated with the
string varient when used in a string context. This manifest as a crash on a ESP-01 board.
Forcing the conversion should fix it in all cases.

Fixes #452

Verified by @DiggiD