### PR TITLE
Experimental support for Electra A/C messages.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -414,6 +414,7 @@ void handleRoot() {
       "<select name='type'>"
         "<option value='27'>Argo</option>"
         "<option value='16'>Daikin</option>"
+        "<option value='48'>Electra</option>"
         "<option value='33'>Fujitsu</option>"
         "<option value='24'>Gree</option>"
         "<option value='38'>Haier (9 bytes)</option>"
@@ -489,6 +490,9 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
       break;
     case DAIKIN:
       stateSize = kDaikinStateLength;
+      break;
+    case ELECTRA_AC:
+      stateSize = kElectraAcStateLength;
       break;
     case MITSUBISHI_AC:
       stateSize = kMitsubishiACStateLength;
@@ -637,6 +641,11 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
 #if SEND_HITACHI_AC2
     case HITACHI_AC2:
       irsend.sendHitachiAC2(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif
+#if SEND_ELECTRA_AC
+    case ELECTRA_AC:
+      irsend.sendElectraAC(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
   }

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -168,7 +168,7 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 #define argBits "bits"
 #define argRepeat "repeats"
 
-#define _MY_VERSION_ "v0.5.5"
+#define _MY_VERSION_ "v0.5.6"
 
 #if IR_LED != 1  // Disable debug output if the LED is on the TX (D1) pin.
 #undef DEBUG

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1179,6 +1179,7 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
     case HITACHI_AC:  // 40
     case HITACHI_AC1:  // 41
     case HITACHI_AC2:  // 42
+    case ELECTRA_AC:  // 48
       parseStringAndSendAirCon(ir_type, code_str);
       break;
 #if SEND_DENON

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -503,6 +503,11 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   if (decodeSamsungAC(results))
     return true;
 #endif
+#if DECODE_ELECTRA_AC
+  DPRINTLN("Attempting Electra AC decode");
+  if (decodeElectraAC(results))
+    return true;
+#endif
 #if DECODE_LUTRON
   DPRINTLN("Attempting Lutron decode");
   if (decodeLutron(results))

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -315,6 +315,10 @@ class IRrecv {
   bool decodeLutron(decode_results *results, uint16_t nbits = kLutronBits,
                      bool strict = true);
 #endif
+#if DECODE_ELECTRA_AC
+  bool decodeElectraAC(decode_results *results,
+                       uint16_t nbits = kElectraAcBits, bool strict = true);
+#endif
 };
 
 #endif  // IRRECV_H_

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -187,11 +187,14 @@
 #define DECODE_LUTRON          true
 #define SEND_LUTRON            true
 
+#define DECODE_ELECTRA_AC      true
+#define SEND_ELECTRA_AC        true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
      DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2 || DECODE_HAIER_AC_YRW02 || \
-     DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC)
+     DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -257,7 +260,8 @@ enum decode_type_t {
   HAIER_AC_YRW02,
   WHIRLPOOL_AC,
   SAMSUNG_AC,
-  LUTRON
+  LUTRON,
+  ELECTRA_AC,
 };
 
 // Message lengths & required repeat values
@@ -278,6 +282,8 @@ const uint16_t kDenonBits = 15;
 const uint16_t kDenonLegacyBits = 14;
 const uint16_t kDishBits = 16;
 const uint16_t kDishMinRepeat = 3;
+const uint16_t kElectraAcStateLength = 13;
+const uint16_t kElectraAcBits = kElectraAcStateLength * 8;
 const uint16_t kFujitsuAcMinRepeat = kNoRepeat;
 const uint16_t kFujitsuAcStateLength = 16;
 const uint16_t kFujitsuAcStateLengthShort = 7;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -289,6 +289,11 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
   void sendLutron(uint64_t data, uint16_t nbits = kLutronBits,
                   uint16_t repeat = kNoRepeat);
 #endif
+#if SEND_ELECTRA_AC
+  void sendElectraAC(unsigned char data[],
+                     uint16_t nbytes = kElectraAcStateLength,
+                     uint16_t repeat = kNoRepeat);
+#endif
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -107,6 +107,7 @@ std::string typeToString(const decode_type_t protocol,
     case DAIKIN:         result = "DAIKIN";            break;
     case DENON:          result = "DENON";             break;
     case DISH:           result = "DISH";              break;
+    case ELECTRA_AC:     result = "ELECTRA_AC";        break;
     case FUJITSU_AC:     result = "FUJITSU_AC";        break;
     case GICABLE:        result = "GICABLE";           break;
     case GLOBALCACHE:    result = "GLOBALCACHE";       break;
@@ -156,6 +157,7 @@ std::string typeToString(const decode_type_t protocol,
 bool hasACState(const decode_type_t protocol) {
   switch (protocol) {
     case DAIKIN:
+    case ELECTRA_AC:
     case FUJITSU_AC:
     case GREE:
     case HAIER_AC:

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -10,7 +10,7 @@
 //          EE      LL      EE      CC    C   TTT   RR  RR  AAAAAAA
 //          EEEEEEE LLLLLLL EEEEEEE  CCCCC    TTT   RR   RR AA   AA
 
-// Elctra A/C added by crankyoldgit
+// Electra A/C added by crankyoldgit
 //
 // Equipment it seems compatible with:
 //  * <Add models (A/C & remotes) you've gotten it working with here>

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -1,0 +1,120 @@
+// Copyright 2018 David Conran
+
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRutils.h"
+
+//          EEEEEEE LL      EEEEEEE  CCCCC  TTTTTTT RRRRRR    AAA
+//          EE      LL      EE      CC    C   TTT   RR   RR  AAAAA
+//          EEEEE   LL      EEEEE   CC        TTT   RRRRRR  AA   AA
+//          EE      LL      EE      CC    C   TTT   RR  RR  AAAAAAA
+//          EEEEEEE LLLLLLL EEEEEEE  CCCCC    TTT   RR   RR AA   AA
+
+// Elctra A/C added by crankyoldgit
+//
+// Equipment it seems compatible with:
+//  * <Add models (A/C & remotes) you've gotten it working with here>
+
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/527
+
+// Constants
+const uint16_t kElectraAcHdrMark = 9166;
+const uint16_t kElectraAcBitMark = 646;
+const uint16_t kElectraAcHdrSpace = 4470;
+const uint16_t kElectraAcOneSpace = 1647;
+const uint16_t kElectraAcZeroSpace = 547;
+const uint32_t kElectraAcMessageGap = 100000;  // Completely made-up guess.
+
+#if SEND_ELECTRA_AC
+// Send a Electra message
+//
+// Args:
+//   data:   Contents of the message to be sent. (Guessing MSBF order)
+//   nbits:  Nr. of bits of data to be sent. Typically kElectraAcBits.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: Alpha / Needs testing against a real device.
+//
+void IRsend::sendElectraAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+  for (uint16_t r = 0; r <= repeat; r++)
+    sendGeneric(kElectraAcHdrMark, kElectraAcHdrSpace,
+                kElectraAcBitMark, kElectraAcOneSpace,
+                kElectraAcBitMark, kElectraAcZeroSpace,
+                kElectraAcBitMark, kElectraAcMessageGap,
+                data, nbytes,
+                38000,  // Complete guess of the modulation frequency.
+                true, 0, 50);
+}
+#endif
+
+#if DECODE_ELECTRA_AC
+// Decode the supplied Electra A/C message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically kElectraAcBits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Alpha / Needs testing against a real device.
+//
+bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
+                             bool strict) {
+  if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
+    return false;
+
+  if (strict) {
+    if (nbits != kElectraAcBits)
+      return false;  // Not strictly a ELECTRA_AC message.
+  }
+
+  // The protocol sends the data normal + inverted, alternating on
+  // each byte. Hence twice the number of expected data bits.
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
+    return false;  // Can't possibly be a valid ELECTRA_AC message.
+
+  uint16_t offset = kStartOffset;
+
+  // Message Header
+  if (!matchMark(results->rawbuf[offset++], kElectraAcHdrMark))
+    return false;
+  if (!matchSpace(results->rawbuf[offset++], kElectraAcHdrSpace))
+    return false;
+
+  // Data Section
+  match_result_t data_result;
+  uint16_t dataBitsSoFar = 0;
+  // Keep reading bytes until we either run out of section or state to fill.
+  for (uint16_t i = 0; offset <= results->rawlen - 16 && i < nbits / 8;
+       i++, dataBitsSoFar += 8, offset += data_result.used) {
+    data_result = matchData(&(results->rawbuf[offset]), 8,
+                            kElectraAcBitMark,
+                            kElectraAcOneSpace,
+                            kElectraAcBitMark,
+                            kElectraAcZeroSpace,
+                            kTolerance, 0, true);
+    if (data_result.success == false)  return false;  // Fail
+    results->state[i] = data_result.data;
+  }
+
+  // Message Footer
+  if (!matchMark(results->rawbuf[offset++], kElectraAcBitMark))
+    return false;
+  if (offset <= results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset++], kElectraAcMessageGap))
+    return false;
+
+  // Compliance
+  if (strict && dataBitsSoFar != nbits)  return false;
+
+  // Success
+  results->decode_type = ELECTRA_AC;
+  results->bits = dataBitsSoFar;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_ELECTRA_AC

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,7 +35,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Gree_test IRrecv_test ir_Pronto_test ir_Fujitsu_test ir_Nikai_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 				ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
-				ir_Whirlpool_test ir_Lutron_test
+				ir_Whirlpool_test ir_Lutron_test ir_Electra_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -78,7 +78,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 		ir_Panasonic.o ir_Whynter.o ir_Coolix.o ir_Aiwa.o ir_Sherwood.o \
 		ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 		ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
-		ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o
+		ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
@@ -447,3 +447,11 @@ ir_Lutron_test.o : ir_Lutron_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 ir_Lutron_test : $(COMMON_OBJ) ir_Lutron_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
+ir_Electra.o : $(USER_DIR)/ir_Electra.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Electra.cpp
+
+ir_Electra_test.o : ir_Electra_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Electra_test.cpp
+
+ir_Electra_test : $(COMMON_OBJ) ir_Electra_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Electra_test.cpp
+++ b/test/ir_Electra_test.cpp
@@ -1,0 +1,95 @@
+// Copyright 2018 David Conran
+
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+
+// Tests for sendElectraAC().
+
+// Test sending typical data only.
+TEST(TestSendElectraAC, SendDataOnly) {
+  IRsendTest irsend(0);
+  irsend.begin();
+  uint8_t data[kElectraAcStateLength] = {
+      0xC3, 0xE1, 0x6F, 0x14, 0x06, 0x00, 0x04,
+      0x00, 0x00, 0x04, 0x00, 0xA0, 0xB0};
+
+  irsend.sendElectraAC(data);
+  EXPECT_EQ(
+      "m9166s4470"
+      "m646s1647m646s1647m646s547m646s547m646s547m646s547m646s1647m646s1647"
+      "m646s1647m646s1647m646s1647m646s547m646s547m646s547m646s547m646s1647"
+      "m646s547m646s1647m646s1647m646s547m646s1647m646s1647m646s1647m646s1647"
+      "m646s547m646s547m646s547m646s1647m646s547m646s1647m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s1647m646s1647m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s547m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s1647m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s547m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s547m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s1647m646s547m646s547"
+      "m646s547m646s547m646s547m646s547m646s547m646s547m646s547m646s547"
+      "m646s1647m646s547m646s1647m646s547m646s547m646s547m646s547m646s547"
+      "m646s1647m646s547m646s1647m646s1647m646s547m646s547m646s547m646s547"
+      "m646s100000", irsend.outputStr());
+}
+
+// Tests for decodeElectraAC().
+// Decode normal ElectraAC messages.
+
+TEST(TestDecodeElectraAC, SyntheticDecode) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  // Synthesised Normal ElectraAC message.
+  irsend.reset();
+  uint8_t expectedState[kElectraAcStateLength] = {
+      0xC3, 0xE1, 0x6F, 0x14, 0x06, 0x00, 0x04,
+      0x00, 0x00, 0x04, 0x00, 0xA0, 0xB0};
+  irsend.sendElectraAC(expectedState);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(ELECTRA_AC, irsend.capture.decode_type);
+  EXPECT_EQ(kElectraAcBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+// Decode a recorded example
+TEST(TestDecodeElectraAC, RealExampleDecode) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  // Real ElectraAC message.
+  // Ref: https://github.com/markszabo/IRremoteESP8266/issues/527
+  uint16_t rawData[211] = {9166, 4470, 642, 1632, 642, 1632, 668, 534, 666, 534,
+      668, 534, 614, 536, 640, 1636, 640, 1646, 694, 1662, 612, 1628, 642, 1666,
+      664, 532, 668, 534, 666, 534, 666, 532, 666, 1644, 642, 532, 640, 1634,
+      668, 1632, 642, 538, 666, 1660, 610, 1666, 664, 1632, 642, 1672, 610, 536,
+      666, 534, 694, 532, 666, 1636, 614, 538, 666, 1632, 642, 536, 666, 544,
+      692, 534, 640, 558, 640, 534, 640, 540, 666, 534, 638, 1666, 638, 1636,
+      640, 550, 666, 534, 640, 540, 666, 534, 640, 540, 666, 536, 638, 540, 666,
+      536, 638, 550, 664, 536, 638, 540, 664, 536, 638, 540, 666, 534, 638,
+      1640, 664, 536, 692, 546, 664, 536, 664, 536, 664, 536, 664, 546, 612,
+      532, 636, 538, 664, 536, 664, 546, 612, 538, 638, 538, 638, 538, 664, 536,
+      690, 538, 662, 538, 664, 538, 662, 548, 664, 536, 662, 538, 662, 562, 638,
+      564, 636, 564, 636, 1668, 582, 556, 652, 572, 612, 568, 636, 564, 610,
+      570, 636, 556, 616, 550, 656, 566, 610, 570, 632, 578, 608, 1640, 662,
+      562, 642, 1686, 582, 570, 634, 566, 604, 576, 636, 566, 610, 578, 634,
+      1664, 584, 590, 660, 1636, 610, 1642, 664, 590, 610, 590, 636, 566, 634,
+      568, 686};  // UNKNOWN 9AD8CDB5
+  uint8_t expectedState[kElectraAcStateLength] = {
+      0xC3, 0xE1, 0x6F, 0x14, 0x06, 0x00, 0x04,
+      0x00, 0x00, 0x04, 0x00, 0xA0, 0xB0};
+
+  irsend.reset();
+  irsend.sendRaw(rawData, 211, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(ELECTRA_AC, irsend.capture.decode_type);
+  EXPECT_EQ(kElectraAcBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -47,7 +47,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Aiwa.o ir_Sherwood.o ir_Kelvinator.o ir_Daikin.o ir_Gree.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
             ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o ir_Hitachi.o \
-						ir_GICable.o ir_Whirlpool.o ir_Lutron.o
+						ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -178,3 +178,6 @@ ir_Whirlpool.o : $(USER_DIR)/ir_Whirlpool.cpp $(GTEST_HEADERS)
 
 ir_Lutron.o : $(USER_DIR)/ir_Lutron.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lutron.cpp
+
+ir_Electra.o : $(USER_DIR)/ir_Electra.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Electra.cpp


### PR DESCRIPTION
* Very basic support for sending and decoding Electra A/C messages.
* Complete guess of MSB First bit ordering for data. May change.
* Unit tests for send and decode.
* Update IRMQTTServer for new protocol.

Ref: #527