### PR TITLE
Update LG (28-bit) HDR mark and space timings.

### DIFF
--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -19,9 +19,9 @@
 
 // Constants
 #define LG_TICK                       50U
-#define LG_HDR_MARK_TICKS            160U
+#define LG_HDR_MARK_TICKS            170U  // 8500
 #define LG_HDR_MARK                  (LG_HDR_MARK_TICKS * LG_TICK)
-#define LG_HDR_SPACE_TICKS            80U
+#define LG_HDR_SPACE_TICKS            85U  // 4250
 #define LG_HDR_SPACE                 (LG_HDR_SPACE_TICKS * LG_TICK)
 #define LG_BIT_MARK_TICKS             11U
 #define LG_BIT_MARK                  (LG_BIT_MARK_TICKS * LG_TICK)

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -30,12 +30,12 @@ TEST(TestSendLG, SendDataOnly) {
   irsend.reset();
   irsend.sendLG(0x4B4AE51);
   EXPECT_EQ(
-      "m8000s4000"
+      "m8500s4250"
       "m550s550m550s1600m550s550m550s550"
       "m550s1600m550s550m550s1600m550s1600m550s550m550s1600m550s550m550s550"
       "m550s1600m550s550m550s1600m550s550m550s1600m550s1600m550s1600m550s550"
       "m550s550m550s1600m550s550m550s1600m550s550m550s550m550s550m550s1600"
-      "m550s51050", irsend.outputStr());
+      "m550s50300", irsend.outputStr());
 
   irsend.reset();
   irsend.sendLG(0xB4B4AE51, LG32_BITS);
@@ -57,13 +57,13 @@ TEST(TestSendLG, SendWithRepeats) {
   irsend.reset();
   irsend.sendLG(0x4B4AE51, LG_BITS, 1);
   EXPECT_EQ(
-      "m8000s4000"
+      "m8500s4250"
       "m550s550m550s1600m550s550m550s550"
       "m550s1600m550s550m550s1600m550s1600m550s550m550s1600m550s550m550s550"
       "m550s1600m550s550m550s1600m550s550m550s1600m550s1600m550s1600m550s550"
       "m550s550m550s1600m550s550m550s1600m550s550m550s550m550s550m550s1600"
-      "m550s51050"
-      "m8000s2250m550s97250", irsend.outputStr());
+      "m550s50300"
+      "m8500s2250m550s96750", irsend.outputStr());
 
   irsend.reset();
   irsend.sendLG(0xB4B4AE51, LG32_BITS, 1);
@@ -86,12 +86,12 @@ TEST(TestSendLG, SendUnusualSize) {
   irsend.reset();
   irsend.sendLG(0x0, 31);
   EXPECT_EQ(
-      "m8000s4000"
+      "m8500s4250"
       "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
       "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
       "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
       "m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
-      "m550s61400", irsend.outputStr());
+      "m550s60650", irsend.outputStr());
 
   irsend.reset();
   irsend.sendLG(0x0, 64);


### PR DESCRIPTION
- Based on data collected in #472 and #488 it appears LG A/C (28bit)
  messages have a header that's closer to 8500+ for the mark and 4250 for
  the space. This puts the new values about midway between the range
  of values seen so hopefully will be compatible with old and new LG devices
  alike.