### PR TITLE
Remove obsolete reverseBits() calls.

### DIFF
--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -474,10 +474,10 @@ bool IRrecv::decodeFujitsuAC(decode_results *results, uint16_t nbits,
                                         kFujitsuAcBitMark,
                                         kFujitsuAcOneSpace,
                                         kFujitsuAcBitMark,
-                                        kFujitsuAcZeroSpace);
+                                        kFujitsuAcZeroSpace,
+                                        kTolerance, kMarkExcess, false);
   if (data_result.success == false)  return false;  // Fail
-  if (reverseBits(data_result.data, kFujitsuAcMinBits - 8) != 0x1010006314)
-    return false;  // Signature failed.
+  if (data_result.data != 0x1010006314)  return false;  // Signature failed.
   dataBitsSoFar += kFujitsuAcMinBits - 8;
   offset += data_result.used;
   results->state[0] = 0x14;
@@ -494,9 +494,10 @@ bool IRrecv::decodeFujitsuAC(decode_results *results, uint16_t nbits,
                             kFujitsuAcBitMark,
                             kFujitsuAcOneSpace,
                             kFujitsuAcBitMark,
-                            kFujitsuAcZeroSpace);
+                            kFujitsuAcZeroSpace,
+                            kTolerance, kMarkExcess, false);
     if (data_result.success == false)  break;  // Fail
-    results->state[i] = (uint8_t) reverseBits(data_result.data, 8);
+    results->state[i] = data_result.data;
   }
 
   // Footer

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -439,38 +439,40 @@ bool IRrecv::decodeGree(decode_results *results, uint16_t nbits, bool strict) {
   if (!matchSpace(results->rawbuf[offset++], kGreeHdrSpace)) return false;
   // Data Block #1 (32 bits)
   data_result = matchData(&(results->rawbuf[offset]), 32, kGreeBitMark,
-                          kGreeOneSpace, kGreeBitMark, kGreeZeroSpace);
+                          kGreeOneSpace, kGreeBitMark, kGreeZeroSpace,
+                          kTolerance, kMarkExcess, false);
   if (data_result.success == false) return false;
   data = data_result.data;
   offset += data_result.used;
 
   // Record Data Block #1 in the state.
-  for (int i = state_pos + 3; i >= state_pos; i--, data >>= 8)
-    results->state[i] = reverseBits(data & 0xFF, 8);
+  for (uint16_t i = 0; i < 4; i++, data >>= 8)
+    results->state[state_pos + i] = data & 0xFF;
   state_pos += 4;
 
   // Block #1 footer (3 bits, B010)
   data_result = matchData(&(results->rawbuf[offset]), kGreeBlockFooterBits,
                           kGreeBitMark, kGreeOneSpace, kGreeBitMark,
-                          kGreeZeroSpace);
+                          kGreeZeroSpace, kTolerance, kMarkExcess, false);
   if (data_result.success == false) return false;
   if (data_result.data != kGreeBlockFooter) return false;
   offset += data_result.used;
 
   // Inter-block gap.
   if (!matchMark(results->rawbuf[offset++], kGreeBitMark)) return false;
-  if (!matchSpace(results->rawbuf[offset++],  kGreeMsgSpace)) return false;
+  if (!matchSpace(results->rawbuf[offset++], kGreeMsgSpace)) return false;
 
   // Data Block #2 (32 bits)
   data_result = matchData(&(results->rawbuf[offset]), 32, kGreeBitMark,
-                          kGreeOneSpace, kGreeBitMark, kGreeZeroSpace);
+                          kGreeOneSpace, kGreeBitMark, kGreeZeroSpace,
+                          kTolerance, kMarkExcess, false);
   if (data_result.success == false) return false;
   data = data_result.data;
   offset += data_result.used;
 
   // Record Data Block #2 in the state.
-  for (int i = state_pos + 3; i >= state_pos; i--, data >>= 8)
-    results->state[i] = reverseBits(data & 0xFF, 8);
+  for (uint16_t i = 0; i < 4; i++, data >>= 8)
+    results->state[state_pos + i] = data & 0xFF;
   state_pos += 4;
 
   // Footer.

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -486,14 +486,15 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                             kKelvinatorBitMarkTicks * mark_tick,
                             kKelvinatorOneSpaceTicks * space_tick,
                             kKelvinatorBitMarkTicks * mark_tick,
-                            kKelvinatorZeroSpaceTicks * space_tick);
+                            kKelvinatorZeroSpaceTicks * space_tick,
+                            kTolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     data = data_result.data;
     offset += data_result.used;
 
     // Record command data in the state.
-    for (int i = state_pos + 3; i >= state_pos; i--, data >>= 8)
-      results->state[i] = reverseBits(data & 0xFF, 8);
+    for (uint16_t i = 0; i < 4; i++, data >>= 8)
+      results->state[state_pos + i] = data & 0xFF;
     state_pos += 4;
 
     // Command data footer (3 bits, B010)
@@ -502,7 +503,8 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                             kKelvinatorBitMarkTicks * mark_tick,
                             kKelvinatorOneSpaceTicks * space_tick,
                             kKelvinatorBitMarkTicks * mark_tick,
-                            kKelvinatorZeroSpaceTicks * space_tick);
+                            kKelvinatorZeroSpaceTicks * space_tick,
+                            kTolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     if (data_result.data != kKelvinatorCmdFooter) return false;
     offset += data_result.used;
@@ -520,14 +522,15 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                             kKelvinatorBitMarkTicks * mark_tick,
                             kKelvinatorOneSpaceTicks * space_tick,
                             kKelvinatorBitMarkTicks * mark_tick,
-                            kKelvinatorZeroSpaceTicks * space_tick);
+                            kKelvinatorZeroSpaceTicks * space_tick,
+                            kTolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     data = data_result.data;
     offset += data_result.used;
 
     // Record option data in the state.
-    for (int i = state_pos + 3; i >= state_pos; i--, data >>= 8)
-      results->state[i] = reverseBits(data & 0xFF, 8);
+    for (uint16_t i = 0; i < 4; i++, data >>= 8)
+      results->state[state_pos + i] = data & 0xFF;
     state_pos += 4;
 
     // Inter-sequence gap. (Double length gap)

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -126,10 +126,11 @@ bool IRrecv::decodeWhirlpoolAC(decode_results *results, uint16_t nbits,
                               kWhirlpoolAcBitMark,
                               kWhirlpoolAcOneSpace,
                               kWhirlpoolAcBitMark,
-                              kWhirlpoolAcZeroSpace);
+                              kWhirlpoolAcZeroSpace,
+                              kTolerance, kMarkExcess, false);
       if (data_result.success == false)  break;  // Fail
       // Data is in LSB order. We need to reverse it.
-      results->state[i] = (uint8_t) reverseBits(data_result.data & 0xFF, 8);
+      results->state[i] = (uint8_t) data_result.data;
     }
     // Section Footer
     if (!matchMark(results->rawbuf[offset++], kWhirlpoolAcBitMark))


### PR DESCRIPTION
matchData() can now handle LSBF order, so remove some unneeded reverseBits() calls.