### PR TITLE
Set Daikin2 modulation to 36.7kHz.

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -755,18 +755,18 @@ void IRsend::sendDaikin2(unsigned char data[], uint16_t nbytes,
     // Leader
     sendGeneric(kDaikin2LeaderMark, kDaikin2LeaderSpace,
                 0, 0, 0, 0, 0, 0, (uint64_t) 0,  // No data payload.
-                0, 38000, false, 0, 50);
+                0, kDaikin2Freq, false, 0, 50);
     // Section #1
     sendGeneric(kDaikin2HdrMark, kDaikin2HdrSpace, kDaikin2BitMark,
                 kDaikin2OneSpace, kDaikin2BitMark, kDaikin2ZeroSpace,
                 kDaikin2BitMark, kDaikin2Gap, data, kDaikin2Section1Length,
-                38000, false, 0, 50);
+                kDaikin2Freq, false, 0, 50);
     // Section #2
     sendGeneric(kDaikin2HdrMark, kDaikin2HdrSpace, kDaikin2BitMark,
                 kDaikin2OneSpace, kDaikin2BitMark, kDaikin2ZeroSpace,
                 kDaikin2BitMark, kDaikin2Gap, data + kDaikin2Section1Length,
                 nbytes - kDaikin2Section1Length,
-                38000, false, 0, 50);
+                kDaikin2Freq, false, 0, 50);
   }
 }
 #endif  // SEND_DAIKIN2

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -128,6 +128,7 @@ const uint64_t kDaikinFirstHeader64 =
     0b1101011100000000000000001100010100000000001001111101101000010001;
 
 // Another variant of the protocol for the Daikin ARC477A1 remote.
+const uint16_t kDaikin2Freq = 36700;  // Modulation Frequency in Hz.
 const uint16_t kDaikin2LeaderMark = 10024;
 const uint16_t kDaikin2LeaderSpace = 25180;
 const uint16_t kDaikin2Gap = kDaikin2LeaderMark + kDaikin2LeaderSpace;


### PR DESCRIPTION
@sheppy99 checked an actual remote and it transmits between 36.5-36.9kHz.
36.7kHz is a standard/common modulation frequency used (e.g. Panasonic) and
directly in the middle of that range.

Ref: https://github.com/markszabo/IRremoteESP8266/pull/600#issuecomment-472190940