### PR TITLE
Experimental support for Samsung 36 bit protocol

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -261,7 +261,7 @@ const uint16_t kMinUnknownSize = 2 * 10;
 // ----------------- End of User Configuration Section -------------------------
 
 // Globals
-#define _MY_VERSION_ "v0.8.3"
+#define _MY_VERSION_ "v0.8.4"
 // HTML arguments we will parse for IR code information.
 #define argType "type"
 #define argData "code"
@@ -467,6 +467,7 @@ void handleRoot() {
         "<option value='2'>RC-6</option>"
         "<option value='21'>RC-MM</option>"
         "<option value='7'>Samsung</option>"
+        "<option value='56'>Samsung36</option>"
         "<option value='11'>Sanyo</option>"
         "<option value='22'>Sanyo LC7461</option>"
         "<option value='14'>Sharp</option>"
@@ -1411,6 +1412,13 @@ bool sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
       if (bits == 0)
         bits = kSamsungBits;
       irsend.sendSAMSUNG(code, bits, repeat);
+      break;
+#endif
+#if SEND_SAMSUNG36
+    case SAMSUNG36:  // 56
+      if (bits == 0)
+        bits = kSamsung36Bits;
+      irsend.sendSamsung36(code, bits, repeat);
       break;
 #endif
 #if SEND_WHYNTER

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -364,6 +364,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting SAMSUNG decode");
   if (decodeSAMSUNG(results)) return true;
 #endif
+#if DECODE_SAMSUNG36
+  DPRINTLN("Attempting Samsung36 decode");
+  if (decodeSamsung36(results)) return true;
+#endif
 #if DECODE_WHYNTER
   DPRINTLN("Attempting Whynter decode");
   if (decodeWhynter(results)) return true;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -216,6 +216,11 @@ class IRrecv {
   bool decodeSAMSUNG(decode_results *results, uint16_t nbits = kSamsungBits,
                      bool strict = true);
 #endif
+#if DECODE_SAMSUNG
+  bool decodeSamsung36(decode_results *results,
+                       const uint16_t nbits = kSamsung36Bits,
+                       const bool strict = true);
+#endif
 #if DECODE_SAMSUNG_AC
   bool decodeSamsungAC(decode_results *results, uint16_t nbits = kSamsungAcBits,
                        bool strict = true);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -86,6 +86,9 @@
 #define DECODE_SAMSUNG         true
 #define SEND_SAMSUNG           true
 
+#define DECODE_SAMSUNG36       true
+#define SEND_SAMSUNG36         true
+
 #define DECODE_SAMSUNG_AC      true
 #define SEND_SAMSUNG_AC        true
 
@@ -285,6 +288,8 @@ enum decode_type_t {
   MWM,
   DAIKIN2,
   VESTEL_AC,
+  TECO,  // (55)
+  SAMSUNG36,
 };
 
 // Message lengths & required repeat values
@@ -373,6 +378,7 @@ const uint16_t kRC6Mode0Bits = 20;  // Excludes the 'start' bit.
 const uint16_t kRC6_36Bits = 36;  // Excludes the 'start' bit.
 const uint16_t kRCMMBits = 24;
 const uint16_t kSamsungBits = 32;
+const uint16_t kSamsung36Bits = 36;
 const uint16_t kSamsungAcStateLength = 14;
 const uint16_t kSamsungAcBits = kSamsungAcStateLength * 8;
 const uint16_t kSamsungAcExtendedStateLength = 21;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -92,6 +92,10 @@ class IRsend {
                    uint16_t repeat = kNoRepeat);
   uint32_t encodeSAMSUNG(uint8_t customer, uint8_t command);
 #endif
+#if SEND_SAMSUNG36
+  void sendSamsung36(const uint64_t data, const uint16_t nbits = kSamsung36Bits,
+                     const uint16_t repeat = kNoRepeat);
+#endif
 #if SEND_SAMSUNG_AC
   void sendSamsungAC(unsigned char data[],
                      uint16_t nbytes = kSamsungAcStateLength,

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -231,6 +231,9 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case SAMSUNG:
       result = "SAMSUNG";
       break;
+    case SAMSUNG36:
+      result = "SAMSUNG36";
+      break;
     case SAMSUNG_AC:
       result = "SAMSUNG_AC";
       break;

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 David Conran
+// Copyright 2017, 2018, 2019 David Conran
 
 #include "ir_Samsung.h"
 #include "IRrecv.h"
@@ -6,6 +6,13 @@
 #include "IRsend.h"
 #include "IRsend_test.h"
 #include "gtest/gtest.h"
+
+
+// General housekeeping
+TEST(TestSamsung, Housekeeping) {
+  ASSERT_EQ("SAMSUNG", typeToString(SAMSUNG));
+  ASSERT_FALSE(hasACState(SAMSUNG));
+}
 
 // Tests for sendSAMSUNG().
 
@@ -279,6 +286,12 @@ TEST(TestDecodeSamsung, FailToDecodeNonSamsungExample) {
 
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture));
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
+}
+
+// General housekeeping
+TEST(TestSamsungAC, Housekeeping) {
+  ASSERT_EQ("SAMSUNG_AC", typeToString(SAMSUNG_AC));
+  ASSERT_TRUE(hasACState(SAMSUNG_AC));
 }
 
 // Tests for sendSamsungAC().
@@ -975,4 +988,134 @@ TEST(TestDecodeSamsungAC, Issue604DecodeExtended) {
       "Power: Off, Mode: 4 (HEAT), Temp: 30C, Fan: 0 (AUTO), Swing: Off, "
       "Beep: Off, Clean: Off, Quiet: Off",
       samsung.toString());
+}
+
+TEST(TestSendSamsung36, SendDataOnly) {
+  IRsendTest irsend(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSamsung36(0);
+  EXPECT_EQ(
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560"
+      "m560s26880",
+      irsend.outputStr());
+  irsend.sendSamsung36(0x400E00FF);
+  EXPECT_EQ(
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880",
+      irsend.outputStr());
+  irsend.reset();
+}
+
+// General housekeeping
+TEST(TestSamsung36, Housekeeping) {
+  ASSERT_EQ("SAMSUNG36", typeToString(SAMSUNG36));
+  ASSERT_FALSE(hasACState(SAMSUNG36));
+}
+
+// Test sending with different repeats.
+TEST(TestSendSamsung36, SendWithRepeats) {
+  IRsendTest irsend(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendSamsung36(0x400E00FF, kSamsung36Bits, 1);  // 1 repeat.
+  EXPECT_EQ(
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880"
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880",
+      irsend.outputStr());
+      irsend.sendSamsung36(0x400E00FF, kSamsung36Bits, 2);  // 2 repeats.
+  EXPECT_EQ(
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880"
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880"
+      "m4480s4480"
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s560m560s560m560s560m560s560"
+      "m560s4480"
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680"
+      "m560s26880",
+      irsend.outputStr());
+}
+
+TEST(TestDecodeSamsung36, RealExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  uint16_t rawData[77] = {
+      4542, 4438, 568, 432, 562, 436, 536, 462, 538, 460, 538, 460, 564, 1434,
+      564, 434, 534, 464, 536, 462, 562, 436, 536, 464, 564, 432, 538, 462, 536,
+      464, 534, 464, 564, 420, 566, 4414, 538, 1462, 566, 1432, 562, 1436, 536,
+      462, 564, 436, 562, 436, 560, 436, 562, 436, 562, 436, 560, 438, 536, 462,
+      562, 436, 562, 1436, 562, 1434, 536, 1462, 564, 1434, 562, 1436, 564,
+      1436, 534, 1462, 534, 1464, 536};  // UNKNOWN E4CD1208
+
+  irsend.sendRaw(rawData, 77, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(SAMSUNG36, irsend.capture.decode_type);
+  EXPECT_EQ(kSamsung36Bits, irsend.capture.bits);
+  EXPECT_EQ(0x400E00FF, irsend.capture.value);
+  EXPECT_EQ(0xE00FF, irsend.capture.command);
+  EXPECT_EQ(0x400, irsend.capture.address);
+}
+
+TEST(TestDecodeSamsung36, SyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+  irsend.reset();
+
+  irsend.sendSamsung36(0x400E00FF);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decodeSamsung36(&irsend.capture));
+  ASSERT_EQ(SAMSUNG36, irsend.capture.decode_type);
+  EXPECT_EQ(kSamsung36Bits, irsend.capture.bits);
+  EXPECT_EQ(0x400E00FF, irsend.capture.value);
+  EXPECT_EQ(0xE00FF, irsend.capture.command);
+  EXPECT_EQ(0x400, irsend.capture.address);
 }


### PR DESCRIPTION
* `sendSamsung36()` & `decodeSamsung36()` added.
* Unit test coverage for those routines.
* Update examples.

For #621