### PR TITLE
Add support for Panasonic CKP series A/Cs.

### DIFF
--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -27,13 +27,13 @@
 //   Code by crankyoldgit
 // Panasonic A/C models supported:
 //   A/C Series/models:
-//     JKE, LKE, DKE, & NKE series. (In theory)
+//     JKE, LKE, DKE, CKP, & NKE series. (In theory)
 //     CS-YW9MKD (confirmed)
-//     CS-ME14CKPG
+//     CS-ME14CKPG / CS-ME12CKPG / CS-ME10CKPG
 //   A/C Remotes:
 //     A75C3747 (confirmed)
 //     A75C3704
-//     A75C2311
+//     A75C2311 (CKP)
 
 // Constants
 // Ref:

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -360,14 +360,17 @@ void IRPanasonicAc::setRaw(const uint8_t state[]) {
   }
 }
 
-void IRPanasonicAc::on() {
-  remote_state[13] |= kPanasonicAcPower;
-}
-
-void IRPanasonicAc::off() {
-  remote_state[13] &= ~kPanasonicAcPower;
-}
-
+// Control the power state of the A/C unit.
+//
+// For CKP models, the remote has no memory of the power state the A/C unit
+// should be in. For those models setting this on/true will toggle the power
+// state of the Panasonic A/C unit with the next meessage.
+// e.g. If the A/C unit is already on, setPower(true) will turn it off.
+//      If the A/C unit is already off, setPower(true) will turn it on.
+//      setPower(false) will leave the A/C power state as it was.
+//
+// For all other models, setPower(true) should set the internal state to
+// turn it on, and setPower(false) should turn it off.
 void IRPanasonicAc::setPower(const bool state) {
   if (state)
     on();
@@ -375,8 +378,19 @@ void IRPanasonicAc::setPower(const bool state) {
     off();
 }
 
+// Return the A/C power state of the remote.
+// Except for CKP models, where it returns if the power state will be toggled
+// on the A/C unit when the next message is sent.
 bool IRPanasonicAc::getPower() {
   return (remote_state[13] & kPanasonicAcPower) == kPanasonicAcPower;
+}
+
+void IRPanasonicAc::on() {
+  remote_state[13] |= kPanasonicAcPower;
+}
+
+void IRPanasonicAc::off() {
+  remote_state[13] &= ~kPanasonicAcPower;
 }
 
 uint8_t IRPanasonicAc::getMode() {

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -328,6 +328,7 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
       break;
     case kPanasonicCkp:
       remote_state[21] |= 0x10;
+      remote_state[23] = 0x01;
     default:
       break;
   }
@@ -335,10 +336,10 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
 
 panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
   if (remote_state[17] == 0x00) {
+    if ((remote_state[21] & 0x10) && (remote_state[23] & 0x01))
+      return kPanasonicCkp;
     if (remote_state[23] & 0x80)
       return kPanasonicJke;
-    if (remote_state[21] & 0x10)
-      return kPanasonicCkp;
   }
   if (remote_state[17] == 0x06 && (remote_state[13] & 0x0F) == 0x02)
     return kPanasonicLke;

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -43,6 +43,9 @@ const uint8_t kPanasonicAcMaxTemp = 30;  // Celsius
 const uint8_t kPanasonicAcFanModeTemp = 27;  // Celsius
 const uint8_t kPanasonicAcQuiet = 1;  // 0b1
 const uint8_t kPanasonicAcPowerful = 0x20;  // 0b100000
+// CKP models have Powerful and Quiet bits swapped.
+const uint8_t kPanasonicAcQuietCkp = 0x20;  // 0b100000
+const uint8_t kPanasonicAcPowerfulCkp = 1;  // 0b1
 const uint8_t kPanasonicAcSwingVAuto = 0xF;
 const uint8_t kPanasonicAcSwingVUp = 0x1;
 const uint8_t kPanasonicAcSwingVDown = 0x5;
@@ -69,6 +72,7 @@ enum panasonic_ac_remote_model_t {
   kPanasonicNke = 2,
   kPanasonicDke = 3,
   kPanasonicJke = 4,
+  kPanasonicCkp = 5,
 };
 
 

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -575,6 +575,15 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
   pana.setRaw(jkeState);
   EXPECT_EQ(kPanasonicJke, pana.getModel());
   EXPECT_STATE_EQ(jkeState, pana.getRaw(), kPanasonicAcBits);
+
+  // This state tickled a bug in getModel(). Should read as CKP.
+  uint8_t ckpState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
+      0x02, 0x20, 0xE0, 0x04, 0x00, 0x67, 0x2E, 0x80, 0xAF, 0x00, 0xC0,
+      0x6B, 0x98, 0x10, 0x00, 0x81, 0x64, 0x05, 0x87};
+  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to JKE
+  pana.setRaw(ckpState);
+  EXPECT_EQ(kPanasonicCkp, pana.getModel());
+  EXPECT_STATE_EQ(ckpState, pana.getRaw(), kPanasonicAcBits);
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetMode) {

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -571,7 +571,7 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
   uint8_t jkeState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
       0x02, 0x20, 0xE0, 0x04, 0x00, 0x32, 0x2E, 0x80, 0xA2, 0x00, 0x00,
       0x06, 0x60, 0x00, 0x00, 0x80, 0x00, 0x06, 0x74};
-  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to JKE
+  pana.setModel(kPanasonicDke);  // Make sure it isn't somehow set to JKE
   pana.setRaw(jkeState);
   EXPECT_EQ(kPanasonicJke, pana.getModel());
   EXPECT_STATE_EQ(jkeState, pana.getRaw(), kPanasonicAcBits);
@@ -580,7 +580,7 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
   uint8_t ckpState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
       0x02, 0x20, 0xE0, 0x04, 0x00, 0x67, 0x2E, 0x80, 0xAF, 0x00, 0xC0,
       0x6B, 0x98, 0x10, 0x00, 0x81, 0x64, 0x05, 0x87};
-  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to CKP
+  pana.setModel(kPanasonicDke);  // Make sure it isn't somehow set to CKP
   pana.setRaw(ckpState);
   EXPECT_EQ(kPanasonicCkp, pana.getModel());
   EXPECT_STATE_EQ(ckpState, pana.getRaw(), kPanasonicAcBits);

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -580,7 +580,7 @@ TEST(TestIRPanasonicAcClass, SetAndGetModel) {
   uint8_t ckpState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06,
       0x02, 0x20, 0xE0, 0x04, 0x00, 0x67, 0x2E, 0x80, 0xAF, 0x00, 0xC0,
       0x6B, 0x98, 0x10, 0x00, 0x81, 0x64, 0x05, 0x87};
-  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to JKE
+  pana.setModel(kPanasonicDke);  // Make sure it isn't some how set to CKP
   pana.setRaw(ckpState);
   EXPECT_EQ(kPanasonicCkp, pana.getModel());
   EXPECT_STATE_EQ(ckpState, pana.getRaw(), kPanasonicAcBits);


### PR DESCRIPTION
* CKP series have Powerful and Quiet bits swapped
* Unit tests based on actual data from a CKP unit.
* Detect and set model info for CKP units.

Ref #544