### PR TITLE
Update Daikin2's Cool mode min temp to 18C

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -901,11 +901,16 @@ void IRDaikin2::setMode(const uint8_t desired_mode) {
   }
   remote_state[25] &= 0b10001111;
   remote_state[25] |= (mode << 4);
+  // Redo the temp setting as Cool mode has a different min temp.
+  if (mode == kDaikinCool) this->setTemp(this->getTemp());
 }
 
 // Set the temp in deg C
 void IRDaikin2::setTemp(const uint8_t desired) {
-  uint8_t temp = std::max(kDaikin2MinTemp, desired);
+  // The A/C has a different min temp if in cool mode.
+  uint8_t temp = std::max(
+      (this->getMode() == kDaikinCool) ? kDaikin2MinCoolTemp : kDaikinMinTemp,
+      desired);
   temp = std::min(kDaikinMaxTemp, temp);
   remote_state[26] = temp * 2;
 }

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -905,7 +905,7 @@ void IRDaikin2::setMode(const uint8_t desired_mode) {
 
 // Set the temp in deg C
 void IRDaikin2::setTemp(const uint8_t desired) {
-  uint8_t temp = std::max(kDaikinMinTemp, desired);
+  uint8_t temp = std::max(kDaikin2MinTemp, desired);
   temp = std::min(kDaikinMaxTemp, temp);
   remote_state[26] = temp * 2;
 }

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -160,7 +160,7 @@ const uint8_t kDaikin2SwingVCirculate = 0xD;
 const uint8_t kDaikin2SwingVAuto = 0xE;
 const uint8_t kDaikin2SwingHAuto = 0xBE;
 const uint8_t kDaikin2SwingHSwing = 0xBF;
-const uint8_t kDaikin2MinTemp = 18;  // Celsius
+const uint8_t kDaikin2MinCoolTemp = 18;  // Min temp (in C) when in Cool mode.
 
 
 // Legacy defines.

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -160,6 +160,7 @@ const uint8_t kDaikin2SwingVCirculate = 0xD;
 const uint8_t kDaikin2SwingVAuto = 0xE;
 const uint8_t kDaikin2SwingHAuto = 0xBE;
 const uint8_t kDaikin2SwingHSwing = 0xBF;
+const uint8_t kDaikin2MinTemp = 18;  // Celsius
 
 
 // Legacy defines.

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1091,26 +1091,40 @@ TEST(TestDaikin2Class, Temperature) {
   IRDaikin2 ac(0);
   ac.begin();
 
+  ac.setMode(kDaikinAuto);
   ac.setTemp(0);
-  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
   ac.setTemp(255);
   EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  ac.setTemp(kDaikin2MinTemp);
-  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+  ac.setTemp(kDaikinMinTemp);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
   ac.setTemp(kDaikinMaxTemp);
   EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  ac.setTemp(kDaikin2MinTemp - 1);
-  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+  ac.setTemp(kDaikinMinTemp - 1);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
   ac.setTemp(kDaikinMaxTemp + 1);
   EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  ac.setTemp(kDaikin2MinTemp + 1);
-  EXPECT_EQ(kDaikin2MinTemp + 1, ac.getTemp());
+  ac.setTemp(kDaikinMinTemp + 1);
+  EXPECT_EQ(kDaikinMinTemp + 1, ac.getTemp());
+
+  // Now try it with Cool mode, which should set the temp to kDaikin2MinCoolTemp
+  ASSERT_TRUE(kDaikinMinTemp + 1 < kDaikin2MinCoolTemp);
+  ac.setMode(kDaikinCool);
+  EXPECT_EQ(kDaikin2MinCoolTemp, ac.getTemp());
+  ac.setTemp(kDaikin2MinCoolTemp - 1);
+  EXPECT_EQ(kDaikin2MinCoolTemp, ac.getTemp());
+  ac.setTemp(kDaikin2MinCoolTemp + 1);
+  EXPECT_EQ(kDaikin2MinCoolTemp + 1, ac.getTemp());
+  // Should be released from that requirement in other modes.
+  ac.setMode(kDaikinAuto);
+  ac.setTemp(kDaikin2MinCoolTemp - 1);
+  EXPECT_EQ(kDaikin2MinCoolTemp - 1, ac.getTemp());
 
   ac.setTemp(21);
   EXPECT_EQ(21, ac.getTemp());

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1085,6 +1085,43 @@ TEST(TestDaikin2Class, CleanSetting) {
   ac.setClean(false);
   ASSERT_FALSE(ac.getClean());
 }
+
+
+TEST(TestDaikin2Class, Temperature) {
+  IRDaikin2 ac(0);
+  ac.begin();
+
+  ac.setTemp(0);
+  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikin2MinTemp);
+  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikin2MinTemp - 1);
+  EXPECT_EQ(kDaikin2MinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp + 1);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikin2MinTemp + 1);
+  EXPECT_EQ(kDaikin2MinTemp + 1, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
 // Test Fresh Air settings.
 TEST(TestDaikin2Class, FreshAirSettings) {
   IRDaikin2 ac(0);


### PR DESCRIPTION
@sheppy99 has found that the daikin2 A/Cs have a min temp of 18C.
Add unit test coverage for IRDaikin2's `set/getTemp()`

Ref: #644