### PR TITLE
Update ir_Sharp.cpp

### DIFF
--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -66,15 +66,24 @@ void IRsend::sendSharpRaw(uint64_t data, uint16_t nbits, uint16_t repeat) {
     // Note: Previously this used to be performed 3 times (normal, inverted,
     //       normal), however all data points to that being incorrect.
     for (uint8_t n = 0; n < 2; n++) {
+#if SEND_DENON
+	    // comment out #define	SEND_SHARP in IRremoteESP8266.h file!!
+      // Invert the data per protocol. This is always called twice, so it's
+      // retured to original upon exiting the inner loop.
+      data ^= SHARP_TOGGLE_MASK;		
+#endif
       sendGeneric(0, 0,  // No Header
                   SHARP_BIT_MARK, SHARP_ONE_SPACE,
                   SHARP_BIT_MARK, SHARP_ZERO_SPACE,
                   SHARP_BIT_MARK, SHARP_GAP,
                   data, nbits, 38, true, 0,  // Repeats are handled already.
                   33);
+#if SEND_SHARP
+	    //	comment out #define	SEND_DENON in IRremoteESP8266.h file!!
       // Invert the data per protocol. This is always called twice, so it's
       // retured to original upon exiting the inner loop.
       data ^= SHARP_TOGGLE_MASK;
+#endif
     }
   }
 }


### PR DESCRIPTION


Hello, using AnalysIR i have learned DENON remote control codes which then, i wrote in my Arduino sketch like this:
`irsend.sendDenon(0x0C641B37UL,DENON_BITS,1);`
Programmed the ESP board and found out that the bits were swapped. I had to move    `data ^= SHARP_TOGGLE_MASK;`   before `sendGeneric` function is called for DENON. Sharp i did not try yet:)
Neccessarry is to uncomment either `SEND_DENON` or `SEND_SHARP` in `IRremoteESP8266.h `file.

In picture, first channel is original DENON remote control RC-877 pressing Vol- button, 2nd channel is my ESP sending the same code as received on 1st channel.
![denonswappedbits](https://user-images.githubusercontent.com/5337511/46702803-d341e480-cc24-11e8-9627-f3938f7abb5b.JPG)

In this picture the codes match after modification.
![denonokbits](https://user-images.githubusercontent.com/5337511/46703011-a2ae7a80-cc25-11e8-991e-a79ac23e6f72.JPG)

