### PR TITLE
 [BUG] Fix Coolix A/C Class to handle special states better.

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -130,7 +130,11 @@ void IRCoolixAC::updateSavedState(void) {
 }
 
 void IRCoolixAC::recoverSavedState(void) {
+  // If the current state is a special one, last known normal one.
   if (isSpecialState()) remote_state = saved_state;
+  // If the saved_state was also a special state, reset as we expect a normal
+  // state out of all this.
+  if (isSpecialState()) stateReset();
 }
 
 uint32_t IRCoolixAC::getNormalState(void) {

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -93,7 +93,7 @@ void IRsend::sendCOOLIX(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   https://github.com/markszabo/IRremoteESP8266/issues/484
 IRCoolixAC::IRCoolixAC(uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRCoolixAC::stateReset() { remote_state = kCoolixDefaultState; }
+void IRCoolixAC::stateReset() { setRaw(kCoolixDefaultState); }
 
 void IRCoolixAC::begin() { _irsend.begin(); }
 
@@ -105,15 +105,46 @@ void IRCoolixAC::send(const uint16_t repeat) {
 
 uint32_t IRCoolixAC::getRaw() { return remote_state; }
 
-void IRCoolixAC::setRaw(const uint32_t new_code) { remote_state = new_code; }
+void IRCoolixAC::setRaw(const uint32_t new_code) {
+  remote_state = new_code;
+  saved_state = new_code;
+}
+
+// Return true if the current state is a special state.
+bool IRCoolixAC::isSpecialState(void) {
+  switch (remote_state) {
+    case kCoolixClean:
+    case kCoolixLed:
+    case kCoolixOff:
+    case kCoolixSwing:
+    case kCoolixSleep:
+    case kCoolixTurbo:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void IRCoolixAC::updateSavedState(void) {
+  if (!isSpecialState()) saved_state = remote_state;
+}
+
+void IRCoolixAC::recoverSavedState(void) {
+  if (isSpecialState()) remote_state = saved_state;
+}
+
+uint32_t IRCoolixAC::getNormalState(void) {
+  return isSpecialState() ? saved_state : remote_state;
+}
 
 void IRCoolixAC::setTempRaw(const uint8_t code) {
+  recoverSavedState();
   remote_state &= ~kCoolixTempMask;  // Clear the old temp.
   remote_state |= (code << 4);
 }
 
 uint8_t IRCoolixAC::getTempRaw() {
-  return (remote_state & kCoolixTempMask) >> 4;
+  return (getNormalState() & kCoolixTempMask) >> 4;
 }
 
 void IRCoolixAC::setTemp(const uint8_t desired) {
@@ -132,6 +163,7 @@ uint8_t IRCoolixAC::getTemp() {
 }
 
 void IRCoolixAC::setSensorTempRaw(const uint8_t code) {
+  recoverSavedState();
   remote_state &= ~kCoolixSensorTempMask;  // Clear previous sensor temp.
   remote_state |= ((code & 0xF) << 8);
 }
@@ -145,7 +177,8 @@ void IRCoolixAC::setSensorTemp(const uint8_t desired) {
 }
 
 uint8_t IRCoolixAC::getSensorTemp() {
-  return ((remote_state & kCoolixSensorTempMask) >> 8) + kCoolixSensorTempMin;
+  return ((getNormalState() & kCoolixSensorTempMask) >> 8) +
+         kCoolixSensorTempMin;
 }
 
 bool IRCoolixAC::getPower() {
@@ -154,25 +187,35 @@ bool IRCoolixAC::getPower() {
 }
 
 void IRCoolixAC::setPower(const bool power) {
-  if (!power) remote_state = kCoolixOff;
-  // There really is no distinct "on" setting, so do nothing.
+  if (power) {
+    // There really is no distinct "on" setting, just ensure it a normal state.
+    recoverSavedState();
+  } else {
+    updateSavedState();
+    remote_state = kCoolixOff;
+  }
 }
 
 bool IRCoolixAC::getSwing() { return remote_state == kCoolixSwing; }
 
 void IRCoolixAC::setSwing() {
   // Assumes that repeated sending "swing" toggles the action on the device.
+  updateSavedState();
   remote_state = kCoolixSwing;
 }
 
 bool IRCoolixAC::getSleep() { return remote_state == kCoolixSleep; }
 
-void IRCoolixAC::setSleep() { remote_state = kCoolixSleep; }
+void IRCoolixAC::setSleep() {
+  updateSavedState();
+  remote_state = kCoolixSleep;
+}
 
 bool IRCoolixAC::getTurbo() { return remote_state == kCoolixTurbo; }
 
 void IRCoolixAC::setTurbo() {
   // Assumes that repeated sending "turbo" toggles the action on the device.
+  updateSavedState();
   remote_state = kCoolixTurbo;
 }
 
@@ -180,19 +223,24 @@ bool IRCoolixAC::getLed() { return remote_state == kCoolixLed; }
 
 void IRCoolixAC::setLed() {
   // Assumes that repeated sending "Led" toggles the action on the device.
+  updateSavedState();
   remote_state = kCoolixLed;
 }
 
 bool IRCoolixAC::getClean() { return remote_state == kCoolixClean; }
 
-void IRCoolixAC::setClean() { remote_state = kCoolixClean; }
+void IRCoolixAC::setClean() {
+  updateSavedState();
+  remote_state = kCoolixClean;
+}
 
 bool IRCoolixAC::getZoneFollow() {
-  return remote_state & kCoolixZoneFollowMask;
+  return getNormalState() & kCoolixZoneFollowMask;
 }
 
 // Internal use only.
 void IRCoolixAC::setZoneFollow(bool state) {
+  recoverSavedState();
   if (state) {
     remote_state |= kCoolixZoneFollowMask;
   } else {
@@ -201,6 +249,7 @@ void IRCoolixAC::setZoneFollow(bool state) {
 }
 
 void IRCoolixAC::clearSensorTemp() {
+  recoverSavedState();
   setZoneFollow(false);
   setSensorTempRaw(kCoolixSensorTempIgnoreCode);
 }
@@ -214,6 +263,7 @@ void IRCoolixAC::setMode(const uint8_t mode) {
     case kCoolixAuto:
     case kCoolixHeat:
     case kCoolixDry:
+      recoverSavedState();
       remote_state = (remote_state & ~kCoolixModeMask) | (actualmode << 2);
       // Force the temp into a known-good state.
       setTemp(getTemp());
@@ -222,15 +272,18 @@ void IRCoolixAC::setMode(const uint8_t mode) {
 }
 
 uint8_t IRCoolixAC::getMode() {
-  uint8_t mode = (remote_state & kCoolixModeMask) >> 2;
+  uint8_t mode = (getNormalState() & kCoolixModeMask) >> 2;
   if (mode == kCoolixDry)
     if (getTempRaw() == kCoolixFanTempCode) return kCoolixFan;
   return mode;
 }
 
-uint8_t IRCoolixAC::getFan() { return (remote_state & kCoolixFanMask) >> 13; }
+uint8_t IRCoolixAC::getFan() {
+  return (getNormalState() & kCoolixFanMask) >> 13;
+}
 
 void IRCoolixAC::setFan(const uint8_t speed) {
+  recoverSavedState();
   uint8_t newspeed = speed;
   switch (speed) {
     case kCoolixFanMin:
@@ -263,6 +316,47 @@ std::string IRCoolixAC::toString() {
     result += "Off";
     return result;  // If it's off, there is no other info.
   }
+  // Special modes.
+  if (getSwing()) {
+    result += ", Swing: Toggle";
+    return result;
+  }
+  if (getSleep()) {
+    result += ", Sleep: Toggle";
+    return result;
+  }
+  if (getTurbo()) {
+    result += ", Turbo: Toggle";
+    return result;
+  }
+  if (getLed()) {
+    result += ", Led: Toggle";
+    return result;
+  }
+  if (getClean()) {
+    result += ", Clean: Toggle";
+    return result;
+  }
+  result += ", Mode: " + uint64ToString(getMode());
+  switch (getMode()) {
+    case kCoolixAuto:
+      result += " (AUTO)";
+      break;
+    case kCoolixCool:
+      result += " (COOL)";
+      break;
+    case kCoolixHeat:
+      result += " (HEAT)";
+      break;
+    case kCoolixDry:
+      result += " (DRY)";
+      break;
+    case kCoolixFan:
+      result += " (FAN)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
   result += ", Fan: " + uint64ToString(getFan());
   switch (getFan()) {
     case kCoolixFanAuto:
@@ -285,47 +379,6 @@ std::string IRCoolixAC::toString() {
       break;
     case kCoolixFanFixed:
       result += " (FIXED)";
-      break;
-    default:
-      result += " (UNKNOWN)";
-  }
-  // Special modes.
-  if (getSwing()) {
-    result += ", Swing: Toggle";
-    return result;
-  }
-  if (getSleep()) {
-    result += ", Sleep: Toggle";
-    return result;
-  }
-  if (getTurbo()) {
-    result += ", Turbo: Toggle";
-    return result;
-  }
-  if (getLed()) {
-    result += ", Led: Toggle";
-    return result;
-  }
-  if (getClean()) {
-    result += ", Mode: Self clean";
-    return result;
-  }
-  result += ", Mode: " + uint64ToString(getMode());
-  switch (getMode()) {
-    case kCoolixAuto:
-      result += " (AUTO)";
-      break;
-    case kCoolixCool:
-      result += " (COOL)";
-      break;
-    case kCoolixHeat:
-      result += " (HEAT)";
-      break;
-    case kCoolixDry:
-      result += " (DRY)";
-      break;
-    case kCoolixFan:
-      result += " (FAN)";
       break;
     default:
       result += " (UNKNOWN)";

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -128,13 +128,17 @@ class IRCoolixAC {
 #endif
 
  private:
-  // The state of the IR remote in IR code form.
-  uint32_t remote_state;
+  uint32_t remote_state; // The state of the IR remote in IR code form.
+  uint32_t saved_state;  // Copy of the state if we required a special mode.
   IRsend _irsend;
   void setTempRaw(const uint8_t code);
   uint8_t getTempRaw();
   void setSensorTempRaw(const uint8_t code);
   void setZoneFollow(const bool state);
+  bool isSpecialState(void);
+  void updateSavedState(void);
+  void recoverSavedState(void);
+  uint32_t getNormalState(void);
 };
 
 #endif  // IR_COOLIX_H_

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -128,8 +128,8 @@ class IRCoolixAC {
 #endif
 
  private:
-  uint32_t remote_state; // The state of the IR remote in IR code form.
-  uint32_t saved_state;  // Copy of the state if we required a special mode.
+  uint32_t remote_state;  // The state of the IR remote in IR code form.
+  uint32_t saved_state;   // Copy of the state if we required a special mode.
   IRsend _irsend;
   void setTempRaw(const uint8_t code);
   uint8_t getTempRaw();

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -530,4 +530,17 @@ TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
       "Sensor Temp: Ignored",
       ac.toString());
   EXPECT_EQ(0xB2BF40, ac.getRaw());
+
+  // Now test if we setRaw() a special state first.
+  ac.setRaw(kCoolixSwing);
+  // Repeat change of settings.
+  ac.setPower(true);
+  ac.setTemp(24);
+  ac.setMode(kCoolixCool);
+  ac.setFan(kCoolixFanAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Fan: 5 (AUTO), Temp: 24C, Zone Follow: Off, "
+      "Sensor Temp: Ignored",
+      ac.toString());
+  EXPECT_EQ(0xB2BF40, ac.getRaw());
 }

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -411,7 +411,7 @@ TEST(TestCoolixACClass, HumanReadable) {
 
   // Initial starting point.
   EXPECT_EQ(
-      "Power: On, Fan: 5 (AUTO), Mode: 2 (AUTO), Temp: 25C, "
+      "Power: On, Mode: 2 (AUTO), Fan: 5 (AUTO), Temp: 25C, "
       "Zone Follow: Off, Sensor Temp: Ignored",
       ircoolix.toString());
 
@@ -420,11 +420,11 @@ TEST(TestCoolixACClass, HumanReadable) {
   ircoolix.setMode(kCoolixCool);
   ircoolix.setFan(kCoolixFanMin);
   EXPECT_EQ(
-      "Power: On, Fan: 4 (MIN), Mode: 0 (COOL), Temp: 22C, "
+      "Power: On, Mode: 0 (COOL), Fan: 4 (MIN), Temp: 22C, "
       "Zone Follow: On, Sensor Temp: 24C",
       ircoolix.toString());
   ircoolix.setSwing();
-  EXPECT_EQ("Power: On, Fan: 3 (UNKNOWN), Swing: Toggle", ircoolix.toString());
+  EXPECT_EQ("Power: On, Swing: Toggle", ircoolix.toString());
   ircoolix.setPower(false);
   EXPECT_EQ("Power: Off", ircoolix.toString());
 }
@@ -434,12 +434,12 @@ TEST(TestCoolixACClass, KnownExamples) {
 
   ircoolix.setRaw(0b101100101011111111100100);
   EXPECT_EQ(
-      "Power: On, Fan: 5 (AUTO), Mode: 4 (FAN), Zone Follow: Off, "
+      "Power: On, Mode: 4 (FAN), Fan: 5 (AUTO), Zone Follow: Off, "
       "Sensor Temp: Ignored",
       ircoolix.toString());
   ircoolix.setRaw(0b101100101001111100000000);
   EXPECT_EQ(
-      "Power: On, Fan: 4 (MIN), Mode: 0 (COOL), Temp: 17C, "
+      "Power: On, Mode: 0 (COOL), Fan: 4 (MIN), Temp: 17C, "
       "Zone Follow: Off, Sensor Temp: Ignored",
       ircoolix.toString());
 }
@@ -449,7 +449,7 @@ TEST(TestCoolixACClass, Issue579FanAuto0) {
 
   ircoolix.setRaw(0xB21F28);
   EXPECT_EQ(
-      "Power: On, Fan: 0 (AUTO0), Mode: 2 (AUTO), Temp: 20C, "
+      "Power: On, Mode: 2 (AUTO), Fan: 0 (AUTO0), Temp: 20C, "
       "Zone Follow: Off, Sensor Temp: Ignored",
       ircoolix.toString());
 }
@@ -490,4 +490,44 @@ TEST(TestCoolixACClass, RealCaptureExample) {
   EXPECT_EQ(kCoolixOff, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
+}
+
+
+// Tests to debug/fix:
+//   https://github.com/markszabo/IRremoteESP8266/issues/624
+TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
+  IRCoolixAC ac(0);
+  ac.begin();
+  // Default
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (AUTO), Fan: 5 (AUTO), Temp: 25C, Zone Follow: Off, "
+      "Sensor Temp: Ignored",
+      ac.toString());
+  EXPECT_EQ(0xB2BFC8, ac.getRaw());
+  // Change of settings.
+  ac.setPower(true);
+  ac.setTemp(24);
+  ac.setMode(kCoolixCool);
+  ac.setFan(kCoolixFanAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Fan: 5 (AUTO), Temp: 24C, Zone Follow: Off, "
+      "Sensor Temp: Ignored",
+      ac.toString());
+  EXPECT_EQ(0xB2BF40, ac.getRaw());
+  // Turn the unit off.
+  ac.setPower(false);
+  EXPECT_EQ(
+      "Power: Off",
+      ac.toString());
+  EXPECT_EQ(kCoolixOff, ac.getRaw());
+  // Repeat change of settings.
+  ac.setPower(true);
+  ac.setTemp(24);
+  ac.setMode(kCoolixCool);
+  ac.setFan(kCoolixFanAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Fan: 5 (AUTO), Temp: 24C, Zone Follow: Off, "
+      "Sensor Temp: Ignored",
+      ac.toString());
+  EXPECT_EQ(0xB2BF40, ac.getRaw());
 }


### PR DESCRIPTION
The Coolix A/C message has a number of special-case states, the class
object didn't handle those cases well.
* Add a saved state to store normal messages when we are asked to send a
  special state message. e.g. off, swing, clean, turbo, sleep, led.
* Change order of output in toString() to handle those cases better.
* Other cosmetic improvements.
* Unit test to cover this situation.

For Issue #624