### PR TITLE
v2.5.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 This library enables you to **send _and_ receive** infra-red signals on an [ESP8266 using the Arduino framework](https://github.com/esp8266/Arduino) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* etc.
 
-## v2.5.0 Now Available
-Version 2.5.0 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
+## v2.5.1 Now Available
+Version 2.5.1 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
 
 #### Upgrading from pre-v2.0
 Usage of the library slight changed at v2.0. You will need to change your usage to work with v2.0 and beyond. You can read more about the changes required on our [Upgrade to v2.0](https://github.com/markszabo/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,24 @@
 # Release Notes
 
+## _v2.5.1 (20181002)_
+
+**[Bug Fixes]**
+- Correct the byte used for Samsung AC Swing. (#529)
+- Fix not sending Samsung A/C messages in IRMQTTServer. (#529)
+
+**[Features]**
+- Experimental support for Electra A/C messages. (#528)
+- Experimental support for Panasonic A/C messages. (#535)
+- Samsung A/C fixes & improvements (#529)
+- IRMQTTServer v0.6.0 (#530)
+
+**[Misc]**
+- Change required WifiManager lib version to v0.14
+- Add alias for RAWTICK to kRawTick. (#535)
+- Update sendLutron() status. (#515)
+- Remove leftover debug message in IRrecvDumpV2 (#526)
+
+
 ## _v2.5.0 (20180919)_
 
 **[Bug Fixes]**

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.5.0
+version=2.5.1
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -48,7 +48,7 @@
 #endif
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.5.0"
+#define _IRREMOTEESP8266_VERSION_ "2.5.1"
 // Supported IR protocols
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to false) all the protocols you do not need/want!


### PR DESCRIPTION
**[Bug Fixes]**
- Correct the byte used for Samsung AC Swing. (#529)
- Fix not sending Samsung A/C messages in IRMQTTServer. (#529)

**[Features]**
- Experimental support for Electra A/C messages. (#528)
- Experimental support for Panasonic A/C messages. (#535)
- Samsung A/C fixes & improvements (#529)
- IRMQTTServer v0.6.0 (#530)

**[Misc]**
- Change required WifiManager lib version to v0.14
- Add alias for RAWTICK to kRawTick. (#535)
- Update sendLutron() status. (#515)
- Remove leftover debug message in IRrecvDumpV2 (#526)