### PR TITLE
v2.5.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 This library enables you to **send _and_ receive** infra-red signals on an [ESP8266 using the Arduino framework](https://github.com/esp8266/Arduino) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* etc.
 
-## v2.5.2 Now Available
-Version 2.5.2 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
+## v2.5.3 Now Available
+Version 2.5.3 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
 
 #### Upgrading from pre-v2.0
 Usage of the library has been slightly changed in v2.0. You will need to change your usage to work with v2.0 and beyond. You can read more about the changes required on our [Upgrade to v2.0](https://github.com/markszabo/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## _v2.5.3 (20181123)_
+
+**[Features]**
+- Add deep support for the Hitachi 28-Byte A/C Protocol (#563)
+- Deep decoding for Whirlpool A/C (#572)
+- Improve security options for IRMQTTServer example. (#575)
+- Require a changed firmware password before upload. (#576)
+
+**[Misc]**
+- Add missing '}' in output of Auto analyse. (#562)
+- Make A/C example code a bit more simple. (#571)
+
+
 ## _v2.5.2 (20181021)_
 
 **[Bug Fixes]**

--- a/keywords.txt
+++ b/keywords.txt
@@ -27,6 +27,7 @@ IRFujitsuAC	KEYWORD1
 IRGreeAC	KEYWORD1
 IRHaierAC	KEYWORD1
 IRHaierACYRW02	KEYWORD1
+IRHitachiAc	KEYWORD1
 IRKelvinatorAC	KEYWORD1
 IRMideaAC	KEYWORD1
 IRMitsubishiAC	KEYWORD1
@@ -34,6 +35,7 @@ IRPanasonicAc	KEYWORD1
 IRSamsungAc	KEYWORD1
 IRToshibaAC	KEYWORD1
 IRTrotecESP	KEYWORD1
+IRWhirlpoolAc	KEYWORD1
 IRrecv	KEYWORD1
 IRsend	KEYWORD1
 IRtimer	KEYWORD1
@@ -46,6 +48,8 @@ match_result_t	KEYWORD1
 #######################################
 
 _delayMicroseconds	KEYWORD2
+_setMode	KEYWORD2
+_setTemp	KEYWORD2
 add	KEYWORD2
 addbit	KEYWORD2
 begin	KEYWORD2
@@ -117,6 +121,7 @@ enableIRIn	KEYWORD2
 enableIROut	KEYWORD2
 enableOffTimer	KEYWORD2
 enableOnTimer	KEYWORD2
+enableTimer	KEYWORD2
 encodeJVC	KEYWORD2
 encodeLG	KEYWORD2
 encodeMagiQuest	KEYWORD2
@@ -166,6 +171,7 @@ getOnTime	KEYWORD2
 getOnTimer	KEYWORD2
 getOnTimerEnabled	KEYWORD2
 getPower	KEYWORD2
+getPowerToggle	KEYWORD2
 getPowerful	KEYWORD2
 getQuiet	KEYWORD2
 getRClevel	KEYWORD2
@@ -177,12 +183,14 @@ getSpeed	KEYWORD2
 getStartClock	KEYWORD2
 getStateLength	KEYWORD2
 getStopClock	KEYWORD2
+getSuper	KEYWORD2
 getSwing	KEYWORD2
 getSwingHorizontal	KEYWORD2
 getSwingVertical	KEYWORD2
 getSwingVerticalAuto	KEYWORD2
 getSwingVerticalPosition	KEYWORD2
 getTemp	KEYWORD2
+getTempOffset	KEYWORD2
 getTempRaw	KEYWORD2
 getTime	KEYWORD2
 getTimer	KEYWORD2
@@ -195,6 +203,7 @@ hasACState	KEYWORD2
 invertBits	KEYWORD2
 isOffTimerEnabled	KEYWORD2
 isOnTimerEnabled	KEYWORD2
+isTimerEnabled	KEYWORD2
 ledOff	KEYWORD2
 ledOn	KEYWORD2
 mark	KEYWORD2
@@ -299,6 +308,7 @@ setNight	KEYWORD2
 setOffTimer	KEYWORD2
 setOnTimer	KEYWORD2
 setPower	KEYWORD2
+setPowerToggle	KEYWORD2
 setPowerful	KEYWORD2
 setQuiet	KEYWORD2
 setRaw	KEYWORD2
@@ -310,6 +320,7 @@ setSleep	KEYWORD2
 setSpeed	KEYWORD2
 setStartClock	KEYWORD2
 setStopClock	KEYWORD2
+setSuper	KEYWORD2
 setSwing	KEYWORD2
 setSwingHorizontal	KEYWORD2
 setSwingVertical	KEYWORD2
@@ -337,6 +348,7 @@ toggleRC6	KEYWORD2
 typeToString	KEYWORD2
 uint64ToString	KEYWORD2
 validChecksum	KEYWORD2
+xorBytes	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
@@ -441,6 +453,8 @@ DENON	LITERAL1
 DENON_48_BITS	LITERAL1
 DENON_BITS	LITERAL1
 DENON_LEGACY_BITS	LITERAL1
+DG11J13A	LITERAL1
+DG11J191	LITERAL1
 DISH	LITERAL1
 DISH_BITS	LITERAL1
 ELECTRA_AC	LITERAL1
@@ -1077,11 +1091,22 @@ kHitachiAc1HdrSpace	LITERAL1
 kHitachiAc1StateLength	LITERAL1
 kHitachiAc2Bits	LITERAL1
 kHitachiAc2StateLength	LITERAL1
+kHitachiAcAuto	LITERAL1
+kHitachiAcAutoTemp	LITERAL1
 kHitachiAcBitMark	LITERAL1
 kHitachiAcBits	LITERAL1
+kHitachiAcCool	LITERAL1
+kHitachiAcDry	LITERAL1
+kHitachiAcFan	LITERAL1
+kHitachiAcFanAuto	LITERAL1
+kHitachiAcFanHigh	LITERAL1
+kHitachiAcFanLow	LITERAL1
 kHitachiAcHdrMark	LITERAL1
 kHitachiAcHdrSpace	LITERAL1
+kHitachiAcHeat	LITERAL1
+kHitachiAcMaxTemp	LITERAL1
 kHitachiAcMinGap	LITERAL1
+kHitachiAcMinTemp	LITERAL1
 kHitachiAcOneSpace	LITERAL1
 kHitachiAcStateLength	LITERAL1
 kHitachiAcZeroSpace	LITERAL1
@@ -1617,15 +1642,65 @@ kTrotecTimerOn	LITERAL1
 kTrotecZeroMark	LITERAL1
 kTrotecZeroSpace	LITERAL1
 kUnknownThreshold	LITERAL1
+kWhirlpoolAcAltTempMask	LITERAL1
+kWhirlpoolAcAltTempPos	LITERAL1
+kWhirlpoolAcAuto	LITERAL1
+kWhirlpoolAcAutoTemp	LITERAL1
 kWhirlpoolAcBitMark	LITERAL1
 kWhirlpoolAcBits	LITERAL1
+kWhirlpoolAcChecksumByte1	LITERAL1
+kWhirlpoolAcChecksumByte2	LITERAL1
+kWhirlpoolAcClockPos	LITERAL1
+kWhirlpoolAcCommand6thSense	LITERAL1
+kWhirlpoolAcCommandFanSpeed	LITERAL1
+kWhirlpoolAcCommandIFeel	LITERAL1
+kWhirlpoolAcCommandLight	LITERAL1
+kWhirlpoolAcCommandMode	LITERAL1
+kWhirlpoolAcCommandOffTimer	LITERAL1
+kWhirlpoolAcCommandOnTimer	LITERAL1
+kWhirlpoolAcCommandPos	LITERAL1
+kWhirlpoolAcCommandPower	LITERAL1
+kWhirlpoolAcCommandSleep	LITERAL1
+kWhirlpoolAcCommandSuper	LITERAL1
+kWhirlpoolAcCommandSwing	LITERAL1
+kWhirlpoolAcCommandTemp	LITERAL1
+kWhirlpoolAcCool	LITERAL1
+kWhirlpoolAcDry	LITERAL1
+kWhirlpoolAcFan	LITERAL1
+kWhirlpoolAcFanAuto	LITERAL1
+kWhirlpoolAcFanHigh	LITERAL1
+kWhirlpoolAcFanLow	LITERAL1
+kWhirlpoolAcFanMask	LITERAL1
+kWhirlpoolAcFanMedium	LITERAL1
+kWhirlpoolAcFanPos	LITERAL1
 kWhirlpoolAcGap	LITERAL1
 kWhirlpoolAcHdrMark	LITERAL1
 kWhirlpoolAcHdrSpace	LITERAL1
+kWhirlpoolAcHeat	LITERAL1
+kWhirlpoolAcHourMask	LITERAL1
+kWhirlpoolAcLightMask	LITERAL1
+kWhirlpoolAcMaxTemp	LITERAL1
 kWhirlpoolAcMinGap	LITERAL1
+kWhirlpoolAcMinTemp	LITERAL1
+kWhirlpoolAcMinuteMask	LITERAL1
+kWhirlpoolAcModeMask	LITERAL1
+kWhirlpoolAcModePos	LITERAL1
+kWhirlpoolAcOffTimerPos	LITERAL1
+kWhirlpoolAcOnTimerPos	LITERAL1
 kWhirlpoolAcOneSpace	LITERAL1
+kWhirlpoolAcPowerToggleMask	LITERAL1
+kWhirlpoolAcPowerTogglePos	LITERAL1
 kWhirlpoolAcSections	LITERAL1
+kWhirlpoolAcSleepMask	LITERAL1
+kWhirlpoolAcSleepPos	LITERAL1
 kWhirlpoolAcStateLength	LITERAL1
+kWhirlpoolAcSuperMask	LITERAL1
+kWhirlpoolAcSuperPos	LITERAL1
+kWhirlpoolAcSwing1Mask	LITERAL1
+kWhirlpoolAcSwing2Mask	LITERAL1
+kWhirlpoolAcTempMask	LITERAL1
+kWhirlpoolAcTempPos	LITERAL1
+kWhirlpoolAcTimerEnableMask	LITERAL1
 kWhirlpoolAcZeroSpace	LITERAL1
 kWhynterBitMark	LITERAL1
 kWhynterBitMarkTicks	LITERAL1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "keywords": "infrared, ir, remote, esp8266",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.5.2
+version=2.5.3
 author=Sebastien Warin, Mark Szabo, Ken Shirriff, David Conran
 maintainer=Mark Szabo, David Conran, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266)

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -48,7 +48,7 @@
 #endif
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.5.2"
+#define _IRREMOTEESP8266_VERSION_ "2.5.3"
 // Supported IR protocols
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to false) all the protocols you do not need/want!

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -77,7 +77,6 @@ const uint8_t kWhirlpoolAcAltTempMask = 0b00001000;
 const uint8_t kWhirlpoolAcAltTempPos = 18;
 
 enum whirlpool_ac_remote_model_t {
-  // TODO(crankyoldgit): Replace with correct model numbers when we have them.
   DG11J13A = 1,  // DG11J1-04 too
   DG11J191,
 };


### PR DESCRIPTION
**[Features]**
- Add deep support for the Hitachi 28-Byte A/C Protocol (#563)
- Deep decoding for Whirlpool A/C (#572)
- Improve security options for IRMQTTServer example. (#575)
- Require a changed firmware password before upload. (#576)

**[Misc]**
- Add missing `}` in output of Auto analyse. (#562)
- Make A/C example code a bit more simple. (#571)