### PR TITLE
Add LEGO(TM) Power Functions IR protocol.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -261,7 +261,7 @@ const uint16_t kMinUnknownSize = 2 * 10;
 // ----------------- End of User Configuration Section -------------------------
 
 // Globals
-#define _MY_VERSION_ "v0.8.4"
+#define _MY_VERSION_ "v0.8.5"
 // HTML arguments we will parse for IR code information.
 #define argType "type"
 #define argData "code"
@@ -451,6 +451,7 @@ void handleRoot() {
         "<option value='43'>GICable</option>"
         "<option value='6'>JVC</option>"
         "<option value='36'>Lasertag</option>"
+        "<option value='58'>LEGOPF</option>"
         "<option value='10'>LG</option>"
         "<option value='51'>LG2</option>"
         "<option value='47'>Lutron</option>"
@@ -1641,6 +1642,13 @@ bool sendIRCode(int const ir_type, uint64_t const code, char const * code_str,
       if (bits == 0)
         bits = kTecoBits;
       irsend.sendTeco(code, bits, repeat);
+      break;
+#endif
+#if SEND_LEGOPF
+    case LEGOPF:  // 58
+      if (bits == 0)
+        bits = kLegoPfBits;
+      irsend.sendLegoPf(code, bits, repeat);
       break;
 #endif
     default:

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -509,6 +509,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting Teco decode");
   if (decodeTeco(results)) return true;
 #endif
+#if DECODE_LEGOPF
+  DPRINTLN("Attempting LEGOPF decode");
+  if (decodeLegoPf(results)) return true;
+#endif
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -351,6 +351,10 @@ class IRrecv {
   bool decodeTeco(decode_results *results, uint16_t nbits = kTecoBits,
                   bool strict = false);
 #endif
+#if DECODE_LEGOPF
+  bool decodeLegoPf(decode_results *results, const uint16_t nbits = kLegoPfBits,
+                    const bool strict = true);
+#endif
 };
 
 #endif  // IRRECV_H_

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -213,8 +213,11 @@
 #define DECODE_TECO            true
 #define SEND_TECO              true
 
-#define DECODE_TCL112AC       true
-#define SEND_TCL112AC         true
+#define DECODE_TCL112AC        true
+#define SEND_TCL112AC          true
+
+#define DECODE_LEGOPF          true
+#define SEND_LEGOPF            true
 
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
@@ -299,6 +302,7 @@ enum decode_type_t {
   TECO,  // (55)
   SAMSUNG36,
   TCL112AC,
+  LEGOPF,
 };
 
 // Message lengths & required repeat values
@@ -356,6 +360,8 @@ const uint16_t kKelvinatorBits = kKelvinatorStateLength * 8;
 const uint16_t kKelvinatorDefaultRepeat = kNoRepeat;
 const uint16_t kLasertagBits = 13;
 const uint16_t kLasertagMinRepeat = kNoRepeat;
+const uint16_t kLegoPfBits = 16;
+const uint16_t kLegoPfMinRepeat = kNoRepeat;
 const uint16_t kLgBits = 28;
 const uint16_t kLg32Bits = 32;
 const uint16_t kLutronBits = 35;
@@ -422,7 +428,7 @@ const uint16_t kWhirlpoolAcStateLength = 21;
 const uint16_t kWhirlpoolAcBits = kWhirlpoolAcStateLength * 8;
 const uint16_t kWhirlpoolAcDefaultRepeat = kNoRepeat;
 const uint16_t kWhynterBits = 32;
-const uint8_t kVestelAcBits = 56;
+const uint8_t  kVestelAcBits = 56;
 
 
 // Legacy defines. (Deprecated)

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -543,6 +543,11 @@ bool IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
       sendLasertag(data, nbits);
       break;
 #endif
+#if SEND_LEGOPF
+    case LEGOPF:
+      sendLegoPf(data, nbits);
+      break;
+#endif
 #if SEND_LG
     case LG:
       sendLG(data, nbits);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -327,6 +327,10 @@ class IRsend {
   void sendTeco(uint64_t data, uint16_t nbits = kTecoBits,
                 uint16_t repeat = kNoRepeat);
 #endif
+#if SEND_LEGOPF
+  void sendLegoPf(const uint64_t data, const uint16_t nbits = kLegoPfBits,
+                  const uint16_t repeat = kLegoPfMinRepeat);
+#endif
 
 
  protected:

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -162,6 +162,9 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case KELVINATOR:
       result = "KELVINATOR";
       break;
+    case LEGOPF:
+      result = "LEGOPF";
+      break;
     case LG:
       result = "LG";
       break;

--- a/src/ir_Lego.cpp
+++ b/src/ir_Lego.cpp
@@ -1,0 +1,128 @@
+// Copyright 2019 David Conran
+
+#include <algorithm>
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRutils.h"
+
+// LEGO
+// (LEGO is a Registrated Trademark of the Lego Group.)
+//
+// Supported Devices:
+// - LEGO Power Functions IR Receiver
+//
+// Ref:
+// - https://github.com/markszabo/IRremoteESP8266/issues/641
+// - https://github.com/markszabo/IRremoteESP8266/files/2974525/LEGO_Power_Functions_RC_v120.pdf
+
+// Constants
+const uint16_t kLegoPfBitMark = 158;
+const uint16_t kLegoPfHdrSpace = 1026;
+const uint16_t kLegoPfZeroSpace = 263;
+const uint16_t kLegoPfOneSpace = 553;
+const uint32_t kLegoPfMinCommandLength = 16000;  // 16ms
+
+
+#if SEND_LEGOPF
+// Send a LEGO Power Functions message.
+//
+// Args:
+//   data:   Contents of the message to be sent.
+//   nbits:  Nr. of bits of data to be sent. Typically kLegoPfBits.
+//   repeat: Nr. of additional times the message is to be sent.
+//           Note: Non-zero repeats results in at least 5 messages per spec.
+//
+// Status: Beta / Should work.
+void IRsend::sendLegoPf(const uint64_t data, const uint16_t nbits,
+                        const uint16_t repeat) {
+  uint8_t channelid = ((data >> (nbits - 4)) & 0b11) + 1;
+  if (repeat) {
+    // We are in repeat mode.
+    // Spec says a pause before transmittion.
+    if (channelid < 4) space((4 - channelid) * kLegoPfMinCommandLength);
+    // Spec says there are a minimum of 5 message repeats.
+    for (uint16_t r = 0; r < std::max(repeat, (uint16_t)5); r++) {
+      // Lego has a special repeat mode which repeats a message with varying
+      // start to start times.
+      sendGeneric(kLegoPfBitMark, kLegoPfHdrSpace,
+                  kLegoPfBitMark, kLegoPfOneSpace,
+                  kLegoPfBitMark, kLegoPfZeroSpace,
+                  kLegoPfBitMark, kLegoPfHdrSpace,
+                  ((r < 2) ? 5 : (6 + 2 * channelid)) * kLegoPfMinCommandLength,
+                  data, nbits, 38000, true, 0, kDutyDefault);
+    }
+  } else {  // No repeat, just a simple message.
+    sendGeneric(kLegoPfBitMark, kLegoPfHdrSpace,
+                kLegoPfBitMark, kLegoPfOneSpace,
+                kLegoPfBitMark, kLegoPfZeroSpace,
+                kLegoPfBitMark, kLegoPfHdrSpace,
+                kLegoPfMinCommandLength * 5,
+                data, nbits, 38000, true, 0, kDutyDefault);
+  }
+}
+#endif  // SEND_LEGO
+
+#if DECODE_LEGOPF
+// Decode the supplied LEGO Power Functions message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically kLegoPfBits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Alpha / Untested.
+bool IRrecv::decodeLegoPf(decode_results* results,
+                          const uint16_t nbits, const bool strict) {
+  // Check if can possibly be a valid LEGO message.
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1) return false;
+  if (strict && nbits != kLegoPfBits) return false;  // Not what is expected
+
+  uint64_t data = 0;
+  uint16_t offset = kStartOffset;
+  match_result_t data_result;
+
+  // Header
+  if (!matchMark(results->rawbuf[offset++], kLegoPfBitMark)) return false;
+  if (!matchSpace(results->rawbuf[offset++], kLegoPfHdrSpace)) return false;
+  // Data (Typically 16 bits)
+  data_result =
+      matchData(&(results->rawbuf[offset]), nbits,
+                kLegoPfBitMark, kLegoPfOneSpace,
+                kLegoPfBitMark, kLegoPfZeroSpace,
+                kTolerance, kMarkExcess, true);
+  if (data_result.success == false) return false;
+  data = data_result.data;
+  offset += data_result.used;
+  uint16_t actualBits = data_result.used / 2;
+
+  // Footer.
+  if (!matchMark(results->rawbuf[offset++], kLegoPfBitMark)) return false;
+  if (offset < results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset], kLegoPfMinCommandLength))
+    return false;
+
+  // Compliance
+  if (actualBits < nbits) return false;
+  if (strict) {
+    if (actualBits != nbits) return false;  // Not as we expected.
+    // Verify the Longitudinal Redundancy Check (LRC)
+    uint16_t lrc_data = data;
+    uint8_t lrc = 0xF;
+    for (uint8_t i = 0; i < 4; i++) {
+      lrc ^= (lrc_data & 0xF);
+      lrc_data >>= 4;
+    }
+    if (lrc) return false;
+  }
+
+  // Success
+  results->decode_type = LEGOPF;
+  results->bits = actualBits;
+  results->value = data;
+  results->address = ((data >> (nbits - 4)) & 0b11) + 1;  // Channel Id
+  results->command = (data >> 4) & 0xFF;  // Stuff between Channel Id and LRC.
+  return true;
+}
+#endif  // DECODE_LEGOPF

--- a/test/Makefile
+++ b/test/Makefile
@@ -36,7 +36,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
-  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test
+  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -80,7 +80,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
-	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o
+	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
@@ -524,4 +524,13 @@ ir_Tcl_test.o : ir_Tcl_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Tcl_test.cpp
 
 ir_Tcl_test : $(COMMON_OBJ) ir_Tcl_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp
+
+ir_Lego_test.o : ir_Lego_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Lego_test.cpp
+
+ir_Lego_test : $(COMMON_OBJ) ir_Lego_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Lego_test.cpp
+++ b/test/ir_Lego_test.cpp
@@ -1,0 +1,191 @@
+// Copyright 2019 David Conran
+
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// General housekeeping
+TEST(TestLego, Housekeeping) {
+  ASSERT_EQ("LEGOPF", typeToString(LEGOPF));
+  ASSERT_FALSE(hasACState(LEGOPF));  // Uses uint64_t, not uint8_t*.
+}
+
+// Tests for sendLego().
+
+// Test sending typical data only.
+TEST(TestSendLegoPf, SendDataOnly) {
+  IRsendTest irsend(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLegoPf(0x1234);
+  EXPECT_EQ(
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s70472", irsend.outputStr());
+
+  irsend.reset();
+  irsend.send(LEGOPF, 0x1234, kLegoPfBits);
+  EXPECT_EQ(
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s70472", irsend.outputStr());
+}
+
+// Test sending typical repeat data.
+TEST(TestSendLegoPf, SendDataWithRepeats) {
+  IRsendTest irsend(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLegoPf(0x1234, kLegoPfBits, 1);
+  EXPECT_EQ(
+      "m0s32000"
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s70472"
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s70472"
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s150472"
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s150472"
+      "m158s1026"
+      "m158s263m158s263m158s263m158s553m158s263m158s263m158s553m158s263"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s150472", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendLegoPf(0x2345, kLegoPfBits, 2);
+  EXPECT_EQ(
+      "m0s16000"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s263m158s263m158s263m158s553m158s553"
+      "m158s263m158s553m158s263m158s263m158s263m158s553m158s263m158s553"
+      "m158s70182"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s263m158s263m158s263m158s553m158s553"
+      "m158s263m158s553m158s263m158s263m158s263m158s553m158s263m158s553"
+      "m158s70182"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s263m158s263m158s263m158s553m158s553"
+      "m158s263m158s553m158s263m158s263m158s263m158s553m158s263m158s553"
+      "m158s182182"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s263m158s263m158s263m158s553m158s553"
+      "m158s263m158s553m158s263m158s263m158s263m158s553m158s263m158s553"
+      "m158s182182"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s263m158s263m158s263m158s553m158s553"
+      "m158s263m158s553m158s263m158s263m158s263m158s553m158s263m158s553"
+      "m158s182182", irsend.outputStr());
+
+  irsend.reset();
+  irsend.sendLegoPf(0x3456, kLegoPfBits, 7);
+  EXPECT_EQ(
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s69892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s69892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s213892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s213892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s213892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s213892"
+      "m158s1026"
+      "m158s263m158s263m158s553m158s553m158s263m158s553m158s263m158s263"
+      "m158s263m158s553m158s263m158s553m158s263m158s553m158s553m158s263"
+      "m158s213892", irsend.outputStr());
+}
+
+// Tests for decodeLego().
+
+// Decode normal "synthetic" messages.
+TEST(TestDecodeLegoPf, SyntheticDecode) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLegoPf(0x000F);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LEGOPF, irsend.capture.decode_type);
+  EXPECT_EQ(kLegoPfBits, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_EQ(0x000F, irsend.capture.value);
+  EXPECT_EQ(1, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendLegoPf(0x100E);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LEGOPF, irsend.capture.decode_type);
+  EXPECT_EQ(kLegoPfBits, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_EQ(0x100E, irsend.capture.value);
+  EXPECT_EQ(2, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
+
+  irsend.reset();
+  irsend.sendLegoPf(0x221E);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LEGOPF, irsend.capture.decode_type);
+  EXPECT_EQ(kLegoPfBits, irsend.capture.bits);
+  EXPECT_FALSE(irsend.capture.repeat);
+  EXPECT_EQ(0x221E, irsend.capture.value);
+  EXPECT_EQ(3, irsend.capture.address);
+  EXPECT_EQ(0x21, irsend.capture.command);
+
+  // Test a bad LRC is not matched.
+  irsend.reset();
+  irsend.sendLegoPf(0x001F);  // LRC should be 0xE, not 0xF.
+  irsend.makeDecodeResult();
+  irrecv.decode(&irsend.capture);
+  EXPECT_NE(LEGOPF, irsend.capture.decode_type);
+}
+
+// Decode normal "synthetic" message with releats.
+TEST(TestDecodeLegoPf, SyntheticDecodeWithRepeat) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  irsend.sendLegoPf(0x330F, kLegoPfBits, 1);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(LEGOPF, irsend.capture.decode_type);
+  EXPECT_EQ(kLegoPfBits, irsend.capture.bits);
+  EXPECT_EQ(0x330F, irsend.capture.value);
+  EXPECT_EQ(4, irsend.capture.address);
+  EXPECT_EQ(0x30, irsend.capture.command);
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -48,7 +48,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
             ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o ir_Hitachi.o \
             ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o ir_Pioneer.o \
-            ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o
+            ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -203,3 +203,6 @@ ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(GTEST_HEADERS)
 
 ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(USER_DIR)/ir_Tcl.h $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp
+
+ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp


### PR DESCRIPTION
Add support for sending & receiving LEGO Power Functions IR messages.
* Unit tests
  - Output compared to IRremote library's old function. Appears compatible.
* Written from just the spec, so should be correct.
* Examples & tools code updated.

Fixes #641