### PR TITLE
Change per byte bit-order in Electra protocol.

### DIFF
--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 David Conran
+// Copyright 2018, 2019 David Conran
 
 #include "IRrecv.h"
 #include "IRsend.h"
@@ -17,6 +17,7 @@
 
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/527
+//   https://github.com/markszabo/IRremoteESP8266/issues/642
 
 // Constants
 const uint16_t kElectraAcHdrMark = 9166;
@@ -42,7 +43,8 @@ void IRsend::sendElectraAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
                 kElectraAcOneSpace, kElectraAcBitMark, kElectraAcZeroSpace,
                 kElectraAcBitMark, kElectraAcMessageGap, data, nbytes,
                 38000,  // Complete guess of the modulation frequency.
-                true, 0, 50);
+                false,  // Send data in LSB order per byte
+                0, 50);
 }
 #endif
 
@@ -56,7 +58,7 @@ void IRsend::sendElectraAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: Alpha / Needs testing against a real device.
+// Status: Beta / Probably works.
 //
 bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
                              bool strict) {
@@ -68,8 +70,6 @@ bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
       return false;  // Not strictly a ELECTRA_AC message.
   }
 
-  // The protocol sends the data normal + inverted, alternating on
-  // each byte. Hence twice the number of expected data bits.
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;  // Can't possibly be a valid ELECTRA_AC message.
 
@@ -87,7 +87,7 @@ bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
        i++, dataBitsSoFar += 8, offset += data_result.used) {
     data_result = matchData(&(results->rawbuf[offset]), 8, kElectraAcBitMark,
                             kElectraAcOneSpace, kElectraAcBitMark,
-                            kElectraAcZeroSpace, kTolerance, 0, true);
+                            kElectraAcZeroSpace, kTolerance, 0, false);
     if (data_result.success == false) return false;  // Fail
     results->state[i] = data_result.data;
   }
@@ -99,7 +99,12 @@ bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
     return false;
 
   // Compliance
-  if (strict && dataBitsSoFar != nbits) return false;
+  if (strict) {
+    if (dataBitsSoFar != nbits) return false;
+    // Verify the checksum.
+    if (sumBytes(results->state, (dataBitsSoFar / 8) - 1) !=
+        results->state[(dataBitsSoFar / 8) - 1]) return false;
+  }
 
   // Success
   results->decode_type = ELECTRA_AC;

--- a/test/ir_Electra_test.cpp
+++ b/test/ir_Electra_test.cpp
@@ -12,9 +12,9 @@
 TEST(TestSendElectraAC, SendDataOnly) {
   IRsendTest irsend(0);
   irsend.begin();
-  uint8_t data[kElectraAcStateLength] = {0xC3, 0xE1, 0x6F, 0x14, 0x06,
-                                         0x00, 0x04, 0x00, 0x00, 0x04,
-                                         0x00, 0xA0, 0xB0};
+  uint8_t data[kElectraAcStateLength] = {0xC3, 0x87, 0xF6, 0x28, 0x60,
+                                         0x00, 0x20, 0x00, 0x00, 0x20,
+                                         0x00, 0x05, 0x0D};
 
   irsend.sendElectraAC(data);
   EXPECT_EQ(
@@ -46,9 +46,9 @@ TEST(TestDecodeElectraAC, SyntheticDecode) {
 
   // Synthesised Normal ElectraAC message.
   irsend.reset();
-  uint8_t expectedState[kElectraAcStateLength] = {0xC3, 0xE1, 0x6F, 0x14, 0x06,
-                                                  0x00, 0x04, 0x00, 0x00, 0x04,
-                                                  0x00, 0xA0, 0xB0};
+  uint8_t expectedState[kElectraAcStateLength] = {0xC3, 0x87, 0xF6, 0x28, 0x60,
+                                                  0x00, 0x20, 0x00, 0x00, 0x20,
+                                                  0x00, 0x05, 0x0D};
   irsend.sendElectraAC(expectedState);
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
@@ -84,9 +84,9 @@ TEST(TestDecodeElectraAC, RealExampleDecode) {
       662,  562,  642, 1686, 582, 570,  634, 566,  604, 576,  636, 566,
       610,  578,  634, 1664, 584, 590,  660, 1636, 610, 1642, 664, 590,
       610,  590,  636, 566,  634, 568,  686};  // UNKNOWN 9AD8CDB5
-  uint8_t expectedState[kElectraAcStateLength] = {0xC3, 0xE1, 0x6F, 0x14, 0x06,
-                                                  0x00, 0x04, 0x00, 0x00, 0x04,
-                                                  0x00, 0xA0, 0xB0};
+  uint8_t expectedState[kElectraAcStateLength] = {0xC3, 0x87, 0xF6, 0x28, 0x60,
+                                                  0x00, 0x20, 0x00, 0x00, 0x20,
+                                                  0x00, 0x05, 0x0D};
 
   irsend.reset();
   irsend.sendRaw(rawData, 211, 38000);


### PR DESCRIPTION
- The per byte bit ordering needs to be reversed. This will **break** existing usage.
- Add checksum calculation/verification to `decodeElectraAC()`
- Update unit tests accordingly.

Ref #642