### PR TITLE
Experimental support for Panasonic A/C messages.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -497,6 +497,9 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
     case MITSUBISHI_AC:
       stateSize = kMitsubishiACStateLength;
       break;
+    case PANASONIC_AC:
+      stateSize = kPanasonicAcStateLength;
+      break;
     case TROTEC:
       stateSize = kTrotecStateLength;
       break;
@@ -646,6 +649,11 @@ void parseStringAndSendAirCon(const uint16_t irType, const String str) {
 #if SEND_ELECTRA_AC
     case ELECTRA_AC:
       irsend.sendElectraAC(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif
+#if SEND_PANASONIC_AC
+    case PANASONIC_AC:
+      irsend.sendPanasonicAC(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
   }
@@ -1180,6 +1188,7 @@ void sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
     case HITACHI_AC1:  // 41
     case HITACHI_AC2:  // 42
     case ELECTRA_AC:  // 48
+    case PANASONIC_AC:  // 49
       parseStringAndSendAirCon(ir_type, code_str);
       break;
 #if SEND_DENON

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -34,6 +34,7 @@
 #include <ir_Kelvinator.h>
 #include <ir_Mitsubishi.h>
 #include <ir_Midea.h>
+#include <ir_Panasonic.h>
 #include <ir_Samsung.h>
 #include <ir_Toshiba.h>
 
@@ -190,6 +191,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_COOLIX
+#if DECODE_PANASONIC_AC
+  if (results->decode_type == PANASONIC_AC) {
+    IRPanasonicAc ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_PANASONIC_AC
   // If we got a human-readable description of the message, display it.
   if (description != "")  Serial.println("Mesg Desc.: " + description);
 }

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -508,6 +508,11 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   if (decodeElectraAC(results))
     return true;
 #endif
+#if DECODE_PANASONIC_AC
+  DPRINTLN("Attempting Panasonic AC decode");
+  if (decodePanasonicAC(results))
+    return true;
+#endif
 #if DECODE_LUTRON
   DPRINTLN("Attempting Lutron decode");
   if (decodeLutron(results))

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -320,6 +320,10 @@ class IRrecv {
   bool decodeElectraAC(decode_results *results,
                        uint16_t nbits = kElectraAcBits, bool strict = true);
 #endif
+#if DECODE_PANASONIC_AC
+  bool decodePanasonicAC(decode_results *results,
+                           uint16_t nbits = kPanasonicAcBits, bool strict = true);
+#endif
 };
 
 #endif  // IRRECV_H_

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -322,7 +322,7 @@ class IRrecv {
 #endif
 #if DECODE_PANASONIC_AC
   bool decodePanasonicAC(decode_results *results,
-                           uint16_t nbits = kPanasonicAcBits, bool strict = true);
+                         uint16_t nbits = kPanasonicAcBits, bool strict = true);
 #endif
 };
 

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -190,11 +190,15 @@
 #define DECODE_ELECTRA_AC      true
 #define SEND_ELECTRA_AC        true
 
+#define DECODE_PANASONIC_AC    true
+#define SEND_PANASONIC_AC      true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
      DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2 || DECODE_HAIER_AC_YRW02 || \
-     DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC)
+     DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC || \
+     DECODE_PANASONIC_AC)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -262,6 +266,7 @@ enum decode_type_t {
   SAMSUNG_AC,
   LUTRON,
   ELECTRA_AC,
+  PANASONIC_AC,
 };
 
 // Message lengths & required repeat values
@@ -325,6 +330,8 @@ const uint16_t kNikaiBits = 24;
 const uint16_t kNECBits = 32;
 const uint16_t kPanasonicBits = 48;
 const uint32_t kPanasonicManufacturer = 0x4004;
+const uint16_t kPanasonicAcStateLength = 27;
+const uint16_t kPanasonicAcBits = kPanasonicAcStateLength * 8;
 const uint16_t kProntoMinLength = 6;
 const uint16_t kRC5RawBits = 14;
 const uint16_t kRC5Bits = kRC5RawBits - 2;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -294,6 +294,11 @@ void send(uint16_t type, uint64_t data, uint16_t nbits);
                      uint16_t nbytes = kElectraAcStateLength,
                      uint16_t repeat = kNoRepeat);
 #endif
+#if SEND_PANASONIC_AC
+  void sendPanasonicAC(unsigned char data[],
+                       uint16_t nbytes = kPanasonicAcStateLength,
+                       uint16_t repeat = kNoRepeat);
+#endif
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -131,6 +131,7 @@ std::string typeToString(const decode_type_t protocol,
     case NEC_LIKE:       result = "NEC (non-strict)";  break;
     case NIKAI:          result = "NIKAI";             break;
     case PANASONIC:      result = "PANASONIC";         break;
+    case PANASONIC_AC:   result = "PANASONIC_AC";      break;
     case PRONTO:         result = "PRONTO";            break;
     case RAW:            result = "RAW";               break;
     case RC5:            result = "RC5";               break;
@@ -167,6 +168,7 @@ bool hasACState(const decode_type_t protocol) {
     case HITACHI_AC2:
     case KELVINATOR:
     case MITSUBISHI_AC:
+    case PANASONIC_AC:
     case SAMSUNG_AC:
     case TOSHIBA_AC:
     case WHIRLPOOL_AC:

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -3,6 +3,9 @@
 
 #include "ir_Panasonic.h"
 #include <algorithm>
+#ifndef ARDUINO
+#include <string>
+#endif
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRutils.h"

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -210,7 +210,7 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
 //   nbits:  Nr. of bits of data to be sent. Typically kPanasonicAcBits.
 //   repeat: Nr. of additional times the message is to be sent.
 //
-// Status: Beta / Needs testing against a real device.
+// Status: Beta / Appears to work with real device(s).
 //:
 // Panasonic A/C models supported:
 //   A/C Series/models:

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -1,6 +1,7 @@
 // Copyright 2015 Kristian Lauszus
-// Copyright 2017 David Conran
+// Copyright 2017, 2018 David Conran
 
+#include "ir_Panasonic.h"
 #include <algorithm>
 #include "IRrecv.h"
 #include "IRsend.h"
@@ -15,6 +16,8 @@
 // Panasonic protocol originally added by Kristian Lauszus from:
 //   https://github.com/z3t0/Arduino-IRremote
 // (Thanks to zenwheel and other people at the original blog post)
+// Panasonic A/C support heavily influenced by:
+//   https://github.com/ToniA/ESPEasy/blob/HeatpumpIR/lib/HeatpumpIR/PanasonicHeatpumpIR.cpp
 
 // Constants
 // Ref:
@@ -41,6 +44,11 @@ const uint16_t kPanasonicMinGapTicks = kPanasonicMinCommandLengthTicks -
      kPanasonicBitMarkTicks);
 const uint32_t kPanasonicMinGap = kPanasonicMinGapTicks * kPanasonicTick;
 
+const uint16_t kPanasonicAcSectionGap = 10000;
+const uint16_t kPanasonicAcSection1Length = 8;
+const uint32_t kPanasonicAcMessageGap = 100000;  // A complete guess.
+
+
 #if (SEND_PANASONIC || SEND_DENON)
 // Send a Panasonic formatted message.
 //
@@ -59,7 +67,7 @@ void IRsend::sendPanasonic64(uint64_t data, uint16_t nbits, uint16_t repeat) {
               kPanasonicBitMark, kPanasonicZeroSpace,
               kPanasonicBitMark,
               kPanasonicMinGap, kPanasonicMinCommandLength,
-              data, nbits, 36700U, true, repeat, 50);
+              data, nbits, kPanasonicFreq, true, repeat, 50);
 }
 
 // Send a Panasonic formatted message.
@@ -183,3 +191,493 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
   return true;
 }
 #endif  // (DECODE_PANASONIC || DECODE_DENON)
+
+#if SEND_PANASONIC_AC
+// Send a Panasonic A/C message.
+//
+// Args:
+//   data:   Contents of the message to be sent. (Guessing MSBF order)
+//   nbits:  Nr. of bits of data to be sent. Typically kPanasonicAcBits.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: Alpha / Needs testing against a real device.
+// Notes:
+//   Supported models: NKE, DKE, JKE, & LKE series.
+//
+void IRsend::sendPanasonicAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+  if (nbytes < kPanasonicAcStateLength)  return;
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // First section. (8 bytes)
+    sendGeneric(kPanasonicHdrMark, kPanasonicHdrSpace,
+                kPanasonicBitMark, kPanasonicOneSpace,
+                kPanasonicBitMark, kPanasonicZeroSpace,
+                kPanasonicBitMark, kPanasonicAcSectionGap,
+                data, kPanasonicAcSection1Length,
+                kPanasonicFreq, false, 0, 50);
+    // First section. (The rest of the data bytes)
+    sendGeneric(kPanasonicHdrMark, kPanasonicHdrSpace,
+                kPanasonicBitMark, kPanasonicOneSpace,
+                kPanasonicBitMark, kPanasonicZeroSpace,
+                kPanasonicBitMark, kPanasonicAcMessageGap,
+                data + kPanasonicAcSection1Length,
+                nbytes - kPanasonicAcSection1Length,
+                kPanasonicFreq, false, 0, 50);
+  }
+}
+#endif  // SEND_PANASONIC_AC
+
+IRPanasonicAc::IRPanasonicAc(uint16_t pin) : _irsend(pin) {
+  stateReset();
+}
+
+void IRPanasonicAc::stateReset() {
+  for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)
+    remote_state[i] = kPanasonicKnownGoodState[i];
+}
+
+void IRPanasonicAc::begin() {
+  _irsend.begin();
+}
+
+// Verify the checksum is valid for a given state.
+// Args:
+//   state:  The array to verify the checksum of.
+//   length: The size of the state.
+// Returns:
+//   A boolean.
+bool IRPanasonicAc::validChecksum(uint8_t state[],
+                                  const uint16_t length) {
+  if (length < 2)  return false;  // 1 byte of data can't have a checksum.
+  return (state[length - 1] == sumBytes(state, length - 1,
+                                        kPanasonicAcChecksumInit));
+}
+
+uint8_t IRPanasonicAc::calcChecksum(uint8_t state[],
+                                    const uint16_t length) {
+  return sumBytes(state, length - 1, kPanasonicAcChecksumInit);
+}
+
+void IRPanasonicAc::fixChecksum(const uint16_t length) {
+  remote_state[length - 1] = calcChecksum(remote_state, length);
+}
+
+void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
+  switch (model) {
+    case kPanasonicDke:
+    case kPanasonicJke:
+    case kPanasonicLke:
+    case kPanasonicNke:
+      break;
+    default:  // Only proceed if we know what to do.
+      return;
+  }
+  // clear & set the various bits and bytes.
+  remote_state[13] &= 0xF0;
+  remote_state[17] = 0x00;
+  remote_state[23] = 0x81;
+  remote_state[25] = 0x00;
+
+  switch (model) {
+    case kPanasonicLke:
+      remote_state[13] |= 0x02;
+      remote_state[17] = 0x06;
+      break;
+    case kPanasonicDke:
+      remote_state[23] = 0x01;
+      remote_state[25] = 0x06;
+      // Has to be done last as setSwingH has model check built-in
+      setSwingH(_swingh);
+      break;
+    case kPanasonicNke:
+      remote_state[17] = 0x06;
+      break;
+    case kPanasonicJke:
+      break;
+    default:
+      break;
+  }
+}
+
+panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
+  if ((remote_state[13] & 0x0F) == 0x02)
+    return kPanasonicLke;
+  if (remote_state[17] == 0x00 && (remote_state[23] & 0x80))
+    return kPanasonicJke;
+  if (remote_state[23] == 0x01 && remote_state[25] == 0x06)
+    return kPanasonicDke;
+  if (remote_state[17] == 0x06)
+    return kPanasonicNke;
+  return kPanasonicUnknown;
+}
+
+uint8_t* IRPanasonicAc::getRaw() {
+  fixChecksum();
+  return remote_state;
+}
+
+void IRPanasonicAc::setRaw(const uint8_t state[]) {
+  for (uint8_t i = 0; i < kPanasonicAcStateLength; i++) {
+    remote_state[i] = state[i];
+  }
+}
+
+void IRPanasonicAc::on() {
+  remote_state[13] |= kPanasonicAcPower;
+}
+
+void IRPanasonicAc::off() {
+  remote_state[13] &= ~kPanasonicAcPower;
+}
+
+void IRPanasonicAc::setPower(const bool state) {
+  if (state)
+    on();
+  else
+    off();
+}
+
+bool IRPanasonicAc::getPower() {
+  return (remote_state[13] & kPanasonicAcPower) == kPanasonicAcPower;
+}
+
+uint8_t IRPanasonicAc::getMode() {
+  return remote_state[13] >> 4;
+}
+
+void IRPanasonicAc::setMode(const uint8_t desired) {
+  uint8_t mode = kPanasonicAcAuto;  // Default to Auto mode.
+  switch (desired) {
+    case kPanasonicAcAuto:
+    case kPanasonicAcCool:
+    case kPanasonicAcHeat:
+    case kPanasonicAcDry:
+    case kPanasonicAcFan:
+      mode = desired;
+  }
+  remote_state[13] &= 0x0F;  // Clear the previous mode bits.
+  remote_state[13] |= mode << 4;
+}
+
+uint8_t IRPanasonicAc::getTemp() {
+  return remote_state[14] >> 1;
+}
+
+void IRPanasonicAc::setTemp(const uint8_t celsius) {
+  uint8_t temperature;
+  temperature = std::max(celsius, kPanasonicAcMinTemp);
+  temperature = std::min(temperature, kPanasonicAcMaxTemp);
+  remote_state[14] = temperature << 1;
+}
+
+uint8_t IRPanasonicAc::getSwingVertical() {
+  return remote_state[16] & 0x0F;
+}
+
+void IRPanasonicAc::setSwingV(const uint8_t desired_elevation) {
+  uint8_t elevation = desired_elevation;
+  if (elevation != kPanasonicAcSwingVAuto) {
+    elevation = std::max(elevation, kPanasonicAcSwingVUp);
+    elevation = std::min(elevation, kPanasonicAcSwingVDown);
+  }
+  remote_state[16] &= 0xF0;
+  remote_state[16] |= elevation;
+}
+
+uint8_t IRPanasonicAc::getSwingHorizontal() {
+  return remote_state[17];
+}
+
+void IRPanasonicAc::setSwingH(const uint8_t desired_direction) {
+  switch (desired_direction) {
+    case kPanasonicAcSwingHAuto:
+    case kPanasonicAcSwingHMiddle:
+    case kPanasonicAcSwingHFullLeft:
+    case kPanasonicAcSwingHLeft:
+    case kPanasonicAcSwingHRight:
+    case kPanasonicAcSwingHFullRight:
+      break;
+    default:  // Ignore anything that isn't valid.
+      return;
+  }
+  _swingh = desired_direction;  // Store the direction for later.
+  uint8_t direction = desired_direction;
+  switch (getModel()) {
+    case kPanasonicDke:
+      break;
+    case kPanasonicNke:
+    case kPanasonicLke:
+      direction = kPanasonicAcSwingHMiddle;
+      break;
+    default:  // Ignore everything else.
+      return;
+  }
+  remote_state[17] = direction;
+}
+
+void IRPanasonicAc::setFan(const uint8_t speed) {
+  if (speed <= kPanasonicAcFanMax || speed == kPanasonicAcFanAuto)
+    remote_state[16] = (remote_state[16] & 0x0F) |
+                       ((speed + kPanasonicAcFanOffset) << 4);
+}
+
+uint8_t IRPanasonicAc::getFan() {
+  return (remote_state[16] >> 4) - kPanasonicAcFanOffset;
+}
+
+bool IRPanasonicAc::getQuiet() {
+  return remote_state[21] & kPanasonicAcQuiet;
+}
+
+void IRPanasonicAc::setQuiet(const bool state) {
+  if (state) {
+    setPowerful(false);  // Powerful is mutually exclusive.
+    remote_state[21] |= kPanasonicAcQuiet;
+  } else {
+    remote_state[21] &= ~kPanasonicAcQuiet;
+  }
+}
+
+bool IRPanasonicAc::getPowerful() {
+  return remote_state[21] & kPanasonicAcPowerful;
+}
+
+void IRPanasonicAc::setPowerful(const bool state) {
+  if (state) {
+    setQuiet(false);  // Quiet is mutually exclusive.
+    remote_state[21] |= kPanasonicAcPowerful;
+  } else {
+    remote_state[21] &= ~kPanasonicAcPowerful;
+  }
+}
+
+// Convert the internal state into a human readable string.
+#ifdef ARDUINO
+String IRPanasonicAc::toString() {
+  String result = "";
+#else
+std::string IRPanasonicAc::toString() {
+  std::string result = "";
+#endif  // ARDUINO
+  result += "Model: " + uint64ToString(getModel());
+  switch (getModel()) {
+    case kPanasonicDke:
+      result += " (DKE)";
+      break;
+    case kPanasonicJke:
+      result += " (JKE)";
+      break;
+    case kPanasonicNke:
+      result += " (NKE)";
+      break;
+    case kPanasonicLke:
+      result += " (LKE)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Power: ";
+  if (getPower())
+    result += "On";
+  else
+    result += "Off";
+  result += ", Mode: " + uint64ToString(getMode());
+  switch (getMode()) {
+    case kPanasonicAcAuto:
+      result += " (AUTO)";
+      break;
+    case kPanasonicAcCool:
+      result += " (COOL)";
+      break;
+    case kPanasonicAcHeat:
+      result += " (HEAT)";
+      break;
+    case kPanasonicAcDry:
+      result += " (DRY)";
+      break;
+    case kPanasonicAcFan:
+      result += " (FAN)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Temp: " + uint64ToString(getTemp()) + "C";
+  result += ", Fan: " + uint64ToString(getFan());
+  switch (getFan()) {
+    case kPanasonicAcFanAuto:
+      result += " (AUTO)";
+      break;
+    case kPanasonicAcFanMax:
+      result += " (MAX)";
+      break;
+    case kPanasonicAcFanMin:
+      result += " (MIN)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+      break;
+  }
+  result += ", Swing (Vertical): " + uint64ToString(getSwingVertical());
+  switch (getSwingVertical()) {
+    case kPanasonicAcSwingVAuto:
+      result += " (AUTO)";
+      break;
+    case kPanasonicAcSwingVUp:
+      result += " (Full Up)";
+      break;
+    case kPanasonicAcSwingVDown:
+      result += " (Full Down)";
+      break;
+    case 2:
+    case 3:
+    case 4:
+      break;
+    default:
+      result += " (UNKNOWN)";
+      break;
+  }
+  if (getModel() != kPanasonicJke) {  // JKE has no Horizontal Swing
+    result += ", Swing (Horizontal): " + uint64ToString(getSwingHorizontal());
+    switch (getSwingHorizontal()) {
+      case kPanasonicAcSwingHAuto:
+        result += " (AUTO)";
+        break;
+      case kPanasonicAcSwingHFullLeft:
+        result += " (Full Left)";
+        break;
+      case kPanasonicAcSwingHLeft:
+        result += " (Left)";
+        break;
+      case kPanasonicAcSwingHMiddle:
+        result += " (Middle)";
+        break;
+      case kPanasonicAcSwingHFullRight:
+        result += " (Full Right)";
+        break;
+      case kPanasonicAcSwingHRight:
+        result += " (Right)";
+        break;
+      default:
+        result += " (UNKNOWN)";
+        break;
+    }
+  }
+  result += ", Quiet: ";
+  if (getQuiet())
+    result += "On";
+  else
+    result += "Off";
+  result += ", Powerful: ";
+  if (getPowerful())
+    result += "On";
+  else
+    result += "Off";
+  return result;
+}
+
+#if DECODE_PANASONIC_AC
+// Decode the supplied Panasonic AC message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically kPanasonicAcBits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Alpha / Needs testing against a real device.
+//
+bool IRrecv::decodePanasonicAC(decode_results *results, uint16_t nbits,
+                               bool strict) {
+  if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
+    return false;
+
+  uint8_t min_nr_of_messages = 1;
+  if (strict) {
+    if (nbits != kPanasonicAcBits)
+      return false;  // Not strictly a PANASONIC_AC message.
+  }
+
+  if (results->rawlen < min_nr_of_messages * (2 * nbits +
+                                              kHeader + kFooter) - 1)
+    return false;  // Can't possibly be a valid PANASONIC_AC message.
+
+  uint16_t dataBitsSoFar = 0;
+  uint16_t offset = kStartOffset;
+  match_result_t data_result;
+
+  // Header
+  if (!matchMark(results->rawbuf[offset], kPanasonicHdrMark)) return false;
+  // Calculate how long the common tick time is based on the header mark.
+  uint32_t m_tick = results->rawbuf[offset++] * kRawTick /
+      kPanasonicHdrMarkTicks;
+  if (!matchSpace(results->rawbuf[offset], kPanasonicHdrSpace)) return false;
+  // Calculate how long the common tick time is based on the header space.
+  uint32_t s_tick = results->rawbuf[offset++] * kRawTick /
+      kPanasonicHdrSpaceTicks;
+
+  uint16_t i = 0;
+  // Data (Section #1)
+  // Keep reading bytes until we either run out of section or state to fill.
+  for (; offset <= results->rawlen - 16 && i < kPanasonicAcSection1Length;
+       i++, dataBitsSoFar += 8, offset += data_result.used) {
+    data_result = matchData(&(results->rawbuf[offset]), 8,
+                            kPanasonicBitMarkTicks * m_tick,
+                            kPanasonicOneSpaceTicks * s_tick,
+                            kPanasonicBitMarkTicks * m_tick,
+                            kPanasonicZeroSpaceTicks * s_tick,
+                            kTolerance, 0, false);
+    if (data_result.success == false) {
+      DPRINT("DEBUG: offset = ");
+      DPRINTLN(offset + data_result.used);
+      return false;  // Fail
+    }
+    results->state[i] = data_result.data;
+  }
+  // Section footer.
+  if (!matchMark(results->rawbuf[offset++], kPanasonicBitMarkTicks * m_tick))
+    return false;
+  if (!matchSpace(results->rawbuf[offset++], kPanasonicAcSectionGap))
+    return false;
+  // Header.
+  if (!matchMark(results->rawbuf[offset++], kPanasonicHdrMarkTicks * m_tick))
+    return false;
+  if (!matchSpace(results->rawbuf[offset++], kPanasonicHdrSpaceTicks * s_tick))
+    return false;
+  // Data (Section #2)
+  // Keep reading bytes until we either run out of data.
+  for (; offset <= results->rawlen - 16 && i < nbits / 8;
+       i++, dataBitsSoFar += 8, offset += data_result.used) {
+    data_result = matchData(&(results->rawbuf[offset]), 8,
+                            kPanasonicBitMarkTicks * m_tick,
+                            kPanasonicOneSpaceTicks * s_tick,
+                            kPanasonicBitMarkTicks * m_tick,
+                            kPanasonicZeroSpaceTicks * s_tick,
+                            kTolerance, 0, false);
+    if (data_result.success == false) {
+      DPRINT("DEBUG: offset = ");
+      DPRINTLN(offset + data_result.used);
+      return false;  // Fail
+    }
+    results->state[i] = data_result.data;
+  }
+  // Message Footer.
+  if (!matchMark(results->rawbuf[offset++], kPanasonicBitMarkTicks * m_tick))
+    return false;
+  if (offset <= results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset++], kPanasonicAcMessageGap))
+    return false;
+
+  // Compliance
+  if (strict) {
+    // Check the signatures of the section blocks. They start with 0x02& 0x20.
+    if (results->state[0] != 0x02 || results->state[1] != 0x20 ||
+        results->state[8] != 0x02 || results->state[9] != 0x20)  return false;
+    if (!IRPanasonicAc::validChecksum(results->state, nbits / 8))  return false;
+  }
+
+  // Success
+  results->decode_type = PANASONIC_AC;
+  results->bits = nbits;
+  return true;
+}
+#endif  // DECODE_PANASONIC_AC

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -1,0 +1,119 @@
+// Copyright 2018 David Conran
+
+#ifndef IR_PANASONIC_H_
+#define IR_PANASONIC_H_
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+//       PPPP    AAA   N   N   AAA    SSSS   OOO   N   N  IIIII   CCCC
+//       P   P  A   A  NN  N  A   A  S      O   O  NN  N    I    C
+//       PPPP   AAAAA  N N N  AAAAA   SSS   O   O  N N N    I    C
+//       P      A   A  N  NN  A   A      S  O   O  N  NN    I    C
+//       P      A   A  N   N  A   A  SSSS    OOO   N   N  IIIII   CCCC
+
+// Panasonic A/C support heavily influenced by:
+//   https://github.com/ToniA/ESPEasy/blob/HeatpumpIR/lib/HeatpumpIR/PanasonicHeatpumpIR.cpp
+
+// Constants
+const uint16_t kPanasonicFreq = 36700;
+
+const uint8_t kPanasonicAcAuto = 0;  // 0b0000
+const uint8_t kPanasonicAcDry = 2;   // 0b0010
+const uint8_t kPanasonicAcCool = 3;  // 0b0011
+const uint8_t kPanasonicAcHeat = 4;  // 0b0010
+const uint8_t kPanasonicAcFan = 6;   // 0b0110
+const uint8_t kPanasonicAcFanMin = 0;
+const uint8_t kPanasonicAcFanMax = 4;
+const uint8_t kPanasonicAcFanAuto = 7;
+const uint8_t kPanasonicAcFanOffset = 3;
+const uint8_t kPanasonicAcPower = 1;  // 0b1
+const uint8_t kPanasonicAcMinTemp = 16;  // Celsius
+const uint8_t kPanasonicAcMaxTemp = 30;  // Celsius
+const uint8_t kPanasonicAcQuiet = 1;  // 0b1
+const uint8_t kPanasonicAcPowerful = 0x20;  // 0b100000
+const uint8_t kPanasonicAcSwingVAuto = 0xF;
+const uint8_t kPanasonicAcSwingVUp = 0x1;
+const uint8_t kPanasonicAcSwingVDown = 0x5;
+const uint8_t kPanasonicAcSwingHAuto = 0xD;
+const uint8_t kPanasonicAcSwingHMiddle = 0x6;
+const uint8_t kPanasonicAcSwingHFullLeft = 0x9;
+const uint8_t kPanasonicAcSwingHLeft = 0xA;
+const uint8_t kPanasonicAcSwingHRight = 0xB;
+const uint8_t kPanasonicAcSwingHFullRight = 0xC;
+const uint8_t kPanasonicAcChecksumInit = 0xF4;
+const uint8_t kPanasonicKnownGoodState[kPanasonicAcStateLength] = {
+  0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
+  0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00,
+  0x00, 0x0E, 0xE0, 0x00, 0x00, 0x81, 0x00, 0x00, 0x00};
+
+enum panasonic_ac_remote_model_t {
+  kPanasonicUnknown = 0,
+  kPanasonicLke = 1,
+  kPanasonicNke = 2,
+  kPanasonicDke = 3,
+  kPanasonicJke = 4,
+};
+
+
+class IRPanasonicAc {
+ public:
+  explicit IRPanasonicAc(uint16_t pin);
+
+  void stateReset();
+#if SEND_PANASONIC
+  void send();
+#endif  // SEND_PANASONIC
+  void begin();
+  void on();
+  void off();
+  void setPower(const bool state);
+  bool getPower();
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setFan(const uint8_t fan);
+  uint8_t getFan();
+  void setMode(const uint8_t mode);
+  uint8_t getMode();
+  void setRaw(const uint8_t state[]);
+  uint8_t* getRaw();
+  static bool validChecksum(uint8_t *state,
+                            const uint16_t length = kPanasonicAcStateLength);
+  static uint8_t calcChecksum(uint8_t *state,
+                               const uint16_t length = kPanasonicAcStateLength);
+  void setQuiet(const bool state);
+  bool getQuiet();
+  void setPowerful(const bool state);
+  bool getPowerful();
+  void setModel(const panasonic_ac_remote_model_t model);
+  panasonic_ac_remote_model_t getModel();
+  void setSwingV(const uint8_t elevation);
+  uint8_t getSwingVertical();
+  void setSwingH(const uint8_t direction);
+  uint8_t getSwingHorizontal();
+
+#ifdef ARDUINO
+  String toString();
+#else
+  std::string toString();
+#endif
+#ifndef UNIT_TEST
+
+ private:
+#endif
+  uint8_t remote_state[kPanasonicAcStateLength];
+  uint8_t _swingh = kPanasonicAcSwingHMiddle;
+  void fixChecksum(const uint16_t length = kPanasonicAcStateLength);
+  static uint8_t calcChecksum(const uint8_t *state,
+                              const uint16_t length = kPanasonicAcStateLength);
+  IRsend _irsend;
+};
+
+#endif  // IR_PANASONIC_H_

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -37,6 +37,7 @@ const uint8_t kPanasonicAcFanOffset = 3;
 const uint8_t kPanasonicAcPower = 1;  // 0b1
 const uint8_t kPanasonicAcMinTemp = 16;  // Celsius
 const uint8_t kPanasonicAcMaxTemp = 30;  // Celsius
+const uint8_t kPanasonicAcFanModeTemp = 27;  // Celsius
 const uint8_t kPanasonicAcQuiet = 1;  // 0b1
 const uint8_t kPanasonicAcPowerful = 0x20;  // 0b100000
 const uint8_t kPanasonicAcSwingVAuto = 0xF;
@@ -49,6 +50,10 @@ const uint8_t kPanasonicAcSwingHLeft = 0xA;
 const uint8_t kPanasonicAcSwingHRight = 0xB;
 const uint8_t kPanasonicAcSwingHFullRight = 0xC;
 const uint8_t kPanasonicAcChecksumInit = 0xF4;
+const uint8_t kPanasonicAcOnTimer =  0b00000010;
+const uint8_t kPanasonicAcOffTimer = 0b00000100;
+
+
 const uint8_t kPanasonicKnownGoodState[kPanasonicAcStateLength] = {
   0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
   0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00,
@@ -76,7 +81,7 @@ class IRPanasonicAc {
   void off();
   void setPower(const bool state);
   bool getPower();
-  void setTemp(const uint8_t temp);
+  void setTemp(const uint8_t temp, const bool remember = true);
   uint8_t getTemp();
   void setFan(const uint8_t fan);
   uint8_t getFan();
@@ -110,6 +115,7 @@ class IRPanasonicAc {
 #endif
   uint8_t remote_state[kPanasonicAcStateLength];
   uint8_t _swingh = kPanasonicAcSwingHMiddle;
+  uint8_t _temp = 25;
   void fixChecksum(const uint16_t length = kPanasonicAcStateLength);
   static uint8_t calcChecksum(const uint8_t *state,
                               const uint16_t length = kPanasonicAcStateLength);

--- a/test/Makefile
+++ b/test/Makefile
@@ -79,13 +79,30 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 		ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 		ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 		ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o
-
+# All the IR Protocol header files.
+PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
+		$(USER_DIR)/ir_Gree.h \
+		$(USER_DIR)/ir_Magiquest.h \
+		$(USER_DIR)/ir_Coolix.h \
+		$(USER_DIR)/ir_Haier.h \
+		$(USER_DIR)/ir_Midea.h \
+		$(USER_DIR)/ir_Toshiba.h \
+		$(USER_DIR)/ir_Daikin.h \
+		$(USER_DIR)/ir_Kelvinator.h \
+		$(USER_DIR)/ir_Mitsubishi.h \
+		$(USER_DIR)/ir_Samsung.h \
+		$(USER_DIR)/ir_Trotec.h \
+		$(USER_DIR)/ir_Fujitsu.h \
+		$(USER_DIR)/ir_LG.h \
+		$(USER_DIR)/ir_Panasonic.h
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
              $(PROTOCOLS) gtest_main.a
 # Common dependencies
 COMMON_DEPS = $(USER_DIR)/IRrecv.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRtimer.h \
-              $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteESP8266.h
+              $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteESP8266.h \
+							$(PROTOCOLS_H)
+
 # Common test dependencies
 COMMON_TEST_DEPS = $(COMMON_DEPS) IRrecv_test.h IRsend_test.h
 

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -580,7 +580,7 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
 TEST(TestIRPanasonicAcClass, SetAndGetMode) {
   IRPanasonicAc pana(0);
   pana.setMode(kPanasonicAcCool);
-  pana.setTemp(25);
+  pana.setTemp(21);
   EXPECT_EQ(kPanasonicAcCool, pana.getMode());
   pana.setMode(kPanasonicAcHeat);
   EXPECT_EQ(kPanasonicAcHeat, pana.getMode());
@@ -588,12 +588,14 @@ TEST(TestIRPanasonicAcClass, SetAndGetMode) {
   EXPECT_EQ(kPanasonicAcAuto, pana.getMode());
   pana.setMode(kPanasonicAcDry);
   EXPECT_EQ(kPanasonicAcDry, pana.getMode());
-  EXPECT_EQ(25, pana.getTemp());  // Temp should be unchanged.
+  EXPECT_EQ(21, pana.getTemp());  // Temp should be unchanged.
   pana.setMode(kPanasonicAcFan);
   EXPECT_EQ(kPanasonicAcFan, pana.getMode());
-  EXPECT_EQ(27, pana.getTemp());  // Temp should change.
+  EXPECT_EQ(kPanasonicAcFanModeTemp, pana.getTemp());  // Temp should change.
   pana.setMode(kPanasonicAcCool);
   EXPECT_EQ(kPanasonicAcCool, pana.getMode());
+  // Temp should be unchanged from the last manual change.
+  EXPECT_EQ(21, pana.getTemp());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetTemp) {

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -566,11 +566,21 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
   EXPECT_EQ(kPanasonicNke, pana.getModel());
   pana.setModel(kPanasonicJke);
   EXPECT_EQ(kPanasonicJke, pana.getModel());
+
+  // This state tickled a bug in getModel(). Should read as a JKE.
+  uint8_t jkeState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
+      0x02, 0x20, 0xE0, 0x04, 0x00, 0x32, 0x2E, 0x80, 0xA2, 0x00, 0x00,
+      0x06, 0x60, 0x00, 0x00, 0x80, 0x00, 0x06, 0x74};
+  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to JKE
+  pana.setRaw(jkeState);
+  EXPECT_EQ(kPanasonicJke, pana.getModel());
+  EXPECT_STATE_EQ(jkeState, pana.getRaw(), kPanasonicAcBits);
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetMode) {
   IRPanasonicAc pana(0);
   pana.setMode(kPanasonicAcCool);
+  pana.setTemp(25);
   EXPECT_EQ(kPanasonicAcCool, pana.getMode());
   pana.setMode(kPanasonicAcHeat);
   EXPECT_EQ(kPanasonicAcHeat, pana.getMode());
@@ -578,6 +588,10 @@ TEST(TestIRPanasonicAcClass, SetAndGetMode) {
   EXPECT_EQ(kPanasonicAcAuto, pana.getMode());
   pana.setMode(kPanasonicAcDry);
   EXPECT_EQ(kPanasonicAcDry, pana.getMode());
+  EXPECT_EQ(25, pana.getTemp());  // Temp should be unchanged.
+  pana.setMode(kPanasonicAcFan);
+  EXPECT_EQ(kPanasonicAcFan, pana.getMode());
+  EXPECT_EQ(27, pana.getTemp());  // Temp should change.
   pana.setMode(kPanasonicAcCool);
   EXPECT_EQ(kPanasonicAcCool, pana.getMode());
 }


### PR DESCRIPTION
* sendPanasonicAC(), decodePanasonicAC(), & IRPanasonicAc class added.
* Unit tests for those.
* Code HEAVILY influenced by the work done at:
  https://github.com/ToniA/ESPEasy/blob/HeatpumpIR/lib/HeatpumpIR/PanasonicHeatpumpIR.cpp
* Should support LKE/DKE/JKE/NKE series units.
* Updated example code as required.

Ref: #525