### PR TITLE
Calculate and use average values for timings when analysing

### DIFF
--- a/tools/auto_analyse_raw_data.py
+++ b/tools/auto_analyse_raw_data.py
@@ -22,7 +22,9 @@ class RawIRMessage(object):
     self.gaps = []
     self.margin = margin
     self.marks = []
+    self.mark_buckets = {}
     self.spaces = []
+    self.space_buckets = {}
     self.output = output
     self.verbose = verbose
     if len(timings) <= 3:
@@ -40,18 +42,22 @@ class RawIRMessage(object):
         self.marks.append(usecs)
       else:
         self.spaces.append(usecs)
-    self.marks = self._reduce_list(self.marks)
-    self.spaces = self._reduce_list(self.spaces)
+    self.marks, self.mark_buckets = self.reduce_list(self.marks)
+    self.spaces, self.space_buckets = self.reduce_list(self.spaces)
 
-  def _reduce_list(self, items):
+  def reduce_list(self, items):
     """Reduce the list of numbers into buckets that are atleast margin apart."""
     result = []
     last = -1
+    buckets = {}
     for item in sorted(items, reverse=True):
       if last == -1 or item < last - self.margin:
         result.append(item)
         last = item
-    return result
+        buckets[last] = [item]
+      else:
+        buckets[last].append(item)
+    return result, buckets
 
   def _usec_compare(self, seen, expected):
     """Compare two usec values and see if they match within a
@@ -151,6 +157,13 @@ class RawIRMessage(object):
     return self._usec_compares(usec, self.gaps)
 
 
+def avg_list(items):
+  """Return the average of a list of numbers."""
+  if items:
+    return sum(items) / len(items)
+  return 0
+
+
 def add_bit(so_far, bit, output=sys.stdout):
   """Add a bit to the end of the bits collected so far. """
   if bit == "reset":
@@ -180,26 +193,32 @@ def convert_rawdata(data_str):
 
 def dump_constants(message, defines, output=sys.stdout):
   """Dump the key constants and generate the C++ #defines."""
+  hdr_mark = avg_list(message.mark_buckets[message.hdr_mark])
+  bit_mark = avg_list(message.mark_buckets[message.bit_mark])
+  hdr_space = avg_list(message.space_buckets[message.hdr_space])
+  one_space = avg_list(message.space_buckets[message.one_space])
+  zero_space = avg_list(message.space_buckets[message.zero_space])
+
   output.write("Guessing key value:\n"
                "kHdrMark   = %d\n"
                "kHdrSpace  = %d\n"
                "kBitMark   = %d\n"
                "kOneSpace  = %d\n"
-               "kZeroSpace = %d\n" %
-               (message.hdr_mark, message.hdr_space, message.bit_mark,
-                message.one_space, message.zero_space))
-  defines.append("const uint16_t kHdrMark = %d;" % message.hdr_mark)
-  defines.append("const uint16_t kBitMark = %d;" % message.bit_mark)
-  defines.append("const uint16_t kHdrSpace = %d;" % message.hdr_space)
-  defines.append("const uint16_t kOneSpace = %d;" % message.one_space)
-  defines.append("const uint16_t kZeroSpace = %d;" % message.zero_space)
+               "kZeroSpace = %d\n" % (hdr_mark, hdr_space, bit_mark, one_space,
+                                      zero_space))
+  defines.append("const uint16_t kHdrMark = %d;" % hdr_mark)
+  defines.append("const uint16_t kBitMark = %d;" % bit_mark)
+  defines.append("const uint16_t kHdrSpace = %d;" % hdr_space)
+  defines.append("const uint16_t kOneSpace = %d;" % one_space)
+  defines.append("const uint16_t kZeroSpace = %d;" % zero_space)
 
+  avg_gaps = [avg_list(message.space_buckets[x]) for x in message.gaps]
   if len(message.gaps) == 1:
-    output.write("kSpaceGap = %d\n" % message.gaps[0])
-    defines.append("const uint16_t kSpaceGap = %d;" % message.gaps[0])
+    output.write("kSpaceGap = %d\n" % avg_gaps[0])
+    defines.append("const uint16_t kSpaceGap = %d;" % avg_gaps[0])
   else:
     count = 0
-    for gap in message.gaps:
+    for gap in avg_gaps:
       # We probably (still) have a gap in the protocol.
       count = count + 1
       output.write("kSpaceGap%d = %d\n" % (count, gap))

--- a/tools/auto_analyse_raw_data.py
+++ b/tools/auto_analyse_raw_data.py
@@ -368,7 +368,7 @@ def generate_irsend_code(defines, normal, bits_str, output=sys.stdout):
                  "    sendGeneric(kHdrMark, kHdrSpace,\n"
                  "                kBitMark, kOneSpace,\n"
                  "                kBitMark, kZeroSpace,\n"
-                 "                kBitMark\n"
+                 "                kBitMark,\n"
                  "                100000, // 100%% made-up guess at the"
                  " message gap.\n"
                  "                data, nbytes,\n"

--- a/tools/auto_analyse_raw_data_test.py
+++ b/tools/auto_analyse_raw_data_test.py
@@ -62,15 +62,15 @@ class TestAutoAnalyseRawData(unittest.TestCase):
     ], ignore)
     analyse.dump_constants(message, defs, output)
     self.assertEqual(defs, [
-        'const uint16_t kHdrMark = 7930;', 'const uint16_t kBitMark = 520;',
-        'const uint16_t kHdrSpace = 3978;', 'const uint16_t kOneSpace = 1508;',
+        'const uint16_t kHdrMark = 7930;', 'const uint16_t kBitMark = 496;',
+        'const uint16_t kHdrSpace = 3965;', 'const uint16_t kOneSpace = 1485;',
         'const uint16_t kZeroSpace = 520;'
     ])
     self.assertEqual(output.getvalue(), 'Guessing key value:\n'
                      'kHdrMark   = 7930\n'
-                     'kHdrSpace  = 3978\n'
-                     'kBitMark   = 520\n'
-                     'kOneSpace  = 1508\n'
+                     'kHdrSpace  = 3965\n'
+                     'kBitMark   = 496\n'
+                     'kOneSpace  = 1485\n'
                      'kZeroSpace = 520\n')
 
   def test_dump_constants_aircon(self):
@@ -93,16 +93,16 @@ class TestAutoAnalyseRawData(unittest.TestCase):
     ], ignore)
     analyse.dump_constants(message, defs, output)
     self.assertEqual(defs, [
-        'const uint16_t kHdrMark = 9008;', 'const uint16_t kBitMark = 676;',
-        'const uint16_t kHdrSpace = 4496;', 'const uint16_t kOneSpace = 1680;',
-        'const uint16_t kZeroSpace = 584;', 'const uint16_t kSpaceGap = 19990;'
+        'const uint16_t kHdrMark = 9008;', 'const uint16_t kBitMark = 650;',
+        'const uint16_t kHdrSpace = 4496;', 'const uint16_t kOneSpace = 1657;',
+        'const uint16_t kZeroSpace = 554;', 'const uint16_t kSpaceGap = 19990;'
     ])
     self.assertEqual(output.getvalue(), 'Guessing key value:\n'
                      'kHdrMark   = 9008\n'
                      'kHdrSpace  = 4496\n'
-                     'kBitMark   = 676\n'
-                     'kOneSpace  = 1680\n'
-                     'kZeroSpace = 584\n'
+                     'kBitMark   = 650\n'
+                     'kOneSpace  = 1657\n'
+                     'kZeroSpace = 554\n'
                      'kSpaceGap = 19990\n')
 
   def test_convert_rawdata(self):
@@ -171,8 +171,7 @@ class TestAutoAnalyseRawData(unittest.TestCase):
             648};"""
     analyse.parse_and_report(input_str, 200, False, output)
     self.assertEqual(
-        output.getvalue(),
-        'Found 139 timing entries.\n'
+        output.getvalue(), 'Found 139 timing entries.\n'
         'Potential Mark Candidates:\n'
         '[9008, 676]\n'
         'Potential Space Candidates:\n'
@@ -184,9 +183,9 @@ class TestAutoAnalyseRawData(unittest.TestCase):
         'Guessing key value:\n'
         'kHdrMark   = 9008\n'
         'kHdrSpace  = 4496\n'
-        'kBitMark   = 676\n'
-        'kOneSpace  = 1680\n'
-        'kZeroSpace = 584\n'
+        'kBitMark   = 650\n'
+        'kOneSpace  = 1657\n'
+        'kZeroSpace = 554\n'
         'kSpaceGap = 19990\n'
         '\n'
         'Decoding protocol based on analysis so far:\n'
@@ -219,8 +218,7 @@ class TestAutoAnalyseRawData(unittest.TestCase):
             494, 520, 494, 1482, 494};"""
     analyse.parse_and_report(input_str, 200, True, output)
     self.assertEqual(
-        output.getvalue(),
-        'Found 37 timing entries.\n'
+        output.getvalue(), 'Found 37 timing entries.\n'
         'Potential Mark Candidates:\n'
         '[7930, 520]\n'
         'Potential Space Candidates:\n'
@@ -231,9 +229,9 @@ class TestAutoAnalyseRawData(unittest.TestCase):
         '\n'
         'Guessing key value:\n'
         'kHdrMark   = 7930\n'
-        'kHdrSpace  = 3978\n'
-        'kBitMark   = 520\n'
-        'kOneSpace  = 1508\n'
+        'kHdrSpace  = 3965\n'
+        'kBitMark   = 496\n'
+        'kOneSpace  = 1485\n'
         'kZeroSpace = 520\n'
         '\n'
         'Decoding protocol based on analysis so far:\n'
@@ -261,9 +259,9 @@ class TestAutoAnalyseRawData(unittest.TestCase):
         '\n'
         "// WARNING: This probably isn't directly usable. It's a guide only.\n"
         'const uint16_t kHdrMark = 7930;\n'
-        'const uint16_t kBitMark = 520;\n'
-        'const uint16_t kHdrSpace = 3978;\n'
-        'const uint16_t kOneSpace = 1508;\n'
+        'const uint16_t kBitMark = 496;\n'
+        'const uint16_t kHdrSpace = 3965;\n'
+        'const uint16_t kOneSpace = 1485;\n'
         'const uint16_t kZeroSpace = 520;\n'
         'const uint16_t kXyzBits = 16;\n'
         '// Function should be safe up to 64 bits.\n'
@@ -325,8 +323,7 @@ class TestAutoAnalyseRawData(unittest.TestCase):
             864, 2620, 864, 864, 864, 864, 3485, 3512, 864, 13996};"""
     analyse.parse_and_report(input_str, 200, True, output)
     self.assertEqual(
-        output.getvalue(),
-        'Found 272 timing entries.\n'
+        output.getvalue(), 'Found 272 timing entries.\n'
         'Potential Mark Candidates:\n'
         '[3485, 864]\n'
         'Potential Space Candidates:\n'
@@ -464,6 +461,30 @@ class TestAutoAnalyseRawData(unittest.TestCase):
         ' frequency.\n'
         '                true, 0, 50);\n'
         '}\n')
+
+  def test_reduce_list(self):
+    """Tests for the reduce_list method."""
+
+    ignore = StringIO.StringIO()
+    message = analyse.RawIRMessage(200, [
+        7930, 3952, 494, 1482, 520, 1482, 494, 1508, 494, 520, 494, 1482, 494,
+        520, 494, 1482, 494, 1482, 494, 3978, 494, 520, 494, 520, 494, 520, 494,
+        520, 520, 520, 494, 520, 494, 520, 494, 1482, 494
+    ], ignore)
+    test_space_data = [4496, 1660, 530, 558, 1636, 1660, 556]
+    result_list, result_dict = message.reduce_list(test_space_data)
+    self.assertEqual([4496, 1660, 558], result_list)
+    self.assertEqual({
+        558: [558, 556, 530],
+        1660: [1660, 1660, 1636],
+        4496: [4496]
+    }, result_dict)
+
+  def test_avg_list(self):
+    """Tests for the avg_list method."""
+
+    self.assertEqual(0, analyse.avg_list([]))
+    self.assertEqual(23, analyse.avg_list([10, 20, 40]))
 
 
 if __name__ == '__main__':

--- a/tools/auto_analyse_raw_data_test.py
+++ b/tools/auto_analyse_raw_data_test.py
@@ -454,7 +454,7 @@ class TestAutoAnalyseRawData(unittest.TestCase):
         '    sendGeneric(kHdrMark, kHdrSpace,\n'
         '                kBitMark, kOneSpace,\n'
         '                kBitMark, kZeroSpace,\n'
-        '                kBitMark\n'
+        '                kBitMark,\n'
         '                100000, // 100% made-up guess at the message gap.\n'
         '                data, nbytes,\n'
         '                38000, // Complete guess of the modulation'


### PR DESCRIPTION
* Add support to tools/auto_analyse_raw_data.py to calculate "better" values for constants by using the averages of the values that fall into the given ranges.
* Fix a minor cosmetic output error in the generated example code.