### PR TITLE
Make A/C example code a bit more simple.

### DIFF
--- a/examples/TurnOnArgoAC/TurnOnArgoAC.ino
+++ b/examples/TurnOnArgoAC/TurnOnArgoAC.ino
@@ -1,4 +1,4 @@
-/* Copyright 2017 crankyoldgit
+/* Copyright 2017, 2018 crankyoldgit
 * An IR LED circuit *MUST* be connected to the ESP8266 on a pin
 * as specified by kIrLed below.
 *
@@ -31,10 +31,10 @@
 #include <ir_Argo.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRArgoAC argoir(kIrLed);  // Set the GPIO to be used to sending the message.
+IRArgoAC ac(kIrLed);  // Set the GPIO to be used to sending the message.
 
 void setup() {
-  argoir.begin();
+  ac.begin();
   Serial.begin(115200);
 }
 
@@ -42,14 +42,14 @@ void loop() {
   Serial.println("Sending...");
 
   // Set up what we want to send. See ir_Argo.cpp for all the options.
-  argoir.setPower(true);
-  argoir.setFan(ARGO_FAN_1);
-  argoir.setCoolMode(ARGO_COOL_AUTO);
-  argoir.setTemp(25);
+  ac.setPower(true);
+  ac.setFan(kArgoFan1);
+  ac.setCoolMode(kArgoCoolAuto);
+  ac.setTemp(25);
 
 #if SEND_ARGO
   // Now send the IR signal.
-  argoir.send();
+  ac.send();
 #else  // SEND_ARGO
   Serial.println("Can't send because SEND_ARGO has been disabled.");
 #endif  // SEND_ARGO

--- a/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
+++ b/examples/TurnOnDaikinAC/TurnOnDaikinAC.ino
@@ -32,10 +32,10 @@
 #include <ir_Daikin.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRDaikinESP daikinir(kIrLed);  // Set the GPIO to be used to sending the message
+IRDaikinESP ac(kIrLed);  // Set the GPIO to be used to sending the message
 
 void setup() {
-  daikinir.begin();
+  ac.begin();
   Serial.begin(115200);
 }
 
@@ -44,25 +44,25 @@ void loop() {
   Serial.println("Sending...");
 
   // Set up what we want to send. See ir_Daikin.cpp for all the options.
-  daikinir.on();
-  daikinir.setFan(1);
-  daikinir.setMode(kDaikinCool);
-  daikinir.setTemp(25);
-  daikinir.setSwingVertical(false);
-  daikinir.setSwingHorizontal(false);
+  ac.on();
+  ac.setFan(1);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(25);
+  ac.setSwingVertical(false);
+  ac.setSwingHorizontal(false);
 
   // Set the current time to 1:33PM (13:33)
   // Time works in minutes past midnight
-  daikinir.setCurrentTime((13*60) + 33);
-  // Turn off about 1 hour later at 2:30PM (15:30)
-  daikinir.enableOffTimer((14*60) + 30);
+  ac.setCurrentTime(13 * 60 + 33);
+  // Turn off about 1 hour later at 2:30PM (14:30)
+  ac.enableOffTimer(14 * 60 + 30);
 
   // Display what we are going to send.
-  Serial.println(daikinir.toString());
+  Serial.println(ac.toString());
 
   // Now send the IR signal.
 #if SEND_DAIKIN
-  daikinir.send();
+  ac.send();
 #endif  // SEND_DAIKIN
 
   delay(15000);

--- a/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
+++ b/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino
@@ -1,27 +1,28 @@
-// Copyright 2017 Jonny Graham
+// Copyright 2017 Jonny Graham, 2018 David Conran
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include <IRremoteESP8266.h>
 #include <IRsend.h>
 #include <ir_Fujitsu.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRFujitsuAC fujitsu(kIrLed);
+IRFujitsuAC ac(kIrLed);
 
 void printState() {
   // Display the settings.
   Serial.println("Fujitsu A/C remote is in the following state:");
-  Serial.printf("  Command:%d,  Mode: %d, Temp: %dC, Fan Speed: %d," \
-                    " Swing Mode: %d\n",
-                fujitsu.getCmd(), fujitsu.getMode(), fujitsu.getTemp(),
-                fujitsu.getFanSpeed(), fujitsu.getSwing());
+  Serial.printf("  %s\n", ac.toString().c_str());
   // Display the encoded IR sequence.
-  unsigned char* ir_code = fujitsu.getRaw();
+  unsigned char* ir_code = ac.getRaw();
   Serial.print("IR Code: 0x");
-  for (uint8_t i = 0; i < fujitsu.getStateLength(); i++)
+  for (uint8_t i = 0; i < ac.getStateLength(); i++)
     Serial.printf("%02X", ir_code[i]);
   Serial.println();
 }
 
 void setup() {
-  fujitsu.begin();
+  ac.begin();
   Serial.begin(115200);
   delay(200);
 
@@ -29,18 +30,18 @@ void setup() {
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");
-  fujitsu.setCmd(FUJITSU_AC_CMD_TURN_ON);
-  fujitsu.setSwing(FUJITSU_AC_SWING_BOTH);
-  fujitsu.setMode(FUJITSU_AC_MODE_COOL);
-  fujitsu.setFanSpeed(FUJITSU_AC_FAN_HIGH);
-  fujitsu.setTemp(24);
+  ac.setCmd(kFujitsuAcCmdTurnOn);
+  ac.setSwing(kFujitsuAcSwingBoth);
+  ac.setMode(kFujitsuAcModeCool);
+  ac.setFanSpeed(kFujitsuAcFanHigh);
+  ac.setTemp(24);  // 24C
 }
 
 void loop() {
   // Now send the IR signal.
   Serial.println("Sending IR command to A/C ...");
 #if SEND_FUJITSU_AC
-  fujitsu.send();
+  ac.send();
 #else  // SEND_FUJITSU_AC
   Serial.println("Can't send because SEND_FUJITSU_AC has been disabled.");
 #endif  // SEND_FUJITSU_AC

--- a/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
+++ b/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino
@@ -1,4 +1,4 @@
-/* Copyright 2016 David Conran
+/* Copyright 2016, 2018 David Conran
 *
 * An IR LED circuit *MUST* be connected to the ESP8266 on a pin
 * as specified by kIrLed below.
@@ -31,21 +31,14 @@
 #include <ir_Kelvinator.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRKelvinatorAC kelvir(kIrLed);  // Set the GPIO to be used for sending messages.
+IRKelvinatorAC ac(kIrLed);  // Set the GPIO to be used for sending messages.
 
 void printState() {
   // Display the settings.
   Serial.println("Kelvinator A/C remote is in the following state:");
-  Serial.printf("  Basic\n  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d\n",
-                kelvir.getPower(), kelvir.getMode(), kelvir.getTemp(),
-                kelvir.getFan());
-  Serial.printf("  Options\n  X-Fan: %d,  Light: %d, Ion Filter: %d\n",
-                kelvir.getXFan(), kelvir.getLight(), kelvir.getIonFilter());
-  Serial.printf("  Swing (V): %d, Swing (H): %d, Turbo: %d, Quiet: %d\n",
-                kelvir.getSwingVertical(), kelvir.getSwingHorizontal(),
-                kelvir.getTurbo(), kelvir.getQuiet());
+  Serial.printf("  %s\n", ac.toString().c_str());
   // Display the encoded IR sequence.
-  unsigned char* ir_code = kelvir.getRaw();
+  unsigned char* ir_code = ac.getRaw();
   Serial.print("IR Code: 0x");
   for (uint8_t i = 0; i < kKelvinatorStateLength; i++)
     Serial.printf("%02X", ir_code[i]);
@@ -53,7 +46,7 @@ void printState() {
 }
 
 void setup() {
-  kelvir.begin();
+  ac.begin();
   Serial.begin(115200);
   delay(200);
 
@@ -62,22 +55,22 @@ void setup() {
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");
-  kelvir.on();
-  kelvir.setFan(1);
-  kelvir.setMode(KELVINATOR_COOL);
-  kelvir.setTemp(26);
-  kelvir.setSwingVertical(false);
-  kelvir.setSwingHorizontal(true);
-  kelvir.setXFan(true);
-  kelvir.setIonFilter(false);
-  kelvir.setLight(true);
+  ac.on();
+  ac.setFan(1);
+  ac.setMode(kKelvinatorCool);
+  ac.setTemp(26);
+  ac.setSwingVertical(false);
+  ac.setSwingHorizontal(true);
+  ac.setXFan(true);
+  ac.setIonFilter(false);
+  ac.setLight(true);
 }
 
 void loop() {
   // Now send the IR signal.
 #if SEND_KELVINATOR
   Serial.println("Sending IR command to A/C ...");
-  kelvir.send();
+  ac.send();
 #endif  // SEND_KELVINATOR
   printState();
   delay(5000);

--- a/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
+++ b/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino
@@ -1,4 +1,4 @@
-/* Copyright 2017 David Conran
+/* Copyright 2017, 2018 David Conran
 *
 * An IR LED circuit *MUST* be connected to the ESP8266 on a pin
 * as specified by kIrLed below.
@@ -31,17 +31,14 @@
 #include <ir_Mitsubishi.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRMitsubishiAC mitsubir(kIrLed);  // Set the GPIO used for sending messages.
+IRMitsubishiAC ac(kIrLed);  // Set the GPIO used for sending messages.
 
 void printState() {
   // Display the settings.
   Serial.println("Mitsubishi A/C remote is in the following state:");
-  Serial.printf("  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d," \
-                    " Vane Mode: %d\n",
-                mitsubir.getPower(), mitsubir.getMode(), mitsubir.getTemp(),
-                mitsubir.getFan(), mitsubir.getVane());
+  Serial.printf("  %s\n", ac.toString().c_str());
   // Display the encoded IR sequence.
-  unsigned char* ir_code = mitsubir.getRaw();
+  unsigned char* ir_code = ac.getRaw();
   Serial.print("IR Code: 0x");
   for (uint8_t i = 0; i < kMitsubishiACStateLength; i++)
     Serial.printf("%02X", ir_code[i]);
@@ -49,7 +46,7 @@ void printState() {
 }
 
 void setup() {
-  mitsubir.begin();
+  ac.begin();
   Serial.begin(115200);
   delay(200);
 
@@ -57,18 +54,18 @@ void setup() {
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");
-  mitsubir.on();
-  mitsubir.setFan(1);
-  mitsubir.setMode(MITSUBISHI_AC_COOL);
-  mitsubir.setTemp(26);
-  mitsubir.setVane(MITSUBISHI_AC_VANE_AUTO);
+  ac.on();
+  ac.setFan(1);
+  ac.setMode(kMitsubishiAcCool);
+  ac.setTemp(26);
+  ac.setVane(kMitsubishiAcVaneAuto);
 }
 
 void loop() {
   // Now send the IR signal.
 #if SEND_MITSUBISHI_AC
   Serial.println("Sending IR command to A/C ...");
-  mitsubir.send();
+  ac.send();
 #endif  // SEND_MITSUBISHI_AC
   printState();
   delay(5000);

--- a/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
+++ b/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
@@ -1,4 +1,4 @@
-/* Copyright 2017 David Conran
+/* Copyright 2017, 2018 David Conran
 *
 * An IR LED circuit *MUST* be connected to the ESP8266 on a pin
 * as specified by kIrLed below.
@@ -31,16 +31,14 @@
 #include <ir_Toshiba.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRToshibaAC toshibair(kIrLed);  // Set the GPIO to be used for sending messages.
+IRToshibaAC ac(kIrLed);  // Set the GPIO to be used for sending messages.
 
 void printState() {
   // Display the settings.
   Serial.println("Toshiba A/C remote is in the following state:");
-  Serial.printf("  Power: %d,  Mode: %d, Temp: %dC, Fan Speed: %d\n",
-                toshibair.getPower(), toshibair.getMode(), toshibair.getTemp(),
-                toshibair.getFan());
+  Serial.printf("  %s\n", ac.toString().c_str());
   // Display the encoded IR sequence.
-  unsigned char* ir_code = toshibair.getRaw();
+  unsigned char* ir_code = ac.getRaw();
   Serial.print("IR Code: 0x");
   for (uint8_t i = 0; i < kToshibaACStateLength; i++)
     Serial.printf("%02X", ir_code[i]);
@@ -48,7 +46,7 @@ void printState() {
 }
 
 void setup() {
-  toshibair.begin();
+  ac.begin();
   Serial.begin(115200);
   delay(200);
 
@@ -56,17 +54,17 @@ void setup() {
   Serial.println("Default state of the remote.");
   printState();
   Serial.println("Setting desired state for A/C.");
-  toshibair.on();
-  toshibair.setFan(1);
-  toshibair.setMode(TOSHIBA_AC_COOL);
-  toshibair.setTemp(26);
+  ac.on();
+  ac.setFan(1);
+  ac.setMode(kToshibaAcCool);
+  ac.setTemp(26);
 }
 
 void loop() {
   // Now send the IR signal.
 #if SEND_TOSHIBA_AC
   Serial.println("Sending IR command to A/C ...");
-  toshibair.send();
+  ac.send();
 #endif  // SEND_TOSHIBA_AC
   printState();
   delay(5000);

--- a/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
+++ b/examples/TurnOnTrotecAC/TurnOnTrotecAC.ino
@@ -31,10 +31,10 @@
 #include <ir_Trotec.h>
 
 const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
-IRTrotecESP trotecir(kIrLed);  // Set the GPIO to be used for sending messages.
+IRTrotecESP ac(kIrLed);  // Set the GPIO to be used for sending messages.
 
 void setup() {
-  trotecir.begin();
+  ac.begin();
   Serial.begin(115200);
 }
 
@@ -42,14 +42,14 @@ void loop() {
   Serial.println("Sending...");
 
   // Set up what we want to send. See ir_Trotec.cpp for all the options.
-  trotecir.setPower(true);
-  trotecir.setSpeed(TROTEC_FAN_LOW);
-  trotecir.setMode(TROTEC_COOL);
-  trotecir.setTemp(25);
+  ac.setPower(true);
+  ac.setSpeed(kTrotecFanLow);
+  ac.setMode(kTrotecCool);
+  ac.setTemp(25);
 
   // Now send the IR signal.
 #if SEND_TROTEC
-  trotecir.send();
+  ac.send();
 #else  // SEND_TROTEC
   Serial.println("Can't send because SEND_TROTEC has been disabled.");
 #endif  // SEND_TROTEC


### PR DESCRIPTION
- Use a common variable name for the AC object in all examples.
- Convert UPPER_CASE to kConstant in examples.
- Use .toString() instead of adhoc .getBlah() calls.