### PR TITLE
Adjust Daikin2 timings and tolerance.

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -1354,9 +1354,10 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
                                            kDaikin2Section2Length};
 
   // Leader
-  if (!matchMark(results->rawbuf[offset++], kDaikin2LeaderMark)) return false;
-  if (!matchSpace(results->rawbuf[offset++], kDaikin2LeaderSpace))
-    return false;
+  if (!matchMark(results->rawbuf[offset++], kDaikin2LeaderMark,
+                 kDaikin2Tolerance)) return false;
+  if (!matchSpace(results->rawbuf[offset++], kDaikin2LeaderSpace,
+                  kDaikin2Tolerance)) return false;
 
   // Sections
   // Keep reading bytes until we either run out of section or state to fill.
@@ -1365,8 +1366,10 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
     pos += sectionSize[section];
 
     // Section Header
-    if (!matchMark(results->rawbuf[offset++], kDaikin2HdrMark)) return false;
-    if (!matchSpace(results->rawbuf[offset++], kDaikin2HdrSpace)) return false;
+    if (!matchMark(results->rawbuf[offset++], kDaikin2HdrMark,
+                   kDaikin2Tolerance)) return false;
+    if (!matchSpace(results->rawbuf[offset++], kDaikin2HdrSpace,
+                    kDaikin2Tolerance)) return false;
 
     // Section Data
     for (; offset <= results->rawlen - 16 && i < pos;
@@ -1375,18 +1378,21 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
       data_result =
           matchData(&(results->rawbuf[offset]), 8, kDaikin2BitMark,
                     kDaikin2OneSpace, kDaikin2BitMark,
-                    kDaikin2ZeroSpace, kTolerance, kMarkExcess, false);
+                    kDaikin2ZeroSpace, kDaikin2Tolerance, kMarkExcess, false);
       if (data_result.success == false) break;  // Fail
       results->state[i] = (uint8_t)data_result.data;
     }
 
     // Section Footer
-    if (!matchMark(results->rawbuf[offset++], kDaikin2BitMark)) return false;
+    if (!matchMark(results->rawbuf[offset++], kDaikin2BitMark,
+                   kDaikin2Tolerance)) return false;
     if (section < kDaikin2Sections - 1) {  // Inter-section gaps.
-      if (!matchSpace(results->rawbuf[offset++], kDaikin2Gap)) return false;
+      if (!matchSpace(results->rawbuf[offset++], kDaikin2Gap,
+                      kDaikin2Tolerance)) return false;
     } else {  // Last section / End of message gap.
       if (offset <= results->rawlen &&
-          !matchAtLeast(results->rawbuf[offset++], kDaikin2Gap)) return false;
+          !matchAtLeast(results->rawbuf[offset++], kDaikin2Gap,
+                        kDaikin2Tolerance)) return false;
     }
   }
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -133,12 +133,13 @@ const uint16_t kDaikin2LeaderSpace = 25180;
 const uint16_t kDaikin2Gap = kDaikin2LeaderMark + kDaikin2LeaderSpace;
 const uint16_t kDaikin2HdrMark = 3500;
 const uint16_t kDaikin2HdrSpace = 1728;
-const uint16_t kDaikin2BitMark = 418;
-const uint16_t kDaikin2OneSpace = 1315;
-const uint16_t kDaikin2ZeroSpace = 451;
+const uint16_t kDaikin2BitMark = 460;
+const uint16_t kDaikin2OneSpace = 1270;
+const uint16_t kDaikin2ZeroSpace = 420;
 const uint16_t kDaikin2Sections = 2;
 const uint16_t kDaikin2Section1Length = 20;
 const uint16_t kDaikin2Section2Length = 19;
+const uint8_t kDaikin2Tolerance = kTolerance + 5;
 
 const uint8_t kDaikin2BitSleepTimer = 0b00100000;
 const uint8_t kDaikin2BitPurify = 0b00010000;


### PR DESCRIPTION
Adjust the data timings of the Daikin2 A/C protocol based on user feedback.
e.g. https://github.com/markszabo/IRremoteESP8266/issues/582#issuecomment-461280851
Also adjust the tolerance value by 5 more percent to match existing unit test data.

Ref #582