### PR TITLE
Update IRsend::send() to include all simple protocols.

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -1,6 +1,6 @@
 // Copyright 2009 Ken Shirriff
 // Copyright 2015 Mark Szabo
-// Copyright 2017 David Conran
+// Copyright 2017,2019 David Conran
 
 #include "IRsend.h"
 #ifndef UNIT_TEST
@@ -488,14 +488,15 @@ void IRsend::sendRaw(uint16_t buf[], uint16_t len, uint16_t hz) {
 }
 #endif  // SEND_RAW
 
-#ifndef UNIT_TEST
 // Send a simple (up to 64 bits) IR message of a given type.
 // An unknown/unsupported type will do nothing.
 // Args:
 //   type:  Protocol number/type of the message you want to send.
 //   data:  The data you want to send (up to 64 bits).
 //   nbits: How many bits long the message is to be.
-void IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
+// Returns:
+//   bool: True if it is a type we can attemp to send, false if not.
+bool IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
   switch (type) {
 #if SEND_AIWA_RC_T501
     case AIWA_RC_T501:
@@ -582,12 +583,33 @@ void IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
 #endif
 #if SEND_NEC
     case NEC:
+    case NEC_LIKE:
       sendNEC(data, nbits);
+      break;
+#endif
+#if SEND_PANASONIC
+    case PANASONIC:
+      sendPanasonic64(data, nbits);
       break;
 #endif
 #if SEND_PIONEER
     case PIONEER:
       sendPioneer(data, nbits);
+      break;
+#endif
+#if SEND_RC5
+    case RC5:
+      sendRC5(data, nbits);
+      break;
+#endif
+#if SEND_RC6
+    case RC6:
+      sendRC6(data, nbits);
+      break;
+#endif
+#if SEND_RCMM
+    case RCMM:
+      sendRCMM(data, nbits);
       break;
 #endif
 #if SEND_SAMSUNG
@@ -620,26 +642,6 @@ void IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
       sendSony(data, nbits);
       break;
 #endif
-#if SEND_PANASONIC
-    case PANASONIC:
-      sendPanasonic64(data, nbits);
-      break;
-#endif
-#if SEND_RC5
-    case RC5:
-      sendRC5(data, nbits);
-      break;
-#endif
-#if SEND_RC6
-    case RC6:
-      sendRC6(data, nbits);
-      break;
-#endif
-#if SEND_RCMM
-    case RCMM:
-      sendRCMM(data, nbits);
-      break;
-#endif
 #if SEND_TECO
     case TECO:
       sendTeco(data, nbits);
@@ -655,6 +657,8 @@ void IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
       sendWhynter(data, nbits);
       break;
 #endif
+    default:
+      return false;
   }
+  return true;
 }
-#endif  // UNIT_TEST

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -489,56 +489,22 @@ void IRsend::sendRaw(uint16_t buf[], uint16_t len, uint16_t hz) {
 #endif  // SEND_RAW
 
 #ifndef UNIT_TEST
-void IRsend::send(uint16_t type, uint64_t data, uint16_t nbits) {
+// Send a simple (up to 64 bits) IR message of a given type.
+// An unknown/unsupported type will do nothing.
+// Args:
+//   type:  Protocol number/type of the message you want to send.
+//   data:  The data you want to send (up to 64 bits).
+//   nbits: How many bits long the message is to be.
+void IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
   switch (type) {
-#if SEND_NEC
-    case NEC:
-      sendNEC(data, nbits);
+#if SEND_AIWA_RC_T501
+    case AIWA_RC_T501:
+      sendAiwaRCT501(data, nbits);
       break;
 #endif
-#if SEND_SONY
-    case SONY:
-      sendSony(data, nbits);
-      break;
-#endif
-#if SEND_RC5
-    case RC5:
-      sendRC5(data, nbits);
-      break;
-#endif
-#if SEND_RC6
-    case RC6:
-      sendRC6(data, nbits);
-      break;
-#endif
-#if SEND_DISH
-    case DISH:
-      sendDISH(data, nbits);
-      break;
-#endif
-#if SEND_JVC
-    case JVC:
-      sendJVC(data, nbits);
-      break;
-#endif
-#if SEND_SAMSUNG
-    case SAMSUNG:
-      sendSAMSUNG(data, nbits);
-      break;
-#endif
-#if SEND_LG
-    case LG:
-      sendLG(data, nbits);
-      break;
-#endif
-#if SEND_LG
-    case LG2:
-      sendLG2(data, nbits);
-      break;
-#endif
-#if SEND_WHYNTER
-    case WHYNTER:
-      sendWhynter(data, nbits);
+#if SEND_CARRIER_AC
+    case CARRIER_AC:
+      sendCarrierAC(data, nbits);
       break;
 #endif
 #if SEND_COOLIX
@@ -551,14 +517,52 @@ void IRsend::send(uint16_t type, uint64_t data, uint16_t nbits) {
       sendDenon(data, nbits);
       break;
 #endif
-#if SEND_SHERWOOD
-    case SHERWOOD:
-      sendSherwood(data, nbits);
+#if SEND_DISH
+    case DISH:
+      sendDISH(data, nbits);
       break;
 #endif
-#if SEND_RCMM
-    case RCMM:
-      sendRCMM(data, nbits);
+#if SEND_GICABLE
+    case GICABLE:
+      sendGICable(data, nbits);
+      break;
+#endif
+#if SEND_GREE
+    case GREE:
+      sendGree(data, nbits);
+      break;
+#endif
+#if SEND_JVC
+    case JVC:
+      sendJVC(data, nbits);
+      break;
+#endif
+#if SEND_LASERTAG
+    case LASERTAG:
+      sendLasertag(data, nbits);
+      break;
+#endif
+#if SEND_LG
+    case LG:
+      sendLG(data, nbits);
+      break;
+    case LG2:
+      sendLG2(data, nbits);
+      break;
+#endif
+#if SEND_LUTRON
+    case LUTRON:
+      sendLutron(data, nbits);
+      break;
+#endif
+#if SEND_MAGIQUEST
+    case MAGIQUEST:
+      sendMagiQuest(data, nbits);
+      break;
+#endif
+#if SEND_MIDEA
+    case MIDEA:
+      sendMidea(data, nbits);
       break;
 #endif
 #if SEND_MITSUBISHI
@@ -571,24 +575,14 @@ void IRsend::send(uint16_t type, uint64_t data, uint16_t nbits) {
       sendMitsubishi2(data, nbits);
       break;
 #endif
-#if SEND_SHARP
-    case SHARP:
-      sendSharpRaw(data, nbits);
+#if SEND_NIKAI
+    case NIKAI:
+      sendNikai(data, nbits);
       break;
 #endif
-#if SEND_AIWA_RC_T501
-    case AIWA_RC_T501:
-      sendAiwaRCT501(data, nbits);
-      break;
-#endif
-#if SEND_MIDEA
-    case MIDEA:
-      sendMidea(data, nbits);
-      break;
-#endif
-#if SEND_GICABLE
-    case GICABLE:
-      sendGICable(data, nbits);
+#if SEND_NEC
+    case NEC:
+      sendNEC(data, nbits);
       break;
 #endif
 #if SEND_PIONEER
@@ -596,11 +590,71 @@ void IRsend::send(uint16_t type, uint64_t data, uint16_t nbits) {
       sendPioneer(data, nbits);
       break;
 #endif
+#if SEND_SAMSUNG
+    case SAMSUNG:
+      sendSAMSUNG(data, nbits);
+      break;
+#endif
+#if SEND_SAMSUNG36
+    case SAMSUNG36:
+      sendSamsung36(data, nbits);
+      break;
+#endif
+#if SEND_SANYO
+    case SANYO_LC7461:
+      sendSanyoLC7461(data, nbits);
+      break;
+#endif
+#if SEND_SHARP
+    case SHARP:
+      sendSharpRaw(data, nbits);
+      break;
+#endif
+#if SEND_SHERWOOD
+    case SHERWOOD:
+      sendSherwood(data, nbits);
+      break;
+#endif
+#if SEND_SONY
+    case SONY:
+      sendSony(data, nbits);
+      break;
+#endif
+#if SEND_PANASONIC
+    case PANASONIC:
+      sendPanasonic64(data, nbits);
+      break;
+#endif
+#if SEND_RC5
+    case RC5:
+      sendRC5(data, nbits);
+      break;
+#endif
+#if SEND_RC6
+    case RC6:
+      sendRC6(data, nbits);
+      break;
+#endif
+#if SEND_RCMM
+    case RCMM:
+      sendRCMM(data, nbits);
+      break;
+#endif
+#if SEND_TECO
+    case TECO:
+      sendTeco(data, nbits);
+      break;
+#endif
 #if SEND_VESTEL_AC
     case VESTEL_AC:
       sendVestelAC(data, nbits);
       break;
 #endif
+#if SEND_WHYNTER
+    case WHYNTER:
+      sendWhynter(data, nbits);
+      break;
+#endif
   }
 }
-#endif
+#endif  // UNIT_TEST

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -68,7 +68,7 @@ class IRsend {
                    const uint8_t *dataptr, const uint16_t nbytes,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
-  void send(decode_type_t type, uint64_t data, uint16_t nbits);
+  bool send(decode_type_t type, uint64_t data, uint16_t nbits);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,
                uint16_t repeat = kNoRepeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -68,7 +68,7 @@ class IRsend {
                    const uint8_t *dataptr, const uint16_t nbytes,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
-  void send(uint16_t type, uint64_t data, uint16_t nbits);
+  void send(decode_type_t type, uint64_t data, uint16_t nbits);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,
                uint16_t repeat = kNoRepeat);

--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -1,7 +1,8 @@
-// Copyright 2017 David Conran
+// Copyright 2017,2019 David Conran
 
 #include "IRsend_test.h"
 #include "IRsend.h"
+#include "IRutils.h"
 #include "gtest/gtest.h"
 
 // Tests sendData().
@@ -287,4 +288,311 @@ TEST(TestLowLevelSend, SpaceNoModulation) {
   irsend.enableIROut(40000, 75);
   irsend.space(1000);
   EXPECT_EQ("[Off]1000usecs", irsend.low_level_sequence);
+}
+
+// Test expected to work/produce a message for irsend:send()
+TEST(TestSend, GenericSimpleSendMethod) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(AIWA_RC_T501, 0x1234, kAiwaRcT501Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
+  EXPECT_EQ(kAiwaRcT501Bits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(CARRIER_AC, 0x1234, kCarrierAcBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(CARRIER_AC, irsend.capture.decode_type);
+  EXPECT_EQ(kCarrierAcBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(COOLIX, 0x1234, kCoolixBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(COOLIX, irsend.capture.decode_type);
+  EXPECT_EQ(kCoolixBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(DENON, 0x1234, kDenonBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(DENON, irsend.capture.decode_type);
+  EXPECT_EQ(kDenonBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(DISH, 0x1234, kDishBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(DISH, irsend.capture.decode_type);
+  EXPECT_EQ(kDishBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(GICABLE, 0x1234, kGicableBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(GICABLE, irsend.capture.decode_type);
+  EXPECT_EQ(kGicableBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(GREE, 0x0009205000200050, kGreeBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(GREE, irsend.capture.decode_type);
+  EXPECT_EQ(kGreeBits, irsend.capture.bits);
+  // No simple value test for gree as it decodes to an Array.
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(JVC, 0x1234, kJvcBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(JVC, irsend.capture.decode_type);
+  EXPECT_EQ(kJvcBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(LASERTAG, 0x123, kLasertagBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LASERTAG, irsend.capture.decode_type);
+  EXPECT_EQ(kLasertagBits, irsend.capture.bits);
+  EXPECT_EQ(0x123, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(LG, 0x700992, kLgBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LG, irsend.capture.decode_type);
+  EXPECT_EQ(kLgBits, irsend.capture.bits);
+  EXPECT_EQ(0x700992, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(LG, 0x700992, kLg32Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LG, irsend.capture.decode_type);
+  EXPECT_EQ(kLg32Bits, irsend.capture.bits);
+  EXPECT_EQ(0x700992, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(LG2, 0x880094D, kLgBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LG2, irsend.capture.decode_type);
+  EXPECT_EQ(kLgBits, irsend.capture.bits);
+  EXPECT_EQ(0x880094D, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(LUTRON, 0x1234, kLutronBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LUTRON, irsend.capture.decode_type);
+  EXPECT_EQ(kLutronBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(MAGIQUEST, 0x560F40020455, kMagiquestBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MAGIQUEST, irsend.capture.decode_type);
+  EXPECT_EQ(kMagiquestBits, irsend.capture.bits);
+  EXPECT_EQ(0x560F40020455, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(MIDEA, 0xA18263FFFF6E, kMideaBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MIDEA, irsend.capture.decode_type);
+  EXPECT_EQ(kMideaBits, irsend.capture.bits);
+  EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(MITSUBISHI, 0x1234, kMitsubishiBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
+  EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(MITSUBISHI2, 0x1234, kMitsubishiBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MITSUBISHI2, irsend.capture.decode_type);
+  EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(NIKAI, 0x1234, kNikaiBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NIKAI, irsend.capture.decode_type);
+  EXPECT_EQ(kNikaiBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(NEC, 0x4BB640BF, kNECBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(kNECBits, irsend.capture.bits);
+  EXPECT_EQ(0x4BB640BF, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(NEC_LIKE, 0x12345678, kNECBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC_LIKE, irsend.capture.decode_type);
+  EXPECT_EQ(kNECBits, irsend.capture.bits);
+  EXPECT_EQ(0x12345678, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(PANASONIC, 0x40040190ED7C, kPanasonicBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
+  EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
+  EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(PIONEER, 0x659A05FAF50AC53A, kPioneerBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(PIONEER, irsend.capture.decode_type);
+  EXPECT_EQ(kPioneerBits, irsend.capture.bits);
+  EXPECT_EQ(0x659A05FAF50AC53A, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(RC5, 0x175, kRC5Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(RC5, irsend.capture.decode_type);
+  EXPECT_EQ(kRC5Bits, irsend.capture.bits);
+  EXPECT_EQ(0x175, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(RC6, 0xC800F740C, kRC6_36Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(RC6, irsend.capture.decode_type);
+  EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
+  EXPECT_EQ(0xC800F740C, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(RCMM, 0x1234, kRCMMBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(RCMM, irsend.capture.decode_type);
+  EXPECT_EQ(kRCMMBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SAMSUNG, 0xE0E09966, kSamsungBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
+  EXPECT_EQ(kSamsungBits, irsend.capture.bits);
+  EXPECT_EQ(0xE0E09966, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SAMSUNG36, 0x1234, kSamsung36Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SAMSUNG36, irsend.capture.decode_type);
+  EXPECT_EQ(kSamsung36Bits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SANYO_LC7461, 0x2468DCB56A9, kSanyoLC7461Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
+  EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
+  EXPECT_EQ(0x2468DCB56A9, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SHARP, 0x7266, kSharpBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SHARP, irsend.capture.decode_type);
+  EXPECT_EQ(kSharpBits, irsend.capture.bits);
+  EXPECT_EQ(0x7266, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SHERWOOD, 0x4BB640BF, kSherwoodBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(NEC, irsend.capture.decode_type);
+  EXPECT_EQ(kSherwoodBits, irsend.capture.bits);
+  EXPECT_EQ(0x4BB640BF, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(SONY, 0x1234, kSony20Bits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(SONY, irsend.capture.decode_type);
+  EXPECT_EQ(kSony20Bits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(TECO, 0x1234, kTecoBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(TECO, irsend.capture.decode_type);
+  EXPECT_EQ(kTecoBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(VESTEL_AC, 0xF4410001FF1201, kVestelACBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(VESTEL_AC, irsend.capture.decode_type);
+  EXPECT_EQ(kVestelACBits, irsend.capture.bits);
+  EXPECT_EQ(0xF4410001FF1201, irsend.capture.value);
+
+  irsend.reset();
+  ASSERT_TRUE(irsend.send(WHYNTER, 0x1234, kWhynterBits));
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(WHYNTER, irsend.capture.decode_type);
+  EXPECT_EQ(kWhynterBits, irsend.capture.bits);
+  EXPECT_EQ(0x1234, irsend.capture.value);
+}
+
+// Test some expected types to  NOT work/produce a message via irsend:send()
+TEST(TestSend, GenericSimpleSendMethodFailure) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  // Check nothing is sent for unexpected protocols
+  irsend.reset();
+  ASSERT_FALSE(irsend.send(KELVINATOR, 0x1234, kKelvinatorBits));
+  irsend.makeDecodeResult();
+  ASSERT_FALSE(irrecv.decode(&irsend.capture));
+
+  // For every A/C protocol which decodes to having a state[].
+  for (int i = 0; i < 200; i++) {
+    if (hasACState((decode_type_t)i) && i != GREE) {  // Gree is an exception.
+      // Check it fails.
+      ASSERT_FALSE(irsend.send((decode_type_t)i, 0, 0));
+    }
+  }
+
+  // Test some other special cases.
+  ASSERT_FALSE(irsend.send(UNKNOWN, 0, 0));
+  ASSERT_FALSE(irsend.send(UNUSED, 0, 0));
+  ASSERT_FALSE(irsend.send(RAW, 0, 0));
+  ASSERT_FALSE(irsend.send(PRONTO, 0, 0));
+  ASSERT_FALSE(irsend.send(GLOBALCACHE, 0, 0));
 }


### PR DESCRIPTION
- Add missing simple (single integer) IR protocols.
- Sort the switch statement alphabetically.

Fixes #628