### PR TITLE
Experimental support for TCL A/C

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -560,7 +560,7 @@ void handleRoot() {
         "<option value='20'>Mitsubishi</option>"
         "<option value='52'>MWM</option>"
         "<option value='46'>Samsung</option>"
-        "<option value='55'>TCL112</option>"
+        "<option value='57'>TCL112</option>"
         "<option value='32'>Toshiba</option>"
         "<option value='28'>Trotec</option>"
         "<option value='45'>Whirlpool</option>"

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -560,6 +560,7 @@ void handleRoot() {
         "<option value='20'>Mitsubishi</option>"
         "<option value='52'>MWM</option>"
         "<option value='46'>Samsung</option>"
+        "<option value='55'>TCL112</option>"
         "<option value='32'>Toshiba</option>"
         "<option value='28'>Trotec</option>"
         "<option value='45'>Whirlpool</option>"
@@ -725,6 +726,9 @@ bool parseStringAndSendAirCon(const uint16_t irType, const String str) {
       // Cap the maximum size.
       stateSize = std::min(stateSize, kStateSizeMax);
       break;
+    case TCL112AC:
+      stateSize = kTcl112AcStateLength;
+      break;
     default:  // Not a protocol we expected. Abort.
       debug("Unexpected AirCon protocol detected. Ignoring.");
       return false;
@@ -853,6 +857,11 @@ bool parseStringAndSendAirCon(const uint16_t irType, const String str) {
 #if SEND_MWM
     case MWM:
       irsend.sendMWM(reinterpret_cast<uint8_t *>(state), stateSize);
+      break;
+#endif
+#if SEND_TCL112AC
+    case TCL112AC:
+      irsend.sendTcl112Ac(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
     default:

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -37,6 +37,7 @@
 #include <ir_Mitsubishi.h>
 #include <ir_Panasonic.h>
 #include <ir_Samsung.h>
+#include <ir_Tcl.h>
 #include <ir_Teco.h>
 #include <ir_Toshiba.h>
 #include <ir_Vestel.h>

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -239,6 +239,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_TECO
+#if DECODE_TCL112AC
+  if (results->decode_type == TCL112AC) {
+    IRTcl112Ac ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_TCL112AC
   // If we got a human-readable description of the message, display it.
   if (description != "") Serial.println("Mesg Desc.: " + description);
 }

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -501,6 +501,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting Vestel AC decode");
   if (decodeVestelAC(results)) return true;
 #endif
+#if DECODE_TCL112AC
+  DPRINTLN("Attempting TCL112AC decode");
+  if (decodeTcl112Ac(results)) return true;
+#endif
 #if DECODE_TECO
   DPRINTLN("Attempting Teco decode");
   if (decodeTeco(results)) return true;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -341,7 +341,11 @@ class IRrecv {
 #endif
 #if DECODE_VESTEL_AC
   bool decodeVestelAC(decode_results *results, uint16_t nbits = kVestelACBits,
-                   bool strict = true);
+                      bool strict = true);
+#endif
+#if DECODE_TCL112AC
+  bool decodeTcl112Ac(decode_results *results, uint16_t nbits = kTcl112AcBits,
+                      bool strict = true);
 #endif
 #if DECODE_TECO
   bool decodeTeco(decode_results *results, uint16_t nbits = kTecoBits,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -213,12 +213,16 @@
 #define DECODE_TECO            true
 #define SEND_TECO              true
 
+#define DECODE_TCL112AC       true
+#define SEND_TCL112AC         true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
      DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2 || DECODE_HAIER_AC_YRW02 || \
      DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC || \
-     DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || DECODE_VESTEL_AC )
+     DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || \
+     DECODE_VESTEL_AC || DECODE_TCL112AC)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -287,13 +291,14 @@ enum decode_type_t {
   LUTRON,
   ELECTRA_AC,
   PANASONIC_AC,
-  PIONEER,  // 50
+  PIONEER,  // (50)
   LG2,
   MWM,
   DAIKIN2,
   VESTEL_AC,
   TECO,  // (55)
   SAMSUNG36,
+  TCL112AC,
 };
 
 // Message lengths & required repeat values
@@ -403,6 +408,9 @@ const uint16_t kSony15Bits = 15;
 const uint16_t kSony20Bits = 20;
 const uint16_t kSonyMinBits = 12;
 const uint16_t kSonyMinRepeat = 2;
+const uint16_t kTcl112AcStateLength = 14;
+const uint16_t kTcl112AcBits = kTcl112AcStateLength * 8;
+const uint16_t kTcl112AcDefaultRepeat = kNoRepeat;
 const uint16_t kTecoBits = 35;
 const uint16_t kTecoDefaultRepeat = kNoRepeat;
 const uint16_t kToshibaACStateLength = 9;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -318,6 +318,11 @@ class IRsend {
   void sendVestelAC(const uint64_t data, const uint16_t nbits = kVestelACBits,
                     const uint16_t repeat = kNoRepeat);
 #endif
+#if SEND_TCL112AC
+  void sendTcl112Ac(const unsigned char data[],
+                    const uint16_t nbytes = kTcl112AcStateLength,
+                    const uint16_t repeat = kTcl112AcDefaultRepeat);
+#endif
 #if SEND_TECO
   void sendTeco(uint64_t data, uint16_t nbits = kTecoBits,
                   uint16_t repeat = kNoRepeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -323,10 +323,13 @@ class IRsend {
                     const uint16_t nbytes = kTcl112AcStateLength,
                     const uint16_t repeat = kTcl112AcDefaultRepeat);
 #endif
+<<<<<<< HEAD
 #if SEND_TECO
   void sendTeco(uint64_t data, uint16_t nbits = kTecoBits,
                   uint16_t repeat = kNoRepeat);
 #endif
+=======
+>>>>>>> Fix linter issue IRsend.h
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -323,13 +323,11 @@ class IRsend {
                     const uint16_t nbytes = kTcl112AcStateLength,
                     const uint16_t repeat = kTcl112AcDefaultRepeat);
 #endif
-<<<<<<< HEAD
 #if SEND_TECO
   void sendTeco(uint64_t data, uint16_t nbits = kTecoBits,
-                  uint16_t repeat = kNoRepeat);
+                uint16_t repeat = kNoRepeat);
 #endif
-=======
->>>>>>> Fix linter issue IRsend.h
+
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -252,6 +252,9 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case SONY:
       result = "SONY";
       break;
+    case TCL112AC:
+      result = "TCL112AC";
+      break;
     case TECO:
       result = "TECO";
       break;
@@ -293,6 +296,7 @@ bool hasACState(const decode_type_t protocol) {
     case MWM:
     case PANASONIC_AC:
     case SAMSUNG_AC:
+    case TCL112AC:
     case TOSHIBA_AC:
     case WHIRLPOOL_AC:
       return true;

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -1,0 +1,107 @@
+// Copyright 2019 David Conran
+
+#include "ir_Tcl.h"
+#include "IRremoteESP8266.h"
+#include "IRutils.h"
+
+// Constants
+
+
+#if SEND_TCL112AC
+void IRsend::sendTcl112Ac(const unsigned char data[], const uint16_t nbytes,
+                          const uint16_t repeat) {
+  sendGeneric(kTcl112AcHdrMark, kTcl112AcHdrSpace,
+              kTcl112AcBitMark, kTcl112AcOneSpace,
+              kTcl112AcBitMark, kTcl112AcZeroSpace,
+              kTcl112AcBitMark, kTcl112AcGap,
+              data, nbytes, 38000, false, repeat, 50);
+}
+#endif  // SEND_TCL112AC
+
+IRTcl112Ac::IRTcl112Ac(uint16_t pin) : _irsend(pin) { stateReset(); }
+
+void IRTcl112Ac::begin() { _irsend.begin(); }
+
+#if SEND_TCL112AC
+void IRTcl112Ac::send(const uint16_t repeat) {
+  checksum();
+  _irsend.sendTcl112Ac(remote_state, kTcl112AcStateLength, repeat);
+}
+#endif  // SEND_TCL112AC
+
+void IRTcl112Ac::checksum() {
+}
+
+void IRTcl112Ac::stateReset() {
+}
+
+uint8_t* IRTcl112Ac::getRaw() {
+  checksum();
+  return remote_state;
+}
+
+void IRTcl112Ac::setRaw(const uint8_t new_code[], const uint16_t length) {
+  for (uint8_t i = 0; i < length && i < kTcl112AcStateLength; i++) {
+    remote_state[i] = new_code[i];
+  }
+}
+
+#if DECODE_TCL112AC
+// Decode the supplied TCL112AC message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically kTcl112AcBits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: BETA / Appears to mostly work.
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/619
+bool IRrecv::decodeTcl112Ac(decode_results *results, uint16_t nbits,
+                            bool strict) {
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
+    return false;  // Can't possibly be a valid Samsung A/C message.
+  if (strict && nbits != kTcl112AcBits) return false;
+
+  uint16_t offset = kStartOffset;
+  uint16_t dataBitsSoFar = 0;
+  match_result_t data_result;
+
+  // Message Header
+  if (!matchMark(results->rawbuf[offset++], kTcl112AcHdrMark)) return false;
+  if (!matchSpace(results->rawbuf[offset++], kTcl112AcHdrSpace)) return false;
+
+  // Data
+  // Keep reading bytes until we either run out of section or state to fill.
+  for (uint16_t i = 0; offset <= results->rawlen - 16 && i < nbits / 8;
+       i++, dataBitsSoFar += 8, offset += data_result.used) {
+    data_result = matchData(&(results->rawbuf[offset]), 8, kTcl112AcBitMark,
+                            kTcl112AcOneSpace, kTcl112AcBitMark,
+                            kTcl112AcZeroSpace, kTolerance, 0, false);
+    if (data_result.success == false) {
+      DPRINT("DEBUG: offset = ");
+      DPRINTLN(offset + data_result.used);
+      return false;  // Fail
+    }
+    results->state[i] = data_result.data;
+  }
+
+  // Footer
+  if (!matchMark(results->rawbuf[offset++], kTcl112AcBitMark)) return false;
+  if (offset <= results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset++], kTcl112AcGap)) return false;
+  // Compliance
+  // Re-check we got the correct size/length due to the way we read the data.
+  if (dataBitsSoFar != nbits) return false;
+  // Success
+  results->decode_type = TCL112AC;
+  results->bits = dataBitsSoFar;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_TCL112AC

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -1,0 +1,36 @@
+// Copyright 2019 David Conran
+
+#ifndef IR_TCL_H_
+#define IR_TCL_H_
+
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+
+// Constants
+const uint16_t kTcl112AcHdrMark = 3000;
+const uint16_t kTcl112AcHdrSpace = 1650;
+const uint16_t kTcl112AcBitMark = 500;
+const uint16_t kTcl112AcOneSpace = 1050;
+const uint16_t kTcl112AcZeroSpace = 325;
+const uint32_t kTcl112AcGap = 100000;  // Just a guess.
+
+class IRTcl112Ac {
+ public:
+  explicit IRTcl112Ac(uint16_t pin);
+
+#if SEND_TCL112AC
+  void send(const uint16_t repeat = kTcl112AcDefaultRepeat);
+#endif  // SEND_TCL
+  void begin(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[],
+              const uint16_t length = kTcl112AcStateLength);
+
+ private:
+  uint8_t remote_state[kTcl112AcStateLength];
+  void stateReset();
+  void checksum();
+  IRsend _irsend;
+};
+
+#endif  // IR_TCL_H_

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -3,6 +3,11 @@
 #ifndef IR_TCL_H_
 #define IR_TCL_H_
 
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
 

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -25,6 +25,13 @@ class IRTcl112Ac {
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kTcl112AcStateLength);
+  void setTemp(const float temp);  // Celsius in 0.5 increments
+  float getTemp(void);
+#ifdef ARDUINO
+  String toString();
+#else
+  std::string toString();
+#endif
 
  private:
   uint8_t remote_state[kTcl112AcStateLength];

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -19,6 +19,17 @@ const uint16_t kTcl112AcOneSpace = 1050;
 const uint16_t kTcl112AcZeroSpace = 325;
 const uint32_t kTcl112AcGap = 100000;  // Just a guess.
 
+const uint8_t kTcl112AcHeat = 1;
+const uint8_t kTcl112AcDry =  2;
+const uint8_t kTcl112AcCool = 3;
+const uint8_t kTcl112AcFan =  7;
+const uint8_t kTcl112AcAuto = 8;
+
+const uint8_t kTcl112AcHalfDegree = 0b00100000;
+const float   kTcl112AcTempMax = 31.0;
+const float   kTcl112AcTempMin = 16.0;
+const uint8_t kTcl112AcPowerMask = 0x04;
+
 class IRTcl112Ac {
  public:
   explicit IRTcl112Ac(uint16_t pin);
@@ -30,8 +41,18 @@ class IRTcl112Ac {
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kTcl112AcStateLength);
-  void setTemp(const float temp);  // Celsius in 0.5 increments
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const float celsius);  // Celsius in 0.5 increments
   float getTemp(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  static uint8_t calcChecksum(uint8_t state[],
+                              const uint16_t length = kTcl112AcStateLength);
+  static bool validChecksum(uint8_t state[],
+                            const uint16_t length = kTcl112AcStateLength);
 #ifdef ARDUINO
   String toString();
 #else
@@ -41,7 +62,7 @@ class IRTcl112Ac {
  private:
   uint8_t remote_state[kTcl112AcStateLength];
   void stateReset();
-  void checksum();
+  void checksum(const uint16_t length = kTcl112AcStateLength);
   IRsend _irsend;
 };
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,7 +36,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
-  ir_MWM_test ir_Vestel_test ir_Teco_test
+  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -80,7 +80,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
-	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o
+	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
@@ -101,6 +101,7 @@ PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
 		$(USER_DIR)/ir_Panasonic.h \
 		$(USER_DIR)/ir_Whirlpool.h \
 		$(USER_DIR)/ir_Vestel.h \
+		$(USER_DIR)/ir_Tcl.h \
 		$(USER_DIR)/ir_Teco.h
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
@@ -514,4 +515,13 @@ ir_Teco_test.o : ir_Teco_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Teco_test.cpp
 
 ir_Teco_test : $(COMMON_OBJ) ir_Teco_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp
+
+ir_Tcl_test.o : ir_Tcl_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Tcl_test.cpp
+
+ir_Tcl_test : $(COMMON_OBJ) ir_Tcl_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -1,0 +1,85 @@
+// Copyright 2019 David Conran
+
+#include "ir_Tcl.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// General housekeeping
+TEST(TestTcl112Ac, Housekeeping) {
+  ASSERT_EQ("TCL112AC", typeToString(TCL112AC));
+  ASSERT_TRUE(hasACState(TCL112AC));
+}
+
+// Tests for decodeTcl112Ac().
+
+// Decode a real Tcl112Ac A/C example from Issue #619
+TEST(TestDecodeTcl112Ac, DecodeRealExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Tcl112Ac A/C example from Issue #619 On.txt
+  uint16_t rawData[227] = {
+      3030, 1658, 494,  1066, 494,  1068, 498,  320,  494,
+      326,  498,  320,  494,  1068, 500,  320,  494,  332,
+      494,  1068, 500,  1062, 496,  324,  492,  1044, 524,
+      322,  492,  326,  498,  1062, 494,  1074, 494,  326,
+      500,  1062, 496,  1066, 490,  328,  496,  322,  492,
+      1070, 498,  322,  494,  332,  492,  1068, 498,  320,
+      494,  326,  498,  320,  496,  324,  500,  320,  494,
+      324,  490,  336,  500,  320,  496,  324,  490,  328,
+      496,  322,  492,  328,  498,  322,  492,  326,  498,
+      328,  496,  322,  492,  328,  498,  1064, 494,  326,
+      498,  320,  494,  1066, 490,  330,  496,  330,  494,
+      1066, 490,  1070, 498,  322,  492,  328,  498,  322,
+      492,  326,  498,  322,  492,  332,  492,  1068, 498,
+      1062, 494,  1066, 500,  318,  496,  324,  490,  328,
+      496,  324,  492,  334,  490,  328,  496,  324,  492,
+      328,  496,  322,  492,  328,  498,  320,  494,  1068,
+      500,  326,  500,  320,  492,  326,  500,  320,  496,
+      324,  500,  318,  496,  324,  490,  328,  496,  330,
+      496,  324,  490,  328,  496,  324,  490,  328,  498,
+      322,  492,  328,  498,  320,  492,  334,  492,  328,
+      498,  322,  494,  326,  498,  320,  494,  324,  500,
+      322,  492,  324,  490,  336,  498,  320,  494,  324,
+      500,  320,  496,  324,  490,  328,  498,  322,  492,
+      328,  496,  1070, 496,  1064, 492,  1070, 498,  322,
+      494,  326,  500,  320,  494,  324,  500,  320,  494,
+      324,  470};  // UNKNOWN CE60D6B9
+  uint8_t expectedState[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x07, 0x40, 0x00, 0x00, 0x00, 0x80, 0x03};
+
+  irsend.sendRaw(rawData, 227, 38000);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(TCL112AC, irsend.capture.decode_type);
+  EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+// Decode a synthetic Tcl112Ac A/C example from Issue #619
+TEST(TestDecodeTcl112Ac, DecodeSyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+
+  uint8_t expectedState[kTcl112AcStateLength] = {0x23, 0xCB, 0x26, 0x01, 0x00,
+                                                 0x24, 0x03, 0x07, 0x40, 0x00,
+                                                 0x00, 0x00, 0x80, 0x03};
+
+  irsend.sendTcl112Ac(expectedState);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(TCL112AC, irsend.capture.decode_type);
+  EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -61,6 +61,10 @@ TEST(TestDecodeTcl112Ac, DecodeRealExample) {
   ASSERT_EQ(TCL112AC, irsend.capture.decode_type);
   EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  IRTcl112Ac ac(0);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ("Temp: 24C", ac.toString());
 }
 
 // Decode a synthetic Tcl112Ac A/C example from Issue #619
@@ -82,4 +86,28 @@ TEST(TestDecodeTcl112Ac, DecodeSyntheticExample) {
   ASSERT_EQ(TCL112AC, irsend.capture.decode_type);
   EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+TEST(TestTcl112AcClass, TemperatureExamples) {
+  const uint8_t temp16C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0F, 0x00, 0x00, 0x00, 0x00, 0x80, 0xCB};
+  const uint8_t temp16point5C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0F, 0x00, 0x00, 0x00, 0x00, 0xA0, 0xEB};
+  const uint8_t temp19point5C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0C, 0x00, 0x00, 0x00, 0x00, 0xA0, 0xE8};
+  const uint8_t temp31C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xBC};
+  IRTcl112Ac ac(0);
+  ac.setRaw(temp16C);
+  EXPECT_EQ("Temp: 16C", ac.toString());
+  ac.setRaw(temp16point5C);
+  EXPECT_EQ("Temp: 16.5C", ac.toString());
+  ac.setRaw(temp19point5C);
+  EXPECT_EQ("Temp: 19.5C", ac.toString());
+  ac.setRaw(temp31C);
+  EXPECT_EQ("Temp: 31C", ac.toString());
 }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -48,7 +48,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
             ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o ir_Hitachi.o \
             ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o ir_Pioneer.o \
-            ir_MWM.o ir_Vestel.o ir_Teco.o
+            ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -200,3 +200,6 @@ ir_Vestel.o : $(USER_DIR)/ir_Vestel.cpp $(GTEST_HEADERS)
 
 ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp
+
+ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(USER_DIR)/ir_Tcl.h $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp


### PR DESCRIPTION
Experimental basic support for 112 bit TCL AC
- Basic send/decode routines.
- Partial support for message decoding/construction:
  - Power
  - Mode
  - Temperature
  - Checksum
- Examples update with support for TCL
- Unit test coverage for additions.

For #619 