### PR TITLE
Add ControlSamsungAC example code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - arduino --verify --board $BD $PWD/examples/TurnOnArgoAC/TurnOnArgoAC.ino
   - arduino --verify --board $BD $PWD/examples/IRMQTTServer/IRMQTTServer.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
+  - arduino --verify --board $BD $PWD/examples/ControlSamsungAC/ControlSamsungAC.ino
   # Also check the tools programs compile.
   - (cd tools; make all)
   # Check for lint issues.

--- a/examples/ControlSamsungAC/ControlSamsungAC.ino
+++ b/examples/ControlSamsungAC/ControlSamsungAC.ino
@@ -1,0 +1,99 @@
+/* Copyright 2019 David Conran
+*
+* An IR LED circuit *MUST* be connected to the ESP8266 on a pin
+* as specified by kIrLed below.
+*
+* TL;DR: The IR LED needs to be driven by a transistor for a good result.
+*
+* Suggested circuit:
+*     https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
+*
+* Common mistakes & tips:
+*   * Don't just connect the IR LED directly to the pin, it won't
+*     have enough current to drive the IR LED effectively.
+*   * Make sure you have the IR LED polarity correct.
+*     See: https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity
+*   * Typical digital camera/phones can be used to see if the IR LED is flashed.
+*     Replace the IR LED with a normal LED if you don't have a digital camera
+*     when debugging.
+*   * Avoid using the following pins unless you really know what you are doing:
+*     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
+*     * Pin 1/TX/TXD0: Any serial transmissions from the ESP8266 will interfere.
+*     * Pin 3/RX/RXD0: Any serial transmissions to the ESP8266 will interfere.
+*   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
+*     for your first time. e.g. ESP-12 etc.
+*/
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include <IRremoteESP8266.h>
+#include <IRsend.h>
+#include <ir_Samsung.h>
+
+const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
+IRSamsungAc ac(kIrLed);     // Set the GPIO used for sending messages.
+
+void printState() {
+  // Display the settings.
+  Serial.println("Samsung A/C remote is in the following state:");
+  Serial.printf("  %s\n", ac.toString().c_str());
+}
+
+void setup() {
+  ac.begin();
+  Serial.begin(115200);
+  delay(200);
+
+  // Set up what we want to send. See ir_Samsung.cpp for all the options.
+  Serial.println("Default state of the remote.");
+  printState();
+  Serial.println("Setting initial state for A/C.");
+  ac.off();
+  ac.setFan(kSamsungAcFanLow);
+  ac.setMode(kSamsungAcCool);
+  ac.setTemp(25);
+  ac.setSwing(false);
+  printState();
+}
+
+void loop() {
+  // Turn the A/C unit on and set to cooling mode.
+  // Power changes require we send an extended message.
+  Serial.println("Sending an extended IR command to A/C ...");
+  ac.on();
+  ac.setMode(kSamsungAcCool);
+  ac.sendExtended();
+  printState();
+  delay(15000);  // wait 15 seconds
+
+  // Increase the fan speed.
+  Serial.println("Sending a normal IR command to A/C ...");
+  ac.setFan(kSamsungAcFanHigh);
+  ac.send();
+  printState();
+  delay(15000);
+
+  // Change to swing the fan.
+  Serial.println("Sending a normal IR command to A/C ...");
+  ac.setSwing(true);
+  ac.send();
+  printState();
+  delay(15000);
+
+  // Change to Fan mode, lower the speed, and stop the swing.
+  Serial.println("Sending a normal IR command to A/C ...");
+  ac.setSwing(false);
+  ac.setMode(kSamsungAcFan);
+  ac.setFan(kSamsungAcFanLow);
+  ac.send();
+  printState();
+  delay(15000);
+
+  // Turn the A/C unit off.
+  // Power changes require we send an extended message.
+  Serial.println("Sending an extended IR command to A/C ...");
+  ac.off();
+  ac.sendExtended();
+  printState();
+  delay(15000);  // wait 15 seconds
+}

--- a/examples/ControlSamsungAC/platformio.ini
+++ b/examples/ControlSamsungAC/platformio.ini
@@ -1,0 +1,17 @@
+[platformio]
+lib_extra_dirs = ../../
+src_dir=.
+
+[common]
+build_flags =
+lib_deps_builtin =
+lib_deps_external =
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -254,6 +254,8 @@ void IRSamsungAc::checksum(uint16_t length) {
 }
 
 #if SEND_SAMSUNG_AC
+// Use for most function/mode/settings changes to the unit.
+// i.e. When the device is already running.
 void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) checksum();
   _irsend.sendSamsungAC(remote_state, kSamsungAcStateLength, repeat);
@@ -261,6 +263,9 @@ void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
 #endif  // SEND_SAMSUNG_AC
 
 #if SEND_SAMSUNG_AC
+// Use this for when you need to power on/off the device.
+// Samsung A/C requires an extended length message when you want to
+// change the power operating mode of the A/C unit.
 void IRSamsungAc::sendExtended(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) checksum();
   uint8_t extended_state[kSamsungAcExtendedStateLength] = {


### PR DESCRIPTION
Created an example of how to control the Samsung AC using the IRSamsungAc class.
This is slightly different from normal as power operations require the use of
the `sendExtended()` method. Hence the example code.