### PR TITLE
Silence a compiler warning about an unused parameter.

### DIFF
--- a/src/IRtimer.cpp
+++ b/src/IRtimer.cpp
@@ -38,8 +38,8 @@ uint32_t IRtimer::elapsed() {
 }
 
 // Only used in unit testing.
-void IRtimer::add(uint32_t usecs) {
 #ifdef UNIT_TEST
+void IRtimer::add(uint32_t usecs) {
   _IRtimer_unittest_now += usecs;
-#endif  // UNIT_TEST
 }
+#endif  // UNIT_TEST

--- a/src/IRtimer.h
+++ b/src/IRtimer.h
@@ -12,7 +12,9 @@ class IRtimer {
   IRtimer();
   void reset();
   uint32_t elapsed();
+#ifdef UNIT_TEST
   static void add(uint32_t usecs);
+#endif  // UNIT_TEST
 
  private:
   uint32_t start;


### PR DESCRIPTION
Compiler warning only happens when compiling for the device, not the unit test.
Safest thing to do is make the entire add() function only available when
unit testing.