### PR TITLE
Improve Daikin2 power on/off.

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -866,10 +866,12 @@ void IRDaikin2::setRaw(const uint8_t new_code[]) {
 
 void IRDaikin2::on() {
   remote_state[25] |= kDaikinBitPower;
+  remote_state[6] &= ~kDaikin2BitPower;
 }
 
 void IRDaikin2::off() {
   remote_state[25] &= ~kDaikinBitPower;
+  remote_state[6] |= kDaikin2BitPower;
 }
 
 void IRDaikin2::setPower(const bool state) {
@@ -880,7 +882,8 @@ void IRDaikin2::setPower(const bool state) {
 }
 
 bool IRDaikin2::getPower() {
-  return (remote_state[25] & kDaikinBitPower);
+  return (remote_state[25] & kDaikinBitPower) &&
+         !(remote_state[6] & kDaikin2BitPower);
 }
 
 uint8_t IRDaikin2::getMode() { return remote_state[25] >> 4; }

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -150,6 +150,7 @@ const uint8_t kDaikin2BitMold = 0b00001000;
 const uint8_t kDaikin2BitClean = 0b00100000;
 const uint8_t kDaikin2BitFreshAir = 0b00000001;
 const uint8_t kDaikin2BitFreshAirHigh = 0b10000000;
+const uint8_t kDaikin2BitPower = 0b10000000;
 const uint8_t kDaikin2LightMask = 0b00110000;
 const uint8_t kDaikin2BeepMask = 0b11000000;
 const uint8_t kDaikin2SwingVHigh = 0x1;


### PR DESCRIPTION
According to @sheppy99 in #644, power on/off control also depends on the
MSB of state[6]. i.e. MSB = 1 (off), MSB = 0 (on)