### PR TITLE
Experimental timer/clock support for Panasonic A/Cs.

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -57,6 +57,8 @@ calcLGChecksum	KEYWORD2
 calcUSecPeriod	KEYWORD2
 calculateChecksum	KEYWORD2
 calibrate	KEYWORD2
+cancelOffTimer	KEYWORD2
+cancelOnTimer	KEYWORD2
 cancelTimers	KEYWORD2
 checkheader	KEYWORD2
 checksum	KEYWORD2
@@ -125,6 +127,7 @@ encodeSAMSUNG	KEYWORD2
 encodeSanyoLC7461	KEYWORD2
 encodeSharp	KEYWORD2
 encodeSony	KEYWORD2
+encodeTime	KEYWORD2
 fixChecksum	KEYWORD2
 fixup	KEYWORD2
 getBeep	KEYWORD2
@@ -187,6 +190,8 @@ getZoneFollow	KEYWORD2
 getiFeel	KEYWORD2
 hasACState	KEYWORD2
 invertBits	KEYWORD2
+isOffTimerEnabled	KEYWORD2
+isOnTimerEnabled	KEYWORD2
 ledOff	KEYWORD2
 ledOn	KEYWORD2
 mark	KEYWORD2
@@ -299,9 +304,7 @@ setSpeed	KEYWORD2
 setStartClock	KEYWORD2
 setStopClock	KEYWORD2
 setSwing	KEYWORD2
-setSwingH	KEYWORD2
 setSwingHorizontal	KEYWORD2
-setSwingV	KEYWORD2
 setSwingVertical	KEYWORD2
 setTemp	KEYWORD2
 setTempRaw	KEYWORD2
@@ -1324,6 +1327,7 @@ kPanasonicAcBits	LITERAL1
 kPanasonicAcChecksumInit	LITERAL1
 kPanasonicAcCool	LITERAL1
 kPanasonicAcDry	LITERAL1
+kPanasonicAcExcess	LITERAL1
 kPanasonicAcFan	LITERAL1
 kPanasonicAcFanAuto	LITERAL1
 kPanasonicAcFanMax	LITERAL1
@@ -1351,6 +1355,9 @@ kPanasonicAcSwingHRight	LITERAL1
 kPanasonicAcSwingVAuto	LITERAL1
 kPanasonicAcSwingVDown	LITERAL1
 kPanasonicAcSwingVUp	LITERAL1
+kPanasonicAcTimeMax	LITERAL1
+kPanasonicAcTimeSpecial	LITERAL1
+kPanasonicAcTolerance	LITERAL1
 kPanasonicBitMark	LITERAL1
 kPanasonicBitMarkTicks	LITERAL1
 kPanasonicBits	LITERAL1

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -22,13 +22,18 @@
 //
 // Panasonic A/C support add by crankyoldgit but heavily influenced by:
 //   https://github.com/ToniA/ESPEasy/blob/HeatpumpIR/lib/HeatpumpIR/PanasonicHeatpumpIR.cpp
+// Panasonic A/C Clock & Timer support:
+//   Reverse Engineering by MikkelTb
+//   Code by crankyoldgit
 // Panasonic A/C models supported:
 //   A/C Series/models:
 //     JKE, LKE, DKE, & NKE series. (In theory)
 //     CS-YW9MKD (confirmed)
+//     CS-ME14CKPG
 //   A/C Remotes:
 //     A75C3747 (confirmed)
 //     A75C3704
+//     A75C2311
 
 // Constants
 // Ref:
@@ -311,8 +316,8 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
     case kPanasonicDke:
       remote_state[23] = 0x01;
       remote_state[25] = 0x06;
-      // Has to be done last as setSwingH has model check built-in
-      setSwingH(_swingh);
+      // Has to be done last as setSwingHorizontal has model check built-in
+      setSwingHorizontal(_swingh);
       break;
     case kPanasonicNke:
       remote_state[17] = 0x06;
@@ -329,7 +334,7 @@ panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
     return kPanasonicJke;
   if (remote_state[17] == 0x06 && (remote_state[13] & 0x0F) == 0x02)
     return kPanasonicLke;
-  if (remote_state[23] == 0x01 && remote_state[25] == 0x06)
+  if (remote_state[23] == 0x01)
     return kPanasonicDke;
   if (remote_state[17] == 0x06)
     return kPanasonicNke;
@@ -413,7 +418,7 @@ uint8_t IRPanasonicAc::getSwingVertical() {
   return remote_state[16] & 0x0F;
 }
 
-void IRPanasonicAc::setSwingV(const uint8_t desired_elevation) {
+void IRPanasonicAc::setSwingVertical(const uint8_t desired_elevation) {
   uint8_t elevation = desired_elevation;
   if (elevation != kPanasonicAcSwingVAuto) {
     elevation = std::max(elevation, kPanasonicAcSwingVUp);
@@ -427,7 +432,7 @@ uint8_t IRPanasonicAc::getSwingHorizontal() {
   return remote_state[17];
 }
 
-void IRPanasonicAc::setSwingH(const uint8_t desired_direction) {
+void IRPanasonicAc::setSwingHorizontal(const uint8_t desired_direction) {
   switch (desired_direction) {
     case kPanasonicAcSwingHAuto:
     case kPanasonicAcSwingHMiddle:
@@ -488,6 +493,104 @@ void IRPanasonicAc::setPowerful(const bool state) {
   } else {
     remote_state[21] &= ~kPanasonicAcPowerful;
   }
+}
+
+uint16_t IRPanasonicAc::encodeTime(const uint8_t hours, const uint8_t mins) {
+  return std::min(hours, (uint8_t) 23) * 60 + std::min(mins, (uint8_t) 59);
+}
+
+uint16_t IRPanasonicAc::getClock() {
+  uint16_t result = ((remote_state[25] & 0b00000111) << 8) + remote_state[24];
+  if (result == kPanasonicAcTimeSpecial) return 0;
+  return result;
+}
+
+void IRPanasonicAc::setClock(const uint16_t mins_since_midnight) {
+  uint16_t corrected = std::min(mins_since_midnight, kPanasonicAcTimeMax);
+  if (mins_since_midnight == kPanasonicAcTimeSpecial)
+    corrected = kPanasonicAcTimeSpecial;
+  remote_state[24] = corrected & 0xFF;
+  remote_state[25] &= 0b11111000;
+  remote_state[25] |= (corrected >> 8);
+}
+
+uint16_t IRPanasonicAc::getOnTimer() {
+  uint16_t result = ((remote_state[19] & 0b00000111) << 8) + remote_state[18];
+  if (result == kPanasonicAcTimeSpecial)  return 0;
+  return result;
+}
+
+void IRPanasonicAc::setOnTimer(const uint16_t mins_since_midnight,
+                               const bool enable) {
+  // Ensure it's on a 10 minute boundary and no overflow.
+  uint16_t corrected = std::min(mins_since_midnight, kPanasonicAcTimeMax);
+  corrected -= corrected % 10;
+  if (mins_since_midnight == kPanasonicAcTimeSpecial)
+    corrected = kPanasonicAcTimeSpecial;
+
+  if (enable)
+    remote_state[13] |= kPanasonicAcOnTimer;  // Set the Ontimer flag.
+  else
+    remote_state[13] &= ~kPanasonicAcOnTimer;  // Clear the Ontimer flag.
+  // Store the time.
+  remote_state[18] = corrected & 0xFF;
+  remote_state[19] &= 0b11111000;
+  remote_state[19] |= (corrected >> 8);
+}
+
+void IRPanasonicAc::cancelOnTimer() {
+  setOnTimer(0, false);
+}
+
+bool IRPanasonicAc::isOnTimerEnabled() {
+  return remote_state[13] & kPanasonicAcOnTimer;
+}
+
+uint16_t IRPanasonicAc::getOffTimer() {
+  uint16_t result = ((remote_state[20] & 0b01111111) << 4) +
+      (remote_state[19] >> 4);
+  if (result == kPanasonicAcTimeSpecial)  return 0;
+  return result;
+}
+
+void IRPanasonicAc::setOffTimer(const uint16_t mins_since_midnight,
+                               const bool enable) {
+  // Ensure its on a 10 minute boundary and no overflow.
+  uint16_t corrected = std::min(mins_since_midnight, kPanasonicAcTimeMax);
+  corrected -= corrected % 10;
+  if (mins_since_midnight == kPanasonicAcTimeSpecial)
+    corrected = kPanasonicAcTimeSpecial;
+
+  if (enable)
+    remote_state[13] |= kPanasonicAcOffTimer;  // Set the OffTimer flag.
+  else
+    remote_state[13] &= ~kPanasonicAcOffTimer;  // Clear the OffTimer flag.
+  // Store the time.
+  remote_state[19] &= 0b00001111;
+  remote_state[19] |= (corrected & 0b00001111) << 4;
+  remote_state[20] &= 0b10000000;
+  remote_state[20] |= corrected >> 4;
+}
+
+void IRPanasonicAc::cancelOffTimer() {
+  setOffTimer(0, false);
+}
+
+bool IRPanasonicAc::isOffTimerEnabled() {
+  return remote_state[13] & kPanasonicAcOffTimer;
+}
+
+#ifdef ARDUINO
+String IRPanasonicAc::timeToString(const uint16_t mins_since_midnight) {
+  String result = "";
+#else
+std::string IRPanasonicAc::timeToString(const uint16_t mins_since_midnight) {
+  std::string result = "";
+#endif  // ARDUINO
+result += uint64ToString(mins_since_midnight / 60) + ":";
+uint8_t mins = mins_since_midnight % 60;
+if (mins < 10)  result += "0";  // Zero pad the minutes.
+return result + uint64ToString(mins);
 }
 
 // Convert the internal state into a human readable string.
@@ -609,6 +712,17 @@ std::string IRPanasonicAc::toString() {
   result += ", Powerful: ";
   if (getPowerful())
     result += "On";
+  else
+    result += "Off";
+  result += ", Clock: " + timeToString(getClock());
+  result += ", On Timer: ";
+  if (isOnTimerEnabled())
+    result += timeToString(getOnTimer());
+  else
+    result += "Off";
+  result += ", Off Timer: ";
+  if (isOffTimerEnabled())
+    result += timeToString(getOffTimer());
   else
     result += "Off";
   return result;

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -55,7 +55,8 @@ const uint8_t kPanasonicAcSwingHFullRight = 0xC;
 const uint8_t kPanasonicAcChecksumInit = 0xF4;
 const uint8_t kPanasonicAcOnTimer =  0b00000010;
 const uint8_t kPanasonicAcOffTimer = 0b00000100;
-
+const uint16_t kPanasonicAcTimeMax = 23 * 60 + 59;  // Mins since midnight.
+const uint16_t kPanasonicAcTimeSpecial = 0x600;
 
 const uint8_t kPanasonicKnownGoodState[kPanasonicAcStateLength] = {
   0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
@@ -102,15 +103,28 @@ class IRPanasonicAc {
   bool getPowerful();
   void setModel(const panasonic_ac_remote_model_t model);
   panasonic_ac_remote_model_t getModel();
-  void setSwingV(const uint8_t elevation);
+  void setSwingVertical(const uint8_t elevation);
   uint8_t getSwingVertical();
-  void setSwingH(const uint8_t direction);
+  void setSwingHorizontal(const uint8_t direction);
   uint8_t getSwingHorizontal();
-
+  static uint16_t encodeTime(const uint8_t hours, const uint8_t mins);
+  uint16_t getClock();
+  void setClock(const uint16_t mins_since_midnight);
+  uint16_t getOnTimer();
+  void setOnTimer(const uint16_t mins_since_midnight, const bool enable = true);
+  void cancelOnTimer();
+  bool isOnTimerEnabled();
+  uint16_t getOffTimer();
+  void setOffTimer(const uint16_t mins_since_midnight,
+                   const bool enable = true);
+  void cancelOffTimer();
+  bool isOffTimerEnabled();
 #ifdef ARDUINO
   String toString();
+  static String timeToString(const uint16_t mins_since_midnight);
 #else
   std::string toString();
+  static std::string timeToString(const uint16_t mins_since_midnight);
 #endif
 #ifndef UNIT_TEST
 

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -634,47 +634,47 @@ TEST(TestIRPanasonicAcClass, SetAndGetSwings) {
   IRPanasonicAc pana(0);
 
   // Vertical
-  pana.setSwingV(kPanasonicAcSwingVAuto);
+  pana.setSwingVertical(kPanasonicAcSwingVAuto);
   EXPECT_EQ(kPanasonicAcSwingVAuto, pana.getSwingVertical());
 
-  pana.setSwingV(kPanasonicAcSwingVUp);
+  pana.setSwingVertical(kPanasonicAcSwingVUp);
   EXPECT_EQ(kPanasonicAcSwingVUp, pana.getSwingVertical());
-  pana.setSwingV(kPanasonicAcSwingVUp - 1);
+  pana.setSwingVertical(kPanasonicAcSwingVUp - 1);
   EXPECT_EQ(kPanasonicAcSwingVUp, pana.getSwingVertical());
-  pana.setSwingV(kPanasonicAcSwingVUp + 1);
+  pana.setSwingVertical(kPanasonicAcSwingVUp + 1);
   EXPECT_EQ(kPanasonicAcSwingVUp + 1, pana.getSwingVertical());
 
-  pana.setSwingV(kPanasonicAcSwingVDown);
+  pana.setSwingVertical(kPanasonicAcSwingVDown);
   EXPECT_EQ(kPanasonicAcSwingVDown, pana.getSwingVertical());
-  pana.setSwingV(kPanasonicAcSwingVDown + 1);
+  pana.setSwingVertical(kPanasonicAcSwingVDown + 1);
   EXPECT_EQ(kPanasonicAcSwingVDown, pana.getSwingVertical());
-  pana.setSwingV(kPanasonicAcSwingVDown - 1);
+  pana.setSwingVertical(kPanasonicAcSwingVDown - 1);
   EXPECT_EQ(kPanasonicAcSwingVDown - 1, pana.getSwingVertical());
 
-  pana.setSwingV(kPanasonicAcSwingVAuto);
+  pana.setSwingVertical(kPanasonicAcSwingVAuto);
   EXPECT_EQ(kPanasonicAcSwingVAuto, pana.getSwingVertical());
 
   // Horizontal is model dependant.
   pana.setModel(kPanasonicNke);  // NKE is always fixed in the middle.
   EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
-  pana.setSwingH(kPanasonicAcSwingHAuto);
+  pana.setSwingHorizontal(kPanasonicAcSwingHAuto);
   EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
 
   pana.setModel(kPanasonicJke);  // JKE has no H swing.
   EXPECT_EQ(0, pana.getSwingHorizontal());
-  pana.setSwingH(kPanasonicAcSwingHMiddle);
+  pana.setSwingHorizontal(kPanasonicAcSwingHMiddle);
   EXPECT_EQ(0, pana.getSwingHorizontal());
 
   pana.setModel(kPanasonicLke);  // LKE is always fixed in the middle.
   EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
-  pana.setSwingH(kPanasonicAcSwingHAuto);
+  pana.setSwingHorizontal(kPanasonicAcSwingHAuto);
   EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
 
   pana.setModel(kPanasonicDke);  // DKE has full control.
   ASSERT_EQ(kPanasonicDke, pana.getModel());
   // Auto was last requested.
   EXPECT_EQ(kPanasonicAcSwingHAuto, pana.getSwingHorizontal());
-  pana.setSwingH(kPanasonicAcSwingHLeft);
+  pana.setSwingHorizontal(kPanasonicAcSwingHLeft);
   EXPECT_EQ(kPanasonicAcSwingHLeft, pana.getSwingHorizontal());
   // Changing models from DKE to something else, then back should not change
   // the intended swing.
@@ -710,28 +710,31 @@ TEST(TestIRPanasonicAcClass, HumanReadable) {
   IRPanasonicAc pana(0);
   EXPECT_EQ("Model: 4 (JKE), Power: Off, Mode: 0 (AUTO), Temp: 0C, "
             "Fan: 253 (UNKNOWN), Swing (Vertical): 0 (UNKNOWN), Quiet: Off, "
-            "Powerful: Off",
+            "Powerful: Off, Clock: 0:00, On Timer: Off, Off Timer: Off",
             pana.toString());
   pana.setPower(true);
   pana.setTemp(kPanasonicAcMaxTemp);
   pana.setMode(kPanasonicAcHeat);
   pana.setFan(kPanasonicAcFanMax);
-  pana.setSwingV(kPanasonicAcSwingVAuto);
+  pana.setSwingVertical(kPanasonicAcSwingVAuto);
   pana.setPowerful(true);
   EXPECT_EQ("Model: 4 (JKE), Power: On, Mode: 4 (HEAT), Temp: 30C, "
             "Fan: 4 (MAX), Swing (Vertical): 15 (AUTO), Quiet: Off, "
-            "Powerful: On", pana.toString());
+            "Powerful: On, Clock: 0:00, On Timer: Off, Off Timer: Off",
+            pana.toString());
   pana.setQuiet(true);
   pana.setModel(kPanasonicLke);
   EXPECT_EQ("Model: 1 (LKE), Power: Off, Mode: 4 (HEAT), Temp: 30C, "
             "Fan: 4 (MAX), Swing (Vertical): 15 (AUTO), "
-            "Swing (Horizontal): 6 (Middle), Quiet: On, Powerful: Off",
+            "Swing (Horizontal): 6 (Middle), Quiet: On, Powerful: Off, "
+            "Clock: 0:00, On Timer: 0:00, Off Timer: Off",
             pana.toString());
   pana.setModel(kPanasonicDke);
-  pana.setSwingH(kPanasonicAcSwingHRight);
+  pana.setSwingHorizontal(kPanasonicAcSwingHRight);
   EXPECT_EQ("Model: 3 (DKE), Power: Off, Mode: 4 (HEAT), Temp: 30C, "
             "Fan: 4 (MAX), Swing (Vertical): 15 (AUTO), "
-            "Swing (Horizontal): 11 (Right), Quiet: On, Powerful: Off",
+            "Swing (Horizontal): 11 (Right), Quiet: On, Powerful: Off, "
+            "Clock: 0:00, On Timer: Off, Off Timer: Off",
             pana.toString());
 }
 
@@ -814,7 +817,8 @@ TEST(TestDecodePanasonicAC, SyntheticExample) {
   pana.setRaw(irsend.capture.state);
   EXPECT_EQ("Model: 4 (JKE), Power: Off, Mode: 3 (COOL), Temp: 25C, "
             "Fan: 7 (AUTO), Swing (Vertical): 15 (AUTO), Quiet: Off, "
-            "Powerful: Off", pana.toString());
+            "Powerful: Off, Clock: 0:00, On Timer: Off, Off Timer: Off",
+            pana.toString());
 }
 
 // Tests for general utility functions.
@@ -884,6 +888,99 @@ TEST(TestDecodePanasonicAC, Issue540) {
   // TODO(crankyoldgit): Try to figure out what model this should be.
   EXPECT_EQ("Model: 0 (UNKNOWN), Power: On, Mode: 3 (COOL), Temp: 26C, "
             "Fan: 7 (AUTO), Swing (Vertical): 15 (AUTO), "
-            "Swing (Horizontal): 13 (AUTO), Quiet: Off, Powerful: Off",
+            "Swing (Horizontal): 13 (AUTO), Quiet: Off, Powerful: Off, "
+            "Clock: 0:00, On Timer: Off, Off Timer: Off",
             pana.toString());
+}
+
+TEST(TestIRPanasonicAcClass, TimeBasics) {
+  EXPECT_EQ(0x186, IRPanasonicAc::encodeTime(6, 30));
+  EXPECT_EQ(0x3CA, IRPanasonicAc::encodeTime(16, 10));
+  EXPECT_EQ(0x448, IRPanasonicAc::encodeTime(18, 16));
+  EXPECT_EQ(0, IRPanasonicAc::encodeTime(0, 0));
+  EXPECT_EQ(kPanasonicAcTimeMax, IRPanasonicAc::encodeTime(23, 59));
+  EXPECT_EQ("16:10",
+            IRPanasonicAc::timeToString(IRPanasonicAc::encodeTime(16, 10)));
+  EXPECT_EQ("6:30",
+            IRPanasonicAc::timeToString(IRPanasonicAc::encodeTime(6, 30)));
+  EXPECT_EQ("18:16",
+            IRPanasonicAc::timeToString(IRPanasonicAc::encodeTime(18, 16)));
+  EXPECT_EQ("1:01",
+            IRPanasonicAc::timeToString(IRPanasonicAc::encodeTime(1, 1)));
+  EXPECT_EQ(kPanasonicAcTimeMax, IRPanasonicAc::encodeTime(23, 59));
+  EXPECT_EQ(kPanasonicAcTimeMax, IRPanasonicAc::encodeTime(25, 72));
+  EXPECT_EQ(59, IRPanasonicAc::encodeTime(0, 72));
+  EXPECT_EQ(23 * 60, IRPanasonicAc::encodeTime(27, 0));
+  EXPECT_EQ("0:00", IRPanasonicAc::timeToString(0));
+  EXPECT_EQ("23:59", IRPanasonicAc::timeToString(kPanasonicAcTimeMax));
+}
+
+TEST(TestIRPanasonicAcClass, TimersAndClock) {
+  IRPanasonicAc pana(0);
+  // Data from Issue #544
+  uint8_t state[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
+      0x02, 0x20, 0xE0, 0x04, 0x00, 0x4E, 0x2E, 0x80, 0xAF, 0x00, 0xCA,
+      0x6B, 0x98, 0x10, 0x00, 0x01, 0x48, 0x04, 0xDB};
+  pana.setRaw(state);
+  EXPECT_TRUE(pana.isOnTimerEnabled());
+  EXPECT_EQ(0x3CA, pana.getOnTimer());
+  EXPECT_TRUE(pana.isOffTimerEnabled());
+  EXPECT_EQ(0x186, pana.getOffTimer());
+  EXPECT_EQ(0x448, pana.getClock());
+
+  pana.cancelOnTimer();
+  EXPECT_FALSE(pana.isOnTimerEnabled());
+  EXPECT_EQ(0, pana.getOnTimer());
+  EXPECT_TRUE(pana.isOffTimerEnabled());
+  EXPECT_EQ(0x186, pana.getOffTimer());
+  EXPECT_EQ(0x448, pana.getClock());
+
+  pana.cancelOffTimer();
+  EXPECT_FALSE(pana.isOnTimerEnabled());
+  EXPECT_EQ(0, pana.getOnTimer());
+  EXPECT_FALSE(pana.isOffTimerEnabled());
+  EXPECT_EQ(0, pana.getOffTimer());
+  EXPECT_EQ(0x448, pana.getClock());
+
+  pana.setOnTimer(7 * 60 + 50);
+  EXPECT_TRUE(pana.isOnTimerEnabled());
+  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
+  EXPECT_FALSE(pana.isOffTimerEnabled());
+  EXPECT_EQ(0, pana.getOffTimer());
+  EXPECT_EQ(0x448, pana.getClock());
+
+  pana.setOnTimer(7 * 60 + 57);  // It should round down.
+  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
+  pana.setOnTimer(28 * 60);  // It should round down.
+  EXPECT_EQ(kPanasonicAcTimeMax - 9, pana.getOnTimer());
+  pana.setOnTimer(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, pana.getOnTimer());
+
+  pana.setOnTimer(7 * 60 + 50);
+  pana.setOffTimer(19 * 60 + 30);
+
+  EXPECT_TRUE(pana.isOnTimerEnabled());
+  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
+  EXPECT_TRUE(pana.isOffTimerEnabled());
+  EXPECT_EQ(19 * 60 + 30, pana.getOffTimer());
+  EXPECT_EQ(0x448, pana.getClock());
+
+  pana.setOffTimer(19 * 60 + 57);  // It should round down.
+  EXPECT_EQ(19 * 60 + 50, pana.getOffTimer());
+  pana.setOffTimer(28 * 60);  // It should round down.
+  EXPECT_EQ(kPanasonicAcTimeMax - 9, pana.getOffTimer());
+  pana.setOffTimer(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, pana.getOffTimer());
+
+
+  pana.setClock(0);
+  EXPECT_EQ(0, pana.getClock());
+  pana.setClock(kPanasonicAcTimeMax);
+  EXPECT_EQ(kPanasonicAcTimeMax, pana.getClock());
+  pana.setClock(kPanasonicAcTimeMax - 1);
+  EXPECT_EQ(kPanasonicAcTimeMax - 1, pana.getClock());
+  pana.setClock(kPanasonicAcTimeMax + 1);
+  EXPECT_EQ(kPanasonicAcTimeMax, pana.getClock());
+  pana.setClock(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, pana.getClock());
 }


### PR DESCRIPTION
- Clock, On Timer, & Off Timer methods for the IRPanasonicAc class.
- Unit tests for those.
- Change SetSwingV() -> SetSwingVertical()
- Change SetSwingH() -> SetSwingHorizontal()

Ref: #544