### PR TITLE
Add deep support for the Hitachi 28-Byte A/C Protocol

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -31,6 +31,7 @@
 #include <ir_Fujitsu.h>
 #include <ir_Gree.h>
 #include <ir_Haier.h>
+#include <ir_Hitachi.h>
 #include <ir_Kelvinator.h>
 #include <ir_Midea.h>
 #include <ir_Mitsubishi.h>

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -198,6 +198,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_PANASONIC_AC
+#if DECODE_HITACHI_AC
+  if (results->decode_type == HITACHI_AC) {
+    IRHitachiAc ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_HITACHI_AC
   // If we got a human-readable description of the message, display it.
   if (description != "") Serial.println("Mesg Desc.: " + description);
 }

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -107,7 +107,8 @@ void IRsend::sendHitachiAC2(unsigned char data[], uint16_t nbytes,
 #endif  // SEND_HITACHI_AC2
 
 // Class for handling the remote control oh a Hitachi 28 byte A/C message.
-// Inspired by: https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
+// Inspired by:
+// https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
 
 IRHitachiAc::IRHitachiAc(uint16_t pin) : _irsend(pin) { stateReset(); }
 
@@ -122,8 +123,7 @@ void IRHitachiAc::stateReset() {
   remote_state[7] = 0x88;
   remote_state[8] = 0x48;
   remote_state[9] = 0x10;
-  for (uint8_t i = 10; i < kHitachiAcStateLength; i++)
-    remote_state[i] = 0x00;
+  for (uint8_t i = 10; i < kHitachiAcStateLength; i++) remote_state[i] = 0x00;
   remote_state[14] = 0x60;
   remote_state[15] = 0x60;
   remote_state[24] = 0x80;
@@ -165,9 +165,7 @@ void IRHitachiAc::send() {
 }
 #endif  // SEND_HITACHI_AC
 
-bool IRHitachiAc::getPower() {
-  return (remote_state[17] & 0x01);
-}
+bool IRHitachiAc::getPower() { return (remote_state[17] & 0x01); }
 
 void IRHitachiAc::setPower(const bool on) {
   if (on)
@@ -180,9 +178,7 @@ void IRHitachiAc::on() { setPower(true); }
 
 void IRHitachiAc::off() { setPower(false); }
 
-uint8_t IRHitachiAc::getMode() {
-  return reverseBits(remote_state[10], 8);
-}
+uint8_t IRHitachiAc::getMode() { return reverseBits(remote_state[10], 8); }
 
 void IRHitachiAc::setMode(const uint8_t mode) {
   uint8_t newmode = mode;
@@ -208,9 +204,7 @@ void IRHitachiAc::setMode(const uint8_t mode) {
   if (mode != kHitachiAcFan) setTemp(_previoustemp);
 }
 
-uint8_t IRHitachiAc::getTemp() {
-  return reverseBits(remote_state[11], 8) >> 1;
-}
+uint8_t IRHitachiAc::getTemp() { return reverseBits(remote_state[11], 8) >> 1; }
 
 void IRHitachiAc::setTemp(const uint8_t celsius) {
   uint8_t temp;
@@ -230,9 +224,7 @@ void IRHitachiAc::setTemp(const uint8_t celsius) {
     remote_state[9] = 0x10;
 }
 
-uint8_t IRHitachiAc::getFan() {
-  return reverseBits(remote_state[13], 8);
-}
+uint8_t IRHitachiAc::getFan() { return reverseBits(remote_state[13], 8); }
 
 void IRHitachiAc::setFan(const uint8_t speed) {
   uint8_t newspeed = std::max(speed, kHitachiAcFanAuto);
@@ -270,7 +262,7 @@ std::string IRHitachiAc::toString() {
   if (getPower())
     result += "On";
   else
-  result += "Off";
+    result += "Off";
   result += ", Mode: " + uint64ToString(getMode());
   switch (getMode()) {
     case kHitachiAcAuto:
@@ -308,15 +300,15 @@ std::string IRHitachiAc::toString() {
       break;
   }
   result += ", Swing (Vertical): ";
-    if (getSwingVertical())
-      result += "On";
-    else
-      result += "Off";
+  if (getSwingVertical())
+    result += "On";
+  else
+    result += "Off";
   result += ", Swing (Horizontal): ";
-    if (getSwingHorizontal())
-      result += "On";
-    else
-      result += "Off";
+  if (getSwingHorizontal())
+    result += "On";
+  else
+    result += "Off";
   return result;
 }
 

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -5,6 +5,7 @@
 // * Hitachi RAS-35THA6 remote
 //
 
+#include "ir_Hitachi.h"
 #include <algorithm>
 #ifndef ARDUINO
 #include <string>
@@ -105,6 +106,220 @@ void IRsend::sendHitachiAC2(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_HITACHI_AC2
 
+// Class for handling the remote control oh a Hitachi 28 byte A/C message.
+// Inspired by: https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
+
+IRHitachiAc::IRHitachiAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+
+void IRHitachiAc::stateReset() {
+  remote_state[0] = 0x80;
+  remote_state[1] = 0x08;
+  remote_state[2] = 0x0C;
+  remote_state[3] = 0x02;
+  remote_state[4] = 0xFD;
+  remote_state[5] = 0x80;
+  remote_state[6] = 0x7F;
+  remote_state[7] = 0x88;
+  remote_state[8] = 0x48;
+  remote_state[9] = 0x10;
+  for (uint8_t i = 10; i < kHitachiAcStateLength; i++)
+    remote_state[i] = 0x00;
+  remote_state[14] = 0x60;
+  remote_state[15] = 0x60;
+  remote_state[24] = 0x80;
+  setTemp(23);
+}
+
+void IRHitachiAc::begin() { _irsend.begin(); }
+
+uint8_t IRHitachiAc::calcChecksum(const uint8_t state[],
+                                  const uint16_t length) {
+  int8_t sum = 62;
+  for (uint16_t i = 0; i < length; i++) sum -= reverseBits(state[i], 8);
+  return reverseBits((uint8_t)sum, 8);
+}
+
+void IRHitachiAc::checksum(const uint16_t length) {
+  remote_state[length - 1] = calcChecksum(remote_state, length);
+}
+
+bool IRHitachiAc::validChecksum(const uint8_t state[], const uint16_t length) {
+  if (length < 2) return true;  // Assume true for lengths that are too short.
+  return (state[length - 1] == calcChecksum(state, length - 1));
+}
+
+uint8_t *IRHitachiAc::getRaw() {
+  checksum();
+  return remote_state;
+}
+
+void IRHitachiAc::setRaw(const uint8_t new_code[], const uint16_t length) {
+  for (uint8_t i = 0; i < length && i < kHitachiAcStateLength; i++)
+    remote_state[i] = new_code[i];
+}
+
+#if SEND_HITACHI_AC
+void IRHitachiAc::send() {
+  checksum();
+  _irsend.sendHitachiAC(remote_state);
+}
+#endif  // SEND_HITACHI_AC
+
+bool IRHitachiAc::getPower() {
+  return (remote_state[17] & 0x01);
+}
+
+void IRHitachiAc::setPower(const bool on) {
+  if (on)
+    remote_state[17] |= 0x01;
+  else
+    remote_state[17] &= 0xFE;
+}
+
+void IRHitachiAc::on() { setPower(true); }
+
+void IRHitachiAc::off() { setPower(false); }
+
+uint8_t IRHitachiAc::getMode() {
+  return reverseBits(remote_state[10], 8);
+}
+
+void IRHitachiAc::setMode(const uint8_t mode) {
+  uint8_t newmode = mode;
+  switch (mode) {
+    case kHitachiAcDry:
+      // Dry mode can only have a speed of 2 to 3.
+      setFan(std::min((uint8_t)3, std::max(kHitachiAcFanLow, getFan())));
+      break;
+    case kHitachiAcFan:
+      // Fan mode sets a special temp.
+      setTemp(64);
+      // Fan mode doesn't have a fan auto speed.
+      if (getFan() == kHitachiAcFanAuto) setFan(kHitachiAcFanLow + 1);
+      break;
+    case kHitachiAcAuto:
+    case kHitachiAcHeat:
+    case kHitachiAcCool:
+      break;
+    default:
+      newmode = kHitachiAcAuto;
+  }
+  remote_state[10] = reverseBits(newmode, 8);
+  if (mode != kHitachiAcFan) setTemp(_previoustemp);
+}
+
+uint8_t IRHitachiAc::getTemp() {
+  return reverseBits(remote_state[11], 8) >> 1;
+}
+
+void IRHitachiAc::setTemp(const uint8_t celsius) {
+  uint8_t temp;
+  if (celsius != 64) _previoustemp = celsius;
+  switch (celsius) {
+    case 64:
+      temp = celsius;
+      break;
+    default:
+      temp = std::min(celsius, kHitachiAcMaxTemp);
+      temp = std::max(temp, kHitachiAcMinTemp);
+  }
+  remote_state[11] = reverseBits(temp << 1, 8);
+  if (temp == kHitachiAcMinTemp)
+    remote_state[9] = 0x90;
+  else
+    remote_state[9] = 0x10;
+}
+
+uint8_t IRHitachiAc::getFan() {
+  return reverseBits(remote_state[13], 8);
+}
+
+void IRHitachiAc::setFan(const uint8_t speed) {
+  uint8_t newspeed = std::max(speed, kHitachiAcFanAuto);
+  newspeed = std::min(speed, kHitachiAcFanHigh);
+  remote_state[13] = reverseBits(newspeed, 8);
+}
+
+bool IRHitachiAc::getSwingVertical() { return remote_state[14] & 0x80; }
+
+void IRHitachiAc::setSwingVertical(const bool on) {
+  if (on)
+    remote_state[14] |= 0x80;
+  else
+    remote_state[14] &= 0x7F;
+}
+
+bool IRHitachiAc::getSwingHorizontal() { return remote_state[15] & 0x80; }
+
+void IRHitachiAc::setSwingHorizontal(const bool on) {
+  if (on)
+    remote_state[15] |= 0x80;
+  else
+    remote_state[15] &= 0x7F;
+}
+
+// Convert the internal state into a human readable string.
+#ifdef ARDUINO
+String IRHitachiAc::toString() {
+  String result = "";
+#else
+std::string IRHitachiAc::toString() {
+  std::string result = "";
+#endif  // ARDUINO
+  result += "Power: ";
+  if (getPower())
+    result += "On";
+  else
+  result += "Off";
+  result += ", Mode: " + uint64ToString(getMode());
+  switch (getMode()) {
+    case kHitachiAcAuto:
+      result += " (AUTO)";
+      break;
+    case kHitachiAcCool:
+      result += " (COOL)";
+      break;
+    case kHitachiAcHeat:
+      result += " (HEAT)";
+      break;
+    case kHitachiAcDry:
+      result += " (DRY)";
+      break;
+    case kHitachiAcFan:
+      result += " (FAN)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Temp: " + uint64ToString(getTemp()) + "C";
+  result += ", Fan: " + uint64ToString(getFan());
+  switch (getFan()) {
+    case kHitachiAcFanAuto:
+      result += " (AUTO)";
+      break;
+    case kHitachiAcFanLow:
+      result += " (LOW)";
+      break;
+    case kHitachiAcFanHigh:
+      result += " (HIGH)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+      break;
+  }
+  result += ", Swing (Vertical): ";
+    if (getSwingVertical())
+      result += "On";
+    else
+      result += "Off";
+  result += ", Swing (Horizontal): ";
+    if (getSwingHorizontal())
+      result += "On";
+    else
+      result += "Off";
+  return result;
+}
+
 #if (DECODE_HITACHI_AC || DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2)
 // Decode the supplied Hitachi A/C message.
 //
@@ -184,6 +399,9 @@ bool IRrecv::decodeHitachiAC(decode_results *results, uint16_t nbits,
       default:
         return false;
     }
+    if (dataBitsSoFar / 8 == kHitachiAcStateLength &&
+        !IRHitachiAc::validChecksum(results->state, kHitachiAcStateLength))
+      return false;
   }
 
   // Success

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -1,0 +1,76 @@
+// Hitachi A/C
+//
+// Copyright 2018 David Conran
+
+#ifndef IR_HITACHI_H_
+#define IR_HITACHI_H_
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+// Constants
+const uint8_t kHitachiAcAuto = 2;
+const uint8_t kHitachiAcHeat = 3;
+const uint8_t kHitachiAcCool = 4;
+const uint8_t kHitachiAcDry = 5;
+const uint8_t kHitachiAcFan = 0xC;
+const uint8_t kHitachiAcFanAuto = 1;
+const uint8_t kHitachiAcFanLow = 2;
+const uint8_t kHitachiAcFanHigh = 5;
+const uint8_t kHitachiAcMinTemp = 16;   // 16C
+const uint8_t kHitachiAcMaxTemp = 32;   // 32C
+const uint8_t kHitachiAcAutoTemp = 23;  // 23C
+
+// Classes
+class IRHitachiAc {
+ public:
+  explicit IRHitachiAc(uint16_t pin);
+
+  void stateReset();
+#if SEND_HITACHI_AC
+  void send();
+#endif  // SEND_HITACHI_AC
+  void begin();
+  void on();
+  void off();
+  void setPower(const bool on);
+  bool getPower();
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setFan(const uint8_t speed);
+  uint8_t getFan();
+  void setMode(const uint8_t mode);
+  uint8_t getMode();
+  void setSwingVertical(const bool on);
+  bool getSwingVertical();
+  void setSwingHorizontal(const bool on);
+  bool getSwingHorizontal();
+  uint8_t* getRaw();
+  void setRaw(const uint8_t new_code[],
+              const uint16_t length = kHitachiAcStateLength);
+  static bool validChecksum(const uint8_t state[],
+                            const uint16_t length = kHitachiAcStateLength);
+  static uint8_t calcChecksum(const uint8_t state[],
+                              const uint16_t length = kHitachiAcStateLength);
+#ifdef ARDUINO
+  String toString();
+#else
+  std::string toString();
+#endif
+
+ private:
+  // The state of the IR remote in IR code form.
+  uint8_t remote_state[kHitachiAcStateLength];
+  void checksum(const uint16_t length = kHitachiAcStateLength);
+  IRsend _irsend;
+  uint8_t _previoustemp;
+};
+
+#endif  // IR_HITACHI_H_

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2018 David Conran
 
+#include "ir_Hitachi.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRremoteESP8266.h"
@@ -184,6 +185,77 @@ TEST(TestSendHitachiAC, SendUnexpectedSizes) {
       irsend.outputStr());
 }
 
+// Tests for IRHitachiAc class.
+TEST(TestIRHitachiAcClass, SetAndGetPower) {
+  IRHitachiAc ac(0);
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestIRHitachiAcClass, SetAndGetSwing) {
+  IRHitachiAc ac(0);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingVertical());
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  ac.setSwingVertical(false);
+  EXPECT_FALSE(ac.getSwingVertical());
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  ac.setSwingVertical(true);
+  EXPECT_TRUE(ac.getSwingVertical());
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  ac.setSwingHorizontal(false);
+  EXPECT_TRUE(ac.getSwingVertical());
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+}
+
+TEST(TestIRHitachiAcClass, SetAndGetTemp) {
+  IRHitachiAc ac(0);
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  ac.setTemp(kHitachiAcMinTemp);
+  EXPECT_EQ(kHitachiAcMinTemp, ac.getTemp());
+  ac.setTemp(kHitachiAcMinTemp - 1);
+  EXPECT_EQ(kHitachiAcMinTemp, ac.getTemp());
+  ac.setTemp(kHitachiAcMaxTemp);
+  EXPECT_EQ(kHitachiAcMaxTemp, ac.getTemp());
+  ac.setTemp(kHitachiAcMaxTemp + 1);
+  EXPECT_EQ(kHitachiAcMaxTemp, ac.getTemp());
+  ac.setTemp(64);
+  EXPECT_EQ(64, ac.getTemp());
+}
+
+TEST(TestIRHitachiAcClass, SetAndGetMode) {
+  IRHitachiAc ac(0);
+  ac.setMode(kHitachiAcCool);
+  ac.setFan(kHitachiAcFanAuto);
+  EXPECT_EQ(kHitachiAcCool, ac.getMode());
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  EXPECT_EQ(kHitachiAcFanAuto, ac.getFan());
+  ac.setMode(kHitachiAcFan);
+  EXPECT_EQ(kHitachiAcFan, ac.getMode());
+  EXPECT_EQ(64, ac.getTemp());
+  EXPECT_NE(kHitachiAcFanAuto, ac.getFan());
+  ac.setMode(kHitachiAcHeat);
+  EXPECT_EQ(25, ac.getTemp());
+  EXPECT_EQ(kHitachiAcHeat, ac.getMode());
+  ac.setMode(kHitachiAcAuto);
+  ac.setFan(kHitachiAcFanAuto);
+  EXPECT_EQ(kHitachiAcAuto, ac.getMode());
+  ac.setMode(kHitachiAcDry);
+  EXPECT_EQ(kHitachiAcDry, ac.getMode());
+  EXPECT_NE(kHitachiAcFanAuto, ac.getFan());
+}
+
 // Tests for decodeHitachiAC().
 
 // Decode a synthetic HitachiAC message.
@@ -266,6 +338,10 @@ TEST(TestDecodeHitachiAC, NormalRealExample1) {
   EXPECT_EQ(HITACHI_AC, irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAcBits);
+  IRHitachiAc ac(0);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ("Power: On, Mode: 4 (COOL), Temp: 16C, Fan: 1 (AUTO), "
+            "Swing (Vertical): Off, Swing (Horizontal): Off", ac.toString());
 }
 
 // Decode another 'real' HitachiAC message.
@@ -328,6 +404,10 @@ TEST(TestDecodeHitachiAC, NormalRealExample2) {
   EXPECT_EQ(HITACHI_AC, irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAcBits);
+  IRHitachiAc ac(0);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ("Power: On, Mode: 3 (HEAT), Temp: 32C, Fan: 5 (HIGH), "
+            "Swing (Vertical): Off, Swing (Horizontal): Off", ac.toString());
 }
 
 // Tests for sendHitachiAC1().

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -256,6 +256,90 @@ TEST(TestIRHitachiAcClass, SetAndGetMode) {
   EXPECT_NE(kHitachiAcFanAuto, ac.getFan());
 }
 
+TEST(TestIRHitachiAcClass, SetAndGetFan) {
+  IRHitachiAc ac(0);
+  ac.setMode(kHitachiAcCool);  // All fan options are available in this mode.
+  ac.setFan(kHitachiAcFanAuto);
+  EXPECT_EQ(kHitachiAcFanAuto, ac.getFan());
+  ac.setFan(kHitachiAcFanLow);
+  EXPECT_EQ(kHitachiAcFanLow, ac.getFan());
+  ac.setFan(kHitachiAcFanHigh);
+  EXPECT_EQ(kHitachiAcFanHigh, ac.getFan());
+  ac.setFan(kHitachiAcFanHigh + 1);
+  EXPECT_EQ(kHitachiAcFanHigh, ac.getFan());
+  ac.setFan(0);
+  EXPECT_EQ(kHitachiAcFanAuto, ac.getFan());
+
+  ac.setMode(kHitachiAcFan);  // No auto-fan in Fan mode.
+  EXPECT_EQ(kHitachiAcFanLow, ac.getFan());
+  ac.setFan(kHitachiAcFanAuto);
+  EXPECT_EQ(kHitachiAcFanLow, ac.getFan());
+  ac.setFan(kHitachiAcFanHigh);
+  EXPECT_EQ(kHitachiAcFanHigh, ac.getFan());
+
+  // Only Low and one higher fan settin in Dry mode.
+  ac.setMode(kHitachiAcDry);
+  EXPECT_EQ(kHitachiAcFanLow + 1, ac.getFan());
+  ac.setFan(kHitachiAcFanHigh);
+  EXPECT_EQ(kHitachiAcFanLow + 1, ac.getFan());
+  ac.setFan(kHitachiAcFanLow);
+  EXPECT_EQ(kHitachiAcFanLow, ac.getFan());
+  ac.setFan(kHitachiAcFanAuto);
+  EXPECT_EQ(kHitachiAcFanLow, ac.getFan());
+}
+
+TEST(TestIRHitachiAcClass, HumanReadable) {
+  IRHitachiAc ac(0);
+
+  ac.setMode(kHitachiAcHeat);
+  ac.setTemp(kHitachiAcMaxTemp);
+  ac.on();
+  ac.setFan(kHitachiAcFanHigh);
+  ac.setSwingVertical(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (HEAT), Temp: 32C, Fan: 5 (HIGH), "
+      "Swing (Vertical): On, Swing (Horizontal): Off",
+      ac.toString());
+  ac.setMode(kHitachiAcCool);
+  ac.setTemp(kHitachiAcMinTemp);
+  ac.setFan(kHitachiAcFanLow);
+  ac.setSwingVertical(false);
+  ac.setSwingHorizontal(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (COOL), Temp: 16C, Fan: 2 (LOW), "
+      "Swing (Vertical): Off, Swing (Horizontal): On",
+      ac.toString());
+}
+
+TEST(TestIRHitachiAcClass, ChecksumCalculation) {
+  IRHitachiAc ac(0);
+
+  const uint8_t originalstate[kHitachiAcStateLength] = {
+      0x80, 0x08, 0x0C, 0x02, 0xFD, 0x80, 0x7F, 0x88, 0x48, 0x80,
+      0x20, 0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0xAC};
+  uint8_t examplestate[kHitachiAcStateLength] = {
+      0x80, 0x08, 0x0C, 0x02, 0xFD, 0x80, 0x7F, 0x88, 0x48, 0x80,
+      0x20, 0x04, 0x00, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0xAC};
+
+  EXPECT_TRUE(IRHitachiAc::validChecksum(examplestate));
+  EXPECT_EQ(0xAC, IRHitachiAc::calcChecksum(examplestate));
+
+  examplestate[kHitachiAcStateLength - 1] =
+      0x12;  // Make the existing checksum invalid
+  EXPECT_FALSE(IRHitachiAc::validChecksum(examplestate));
+  EXPECT_EQ(0xAC, IRHitachiAc::calcChecksum(examplestate));
+  ac.setRaw(examplestate);
+  // Extracting the state from the object should have a correct checksum.
+  EXPECT_TRUE(IRHitachiAc::validChecksum(ac.getRaw()));
+  EXPECT_STATE_EQ(originalstate, ac.getRaw(), kHitachiAcBits);
+
+  examplestate[8] = 0x12;  // Force a different checksum calc.
+  EXPECT_FALSE(IRHitachiAc::validChecksum(examplestate));
+  EXPECT_EQ(0xFF, IRHitachiAc::calcChecksum(examplestate));
+}
+
 // Tests for decodeHitachiAC().
 
 // Decode a synthetic HitachiAC message.

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -340,8 +340,10 @@ TEST(TestDecodeHitachiAC, NormalRealExample1) {
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAcBits);
   IRHitachiAc ac(0);
   ac.setRaw(irsend.capture.state);
-  EXPECT_EQ("Power: On, Mode: 4 (COOL), Temp: 16C, Fan: 1 (AUTO), "
-            "Swing (Vertical): Off, Swing (Horizontal): Off", ac.toString());
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (COOL), Temp: 16C, Fan: 1 (AUTO), "
+      "Swing (Vertical): Off, Swing (Horizontal): Off",
+      ac.toString());
 }
 
 // Decode another 'real' HitachiAC message.
@@ -406,8 +408,10 @@ TEST(TestDecodeHitachiAC, NormalRealExample2) {
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAcBits);
   IRHitachiAc ac(0);
   ac.setRaw(irsend.capture.state);
-  EXPECT_EQ("Power: On, Mode: 3 (HEAT), Temp: 32C, Fan: 5 (HIGH), "
-            "Swing (Vertical): Off, Swing (Horizontal): Off", ac.toString());
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (HEAT), Temp: 32C, Fan: 5 (HIGH), "
+      "Swing (Vertical): Off, Swing (Horizontal): Off",
+      ac.toString());
 }
 
 // Tests for sendHitachiAC1().


### PR DESCRIPTION
Experimental IRHitachiAc class.
* Limited to basic functions.
* Unit tests
* Update IRrecvDumpV2 to reflect improvements.

Note: We incorrectly (historically) have Hitachi as MSB First bit ordering, it's really in LSBF order.
Due to legacy usage, we'll keep the sending routines and array data in MSBF and reverse bits as needed.

Fixes #417 
Fixes #453 