### PR TITLE
Add Panasonic AC RKR model & Example

### DIFF
--- a/.github/Contributors.md
+++ b/.github/Contributors.md
@@ -13,6 +13,7 @@
 - [Denes Varga](https://github.com/denxhun/)
 - [Brett T. Warden](https://github.com/bwarden/)
 - [Fabien Valthier](https://github.com/hcoohb)
+- [Ajay Pala](https://github.com/ajaypala/)
 
 All contributors can be found on the [contributors site](https://github.com/markszabo/IRremoteESP8266/graphs/contributors).
 

--- a/examples/TurnOnPanasonicAC/TurnOnPanasonicAC.ino
+++ b/examples/TurnOnPanasonicAC/TurnOnPanasonicAC.ino
@@ -1,0 +1,74 @@
+/* Copyright 2017, 2018 David Conran
+*
+* An IR LED circuit *MUST* be connected to the ESP8266 on a pin
+* as specified by kIrLed below.
+*
+* TL;DR: The IR LED needs to be driven by a transistor for a good result.
+*
+* Suggested circuit:
+*     https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
+*
+* Common mistakes & tips:
+*   * Don't just connect the IR LED directly to the pin, it won't
+*     have enough current to drive the IR LED effectively.
+*   * Make sure you have the IR LED polarity correct.
+*     See: https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity
+*   * Typical digital camera/phones can be used to see if the IR LED is flashed.
+*     Replace the IR LED with a normal LED if you don't have a digital camera
+*     when debugging.
+*   * Avoid using the following pins unless you really know what you are doing:
+*     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
+*     * Pin 1/TX/TXD0: Any serial transmissions from the ESP8266 will interfere.
+*     * Pin 3/RX/RXD0: Any serial transmissions to the ESP8266 will interfere.
+*   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
+*     for your first time. e.g. ESP-12 etc.
+*/
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include <IRremoteESP8266.h>
+#include <IRsend.h>
+#include <ir_Panasonic.h>
+
+const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
+IRPanasonicAc ac(kIrLed);  // Set the GPIO used for sending messages.
+
+void printState() {
+  // Display the settings.
+  Serial.println("Panasonic A/C remote is in the following state:");
+  Serial.printf("  %s\n", ac.toString().c_str());
+  // Display the encoded IR sequence.
+  unsigned char* ir_code = ac.getRaw();
+  Serial.print("IR Code: 0x");
+  for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)
+    Serial.printf("%02X", ir_code[i]);
+  Serial.println();
+}
+
+void setup() {
+  ac.begin();
+  Serial.begin(115200);
+  delay(200);
+
+  // Set up what we want to send. See ir_Panasonic.cpp for all the options.
+  Serial.println("Default state of the remote.");
+  printState();
+  Serial.println("Setting desired state for A/C.");
+  ac.setModel(kPanasonicRkr);
+  ac.on();
+  ac.setFan(kPanasonicAcFanAuto);
+  ac.setMode(kPanasonicAcCool);
+  ac.setTemp(26);
+  ac.setSwingVertical(kPanasonicAcSwingVAuto);
+  ac.setSwingHorizontal(kPanasonicAcSwingHAuto);
+}
+
+void loop() {
+  // Now send the IR signal.
+#if SEND_PANASONIC_AC
+  Serial.println("Sending IR command to A/C ...");
+  ac.send();
+#endif  // SEND_PANASONIC_AC
+  printState();
+  delay(5000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1527,6 +1527,7 @@ kPanasonicMinGapTicks	LITERAL1
 kPanasonicNke	LITERAL1
 kPanasonicOneSpace	LITERAL1
 kPanasonicOneSpaceTicks	LITERAL1
+kPanasonicRkr	LITERAL1
 kPanasonicTick	LITERAL1
 kPanasonicUnknown	LITERAL1
 kPanasonicZeroSpace	LITERAL1

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -27,8 +27,8 @@
 //   Code by crankyoldgit
 // Panasonic A/C models supported:
 //   A/C Series/models:
-//     JKE, LKE, DKE, CKP, & NKE series. (In theory)
-//     CS-YW9MKD (confirmed)
+//     JKE, LKE, DKE, CKP, RKR, & NKE series. (In theory)
+//     CS-YW9MKD, CS-Z9RKR (confirmed)
 //     CS-ME14CKPG / CS-ME12CKPG / CS-ME10CKPG
 //   A/C Remotes:
 //     A75C3747 (confirmed)
@@ -211,7 +211,7 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
 //:
 // Panasonic A/C models supported:
 //   A/C Series/models:
-//     JKE, LKE, DKE, & NKE series.
+//     JKE, LKE, DKE, CKP, RKR, & NKE series.
 //     CS-YW9MKD
 //   A/C Remotes:
 //     A75C3747
@@ -281,6 +281,7 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
     case kPanasonicLke:
     case kPanasonicNke:
     case kPanasonicCkp:
+    case kPanasonicRkr:
       break;
     default:  // Only proceed if we know what to do.
       return;
@@ -311,12 +312,17 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
     case kPanasonicCkp:
       remote_state[21] |= 0x10;
       remote_state[23] = 0x01;
+      break;
+    case kPanasonicRkr:
+      remote_state[13] |= 0x08;
+      remote_state[23] = 0x89;
     default:
       break;
   }
 }
 
 panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
+  if (remote_state[23] == 0x89) return kPanasonicRkr;
   if (remote_state[17] == 0x00) {
     if ((remote_state[21] & 0x10) && (remote_state[23] & 0x01))
       return kPanasonicCkp;
@@ -438,6 +444,7 @@ void IRPanasonicAc::setSwingHorizontal(const uint8_t desired_direction) {
   uint8_t direction = desired_direction;
   switch (getModel()) {
     case kPanasonicDke:
+    case kPanasonicRkr:
       break;
     case kPanasonicNke:
     case kPanasonicLke:
@@ -621,6 +628,9 @@ std::string IRPanasonicAc::toString() {
       break;
     case kPanasonicCkp:
       result += " (CKP)";
+      break;
+    case kPanasonicRkr:
+      result += " (RKR)";
       break;
     default:
       result += " (UNKNOWN)";

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -467,7 +467,7 @@ uint8_t IRPanasonicAc::getFan() {
 }
 
 bool IRPanasonicAc::getQuiet() {
-  switch(getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return remote_state[21] & kPanasonicAcQuietCkp;
@@ -478,7 +478,7 @@ bool IRPanasonicAc::getQuiet() {
 
 void IRPanasonicAc::setQuiet(const bool state) {
   uint8_t quiet;
-  switch(getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       quiet = kPanasonicAcQuietCkp;
@@ -496,7 +496,7 @@ void IRPanasonicAc::setQuiet(const bool state) {
 }
 
 bool IRPanasonicAc::getPowerful() {
-  switch(getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return remote_state[21] & kPanasonicAcPowerfulCkp;
@@ -507,7 +507,7 @@ bool IRPanasonicAc::getPowerful() {
 
 void IRPanasonicAc::setPowerful(const bool state) {
   uint8_t powerful;
-  switch(getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       powerful = kPanasonicAcPowerfulCkp;

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -467,18 +467,25 @@ uint8_t IRPanasonicAc::getFan() {
 }
 
 bool IRPanasonicAc::getQuiet() {
-  if (getModel() == kPanasonicCkp)
-    return remote_state[21] & kPanasonicAcQuietCkp;
-  else
-    return remote_state[21] & kPanasonicAcQuiet;
+  switch(getModel()) {
+    case kPanasonicRkr:
+    case kPanasonicCkp:
+      return remote_state[21] & kPanasonicAcQuietCkp;
+    default:
+      return remote_state[21] & kPanasonicAcQuiet;
+  }
 }
 
 void IRPanasonicAc::setQuiet(const bool state) {
   uint8_t quiet;
-  if (getModel() == kPanasonicCkp)
-    quiet = kPanasonicAcQuietCkp;
-  else
-    quiet = kPanasonicAcQuiet;
+  switch(getModel()) {
+    case kPanasonicRkr:
+    case kPanasonicCkp:
+      quiet = kPanasonicAcQuietCkp;
+      break;
+    default:
+      quiet = kPanasonicAcQuiet;
+  }
 
   if (state) {
     setPowerful(false);  // Powerful is mutually exclusive.
@@ -489,18 +496,25 @@ void IRPanasonicAc::setQuiet(const bool state) {
 }
 
 bool IRPanasonicAc::getPowerful() {
-  if (getModel() == kPanasonicCkp)
-    return remote_state[21] & kPanasonicAcPowerfulCkp;
-  else
-    return remote_state[21] & kPanasonicAcPowerful;
+  switch(getModel()) {
+    case kPanasonicRkr:
+    case kPanasonicCkp:
+      return remote_state[21] & kPanasonicAcPowerfulCkp;
+    default:
+      return remote_state[21] & kPanasonicAcPowerful;
+  }
 }
 
 void IRPanasonicAc::setPowerful(const bool state) {
   uint8_t powerful;
-  if (getModel() == kPanasonicCkp)
-    powerful = kPanasonicAcPowerfulCkp;
-  else
-    powerful = kPanasonicAcPowerful;
+  switch(getModel()) {
+    case kPanasonicRkr:
+    case kPanasonicCkp:
+      powerful = kPanasonicAcPowerfulCkp;
+      break;
+    default:
+      powerful = kPanasonicAcPowerful;
+  }
 
   if (state) {
     setQuiet(false);  // Quiet is mutually exclusive.

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -43,7 +43,7 @@ const uint8_t kPanasonicAcMaxTemp = 30;      // Celsius
 const uint8_t kPanasonicAcFanModeTemp = 27;  // Celsius
 const uint8_t kPanasonicAcQuiet = 1;         // 0b1
 const uint8_t kPanasonicAcPowerful = 0x20;   // 0b100000
-// CKP models have Powerful and Quiet bits swapped.
+// CKP & RKR models have Powerful and Quiet bits swapped.
 const uint8_t kPanasonicAcQuietCkp = 0x20;  // 0b100000
 const uint8_t kPanasonicAcPowerfulCkp = 1;  // 0b1
 const uint8_t kPanasonicAcSwingVAuto = 0xF;

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -73,6 +73,7 @@ enum panasonic_ac_remote_model_t {
   kPanasonicDke = 3,
   kPanasonicJke = 4,
   kPanasonicCkp = 5,
+  kPanasonicRkr = 6,
 };
 
 class IRPanasonicAc {


### PR DESCRIPTION
Added support for my Panasonic AC Model CS-Z9RKR. Following functions are tested and working:
- Mode
- Temperature
- Swing H
- Swing V
- Fan Speed
- Powerful/Quiet

Functions not tested: 
- Clock & Timer functions

Functions not working or implemented:
- iAuto-X
- Econavi  (Not part of state)
- Nanoe-g (Not part of state)
- Mild Dry
