### PR TITLE
[BUG] Fix incorrect #define usage.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -777,7 +777,7 @@ bool parseStringAndSendAirCon(const uint16_t irType, const String str) {
       irsend.sendDaikin2(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
-#if MITSUBISHI_AC
+#if SEND_MITSUBISHI_AC
     case MITSUBISHI_AC:
       irsend.sendMitsubishiAC(reinterpret_cast<uint8_t *>(state));
       break;
@@ -847,7 +847,7 @@ bool parseStringAndSendAirCon(const uint16_t irType, const String str) {
       irsend.sendPanasonicAC(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
-#if SEND_MWM_
+#if SEND_MWM
     case MWM:
       irsend.sendMWM(reinterpret_cast<uint8_t *>(state), stateSize);
       break;


### PR DESCRIPTION
Originally reported in https://github.com/letscontrolit/ESPEasy/issues/2230

MITSUBISHI_AC -> SEND_MITSUBISHI_AC
SEND_MWM_ -> SEND_MWM

Fixes #596