### PR TITLE
Final changes for the 2.5 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@
 
 This library enables you to **send _and_ receive** infra-red signals on an [ESP8266 using the Arduino framework](https://github.com/esp8266/Arduino) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* etc.
 
-## v2.4.3 Now Available
-Version 2.4.3 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
+## v2.5.0 Now Available
+Version 2.5.0 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
 
 #### Upgrading from pre-v2.0
 Usage of the library slight changed at v2.0. You will need to change your usage to work with v2.0 and beyond. You can read more about the changes required on our [Upgrade to v2.0](https://github.com/markszabo/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.
+
+#### Upgrading from pre-v2.5
+The library has changed from using constants declared as `#define` to
+[const](https://google.github.io/styleguide/cppguide.html#Constant_Names) with
+the appropriate naming per the
+[C++ style guide](https://google.github.io/styleguide/cppguide.html).
+This may potentially cause old programs to not compile.
+The most likely externally used `#define`s have been _aliased_ for limited
+backward compatibility for projects using the old style. Going forward, only the
+new `kConstantName` style will be supported for new protocol additions.
+
+In the unlikely case it does break your code, then you may have been referencing
+something you likely should not have. You should be able to quickly determine
+the new name from the old. e.g. `CONSTANT_NAME` to `kConstantName`.
+Use common sense or examining the library's code if this does affect code.
 
 ## Troubleshooting
 Before reporting an issue or asking for help, please try to follow our [Troubleshooting Guide](https://github.com/markszabo/IRremoteESP8266/wiki/Troubleshooting-Guide) first.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,6 +6,8 @@
 - Fix HTML menu error for GICABLE in IRMQTTServer. (#516)
 - Fix Mitsubishi A/C mode setting. (#514)
 - Add missing ',' in auto analyse tool generated code. (#513)
+- Fix Fujitsu checksum validation. (#501)
+- Remove errant Repeat debug statement in IRMQTTServer. (#507)
 
 **[Features]**
 - Mitsubishi A/C decode improvements. (#514)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## _v2.5.0 (20180919)_
+
+**[Bug Fixes]**
+- Fix HTML menu error for GICABLE in IRMQTTServer. (#516)
+- Fix Mitsubishi A/C mode setting. (#514)
+- Add missing ',' in auto analyse tool generated code. (#513)
+
+**[Features]**
+- Mitsubishi A/C decode improvements. (#514)
+- Basic support for Whirlpool A/C messages. (#511)
+- Basic support for Samsung A/C messages. (#512)
+- Experimental support for detailed Samsung A/C messages. (#521)
+- Experimental support for detailed Coolix A/C messages. (#518)
+- Experimental support for Lutron protocol. (#516)
+- Calculate and use average values for timings in analysing tool. (#513)
+
+**[Misc]**
+- Style change from using #define's for constants to `const kConstantName`.
+- Improve the JVC example code.
+
+
 ## _v2.4.3 (20180727)_
 
 **[Bug Fixes]**

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "2.5.0-dev",
+  "version": "2.5.0",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.5.0-dev
+version=2.5.0
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -48,7 +48,7 @@
 #endif
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.5.0-dev"
+#define _IRREMOTEESP8266_VERSION_ "2.5.0"
 // Supported IR protocols
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to false) all the protocols you do not need/want!


### PR DESCRIPTION
## _v2.5.0 (20180919)_

**[Bug Fixes]**
- Fix HTML menu error for GICABLE in IRMQTTServer. (#516)
- Fix Mitsubishi A/C mode setting. (#514)
- Add missing ',' in auto analyse tool generated code. (#513)
- Fix Fujitsu checksum validation. (#501)
- Remove errant Repeat debug statement in IRMQTTServer. (#507)

**[Features]**
- Mitsubishi A/C decode improvements. (#514)
- Basic support for Whirlpool A/C messages. (#511)
- Basic support for Samsung A/C messages. (#512)
- Experimental support for detailed Samsung A/C messages. (#521)
- Experimental support for detailed Coolix A/C messages. (#518)
- Experimental support for Lutron protocol. (#516)
- Calculate and use average values for timings in analysing tool. (#513)

**[Misc]**
- Style change from using #define's for constants to `const kConstantName`.
- Improve the JVC example code.