### PR TITLE
Add IR receiving support to IRMQTTServer.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -243,6 +243,7 @@ String lastMqttCmd = "None";
 uint32_t lastMqttCmdTime = 0;
 uint32_t lastConnectedTime = 0;
 uint32_t lastDisconnectedTime = 0;
+uint32_t mqttDisconnectCounter = 0;
 bool wasConnected = true;
 #ifdef IR_RX
 String lastIrReceived = "None";
@@ -341,6 +342,7 @@ void handleRoot() {
     (mqtt_client.connected() ? "Connected " + timeSince(lastDisconnectedTime)
                              : "Disconnected " + timeSince(lastConnectedTime)) +
     ")</i><br>"
+    "Disconnections: " + String(mqttDisconnectCounter - 1) + "<br>"
     "Client id: " + mqtt_clientid + "<br>"
     "Command topic: " MQTTcommand "<br>"
     "Acknowledgements topic: " MQTTack "<br>"
@@ -1129,6 +1131,7 @@ void loop(void) {
     if (wasConnected) {
       lastDisconnectedTime = now;
       wasConnected = false;
+      mqttDisconnectCounter++;
     }
     // Reconnect if it's longer than kMqttReconnectTime since we last tried.
     if (now - lastReconnectAttempt > kMqttReconnectTime) {

--- a/keywords.txt
+++ b/keywords.txt
@@ -201,6 +201,7 @@ printState	KEYWORD2
 readbits	KEYWORD2
 renderTime	KEYWORD2
 reset	KEYWORD2
+resultToHexidecimal	KEYWORD2
 resultToHumanReadableBasic	KEYWORD2
 resultToSourceCode	KEYWORD2
 resultToTimingInfo	KEYWORD2

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -303,6 +303,28 @@ std::string resultToTimingInfo(const decode_results *results) {
   return output;
 }
 
+// Convert the decode_results structure's value/state to simple hexadecimal.
+//
+#ifdef ARDUINO
+String resultToHexidecimal(const decode_results *result) {
+  String output = "";
+#else
+std::string resultToHexidecimal(const decode_results *result) {
+  std::string output = "";
+#endif
+  if (hasACState(result->decode_type)) {
+  #if DECODE_AC
+      for (uint16_t i = 0; result->bits > i * 8; i++) {
+        if (result->state[i] < 0x10)  output += "0";  // Zero pad
+        output += uint64ToString(result->state[i], 16);
+      }
+  #endif  // DECODE_AC
+  } else {
+    output += uint64ToString(result->value, 16);
+  }
+  return output;
+}
+
 // Dump out the decode_results structure.
 //
 #ifdef ARDUINO
@@ -318,16 +340,7 @@ std::string resultToHumanReadableBasic(const decode_results *results) {
 
   // Show Code & length
   output += "Code      : ";
-  if (hasACState(results->decode_type)) {
-#if DECODE_AC
-      for (uint16_t i = 0; results->bits > i * 8; i++) {
-        if (results->state[i] < 0x10)  output += "0";  // Zero pad
-        output += uint64ToString(results->state[i], 16);
-      }
-#endif  // DECODE_AC
-  } else {
-    output += uint64ToString(results->value, 16);
-  }
+  output += resultToHexidecimal(results);
   output += " (" + uint64ToString(results->bits) + " bits)\n";
   return output;
 }

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -23,6 +23,7 @@ void serialPrintUint64(uint64_t input, uint8_t base = 10);
 String resultToSourceCode(const decode_results *results);
 String resultToTimingInfo(const decode_results *results);
 String resultToHumanReadableBasic(const decode_results *results);
+String resultToHexidecimal(const decode_results *result);
 #else
 std::string uint64ToString(uint64_t input, uint8_t base = 10);
 std::string typeToString(const decode_type_t protocol,
@@ -30,6 +31,7 @@ std::string typeToString(const decode_type_t protocol,
 std::string resultToSourceCode(const decode_results *results);
 std::string resultToTimingInfo(const decode_results *results);
 std::string resultToHumanReadableBasic(const decode_results *results);
+std::string resultToHexidecimal(const decode_results *result);
 #endif
 bool hasACState(const decode_type_t protocol);
 uint16_t getCorrectedRawLength(const decode_results *results);


### PR DESCRIPTION
- Should capture IR messages from an IR RX module and send them to MQTT
  in a "compatiable" format similar to that required for sening via MQTT.
- Slight HTML layout changes/improvements.
- Minor changes to IRutils to make life easier.
- Tested on my own D1 and Nodemcu devices. Seems to work fine.
- The new capability can be completely disabled, but should work fine
  even if no IR RX module is attached.

Inspired by Issue #536