### PR TITLE
Initial prototype of a common interface for all A/Cs.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -23,6 +23,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_Panasonic.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -151,7 +152,7 @@ void IRac::daikin2(IRDaikin2 *ac,
   ac->setMold(clean);
   ac->setBeep(beep);
   if (sleep > 0) ac->enableSleepTimer(sleep);
-  if (clock >= 0) ac->setCurrentTime(sleep);
+  if (clock >= 0) ac->setCurrentTime(clock);
   ac->send();
 }
 #endif  // SEND_DAIKIN2
@@ -349,6 +350,32 @@ void IRac::mitsubishi(IRMitsubishiAC *ac,
 }
 #endif  // SEND_MITSUBISHI_AC
 
+#if SEND_PANASONIC_AC
+void IRac::panasonic(IRPanasonicAc *ac, panasonic_ac_remote_model_t model,
+                     bool on, stdAc::opmode_t mode, float degrees,
+                     stdAc::fanspeed_t fan,
+                     stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                     bool quiet, bool turbo, int16_t clock) {
+  ac->setModel(model);
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(ac->convertSwingV(swingv));
+  ac->setSwingHorizontal(ac->convertSwingH(swingh));
+  ac->setQuiet(quiet);
+  ac->setPowerful(turbo);
+  // No Light setting available.
+  // No Econo setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  if (clock >= 0) ac->setClock(clock);
+  ac->send();
+}
+#endif  // SEND_PANASONIC_AC
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -496,6 +523,16 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_MITSUBISHI_AC
+#if SEND_PANASONIC_AC
+    case PANASONIC_AC:
+    {
+      IRPanasonicAc ac(_pin);
+      ac.begin();
+      panasonic(&ac, (panasonic_ac_remote_model_t)model, on, mode, degC, fan,
+                swingv, swingh, quiet, turbo, clock);
+      break;
+    }
+#endif  // SEND_PANASONIC_AC
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -231,6 +231,28 @@ void IRac::haier(IRHaierAC *ac,
 }
 #endif  // SEND_HAIER_AC
 
+#if SEND_HAIER_AC_YRW02
+void IRac::haierYrwo2(IRHaierACYRW02 *ac,
+                      bool on, stdAc::opmode_t mode, float degrees,
+                      stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                      bool turbo, bool filter, int16_t sleep) {
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwing(ac->convertSwingV(swingv));
+  // No Horizontal Swing setting available.
+  // No Quiet setting available.
+  ac->setTurbo(turbo);
+  // No Light setting available.
+  ac->setHealth(filter);
+  // No Clean setting available.
+  // No Beep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
+  ac->setPower(on);
+  ac->send();
+}
+#endif  // SEND_HAIER_AC_YRW02
+
 #if SEND_KELVINATOR
 void IRac::kelvinator(IRKelvinatorAC *ac,
                       bool on, stdAc::opmode_t mode, float degrees,
@@ -357,6 +379,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_HAIER_AC
+#if SEND_HAIER_AC_YRW02
+    case HAIER_AC_YRW02:
+    {
+      IRHaierACYRW02 ac(_pin);
+      ac.begin();
+      haierYrwo2(&ac, on, mode, degC, fan, swingv, turbo, filter, sleep);
+      break;
+    }
+#endif  // SEND_HAIER_AC_YRW02
 #if SEND_KELVINATOR
     case KELVINATOR:
     {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -137,6 +137,28 @@ void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
   ac->send();
 }
 
+void IRac::gree(IRGreeAC *ac,
+                bool on, stdAc::opmode_t mode, float degrees,
+                stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                bool turbo, bool light, bool clean, int16_t sleep) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(swingv == stdAc::swingv_t::kAuto,  // Set auto flag.
+                       ac->convertSwingV(swingv));
+  ac->setLight(light);
+  ac->setTurbo(turbo);
+  ac->setXFan(clean);
+  ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
+  // No Horizontal Swing setting available.
+  // No Filter setting available.
+  // No Beep setting available.
+  // No Quiet setting available.
+  // No Clock setting available.
+  ac->send();
+}
+
 void IRac::kelvinator(IRKelvinatorAC *ac,
                       bool on, stdAc::opmode_t mode, float degrees,
                       stdAc::fanspeed_t fan,
@@ -235,6 +257,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_FUJITSU_AC
+#if SEND_GREE
+    case GREE:
+    {
+      IRGreeAC ac(_pin);
+      ac.begin();
+      gree(&ac, on, mode, degC, fan, swingv, light, turbo, clean, sleep);
+      break;
+    }
+#endif  // SEND_GREE
 #if SEND_KELVINATOR
     case KELVINATOR:
     {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -26,6 +26,7 @@
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
+#include "ir_Teco.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -438,6 +439,28 @@ void IRac::tcl112(IRTcl112Ac *ac,
 }
 #endif  // SEND_TCL112AC
 
+#if SEND_TECO
+void IRac::teco(IRTecoAc *ac,
+                bool on, stdAc::opmode_t mode, float degrees,
+                stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwing(swingv != stdAc::swingv_t::kOff);
+  // No Horizontal swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep is either on/off, so convert to boolean.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_TECO
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -614,6 +637,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_TCL112AC
+#if SEND_TECO
+    case TECO:
+    {
+      IRTecoAc ac(_pin);
+      ac.begin();
+      teco(&ac, on, mode, degC, fan, swingv, sleep);
+      break;
+    }
+#endif  // SEND_TECO
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -21,6 +21,7 @@
 #include "ir_Haier.h"
 #include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
+#include "ir_Midea.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -302,6 +303,28 @@ void IRac::kelvinator(IRKelvinatorAC *ac,
 }
 #endif  // SEND_KELVINATOR
 
+#if SEND_MIDEA
+void IRac::midea(IRMideaAC *ac,
+                 bool on, stdAc::opmode_t mode, float degrees,
+                 stdAc::fanspeed_t fan, int16_t sleep) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees, true);  // true means use Celsius.
+  ac->setFan(ac->convertFan(fan));
+  // No Vertical swing setting available.
+  // No Horizontal swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_MIDEA
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -431,6 +454,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_KELVINATOR
+#if SEND_MIDEA
+    case MIDEA:
+    {
+      IRMideaAC ac(_pin);
+      ac.begin();
+      midea(&ac, on, mode, degC, fan, sleep);
+      break;
+    }
+#endif  // SEND_MIDEA
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -28,6 +28,7 @@
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
+#include "ir_Trotec.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -484,6 +485,28 @@ void IRac::toshiba(IRToshibaAC *ac,
 }
 #endif  // SEND_TOSHIBA_AC
 
+#if SEND_TROTEC
+void IRac::trotec(IRTrotecESP *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan, int16_t sleep) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setSpeed(ac->convertFan(fan));
+  // No Vertical swing setting available.
+  // No Horizontal swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep is either on/off, so convert to boolean.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_TROTEC
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -678,6 +701,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_TOSHIBA_AC
+#if SEND_TROTEC
+    case TROTEC:
+    {
+      IRTrotecESP ac(_pin);
+      ac.begin();
+      trotec(&ac, on, mode, degC, fan, sleep);
+      break;
+    }
+#endif  // SEND_TROTEC
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -577,25 +577,26 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
-//   model:   The specific model of A/C if applicable.
-//   on:      Should the unit be powered on?
+//   model:   The specific model of A/C if supported/applicable.
+//   on:      Should the unit be powered on? (or in some cases, toggled)
 //   mode:    What operating mode should the unit perform? e.g. Cool, Heat etc.
 //   degrees: What temperature should the unit be set to?
 //   celsius: Use degreees Celsius, otherwise Fahrenheit.
 //   fan:     Fan speed.
+// The following args are all "if supported" by the underlying A/C classes.
 //   swingv:  Control the vertical swing of the vanes.
 //   swingh:  Control the horizontal swing of the vanes.
 //   quiet:   Set the unit to quiet (fan) operation mode.
 //   turbo:   Set the unit to turbo operating mode. e.g. Max fan & cooling etc.
 //   econo:   Set the unit to economical operating mode.
 //   light:   Turn on the display/LEDs etc.
-//   filter:  Turn on any particle/ion filter etc.
+//   filter:  Turn on any particle/ion/allergy filter etc.
 //   clean:   Turn on any settings to reduce mold etc. (Not self-clean mode.)
 //   beep:    Control if the unit beeps upon receiving commands.
-//   sleep:   Nr. of mins of sleep mode, or use sleep mode. (<= 0 means off.)
+//   sleep:   Nr. of mins of sleep mode, or use sleep mode. (< 0 means off.)
 //   clock:   Nr. of mins past midnight to set the clock to. (< 0 means off.)
 // Returns:
-//   boolean: True is accepted/converted/attempted. False is unsupported.
+//   boolean: True, if accepted/converted/attempted. False, if unsupported.
 bool IRac::sendAc(const decode_type_t vendor, const uint16_t model,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const bool celsius,

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1,0 +1,199 @@
+// Copyright 2019 David Conran
+
+// Provide a universal/standard interface for sending A/C nessages.
+// It does not provide complete and maximum granular control but tries
+// to off most common functionallity across all supported devices.
+
+#include "IRac.h"
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+
+#ifndef ARDUINO
+#include <string>
+#endif
+#include "IRsend.h"
+#include "IRremoteESP8266.h"
+#include "ir_Daikin.h"
+#include "ir_Fujitsu.h"
+#include "ir_Kelvinator.h"
+
+IRac::IRac(uint8_t pin) { _pin = pin; }
+
+void IRac::daikin(IRDaikinESP *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan,
+                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                  bool quiet, bool turbo, bool econo, bool clean) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical((int8_t)swingv >= 0);
+  ac->setSwingHorizontal((int8_t)swingh >= 0);
+  ac->setQuiet(quiet);
+  // No Light setting available.
+  // No Filter setting available.
+  ac->setPowerful(turbo);
+  ac->setEcono(econo);
+  ac->setMold(clean);
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+
+void IRac::daikin2(IRDaikin2 *ac,
+                   bool on, stdAc::opmode_t mode, float degrees,
+                   stdAc::fanspeed_t fan,
+                   stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                   bool quiet, bool turbo, bool light, bool econo, bool filter,
+                   bool clean, bool beep, int16_t sleep, int32_t clock) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(ac->convertSwingV(swingv));
+  ac->setSwingHorizontal((int8_t)swingh >= 0);
+  ac->setQuiet(quiet);
+  ac->setLight(light);
+  ac->setPowerful(turbo);
+  ac->setEcono(econo);
+  ac->setPurify(filter);
+  ac->setMold(clean);
+  ac->setBeep(beep);
+  if (sleep > 0) ac->enableSleepTimer(sleep);
+  if (clock >= 0) ac->setCurrentTime(sleep);
+  ac->send();
+}
+
+void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
+                   bool on, stdAc::opmode_t mode, float degrees,
+                   stdAc::fanspeed_t fan,
+                   stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                   bool quiet) {
+  ac->setModel(model);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFanSpeed(ac->convertFan(fan));
+  uint8_t swing = kFujitsuAcSwingOff;
+  if (swingv > stdAc::swingv_t::kOff) swing |= kFujitsuAcSwingVert;
+  if (swingh > stdAc::swingh_t::kOff) swing |= kFujitsuAcSwingHoriz;
+  ac->setSwing(swing);
+  if (quiet) ac->setFanSpeed(kFujitsuAcFanQuiet);
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Econo setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  if (!on) ac->off();
+  ac->send();
+}
+
+void IRac::kelvinator(IRKelvinatorAC *ac,
+                      bool on, stdAc::opmode_t mode, float degrees,
+                      stdAc::fanspeed_t fan,
+                      stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                      bool quiet, bool turbo, bool light,
+                      bool filter, bool clean) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan((uint8_t)fan);  // No conversion needed.
+  ac->setSwingVertical((int8_t)swingv >= 0);
+  ac->setSwingHorizontal((int8_t)swingh >= 0);
+  ac->setQuiet(quiet);
+  ac->setTurbo(turbo);
+  ac->setLight(light);
+  ac->setIonFilter(filter);
+  ac->setXFan(clean);
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+
+// Send A/C message for a given device using common A/C settings.
+// Args:
+//   vendor:  The type of A/C protocol to use.
+//   model:   The specific model of A/C if applicable.
+//   on:      Should the unit be powered on?
+//   mode:    What operating mode should the unit perform? e.g. Cool, Heat etc.
+//   degrees: What temperature should the unit be set to?
+//   celsius: Use degreees Celsius, otherwise Fahrenheit.
+//   fan:     Fan speed.
+//   swingv:  Control the vertical swing of the vanes.
+//   swingh:  Control the horizontal swing of the vanes.
+//   quiet:   Set the unit to quiet (fan) operation mode.
+//   turbo:   Set the unit to turbo operating mode. e.g. Max fan & cooling etc.
+//   econo:   Set the unit to economical operating mode.
+//   light:   Turn on the display/LEDs etc.
+//   filter:  Turn on any particle/ion filter etc.
+//   clean:   Turn on any settings to reduce mold etc. (Not self-clean mode.)
+//   beep:    Control if the unit beeps upon receiving commands.
+//   sleep:   Nr. of mins of sleep mode, or use sleep mode. (<= 0 means off.)
+//   clock:   Nr. of mins past midnight to set the clock to. (< 0 means off.)
+// Returns:
+//   boolean: True is accepted/converted/attempted. False is unsupported.
+bool IRac::sendAc(decode_type_t vendor, uint16_t model,
+                  bool on, stdAc::opmode_t mode, float degrees, bool celsius,
+                  stdAc::fanspeed_t fan,
+                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                  bool quiet, bool turbo, bool econo, bool light,
+                  bool filter, bool clean, bool beep,
+                  int16_t sleep, int32_t clock) {
+  // Convert the temperature to Celsius.
+  float degC;
+  if (celsius)
+    degC = degrees;
+  else
+    degC = (degrees - 32.0) * (5.0 / 9.0);
+
+  // Per vendor settings & setup.
+  switch (vendor) {
+#if SEND_DAIKIN
+    case DAIKIN:
+    {
+      IRDaikinESP ac(_pin);
+      daikin(&ac, on, mode, degC, fan, swingv, swingh,
+             quiet, turbo, econo, clean);
+      break;
+    }
+#endif  // SEND_DAIKIN
+#if SEND_DAIKIN2
+    case DAIKIN2:
+    {
+      IRDaikin2 ac(_pin);
+      daikin2(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo,
+              light, econo, filter, clean, beep, sleep, clock);
+      break;
+    }
+#endif  // SEND_DAIKIN2
+#if SEND_FUJITSU_AC
+    case FUJITSU_AC:
+    {
+      IRFujitsuAC ac(_pin);
+      ac.begin();
+      fujitsu(&ac, (fujitsu_ac_remote_model_t)model, on, mode, degC, fan,
+              swingv, swingh, quiet);
+      break;
+    }
+#endif  // SEND_FUJITSU_AC
+#if SEND_KELVINATOR
+    case KELVINATOR:
+    {
+      IRKelvinatorAC ac(_pin);
+      ac.begin();
+      kelvinator(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo,
+                 light, filter, clean);
+      break;
+    }
+#endif  // SEND_KELVINATOR
+    default:
+      return false;  // Fail, didn't match anything.
+  }
+  return true;  // Success.
+}

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -25,6 +25,7 @@
 #include "ir_Mitsubishi.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
+#include "ir_Tcl.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -412,6 +413,31 @@ void IRac::samsung(IRSamsungAc *ac,
 }
 #endif  // SEND_SAMSUNG_AC
 
+#if SEND_TCL112AC
+void IRac::tcl112(IRTcl112Ac *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan,
+                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                  bool turbo, bool light, bool econo, bool filter) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(swingv != stdAc::swingv_t::kOff);
+  ac->setSwingHorizontal(swingh != stdAc::swingh_t::kOff);
+  // No Quiet setting available.
+  ac->setTurbo(turbo);
+  ac->setLight(light);
+  ac->setEcono(econo);
+  ac->setHealth(filter);
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_TCL112AC
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -578,6 +604,16 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_SAMSUNG_AC
+#if SEND_TCL112AC
+    case TCL112AC:
+    {
+      IRTcl112Ac ac(_pin);
+      ac.begin();
+      tcl112(&ac, on, mode, degC, fan, swingv, swingh, turbo, light, econo,
+             filter);
+      break;
+    }
+#endif  // SEND_TCL112AC
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -36,9 +36,9 @@ IRac::IRac(uint8_t pin) { _pin = pin; }
 
 #if SEND_ARGO
 void IRac::argo(IRArgoAC *ac,
-                bool on, stdAc::opmode_t mode, float degrees,
-                stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                bool turbo, int16_t sleep) {
+                const bool on, const stdAc::opmode_t mode, const float degrees,
+                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                const bool turbo, const int16_t sleep) {
   ac->setPower(on);
   switch (mode) {
     case stdAc::opmode_t::kCool:
@@ -70,10 +70,11 @@ void IRac::argo(IRArgoAC *ac,
 
 #if SEND_COOLIX
 void IRac::coolix(IRCoolixAC *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool turbo, bool light, bool clean, int16_t sleep) {
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool turbo, const bool light, const bool clean,
+                  const int16_t sleep) {
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
@@ -115,10 +116,11 @@ void IRac::coolix(IRCoolixAC *ac,
 
 #if SEND_DAIKIN
 void IRac::daikin(IRDaikinESP *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool quiet, bool turbo, bool econo, bool clean) {
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool quiet, const bool turbo, const bool econo,
+                  const bool clean) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -140,11 +142,12 @@ void IRac::daikin(IRDaikinESP *ac,
 
 #if SEND_DAIKIN2
 void IRac::daikin2(IRDaikin2 *ac,
-                   bool on, stdAc::opmode_t mode, float degrees,
-                   stdAc::fanspeed_t fan,
-                   stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                   bool quiet, bool turbo, bool light, bool econo, bool filter,
-                   bool clean, bool beep, int16_t sleep, int32_t clock) {
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees, const stdAc::fanspeed_t fan,
+                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                   const bool quiet, const bool turbo, const bool light,
+                   const bool econo, const bool filter, const bool clean,
+                   const bool beep, const int16_t sleep, const int16_t clock) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -165,11 +168,11 @@ void IRac::daikin2(IRDaikin2 *ac,
 #endif  // SEND_DAIKIN2
 
 #if SEND_FUJITSU_AC
-void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
-                   bool on, stdAc::opmode_t mode, float degrees,
-                   stdAc::fanspeed_t fan,
-                   stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                   bool quiet) {
+void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees, const stdAc::fanspeed_t fan,
+                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                   const bool quiet) {
   ac->setModel(model);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -194,9 +197,10 @@ void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
 
 #if SEND_GREE
 void IRac::gree(IRGreeAC *ac,
-                bool on, stdAc::opmode_t mode, float degrees,
-                stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                bool turbo, bool light, bool clean, int16_t sleep) {
+                const bool on, const stdAc::opmode_t mode, const float degrees,
+                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                const bool turbo, const bool light, const bool clean,
+                const int16_t sleep) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -218,9 +222,9 @@ void IRac::gree(IRGreeAC *ac,
 
 #if SEND_HAIER_AC
 void IRac::haier(IRHaierAC *ac,
-                 bool on, stdAc::opmode_t mode, float degrees,
-                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                 bool filter, int16_t sleep, int16_t clock) {
+                 const bool on, const stdAc::opmode_t mode, const float degrees,
+                 const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                 const bool filter, const int16_t sleep, const int16_t clock) {
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
@@ -244,9 +248,10 @@ void IRac::haier(IRHaierAC *ac,
 
 #if SEND_HAIER_AC_YRW02
 void IRac::haierYrwo2(IRHaierACYRW02 *ac,
-                      bool on, stdAc::opmode_t mode, float degrees,
-                      stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                      bool turbo, bool filter, int16_t sleep) {
+                      const bool on, const stdAc::opmode_t mode,
+                      const float degrees, const stdAc::fanspeed_t fan,
+                      const stdAc::swingv_t swingv, const bool turbo,
+                      const bool filter, const int16_t sleep) {
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
@@ -266,9 +271,9 @@ void IRac::haierYrwo2(IRHaierACYRW02 *ac,
 
 #if SEND_HITACHI_AC
 void IRac::hitachi(IRHitachiAc *ac,
-                   bool on, stdAc::opmode_t mode, float degrees,
-                   stdAc::fanspeed_t fan,
-                   stdAc::swingv_t swingv, stdAc::swingh_t swingh) {
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees, const stdAc::fanspeed_t fan,
+                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -289,11 +294,12 @@ void IRac::hitachi(IRHitachiAc *ac,
 
 #if SEND_KELVINATOR
 void IRac::kelvinator(IRKelvinatorAC *ac,
-                      bool on, stdAc::opmode_t mode, float degrees,
-                      stdAc::fanspeed_t fan,
-                      stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                      bool quiet, bool turbo, bool light,
-                      bool filter, bool clean) {
+                      const bool on, const stdAc::opmode_t mode,
+                      const float degrees, const stdAc::fanspeed_t fan,
+                      const stdAc::swingv_t swingv,
+                      const stdAc::swingh_t swingh,
+                      const bool quiet, const bool turbo, const bool light,
+                      const bool filter, const bool clean) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -314,8 +320,8 @@ void IRac::kelvinator(IRKelvinatorAC *ac,
 
 #if SEND_MIDEA
 void IRac::midea(IRMideaAC *ac,
-                 bool on, stdAc::opmode_t mode, float degrees,
-                 stdAc::fanspeed_t fan, int16_t sleep) {
+                 const bool on, const stdAc::opmode_t mode, const float degrees,
+                 const stdAc::fanspeed_t fan, const int16_t sleep) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees, true);  // true means use Celsius.
@@ -336,9 +342,10 @@ void IRac::midea(IRMideaAC *ac,
 
 #if SEND_MITSUBISHI_AC
 void IRac::mitsubishi(IRMitsubishiAC *ac,
-                      bool on, stdAc::opmode_t mode, float degrees,
-                      stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                      bool quiet, int16_t clock) {
+                      const bool on, const stdAc::opmode_t mode,
+                      const float degrees,
+                      const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                      const bool quiet, const int16_t clock) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -358,11 +365,11 @@ void IRac::mitsubishi(IRMitsubishiAC *ac,
 #endif  // SEND_MITSUBISHI_AC
 
 #if SEND_PANASONIC_AC
-void IRac::panasonic(IRPanasonicAc *ac, panasonic_ac_remote_model_t model,
-                     bool on, stdAc::opmode_t mode, float degrees,
-                     stdAc::fanspeed_t fan,
-                     stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                     bool quiet, bool turbo, int16_t clock) {
+void IRac::panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,
+                     const bool on, const stdAc::opmode_t mode,
+                     const float degrees, const stdAc::fanspeed_t fan,
+                     const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                     const bool quiet, const bool turbo, const int16_t clock) {
   ac->setModel(model);
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
@@ -385,10 +392,11 @@ void IRac::panasonic(IRPanasonicAc *ac, panasonic_ac_remote_model_t model,
 
 #if SEND_SAMSUNG_AC
 void IRac::samsung(IRSamsungAc *ac,
-                   bool on, stdAc::opmode_t mode, float degrees,
-                   stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                   bool quiet, bool turbo, bool clean, bool beep,
-                   bool sendOnOffHack) {
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees,
+                   const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                   const bool quiet, const bool turbo, const bool clean,
+                   const bool beep, const bool sendOnOffHack) {
   if (sendOnOffHack) {
     // Use a hack to for the unit on or off.
     // See: https://github.com/markszabo/IRremoteESP8266/issues/604#issuecomment-475020036
@@ -420,10 +428,11 @@ void IRac::samsung(IRSamsungAc *ac,
 
 #if SEND_TCL112AC
 void IRac::tcl112(IRTcl112Ac *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool turbo, bool light, bool econo, bool filter) {
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool turbo, const bool light, const bool econo,
+                  const bool filter) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -445,8 +454,9 @@ void IRac::tcl112(IRTcl112Ac *ac,
 
 #if SEND_TECO
 void IRac::teco(IRTecoAc *ac,
-                bool on, stdAc::opmode_t mode, float degrees,
-                stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep) {
+                const bool on, const stdAc::opmode_t mode, const float degrees,
+                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                const int16_t sleep) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -467,8 +477,8 @@ void IRac::teco(IRTecoAc *ac,
 
 #if SEND_TOSHIBA_AC
 void IRac::toshiba(IRToshibaAC *ac,
-                   bool on, stdAc::opmode_t mode, float degrees,
-                   stdAc::fanspeed_t fan) {
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees, const stdAc::fanspeed_t fan) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -489,8 +499,9 @@ void IRac::toshiba(IRToshibaAC *ac,
 
 #if SEND_TROTEC
 void IRac::trotec(IRTrotecESP *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan, int16_t sleep) {
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const int16_t sleep) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -511,10 +522,11 @@ void IRac::trotec(IRTrotecESP *ac,
 
 #if SEND_VESTEL_AC
 void IRac::vestel(IRVestelAc *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                  bool turbo, bool filter, int16_t sleep, int16_t clock,
-                  bool sendNormal) {
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees,
+                  const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                  const bool turbo, const bool filter, const int16_t sleep,
+                  const int16_t clock, const bool sendNormal) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -537,10 +549,12 @@ void IRac::vestel(IRVestelAc *ac,
 #endif  // SEND_VESTEL_AC
 
 #if SEND_WHIRLPOOL_AC
-void IRac::whirlpool(IRWhirlpoolAc *ac, whirlpool_ac_remote_model_t model,
-                     bool on, stdAc::opmode_t mode, float degrees,
-                     stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                     bool turbo, bool light, int16_t sleep, int16_t clock) {
+void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
+                     const bool on, const stdAc::opmode_t mode,
+                     const float degrees,
+                     const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                     const bool turbo, const bool light,
+                     const int16_t sleep, const int16_t clock) {
   ac->setModel(model);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -582,13 +596,14 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, whirlpool_ac_remote_model_t model,
 //   clock:   Nr. of mins past midnight to set the clock to. (< 0 means off.)
 // Returns:
 //   boolean: True is accepted/converted/attempted. False is unsupported.
-bool IRac::sendAc(decode_type_t vendor, uint16_t model,
-                  bool on, stdAc::opmode_t mode, float degrees, bool celsius,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool quiet, bool turbo, bool econo, bool light,
-                  bool filter, bool clean, bool beep,
-                  int16_t sleep, int32_t clock) {
+bool IRac::sendAc(const decode_type_t vendor, const uint16_t model,
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const bool celsius,
+                  const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool quiet, const bool turbo, const bool econo,
+                  const bool light, const bool filter, const bool clean,
+                  const bool beep, const int16_t sleep, const int16_t clock) {
   // Convert the temperature to Celsius.
   float degC;
   if (celsius)

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -27,6 +27,7 @@
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
+#include "ir_Toshiba.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
@@ -461,6 +462,28 @@ void IRac::teco(IRTecoAc *ac,
 }
 #endif  // SEND_TECO
 
+#if SEND_TOSHIBA_AC
+void IRac::toshiba(IRToshibaAC *ac,
+                   bool on, stdAc::opmode_t mode, float degrees,
+                   stdAc::fanspeed_t fan) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  // No Vertical swing setting available.
+  // No Horizontal swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_TOSHIBA_AC
+
 // Send A/C message for a given device using common A/C settings.
 // Args:
 //   vendor:  The type of A/C protocol to use.
@@ -646,6 +669,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_TECO
+#if SEND_TOSHIBA_AC
+    case TOSHIBA_AC:
+    {
+      IRToshibaAC ac(_pin);
+      ac.begin();
+      toshiba(&ac, on, mode, degC, fan);
+      break;
+    }
+#endif  // SEND_TOSHIBA_AC
     default:
       return false;  // Fail, didn't match anything.
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -19,6 +19,7 @@
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
 #include "ir_Haier.h"
+#include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
@@ -253,6 +254,29 @@ void IRac::haierYrwo2(IRHaierACYRW02 *ac,
 }
 #endif  // SEND_HAIER_AC_YRW02
 
+#if SEND_HITACHI_AC
+void IRac::hitachi(IRHitachiAc *ac,
+                   bool on, stdAc::opmode_t mode, float degrees,
+                   stdAc::fanspeed_t fan,
+                   stdAc::swingv_t swingv, stdAc::swingh_t swingh) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(swingv != stdAc::swingv_t::kOff);
+  ac->setSwingHorizontal(swingh != stdAc::swingh_t::kOff);
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_HITACHI_AC
+
 #if SEND_KELVINATOR
 void IRac::kelvinator(IRKelvinatorAC *ac,
                       bool on, stdAc::opmode_t mode, float degrees,
@@ -388,6 +412,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_HAIER_AC_YRW02
+#if SEND_HITACHI_AC
+    case HITACHI_AC:
+    {
+      IRHitachiAc ac(_pin);
+      ac.begin();
+      hitachi(&ac, on, mode, degC, fan, swingv, swingh);
+      break;
+    }
+#endif  // SEND_HITACHI_AC
 #if SEND_KELVINATOR
     case KELVINATOR:
     {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -18,6 +18,7 @@
 #include "ir_Coolix.h"
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
+#include "ir_Haier.h"
 #include "ir_Kelvinator.h"
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
@@ -204,6 +205,32 @@ void IRac::gree(IRGreeAC *ac,
 }
 #endif  // SEND_GREE
 
+#if SEND_HAIER_AC
+void IRac::haier(IRHaierAC *ac,
+                 bool on, stdAc::opmode_t mode, float degrees,
+                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                 bool filter, int16_t sleep, int16_t clock) {
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwing(ac->convertSwingV(swingv));
+  // No Horizontal Swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  ac->setHealth(filter);
+  // No Clean setting available.
+  // No Beep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
+  if (clock >=0) ac->setCurrTime(clock);
+  if (on)
+    ac->setCommand(kHaierAcCmdOn);
+  else
+    ac->setCommand(kHaierAcCmdOff);
+  ac->send();
+}
+#endif  // SEND_HAIER_AC
+
 #if SEND_KELVINATOR
 void IRac::kelvinator(IRKelvinatorAC *ac,
                       bool on, stdAc::opmode_t mode, float degrees,
@@ -321,6 +348,15 @@ bool IRac::sendAc(decode_type_t vendor, uint16_t model,
       break;
     }
 #endif  // SEND_GREE
+#if SEND_HAIER_AC
+    case HAIER_AC:
+    {
+      IRHaierAC ac(_pin);
+      ac.begin();
+      haier(&ac, on, mode, degC, fan, swingv, filter, sleep, clock);
+      break;
+    }
+#endif  // SEND_HAIER_AC
 #if SEND_KELVINATOR
     case KELVINATOR:
     {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -56,6 +56,7 @@ void IRac::argo(IRArgoAC *ac,
 }
 #endif  // SEND_ARGO
 
+#if SEND_COOLIX
 void IRac::coolix(IRCoolixAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,
                   stdAc::fanspeed_t fan,
@@ -98,7 +99,9 @@ void IRac::coolix(IRCoolixAC *ac,
   ac->setPower(on);
   ac->send();
 }
+#endif  // SEND_COOLIX
 
+#if SEND_DAIKIN
 void IRac::daikin(IRDaikinESP *ac,
                   bool on, stdAc::opmode_t mode, float degrees,
                   stdAc::fanspeed_t fan,
@@ -121,7 +124,9 @@ void IRac::daikin(IRDaikinESP *ac,
   // No Clock setting available.
   ac->send();
 }
+#endif  // SEND_DAIKIN
 
+#if SEND_DAIKIN2
 void IRac::daikin2(IRDaikin2 *ac,
                    bool on, stdAc::opmode_t mode, float degrees,
                    stdAc::fanspeed_t fan,
@@ -145,7 +150,9 @@ void IRac::daikin2(IRDaikin2 *ac,
   if (clock >= 0) ac->setCurrentTime(sleep);
   ac->send();
 }
+#endif  // SEND_DAIKIN2
 
+#if SEND_FUJITSU_AC
 void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
                    bool on, stdAc::opmode_t mode, float degrees,
                    stdAc::fanspeed_t fan,
@@ -171,7 +178,9 @@ void IRac::fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
   if (!on) ac->off();
   ac->send();
 }
+#endif  // SEND_FUJITSU_AC
 
+#if SEND_GREE
 void IRac::gree(IRGreeAC *ac,
                 bool on, stdAc::opmode_t mode, float degrees,
                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
@@ -193,7 +202,9 @@ void IRac::gree(IRGreeAC *ac,
   // No Clock setting available.
   ac->send();
 }
+#endif  // SEND_GREE
 
+#if SEND_KELVINATOR
 void IRac::kelvinator(IRKelvinatorAC *ac,
                       bool on, stdAc::opmode_t mode, float degrees,
                       stdAc::fanspeed_t fan,
@@ -216,6 +227,7 @@ void IRac::kelvinator(IRKelvinatorAC *ac,
   // No Clock setting available.
   ac->send();
 }
+#endif  // SEND_KELVINATOR
 
 // Send A/C message for a given device using common A/C settings.
 // Args:

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -19,6 +19,7 @@
 #include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
+#include "ir_Mitsubishi.h"
 
 class IRac {
  public:
@@ -106,5 +107,11 @@ class IRac {
              bool on, stdAc::opmode_t mode, float degrees,
              stdAc::fanspeed_t fan, int16_t sleep);
 #endif  // SEND_MIDEA
+#if SEND_MITSUBISHI_AC
+  void mitsubishi(IRMitsubishiAC *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                  bool quiet, int16_t clock = -1);
+#endif  // SEND_MITSUBISHI_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -13,6 +13,7 @@
 #include "ir_Coolix.h"
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
+#include "ir_Gree.h"
 #include "ir_Kelvinator.h"
 
 class IRac {
@@ -51,6 +52,10 @@ class IRac {
                stdAc::fanspeed_t fan,
                stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                bool quiet);
+  void gree(IRGreeAC *ac,
+            bool on, stdAc::opmode_t mode, float degrees,
+            stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+            bool turbo, bool light, bool clean, int16_t sleep);
   void kelvinator(IRKelvinatorAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,
                   stdAc::fanspeed_t fan,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -27,6 +27,7 @@
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
 #include "ir_Vestel.h"
+#include "ir_Whirlpool.h"
 
 class IRac {
  public:
@@ -163,5 +164,12 @@ class IRac {
               bool turbo, bool filter, int16_t sleep = -1, int16_t clock = -1,
               bool sendNormal = true);
 #endif  // SEND_VESTEL_AC
+#if SEND_WHIRLPOOL_AC
+  void whirlpool(IRWhirlpoolAc *ac, whirlpool_ac_remote_model_t model,
+                 bool on, stdAc::opmode_t mode, float degrees,
+                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                 bool turbo, bool light,
+                 int16_t sleep = -1, int16_t clock = -1);
+#endif  // SEND_WHIRLPOOL_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -26,6 +26,7 @@
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
+#include "ir_Vestel.h"
 
 class IRac {
  public:
@@ -155,5 +156,12 @@ class IRac {
               bool on, stdAc::opmode_t mode, float degrees,
               stdAc::fanspeed_t fan, int16_t sleep = -1);
 #endif  // SEND_TROTEC
+#if SEND_VESTEL_AC
+  void vestel(IRVestelAc *ac,
+              bool on, stdAc::opmode_t mode, float degrees,
+              stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+              bool turbo, bool filter, int16_t sleep = -1, int16_t clock = -1,
+              bool sendNormal = true);
+#endif  // SEND_VESTEL_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -21,6 +21,7 @@
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
 #include "ir_Panasonic.h"
+#include "ir_Samsung.h"
 
 class IRac {
  public:
@@ -121,5 +122,12 @@ class IRac {
                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                  bool quiet, bool turbo, int16_t clock = -1);
 #endif  // SEND_PANASONIC_AC
+#if SEND_SAMSUNG_AC
+void samsung(IRSamsungAc *ac,
+             bool on, stdAc::opmode_t mode, float degrees,
+             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+             bool quiet, bool turbo, bool clean, bool beep,
+             bool sendOnOffHack = true);
+#endif  // SEND_SAMSUNG_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -32,13 +32,14 @@
 class IRac {
  public:
   explicit IRac(uint8_t pin);
-  bool sendAc(decode_type_t vendor, uint16_t model,
-              bool on, stdAc::opmode_t mode, float degrees, bool celsius,
-              stdAc::fanspeed_t fan,
-              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-              bool quiet, bool turbo, bool econo, bool light,
-              bool filter, bool clean, bool beep,
-              int16_t sleep, int32_t clock);
+  bool sendAc(const decode_type_t vendor, const uint16_t model,
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const bool celsius, const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+              const bool quiet, const bool turbo, const bool econo,
+              const bool light, const bool filter, const bool clean,
+              const bool beep, const int16_t sleep = -1,
+              const int16_t clock = -1);
 #ifndef UNIT_TEST
 
  private:
@@ -46,130 +47,143 @@ class IRac {
   uint8_t _pin;
 #if SEND_ARGO
   void argo(IRArgoAC *ac,
-            bool on, stdAc::opmode_t mode, float degrees, stdAc::fanspeed_t fan,
-            stdAc::swingv_t swingv, bool turbo, int16_t sleep = -1);
+            const bool on, const stdAc::opmode_t mode, const float degrees,
+            const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+            const bool turbo, const int16_t sleep = -1);
 #endif  // SEND_ARGO
 #if SEND_COOLIX
   void coolix(IRCoolixAC *ac,
-              bool on, stdAc::opmode_t mode, float degrees,
-              stdAc::fanspeed_t fan,
-              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-              bool turbo, bool light, bool clean, int16_t sleep = -1);
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+              const bool turbo, const bool light, const bool clean,
+              const int16_t sleep = -1);
 #endif  // SEND_COOLIX
 #if SEND_DAIKIN
   void daikin(IRDaikinESP *ac,
-              bool on, stdAc::opmode_t mode, float degrees,
-              stdAc::fanspeed_t fan,
-              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-              bool quiet, bool turbo, bool econo, bool clean);
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+              const bool quiet, const bool turbo, const bool econo,
+              const bool clean);
 #endif  // SEND_DAIKIN
 #if SEND_DAIKIN2
   void daikin2(IRDaikin2 *ac,
-               bool on, stdAc::opmode_t mode, float degrees,
-               stdAc::fanspeed_t fan,
-               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-               bool quiet, bool turbo, bool light, bool econo, bool filter,
-               bool clean, bool beep, int16_t sleep = -1, int32_t clock = -1);
+               const bool on, const stdAc::opmode_t mode,
+               const float degrees, const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+               const bool quiet, const bool turbo, const bool light,
+               const bool econo, const bool filter, const bool clean,
+               const bool beep, const int16_t sleep = -1,
+               const int16_t clock = -1);
 #endif  // SEND_DAIKIN2
 #if SEND_FUJITSU_AC
-  void fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
-               bool on, stdAc::opmode_t mode, float degrees,
-               stdAc::fanspeed_t fan,
-               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-               bool quiet);
+  void fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
+               const bool on, const stdAc::opmode_t mode, const float degrees,
+               const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+               const bool quiet);
 #endif  // SEND_FUJITSU_AC
 #if SEND_GREE
   void gree(IRGreeAC *ac,
-            bool on, stdAc::opmode_t mode, float degrees,
-            stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-            bool turbo, bool light, bool clean, int16_t sleep);
+            const bool on, const stdAc::opmode_t mode, const float degrees,
+            const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+            const bool turbo, const bool light, const bool clean,
+            const int16_t sleep = -1);
 #endif  // SEND_GREE
 #if SEND_HAIER_AC
   void haier(IRHaierAC *ac,
-             bool on, stdAc::opmode_t mode, float degrees,
-             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-             bool filter, int16_t sleep = -1, int16_t clock = -1);
+             const bool on, const stdAc::opmode_t mode, const float degrees,
+             const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+             const bool filter, const int16_t sleep = -1,
+             const int16_t clock = -1);
 #endif  // SEND_HAIER_AC
 #if SEND_HAIER_AC_YRW02
   void haierYrwo2(IRHaierACYRW02 *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                  bool turbo, bool filter, int16_t sleep = -1);
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv,
+                  const bool turbo, const bool filter,
+                  const int16_t sleep = -1);
 #endif  // SEND_HAIER_AC_YRW02
 #if SEND_HITACHI_AC
   void hitachi(IRHitachiAc *ac,
-               bool on, stdAc::opmode_t mode, float degrees,
-               stdAc::fanspeed_t fan,
-               stdAc::swingv_t swingv, stdAc::swingh_t swingh);
+               const bool on, const stdAc::opmode_t mode,
+               const float degrees, const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh);
 #endif  // SEND_HITACHI_AC
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool quiet, bool turbo, bool light,
-                  bool filter, bool clean);
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool quiet, const bool turbo, const bool light,
+                  const bool filter, const bool clean);
 #endif  // SEND_KELVINATOR
 #if SEND_MIDEA
   void midea(IRMideaAC *ac,
-             bool on, stdAc::opmode_t mode, float degrees,
-             stdAc::fanspeed_t fan, int16_t sleep);
+             const bool on, const stdAc::opmode_t mode, const float degrees,
+             const stdAc::fanspeed_t fan, const int16_t sleep = -1);
 #endif  // SEND_MIDEA
 #if SEND_MITSUBISHI_AC
   void mitsubishi(IRMitsubishiAC *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                  bool quiet, int16_t clock = -1);
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees,
+                  const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                  const bool quiet, const int16_t clock = -1);
 #endif  // SEND_MITSUBISHI_AC
 #if SEND_PANASONIC_AC
-  void panasonic(IRPanasonicAc *ac, panasonic_ac_remote_model_t model,
-                 bool on, stdAc::opmode_t mode, float degrees,
-                 stdAc::fanspeed_t fan,
-                 stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                 bool quiet, bool turbo, int16_t clock = -1);
+  void panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,
+                 const bool on, const stdAc::opmode_t mode, const float degrees,
+                 const stdAc::fanspeed_t fan,
+                 const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                 const bool quiet, const bool turbo, const int16_t clock = -1);
 #endif  // SEND_PANASONIC_AC
 #if SEND_SAMSUNG_AC
   void samsung(IRSamsungAc *ac,
-               bool on, stdAc::opmode_t mode, float degrees,
-               stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-               bool quiet, bool turbo, bool clean, bool beep,
-               bool sendOnOffHack = true);
+               const bool on, const stdAc::opmode_t mode, const float degrees,
+               const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+               const bool quiet, const bool turbo, const bool clean,
+               const bool beep, const bool sendOnOffHack = true);
 #endif  // SEND_SAMSUNG_AC
 #if SEND_TCL112AC
   void tcl112(IRTcl112Ac *ac,
-              bool on, stdAc::opmode_t mode, float degrees,
-              stdAc::fanspeed_t fan,
-              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-              bool turbo, bool light, bool econo, bool filter);
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+              const bool turbo, const bool light, const bool econo,
+              const bool filter);
 #endif  // SEND_TCL112AC
 #if SEND_TECO
   void teco(IRTecoAc *ac,
-            bool on, stdAc::opmode_t mode, float degrees,
-            stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep = -1);
+            const bool on, const stdAc::opmode_t mode, const float degrees,
+            const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+            const int16_t sleep = -1);
 #endif  // SEND_TECO
 #if SEND_TOSHIBA_AC
   void toshiba(IRToshibaAC *ac,
-               bool on, stdAc::opmode_t mode, float degrees,
-               stdAc::fanspeed_t fan);
+               const bool on, const stdAc::opmode_t mode, const float degrees,
+               const stdAc::fanspeed_t fan);
 #endif  // SEND_TOSHIBA_AC
 #if SEND_TROTEC
   void trotec(IRTrotecESP *ac,
-              bool on, stdAc::opmode_t mode, float degrees,
-              stdAc::fanspeed_t fan, int16_t sleep = -1);
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const stdAc::fanspeed_t fan, const int16_t sleep = -1);
 #endif  // SEND_TROTEC
 #if SEND_VESTEL_AC
   void vestel(IRVestelAc *ac,
-              bool on, stdAc::opmode_t mode, float degrees,
-              stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-              bool turbo, bool filter, int16_t sleep = -1, int16_t clock = -1,
-              bool sendNormal = true);
+              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+              const bool turbo, const bool filter,
+              const int16_t sleep = -1, const int16_t clock = -1,
+              const bool sendNormal = true);
 #endif  // SEND_VESTEL_AC
 #if SEND_WHIRLPOOL_AC
-  void whirlpool(IRWhirlpoolAc *ac, whirlpool_ac_remote_model_t model,
-                 bool on, stdAc::opmode_t mode, float degrees,
-                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                 bool turbo, bool light,
-                 int16_t sleep = -1, int16_t clock = -1);
+  void whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
+                 const bool on, const stdAc::opmode_t mode, const float degrees,
+                 const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
+                 const bool turbo, const bool light,
+                 const int16_t sleep = -1, const int16_t clock = -1);
 #endif  // SEND_WHIRLPOOL_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -24,6 +24,7 @@
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
+#include "ir_Toshiba.h"
 
 class IRac {
  public:
@@ -125,23 +126,28 @@ class IRac {
                  bool quiet, bool turbo, int16_t clock = -1);
 #endif  // SEND_PANASONIC_AC
 #if SEND_SAMSUNG_AC
-void samsung(IRSamsungAc *ac,
-             bool on, stdAc::opmode_t mode, float degrees,
-             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-             bool quiet, bool turbo, bool clean, bool beep,
-             bool sendOnOffHack = true);
+  void samsung(IRSamsungAc *ac,
+               bool on, stdAc::opmode_t mode, float degrees,
+               stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+               bool quiet, bool turbo, bool clean, bool beep,
+               bool sendOnOffHack = true);
 #endif  // SEND_SAMSUNG_AC
 #if SEND_TCL112AC
-void tcl112(IRTcl112Ac *ac,
-            bool on, stdAc::opmode_t mode, float degrees,
-            stdAc::fanspeed_t fan,
-            stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-            bool turbo, bool light, bool econo, bool filter);
+  void tcl112(IRTcl112Ac *ac,
+              bool on, stdAc::opmode_t mode, float degrees,
+              stdAc::fanspeed_t fan,
+              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+              bool turbo, bool light, bool econo, bool filter);
 #endif  // SEND_TCL112AC
 #if SEND_TECO
-void teco(IRTecoAc *ac,
-          bool on, stdAc::opmode_t mode, float degrees,
-          stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep = -1);
+  void teco(IRTecoAc *ac,
+            bool on, stdAc::opmode_t mode, float degrees,
+            stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep = -1);
 #endif  // SEND_TECO
+#if SEND_TOSHIBA_AC
+  void toshiba(IRToshibaAC *ac,
+               bool on, stdAc::opmode_t mode, float degrees,
+               stdAc::fanspeed_t fan);
+#endif  // SEND_TOSHIBA_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -22,6 +22,7 @@
 #include "ir_Mitsubishi.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
+#include "ir_Tcl.h"
 
 class IRac {
  public:
@@ -129,5 +130,12 @@ void samsung(IRSamsungAc *ac,
              bool quiet, bool turbo, bool clean, bool beep,
              bool sendOnOffHack = true);
 #endif  // SEND_SAMSUNG_AC
+#if SEND_TCL112AC
+void tcl112(IRTcl112Ac *ac,
+            bool on, stdAc::opmode_t mode, float degrees,
+            stdAc::fanspeed_t fan,
+            stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+            bool turbo, bool light, bool econo, bool filter);
+#endif  // SEND_TCL112AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -16,6 +16,7 @@
 #include "ir_Fujitsu.h"
 #include "ir_Gree.h"
 #include "ir_Haier.h"
+#include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
 
 class IRac {
@@ -85,6 +86,12 @@ void haierYrwo2(IRHaierACYRW02 *ac,
                 stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
                 bool turbo, bool filter, int16_t sleep = -1);
 #endif  // SEND_HAIER_AC_YRW02
+#if SEND_HITACHI_AC
+void hitachi(IRHitachiAc *ac,
+             bool on, stdAc::opmode_t mode, float degrees,
+             stdAc::fanspeed_t fan,
+             stdAc::swingv_t swingv, stdAc::swingh_t swingh);
+#endif  // SEND_HITACHI_AC
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -18,6 +18,7 @@
 #include "ir_Haier.h"
 #include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
+#include "ir_Midea.h"
 
 class IRac {
  public:
@@ -75,22 +76,22 @@ class IRac {
             bool turbo, bool light, bool clean, int16_t sleep);
 #endif  // SEND_GREE
 #if SEND_HAIER_AC
-void haier(IRHaierAC *ac,
-           bool on, stdAc::opmode_t mode, float degrees,
-           stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-           bool filter, int16_t sleep = -1, int16_t clock = -1);
+  void haier(IRHaierAC *ac,
+             bool on, stdAc::opmode_t mode, float degrees,
+             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+             bool filter, int16_t sleep = -1, int16_t clock = -1);
 #endif  // SEND_HAIER_AC
 #if SEND_HAIER_AC_YRW02
-void haierYrwo2(IRHaierACYRW02 *ac,
-                bool on, stdAc::opmode_t mode, float degrees,
-                stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
-                bool turbo, bool filter, int16_t sleep = -1);
+  void haierYrwo2(IRHaierACYRW02 *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                  bool turbo, bool filter, int16_t sleep = -1);
 #endif  // SEND_HAIER_AC_YRW02
 #if SEND_HITACHI_AC
-void hitachi(IRHitachiAc *ac,
-             bool on, stdAc::opmode_t mode, float degrees,
-             stdAc::fanspeed_t fan,
-             stdAc::swingv_t swingv, stdAc::swingh_t swingh);
+  void hitachi(IRHitachiAc *ac,
+               bool on, stdAc::opmode_t mode, float degrees,
+               stdAc::fanspeed_t fan,
+               stdAc::swingv_t swingv, stdAc::swingh_t swingh);
 #endif  // SEND_HITACHI_AC
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
@@ -100,5 +101,10 @@ void hitachi(IRHitachiAc *ac,
                   bool quiet, bool turbo, bool light,
                   bool filter, bool clean);
 #endif  // SEND_KELVINATOR
+#if SEND_MIDEA
+  void midea(IRMideaAC *ac,
+             bool on, stdAc::opmode_t mode, float degrees,
+             stdAc::fanspeed_t fan, int16_t sleep);
+#endif  // SEND_MIDEA
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -10,6 +10,7 @@
 #include <string>
 #endif
 #include "IRremoteESP8266.h"
+#include "ir_Argo.h"
 #include "ir_Coolix.h"
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
@@ -31,6 +32,9 @@ class IRac {
  private:
 #endif
   uint8_t _pin;
+  void argo(IRArgoAC *ac,
+            bool on, stdAc::opmode_t mode, float degrees, stdAc::fanspeed_t fan,
+            stdAc::swingv_t swingv, bool turbo, int16_t sleep = -1);
   void coolix(IRCoolixAC *ac,
               bool on, stdAc::opmode_t mode, float degrees,
               stdAc::fanspeed_t fan,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -32,39 +32,53 @@ class IRac {
  private:
 #endif
   uint8_t _pin;
+#if SEND_ARGO
   void argo(IRArgoAC *ac,
             bool on, stdAc::opmode_t mode, float degrees, stdAc::fanspeed_t fan,
             stdAc::swingv_t swingv, bool turbo, int16_t sleep = -1);
+#endif  // SEND_ARGO
+#if SEND_COOLIX
   void coolix(IRCoolixAC *ac,
               bool on, stdAc::opmode_t mode, float degrees,
               stdAc::fanspeed_t fan,
               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
               bool turbo, bool light, bool clean, int16_t sleep = -1);
+#endif  // SEND_COOLIX
+#if SEND_DAIKIN
   void daikin(IRDaikinESP *ac,
               bool on, stdAc::opmode_t mode, float degrees,
               stdAc::fanspeed_t fan,
               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
               bool quiet, bool turbo, bool econo, bool clean);
+#endif  // SEND_DAIKIN
+#if SEND_DAIKIN2
   void daikin2(IRDaikin2 *ac,
                bool on, stdAc::opmode_t mode, float degrees,
                stdAc::fanspeed_t fan,
                stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                bool quiet, bool turbo, bool light, bool econo, bool filter,
                bool clean, bool beep, int16_t sleep = -1, int32_t clock = -1);
+#endif  // SEND_DAIKIN2
+#if SEND_FUJITSU_AC
   void fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
                bool on, stdAc::opmode_t mode, float degrees,
                stdAc::fanspeed_t fan,
                stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                bool quiet);
+#endif  // SEND_FUJITSU_AC
+#if SEND_GREE
   void gree(IRGreeAC *ac,
             bool on, stdAc::opmode_t mode, float degrees,
             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
             bool turbo, bool light, bool clean, int16_t sleep);
+#endif  // SEND_GREE
+#if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,
                   stdAc::fanspeed_t fan,
                   stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                   bool quiet, bool turbo, bool light,
                   bool filter, bool clean);
+#endif  // SEND_KELVINATOR
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -15,6 +15,7 @@
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
 #include "ir_Gree.h"
+#include "ir_Haier.h"
 #include "ir_Kelvinator.h"
 
 class IRac {
@@ -72,6 +73,12 @@ class IRac {
             stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
             bool turbo, bool light, bool clean, int16_t sleep);
 #endif  // SEND_GREE
+#if SEND_HAIER_AC
+void haier(IRHaierAC *ac,
+           bool on, stdAc::opmode_t mode, float degrees,
+           stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+           bool filter, int16_t sleep = -1, int16_t clock = -1);
+#endif  // SEND_HAIER_AC
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -20,6 +20,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_Panasonic.h"
 
 class IRac {
  public:
@@ -113,5 +114,12 @@ class IRac {
                   stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
                   bool quiet, int16_t clock = -1);
 #endif  // SEND_MITSUBISHI_AC
+#if SEND_PANASONIC_AC
+  void panasonic(IRPanasonicAc *ac, panasonic_ac_remote_model_t model,
+                 bool on, stdAc::opmode_t mode, float degrees,
+                 stdAc::fanspeed_t fan,
+                 stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                 bool quiet, bool turbo, int16_t clock = -1);
+#endif  // SEND_PANASONIC_AC
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -1,0 +1,55 @@
+#ifndef IRAC_H_
+#define IRAC_H_
+
+// Copyright 2019 David Conran
+
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#ifndef ARDUINO
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "ir_Daikin.h"
+#include "ir_Fujitsu.h"
+#include "ir_Kelvinator.h"
+
+class IRac {
+ public:
+  explicit IRac(uint8_t pin);
+  bool sendAc(decode_type_t vendor, uint16_t model,
+              bool on, stdAc::opmode_t mode, float degrees, bool celsius,
+              stdAc::fanspeed_t fan,
+              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+              bool quiet, bool turbo, bool econo, bool light,
+              bool filter, bool clean, bool beep,
+              int16_t sleep, int32_t clock);
+#ifndef UNIT_TEST
+
+ private:
+#endif
+  uint8_t _pin;
+  void kelvinator(IRKelvinatorAC *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan,
+                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                  bool quiet, bool turbo, bool light,
+                  bool filter, bool clean);
+  void daikin(IRDaikinESP *ac,
+              bool on, stdAc::opmode_t mode, float degrees,
+              stdAc::fanspeed_t fan,
+              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+              bool quiet, bool turbo, bool econo, bool clean);
+  void daikin2(IRDaikin2 *ac,
+               bool on, stdAc::opmode_t mode, float degrees,
+               stdAc::fanspeed_t fan,
+               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+               bool quiet, bool turbo, bool light, bool econo, bool filter,
+               bool clean, bool beep, int16_t sleep = -1, int32_t clock = -1);
+  void fujitsu(IRFujitsuAC *ac, fujitsu_ac_remote_model_t model,
+               bool on, stdAc::opmode_t mode, float degrees,
+               stdAc::fanspeed_t fan,
+               stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+               bool quiet);
+};
+#endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -79,6 +79,12 @@ void haier(IRHaierAC *ac,
            stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
            bool filter, int16_t sleep = -1, int16_t clock = -1);
 #endif  // SEND_HAIER_AC
+#if SEND_HAIER_AC_YRW02
+void haierYrwo2(IRHaierACYRW02 *ac,
+                bool on, stdAc::opmode_t mode, float degrees,
+                stdAc::fanspeed_t fan, stdAc::swingv_t swingv,
+                bool turbo, bool filter, int16_t sleep = -1);
+#endif  // SEND_HAIER_AC_YRW02
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,
                   bool on, stdAc::opmode_t mode, float degrees,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -23,6 +23,7 @@
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
+#include "ir_Teco.h"
 
 class IRac {
  public:
@@ -137,5 +138,10 @@ void tcl112(IRTcl112Ac *ac,
             stdAc::swingv_t swingv, stdAc::swingh_t swingh,
             bool turbo, bool light, bool econo, bool filter);
 #endif  // SEND_TCL112AC
+#if SEND_TECO
+void teco(IRTecoAc *ac,
+          bool on, stdAc::opmode_t mode, float degrees,
+          stdAc::fanspeed_t fan, stdAc::swingv_t swingv, int16_t sleep = -1);
+#endif  // SEND_TECO
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -10,6 +10,7 @@
 #include <string>
 #endif
 #include "IRremoteESP8266.h"
+#include "ir_Coolix.h"
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
 #include "ir_Kelvinator.h"
@@ -29,12 +30,11 @@ class IRac {
  private:
 #endif
   uint8_t _pin;
-  void kelvinator(IRKelvinatorAC *ac,
-                  bool on, stdAc::opmode_t mode, float degrees,
-                  stdAc::fanspeed_t fan,
-                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
-                  bool quiet, bool turbo, bool light,
-                  bool filter, bool clean);
+  void coolix(IRCoolixAC *ac,
+              bool on, stdAc::opmode_t mode, float degrees,
+              stdAc::fanspeed_t fan,
+              stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+              bool turbo, bool light, bool clean, int16_t sleep = -1);
   void daikin(IRDaikinESP *ac,
               bool on, stdAc::opmode_t mode, float degrees,
               stdAc::fanspeed_t fan,
@@ -51,5 +51,11 @@ class IRac {
                stdAc::fanspeed_t fan,
                stdAc::swingv_t swingv, stdAc::swingh_t swingh,
                bool quiet);
+  void kelvinator(IRKelvinatorAC *ac,
+                  bool on, stdAc::opmode_t mode, float degrees,
+                  stdAc::fanspeed_t fan,
+                  stdAc::swingv_t swingv, stdAc::swingh_t swingh,
+                  bool quiet, bool turbo, bool light,
+                  bool filter, bool clean);
 };
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -25,6 +25,7 @@
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
+#include "ir_Trotec.h"
 
 class IRac {
  public:
@@ -149,5 +150,10 @@ class IRac {
                bool on, stdAc::opmode_t mode, float degrees,
                stdAc::fanspeed_t fan);
 #endif  // SEND_TOSHIBA_AC
+#if SEND_TROTEC
+  void trotec(IRTrotecESP *ac,
+              bool on, stdAc::opmode_t mode, float degrees,
+              stdAc::fanspeed_t fan, int16_t sleep = -1);
+#endif  // SEND_TROTEC
 };
 #endif  // IRAC_H_

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -31,6 +31,46 @@ const uint16_t kMaxAccurateUsecDelay = 16383;
 //  Usecs to wait between messages we don't know the proper gap time.
 const uint32_t kDefaultMessageGap = 100000;
 
+
+namespace stdAc {
+  enum class opmode_t {
+    kAuto = 0,
+    kCool = 1,
+    kHeat = 2,
+    kDry  = 3,
+    kFan  = 4,
+  };
+
+  enum class fanspeed_t {
+    kAuto = 0,
+    kMin =  1,
+    kLow =  2,
+    kMedium =  3,
+    kHigh = 4,
+    kMax =  5,
+  };
+
+  enum class swingv_t {
+    kOff =    -1,
+    kAuto =    0,
+    kHighest = 1,
+    kHigh =    2,
+    kMiddle =  3,
+    kLow =     4,
+    kLowest =  5,
+  };
+
+  enum class swingh_t {
+    kOff =     -1,
+    kAuto =     0,  // a.k.a. On.
+    kLeftMax =  1,
+    kLeft =     2,
+    kMiddle =   3,
+    kRight =    4,
+    kRightMax = 5,
+  };
+};  // namespace stdAc
+
 // Classes
 class IRsend {
  public:

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -139,9 +139,9 @@ class IRsend {
                      const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_SAMSUNG_AC
-  void sendSamsungAC(unsigned char data[],
-                     uint16_t nbytes = kSamsungAcStateLength,
-                     uint16_t repeat = kSamsungAcDefaultRepeat);
+  void sendSamsungAC(const unsigned char data[],
+                     const uint16_t nbytes = kSamsungAcStateLength,
+                     const uint16_t repeat = kSamsungAcDefaultRepeat);
 #endif
 #if SEND_LG
   void sendLG(uint64_t data, uint16_t nbits = kLgBits,

--- a/src/IRtimer.cpp
+++ b/src/IRtimer.cpp
@@ -7,7 +7,7 @@
 
 #ifdef UNIT_TEST
 // Used to help simulate elapsed time in unit tests.
-extern uint32_t _IRtimer_unittest_now;
+uint32_t _IRtimer_unittest_now = 0;
 #endif  // UNIT_TEST
 
 // This class performs a simple time in useconds since instantiated.

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -228,3 +228,37 @@ void IRArgoAC::setRoomTemp(uint8_t temp) {
   argo[3] += temp << 5;  // Append to bit 5,6,7
   argo[4] += temp >> 3;  // Remove lowest 3 bits and append in 0,1
 }
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRArgoAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kArgoFan1;
+    case stdAc::fanspeed_t::kMedium:
+      return kArgoFan2;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kArgoFan3;
+    default:
+      return kArgoFanAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRArgoAC::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+      return kArgoFlapFull;
+    case stdAc::swingv_t::kHigh:
+      return kArgoFlap5;
+    case stdAc::swingv_t::kMiddle:
+      return kArgoFlap4;
+    case stdAc::swingv_t::kLow:
+      return kArgoFlap3;
+    case stdAc::swingv_t::kLowest:
+      return kArgoFlap1;
+    default:
+      return kArgoFlapAuto;
+  }
+}

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -6,6 +6,10 @@
 
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
+
 
 //  ARGO Ulisse DCI
 
@@ -55,7 +59,7 @@ const uint8_t kArgoFlapFull = 7;  // 0b111
 #define ARGO_COOL_ON              kArgoCoolOn
 #define ARGO_COOL_OFF             kArgoCoolOff
 #define ARGO_COOL_AUTO            kArgoCoolAuto
-#define ARGO_COOl_HUM             kArgoCoolHum
+#define ARGO_COOL_HUM             kArgoCoolHum
 #define ARGO_HEAT_ON              kArgoHeatOn
 #define ARGO_HEAT_AUTO            kArgoHeatAuto
 #define ARGO_HEAT_BLINK           kArgoHeatBlink
@@ -118,13 +122,19 @@ class IRArgoAC {
   void setRoomTemp(uint8_t temp);
 
   uint8_t* getRaw();
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;  // instance of the IR send class
+#else
+  IRsendTest _irsend;  // instance of the testing IR send class
+#endif
   // # of bytes per command
   uint8_t argo[kArgoStateLength];  // Defined in IRremoteESP8266.h
   void stateReset();
   void checksum();
-  IRsend _irsend;  // instance of the IR send class
 
   // Attributes
   uint8_t set_temp;

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -305,6 +305,38 @@ void IRCoolixAC::setFan(const uint8_t speed) {
   remote_state |= ((newspeed << 13) & kCoolixFanMask);
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRCoolixAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kCoolixCool;
+    case stdAc::opmode_t::kHeat:
+      return kCoolixHeat;
+    case stdAc::opmode_t::kDry:
+      return kCoolixDry;
+    case stdAc::opmode_t::kFan:
+      return kCoolixFan;
+    default:
+      return kCoolixAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRCoolixAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kCoolixFanMin;
+    case stdAc::fanspeed_t::kMedium:
+      return kCoolixFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kCoolixFanMax;
+    default:
+      return kCoolixFanAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRCoolixAC::toString() {

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //             CCCCC   OOOOO   OOOOO  LL      IIIII XX    XX
 //            CC    C OO   OO OO   OO LL       III   XX  XX
@@ -30,11 +33,11 @@
 
 // Constants
 // Modes
-const uint8_t kCoolixCool = 0b00;
-const uint8_t kCoolixDry = 0b01;
-const uint8_t kCoolixAuto = 0b10;
-const uint8_t kCoolixHeat = 0b11;
-const uint8_t kCoolixFan = 4;                                 // Synthetic.
+const uint8_t kCoolixCool = 0b000;
+const uint8_t kCoolixDry = 0b001;
+const uint8_t kCoolixAuto = 0b010;
+const uint8_t kCoolixHeat = 0b011;
+const uint8_t kCoolixFan = 0b100;                                 // Synthetic.
 const uint32_t kCoolixModeMask = 0b000000000000000000001100;  // 0xC
 const uint32_t kCoolixZoneFollowMask = 0b000010000000000000000000;  // 0x80000
 // Fan Control
@@ -120,17 +123,22 @@ class IRCoolixAC {
   bool getZoneFollow();
   uint32_t getRaw();
   void setRaw(const uint32_t new_code);
-
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   uint32_t remote_state;  // The state of the IR remote in IR code form.
   uint32_t saved_state;   // Copy of the state if we required a special mode.
-  IRsend _irsend;
   void setTempRaw(const uint8_t code);
   uint8_t getTempRaw();
   void setSensorTempRaw(const uint8_t code);

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -635,7 +635,6 @@ uint8_t IRDaikinESP::convertFan(stdAc::fanspeed_t speed) {
 }
 
 #if DECODE_DAIKIN
-
 void addbit(bool val, unsigned char data[]) {
   uint8_t curbit = data[kDaikinCurBit];
   uint8_t curindex = data[kDaikinCurIndex];

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -16,6 +16,9 @@ Copyright 2018-2019 crankyoldgit
 #include "IRrecv.h"
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 #include "IRutils.h"
 
 //                DDDDD     AAA   IIIII KK  KK IIIII NN   NN
@@ -595,6 +598,40 @@ void IRDaikinESP::setCommand(uint32_t value) {
 
   value >>= 20;
   setCurrentTime(value);
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRDaikinESP::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kDaikinCool;
+    case stdAc::opmode_t::kHeat:
+      return kDaikinHeat;
+    case stdAc::opmode_t::kDry:
+      return kDaikinDry;
+    case stdAc::opmode_t::kFan:
+      return kDaikinFan;
+    default:
+      return kDaikinAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRDaikinESP::convertFan(stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kDaikinFanQuiet;
+    case stdAc::fanspeed_t::kLow:
+      return kDaikinFanMin;
+    case stdAc::fanspeed_t::kMedium:
+      return kDaikinFanMin + 1;
+    case stdAc::fanspeed_t::kHigh:
+      return kDaikinFanMax - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kDaikinFanMax;
+    default:
+      return kDaikinFanAuto;
+  }
 }
 
 #if DECODE_DAIKIN
@@ -1177,6 +1214,54 @@ void IRDaikin2::setPurify(const bool on) {
 }
 
 bool IRDaikin2::getPurify() { return remote_state[36] & kDaikin2BitPurify; }
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRDaikin2::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kDaikinCool;
+    case stdAc::opmode_t::kHeat:
+      return kDaikinHeat;
+    case stdAc::opmode_t::kDry:
+      return kDaikinDry;
+    case stdAc::opmode_t::kFan:
+      return kDaikinFan;
+    default:
+      return kDaikinAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRDaikin2::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kDaikinFanQuiet;
+    case stdAc::fanspeed_t::kLow:
+      return kDaikinFanMin;
+    case stdAc::fanspeed_t::kMedium:
+      return kDaikinFanMin + 1;
+    case stdAc::fanspeed_t::kHigh:
+      return kDaikinFanMax - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kDaikinFanMax;
+    default:
+      return kDaikinFanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native version.
+uint8_t IRDaikin2::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+    case stdAc::swingv_t::kHigh:
+    case stdAc::swingv_t::kMiddle:
+    case stdAc::swingv_t::kLow:
+    case stdAc::swingv_t::kLowest:
+      return (uint8_t)position + kDaikin2SwingVHigh;
+    default:
+      return kDaikin2SwingVAuto;
+  }
+}
 
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -12,6 +12,9 @@
 #include "IRrecv.h"
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Option to disable the additional Daikin debug info to conserve memory
 #define DAIKIN_DEBUG false
@@ -229,6 +232,8 @@ class IRDaikinESP {
   void setCommand(uint32_t value);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikinStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
   static String renderTime(uint16_t timemins);
@@ -236,8 +241,10 @@ class IRDaikinESP {
   std::string toString();
   static std::string renderTime(uint16_t timemins);
 #endif
+#ifndef UNIT_TEST
 
  private:
+#endif
   // # of bytes per command
   uint8_t daikin[kDaikinStateLength];
   void stateReset();
@@ -245,7 +252,11 @@ class IRDaikinESP {
   void setBit(uint8_t byte, uint8_t bitmask);
   void clearBit(uint8_t byte, uint8_t bitmask);
   uint8_t getBit(uint8_t byte, uint8_t bitmask);
+#ifndef UNIT_TEST
   IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
 };
 
 // Class to emulate a Daikin ARC477A1 remote.
@@ -317,6 +328,9 @@ class IRDaikin2 {
   void setCommand(uint32_t value);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikin2StateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
 #ifdef ARDUINO
   String toString();
   static String renderTime(uint16_t timemins);
@@ -324,15 +338,21 @@ class IRDaikin2 {
   std::string toString();
   static std::string renderTime(uint16_t timemins);
 #endif
+#ifndef UNIT_TEST
 
  private:
+#endif
   // # of bytes per command
   uint8_t remote_state[kDaikin2StateLength];
   void stateReset();
   void checksum();
   void clearOnTimerFlag();
   void clearSleepTimerFlag();
+#ifndef UNIT_TEST
   IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
 };
 
 #endif  // IR_DAIKIN_H_

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -244,6 +244,9 @@ class IRDaikinESP {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   // # of bytes per command
   uint8_t daikin[kDaikinStateLength];
@@ -252,11 +255,6 @@ class IRDaikinESP {
   void setBit(uint8_t byte, uint8_t bitmask);
   void clearBit(uint8_t byte, uint8_t bitmask);
   uint8_t getBit(uint8_t byte, uint8_t bitmask);
-#ifndef UNIT_TEST
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
 };
 
 // Class to emulate a Daikin ARC477A1 remote.
@@ -341,6 +339,9 @@ class IRDaikin2 {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   // # of bytes per command
   uint8_t remote_state[kDaikin2StateLength];
@@ -348,11 +349,6 @@ class IRDaikin2 {
   void checksum();
   void clearOnTimerFlag();
   void clearSleepTimerFlag();
-#ifndef UNIT_TEST
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
 };
 
 #endif  // IR_DAIKIN_H_

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -281,6 +281,7 @@ void IRFujitsuAC::setMode(uint8_t mode) {
 }
 
 uint8_t IRFujitsuAC::getMode() { return _mode; }
+
 // Set the requested swing operation mode of the a/c unit.
 void IRFujitsuAC::setSwing(uint8_t swingMode) {
   switch (_model) {
@@ -317,6 +318,39 @@ bool IRFujitsuAC::validChecksum(uint8_t state[], uint16_t length) {
       return true;  // Assume the checksum is valid for other lengths.
   }
   return checksum == (uint8_t)(sum_complement - sum);  // Does it match?
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRFujitsuAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kFujitsuAcModeCool;
+    case stdAc::opmode_t::kHeat:
+      return kFujitsuAcModeHeat;
+    case stdAc::opmode_t::kDry:
+      return kFujitsuAcModeDry;
+    case stdAc::opmode_t::kFan:
+      return kFujitsuAcModeFan;
+    default:
+      return kFujitsuAcModeAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRFujitsuAC::convertFan(stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kFujitsuAcFanQuiet;
+    case stdAc::fanspeed_t::kLow:
+      return kFujitsuAcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kFujitsuAcFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kFujitsuAcFanHigh;
+    default:
+      return kFujitsuAcFanAuto;
+  }
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -13,6 +13,9 @@
 #include "IRrecv.h"
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // FUJITSU A/C support added by Jonny Graham
 
@@ -99,15 +102,21 @@ class IRFujitsuAC {
   uint8_t getStateLength();
   static bool validChecksum(uint8_t* state, uint16_t length);
   bool getPower();
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
-  uint8_t remote_state[kFujitsuAcStateLength];
   IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  uint8_t remote_state[kFujitsuAcStateLength];
   uint8_t _temp;
   uint8_t _fanSpeed;
   uint8_t _mode;

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -305,6 +305,57 @@ uint8_t IRGreeAC::getSwingVerticalPosition() {
   return remote_state[4] & kGreeSwingPosMask;
 }
 
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRGreeAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kGreeCool;
+    case stdAc::opmode_t::kHeat:
+      return kGreeHeat;
+    case stdAc::opmode_t::kDry:
+      return kGreeDry;
+    case stdAc::opmode_t::kFan:
+      return kGreeFan;
+    default:
+      return kGreeAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRGreeAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kGreeFanMin;
+    case stdAc::fanspeed_t::kLow:
+    case stdAc::fanspeed_t::kMedium:
+      return kGreeFanMax - 1;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kGreeFanMax;
+    default:
+      return kGreeFanAuto;
+  }
+}
+
+// Convert a standard A/C Vertical Swing into its native version.
+uint8_t IRGreeAC::convertSwingV(const stdAc::swingv_t swingv) {
+  switch (swingv) {
+    case stdAc::swingv_t::kHighest:
+      return kGreeSwingUp;
+    case stdAc::swingv_t::kHigh:
+      return kGreeSwingMiddleUp;
+    case stdAc::swingv_t::kMiddle:
+      return kGreeSwingMiddle;
+    case stdAc::swingv_t::kLow:
+      return kGreeSwingMiddleDown;
+    case stdAc::swingv_t::kLowest:
+      return kGreeSwingDown;
+    default:
+      return kGreeSwingAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRGreeAC::toString() {

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //                      GGGG  RRRRRR  EEEEEEE EEEEEEE
 //                     GG  GG RR   RR EE      EE
@@ -44,6 +47,8 @@ const uint8_t kGreeSwingPosMask = 0b00001111;
 
 const uint8_t kGreeMinTemp = 16;  // Celsius
 const uint8_t kGreeMaxTemp = 30;  // Celsius
+const uint8_t kGreeFanAuto = 0;
+const uint8_t kGreeFanMin = 1;
 const uint8_t kGreeFanMax = 3;
 
 const uint8_t kGreeSwingLastPos = 0b00000000;
@@ -108,7 +113,9 @@ class IRGreeAC {
   void setSwingVertical(const bool automatic, const uint8_t position);
   bool getSwingVerticalAuto();
   uint8_t getSwingVerticalPosition();
-
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t swingv);
   uint8_t* getRaw();
   void setRaw(uint8_t new_code[]);
   static bool validChecksum(const uint8_t state[],
@@ -118,13 +125,17 @@ class IRGreeAC {
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else  // UNIT_TEST
+  IRsendTest _irsend;
+#endif  // UNIT_TEST
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kGreeStateLength];
   void checksum(const uint16_t length = kGreeStateLength);
   void fixup();
-  IRsend _irsend;
 };
 
 #endif  // IR_GREE_H_

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -312,6 +312,55 @@ std::string IRHaierAC::timeToString(const uint16_t nr_mins) {
   return result;
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRHaierAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kHaierAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kHaierAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kHaierAcDry;
+    case stdAc::opmode_t::kFan:
+      return kHaierAcFan;
+    default:
+      return kHaierAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRHaierAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kHaierAcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kHaierAcFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kHaierAcFanHigh;
+    default:
+      return kHaierAcFanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRHaierAC::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+    case stdAc::swingv_t::kHigh:
+    case stdAc::swingv_t::kMiddle:
+      return kHaierAcSwingUp;
+    case stdAc::swingv_t::kLow:
+    case stdAc::swingv_t::kLowest:
+      return kHaierAcSwingDown;
+    case stdAc::swingv_t::kOff:
+      return kHaierAcSwingOff;
+    default:
+      return kHaierAcSwingChg;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRHaierAC::toString() {
@@ -626,6 +675,22 @@ void IRHaierACYRW02::setSwing(uint8_t state) {
 
   remote_state[1] &= 0b11110000;
   remote_state[1] |= newstate;
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRHaierACYRW02::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kHaierAcYrw02Cool;
+    case stdAc::opmode_t::kHeat:
+      return kHaierAcYrw02Heat;
+    case stdAc::opmode_t::kDry:
+      return kHaierAcYrw02Dry;
+    case stdAc::opmode_t::kFan:
+      return kHaierAcYrw02Fan;
+    default:
+      return kHaierAcYrw02Auto;
+  }
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -693,6 +693,41 @@ uint8_t IRHaierACYRW02::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRHaierACYRW02::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kHaierAcYrw02FanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kHaierAcYrw02FanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kHaierAcYrw02FanHigh;
+    default:
+      return kHaierAcYrw02FanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRHaierACYRW02::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+    case stdAc::swingv_t::kHigh:
+      return kHaierAcYrw02SwingTop;
+    case stdAc::swingv_t::kMiddle:
+      return kHaierAcYrw02SwingMiddle;
+    case stdAc::swingv_t::kLow:
+      return kHaierAcYrw02SwingDown;
+    case stdAc::swingv_t::kLowest:
+      return kHaierAcYrw02SwingBottom;
+    case stdAc::swingv_t::kOff:
+      return kHaierAcYrw02SwingOff;
+    default:
+      return kHaierAcYrw02SwingAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRHaierACYRW02::toString() {

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -293,6 +293,8 @@ class IRHaierACYRW02 {
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kHaierACYRW02StateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
 #ifdef ARDUINO
   String toString();
 #else

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -11,6 +11,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //                      HH   HH   AAA   IIIII EEEEEEE RRRRRR
 //                      HH   HH  AAAAA   III  EE      RR   RR
@@ -223,6 +226,10 @@ class IRHaierAC {
   void setRaw(uint8_t new_code[]);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kHaierACStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
+
 #ifdef ARDUINO
   String toString();
   static String timeToString(const uint16_t nr_mins);
@@ -230,14 +237,18 @@ class IRHaierAC {
   std::string toString();
   static std::string timeToString(const uint16_t nr_mins);
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   uint8_t remote_state[kHaierACStateLength];
   void stateReset();
   void checksum();
   static uint16_t getTime(const uint8_t ptr[]);
   static void setTime(uint8_t ptr[], const uint16_t nr_mins);
-  IRsend _irsend;
 };
 
 class IRHaierACYRW02 {
@@ -281,17 +292,22 @@ class IRHaierACYRW02 {
   void setRaw(uint8_t new_code[]);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kHaierACYRW02StateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   uint8_t remote_state[kHaierACYRW02StateLength];
   void stateReset();
   void checksum();
-  IRsend _irsend;
 };
 
 #endif  // IR_HAIER_H_

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -106,7 +106,7 @@ void IRsend::sendHitachiAC2(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_HITACHI_AC2
 
-// Class for handling the remote control oh a Hitachi 28 byte A/C message.
+// Class for handling the remote control on a Hitachi 28 byte A/C message.
 // Inspired by:
 // https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
 
@@ -255,6 +255,40 @@ void IRHitachiAc::setSwingHorizontal(const bool on) {
     remote_state[15] |= 0x80;
   else
     remote_state[15] &= 0x7F;
+}
+
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRHitachiAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kHitachiAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kHitachiAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kHitachiAcDry;
+    case stdAc::opmode_t::kFan:
+      return kHitachiAcFan;
+    default:
+      return kHitachiAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRHitachiAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kHitachiAcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kHitachiAcFanLow + 1;
+    case stdAc::fanspeed_t::kHigh:
+      return kHitachiAcFanHigh - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kHitachiAcFanHigh;
+    default:
+      return kHitachiAcFanAuto;
+  }
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Constants
 const uint8_t kHitachiAcAuto = 2;
@@ -59,17 +62,23 @@ class IRHitachiAc {
                             const uint16_t length = kHitachiAcStateLength);
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kHitachiAcStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kHitachiAcStateLength];
   void checksum(const uint16_t length = kHitachiAcStateLength);
-  IRsend _irsend;
   uint8_t _previoustemp;
 };
 

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -19,6 +19,7 @@
 #ifndef ARDUINO
 #include <string>
 #endif
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRutils.h"
@@ -345,6 +346,22 @@ void IRKelvinatorAC::setTurbo(bool state) {
 
 bool IRKelvinatorAC::getTurbo() {
   return ((remote_state[2] & kKelvinatorTurbo) != 0);
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRKelvinatorAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kKelvinatorCool;
+    case stdAc::opmode_t::kHeat:
+      return kKelvinatorHeat;
+    case stdAc::opmode_t::kDry:
+      return kKelvinatorDry;
+    case stdAc::opmode_t::kFan:
+      return kKelvinatorFan;
+    default:
+      return kKelvinatorAuto;
+  }
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // KK  KK EEEEEEE LL     VV     VV IIIII NN   NN   AAA   TTTTTTT  OOOOO  RRRRRR
 // KK KK  EE      LL     VV     VV  III  NNN  NN  AAAAA    TTT   OO   OO RR   RR
@@ -163,18 +166,25 @@ class IRKelvinatorAC {
       const uint8_t* block, const uint16_t length = kKelvinatorStateLength / 2);
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kKelvinatorStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+#endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kKelvinatorStateLength];
   void checksum(const uint16_t length = kKelvinatorStateLength);
   void fixup();
+#ifdef UNIT_TEST
+  IRsendTest _irsend;
+#else
   IRsend _irsend;
+#endif
 };
 
 #endif  // IR_KELVINATOR_H_

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -175,16 +175,14 @@ class IRKelvinatorAC {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kKelvinatorStateLength];
   void checksum(const uint16_t length = kKelvinatorStateLength);
   void fixup();
-#ifdef UNIT_TEST
-  IRsendTest _irsend;
-#else
-  IRsend _irsend;
-#endif
 };
 
 #endif  // IR_KELVINATOR_H_

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -257,6 +257,39 @@ void IRMideaAC::checksum() {
   remote_state |= calcChecksum(remote_state);
 }
 
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRMideaAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kMideaACCool;
+    case stdAc::opmode_t::kHeat:
+      return kMideaACHeat;
+    case stdAc::opmode_t::kDry:
+      return kMideaACDry;
+    case stdAc::opmode_t::kFan:
+      return kMideaACFan;
+    default:
+      return kMideaACAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRMideaAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kMideaACFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kMideaACFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kMideaACFanHigh;
+    default:
+      return kMideaACFanAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRMideaAC::toString() {

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -11,6 +11,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //                  MM    MM IIIII DDDDD   EEEEEEE   AAA
 //                  MMM  MMM  III  DD  DD  EE       AAAAA
@@ -85,6 +88,8 @@ class IRMideaAC {
   static bool validChecksum(const uint64_t state);
   void setSleep(const bool state);
   bool getSleep();
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
@@ -93,11 +98,13 @@ class IRMideaAC {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   uint64_t remote_state;
   void checksum();
   static uint8_t calcChecksum(const uint64_t state);
-  IRsend _irsend;
 };
 
 #endif  // IR_MIDEA_H_

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -615,6 +615,52 @@ void IRMitsubishiAC::setTimer(uint8_t timer) {
   remote_state[13] = timer & 0b111;
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRMitsubishiAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kMitsubishiAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kMitsubishiAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kMitsubishiAcDry;
+    default:
+      return kMitsubishiAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRMitsubishiAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kMitsubishiAcFanSilent;
+    case stdAc::fanspeed_t::kLow:
+      return kMitsubishiAcFanRealMax - 3;
+    case stdAc::fanspeed_t::kMedium:
+      return kMitsubishiAcFanRealMax - 2;
+    case stdAc::fanspeed_t::kHigh:
+      return kMitsubishiAcFanRealMax - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kMitsubishiAcFanRealMax;
+    default:
+      return kMitsubishiAcFanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRMitsubishiAC::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+    case stdAc::swingv_t::kHigh:
+    case stdAc::swingv_t::kMiddle:
+    case stdAc::swingv_t::kLow:
+    case stdAc::swingv_t::kLowest:
+      return kMitsubishiAcVaneAutoMove;
+    default:
+      return kMitsubishiAcVaneAuto;
+  }
+}
+
 #ifdef ARDUINO
 String IRMitsubishiAC::timeToString(uint64_t time) {
   String result = "";

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -12,6 +12,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //    MMMMM  IIIII TTTTT   SSSS  U   U  BBBB   IIIII   SSSS  H   H  IIIII
 //    M M M    I     T    S      U   U  B   B    I    S      H   H    I
@@ -89,13 +92,21 @@ class IRMitsubishiAC {
   void setStopClock(uint8_t clock);
   uint8_t getTimer();
   void setTimer(uint8_t timer);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
 #ifdef ARDUINO
   String timeToString(uint64_t time);
 #else
@@ -103,7 +114,6 @@ class IRMitsubishiAC {
 #endif
   uint8_t remote_state[kMitsubishiACStateLength];
   void checksum();
-  IRsend _irsend;
 };
 
 #endif  // IR_MITSUBISHI_H_

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -618,7 +618,6 @@ std::string IRPanasonicAc::timeToString(const uint16_t mins_since_midnight) {
   return result + uint64ToString(mins);
 }
 
-
 // Convert a standard A/C mode into its native mode.
 uint8_t IRPanasonicAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -618,6 +618,74 @@ std::string IRPanasonicAc::timeToString(const uint16_t mins_since_midnight) {
   return result + uint64ToString(mins);
 }
 
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRPanasonicAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kPanasonicAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kPanasonicAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kPanasonicAcDry;
+    case stdAc::opmode_t::kFan:
+      return kPanasonicAcFan;
+    default:
+      return kPanasonicAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRPanasonicAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kPanasonicAcFanMin;
+    case stdAc::fanspeed_t::kLow:
+      return kPanasonicAcFanMin + 1;
+    case stdAc::fanspeed_t::kMedium:
+      return kPanasonicAcFanMin + 2;
+    case stdAc::fanspeed_t::kHigh:
+      return kPanasonicAcFanMin + 3;
+    case stdAc::fanspeed_t::kMax:
+      return kPanasonicAcFanMax;
+    default:
+      return kPanasonicAcFanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRPanasonicAc::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kHighest:
+    case stdAc::swingv_t::kHigh:
+    case stdAc::swingv_t::kMiddle:
+      return kPanasonicAcSwingVUp;
+    case stdAc::swingv_t::kLow:
+    case stdAc::swingv_t::kLowest:
+      return kPanasonicAcSwingVDown;
+    default:
+      return kPanasonicAcSwingVAuto;
+  }
+}
+
+// Convert a standard A/C horizontal swing into its native setting.
+uint8_t IRPanasonicAc::convertSwingH(const stdAc::swingh_t position) {
+  switch (position) {
+    case stdAc::swingh_t::kLeftMax:
+      return kPanasonicAcSwingHFullLeft;
+    case stdAc::swingh_t::kLeft:
+      return kPanasonicAcSwingHLeft;
+    case stdAc::swingh_t::kMiddle:
+      return kPanasonicAcSwingHMiddle;
+    case stdAc::swingh_t::kRight:
+    return kPanasonicAcSwingHRight;
+    case stdAc::swingh_t::kRightMax:
+      return kPanasonicAcSwingHFullRight;
+    default:
+      return kPanasonicAcSwingHAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRPanasonicAc::toString() {

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -12,6 +12,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //       PPPP    AAA   N   N   AAA    SSSS   OOO   N   N  IIIII   CCCC
 //       P   P  A   A  NN  N  A   A  S      O   O  NN  N    I    C
@@ -123,6 +126,10 @@ class IRPanasonicAc {
                    const bool enable = true);
   void cancelOffTimer();
   bool isOffTimerEnabled();
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
+  uint8_t convertSwingH(const stdAc::swingh_t position);
 #ifdef ARDUINO
   String toString();
   static String timeToString(const uint16_t mins_since_midnight);
@@ -133,6 +140,9 @@ class IRPanasonicAc {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   uint8_t remote_state[kPanasonicAcStateLength];
   uint8_t _swingh;
@@ -140,7 +150,6 @@ class IRPanasonicAc {
   void fixChecksum(const uint16_t length = kPanasonicAcStateLength);
   static uint8_t calcChecksum(const uint8_t *state,
                               const uint16_t length = kPanasonicAcStateLength);
-  IRsend _irsend;
 };
 
 #endif  // IR_PANASONIC_H_

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -301,7 +301,8 @@ bool IRrecv::decodeSamsung36(decode_results *results, const uint16_t nbits,
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/505
-void IRsend::sendSamsungAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
   if (nbytes < kSamsungAcStateLength && nbytes % kSamsungACSectionLength)
     return;  // Not an appropriate number of bytes to send a proper message.
 
@@ -385,9 +386,7 @@ void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) checksum();
   _irsend.sendSamsungAC(remote_state, kSamsungAcStateLength, repeat);
 }
-#endif  // SEND_SAMSUNG_AC
 
-#if SEND_SAMSUNG_AC
 // Use this for when you need to power on/off the device.
 // Samsung A/C requires an extended length message when you want to
 // change the power operating mode of the A/C unit.
@@ -405,6 +404,28 @@ void IRSamsungAc::sendExtended(const uint16_t repeat, const bool calcchecksum) {
   // extended_state[8] seems special. This is a guess on how to calculate it.
   extended_state[8] = (extended_state[1] & 0x9F) | 0x40;
   // Send it.
+  _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
+}
+
+// Send the special extended "On" message as the library can't seem to reproduce
+// this message automatically.
+// See: https://github.com/markszabo/IRremoteESP8266/issues/604#issuecomment-475020036
+void IRSamsungAc::sendOn(const uint16_t repeat) {
+  const uint8_t extended_state[21] = {
+      0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0,
+      0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
+      0x01, 0xE2, 0xFE, 0x71, 0x80, 0x11, 0xF0};
+  _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
+}
+
+// Send the special extended "Off" message as the library can't seem to
+// reproduce this message automatically.
+// See: https://github.com/markszabo/IRremoteESP8266/issues/604#issuecomment-475020036
+void IRSamsungAc::sendOff(const uint16_t repeat) {
+  const uint8_t extended_state[21] = {
+      0x02, 0xB2, 0x0F, 0x00, 0x00, 0x00, 0xC0,
+      0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
+      0x01, 0x02, 0xFF, 0x71, 0x80, 0x11, 0xC0};
   _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
 }
 #endif  // SEND_SAMSUNG_AC
@@ -553,6 +574,39 @@ void IRSamsungAc::setQuiet(const bool state) {
     setFan(kSamsungAcFanAuto);  // Quiet mode seems to set fan speed to auto.
   } else {
     remote_state[11] &= ~kSamsungAcQuietMask11;
+  }
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRSamsungAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kSamsungAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kSamsungAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kSamsungAcDry;
+    case stdAc::opmode_t::kFan:
+      return kSamsungAcFan;
+    default:
+      return kSamsungAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRSamsungAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kSamsungAcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kSamsungAcFanMed;
+    case stdAc::fanspeed_t::kHigh:
+      return kSamsungAcFanHigh;
+    case stdAc::fanspeed_t::kMax:
+      return kSamsungAcFanTurbo;
+    default:
+      return kSamsungAcFanAuto;
   }
 }
 

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //              SSSS   AAA    MMM    SSSS  U   U  N   N   GGGG
 //             S      A   A  M M M  S      U   U  NN  N  G
@@ -66,6 +69,8 @@ class IRSamsungAc {
             const bool calcchecksum = true);
   void sendExtended(const uint16_t repeat = kSamsungAcDefaultRepeat,
                     const bool calcchecksum = true);
+  void sendOn(const uint16_t repeat = kSamsungAcDefaultRepeat);
+  void sendOff(const uint16_t repeat = kSamsungAcDefaultRepeat);
 #endif  // SEND_SAMSUNG_AC
   void begin();
   void on();
@@ -93,17 +98,23 @@ class IRSamsungAc {
                             const uint16_t length = kSamsungAcStateLength);
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kSamsungAcStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kSamsungAcExtendedStateLength];
   void checksum(const uint16_t length = kSamsungAcStateLength);
-  IRsend _irsend;
 };
 
 #endif  // IR_SAMSUNG_H_

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -259,6 +259,38 @@ bool IRTcl112Ac::getTurbo(void) {
   return remote_state[6] & kTcl112AcBitTurbo;
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRTcl112Ac::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kTcl112AcCool;
+    case stdAc::opmode_t::kHeat:
+      return kTcl112AcHeat;
+    case stdAc::opmode_t::kDry:
+      return kTcl112AcDry;
+    case stdAc::opmode_t::kFan:
+      return kTcl112AcFan;
+    default:
+      return kTcl112AcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRTcl112Ac::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kTcl112AcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kTcl112AcFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kTcl112AcFanHigh;
+    default:
+      return kTcl112AcFanAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRTcl112Ac::toString() {

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -10,6 +10,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Constants
 const uint16_t kTcl112AcHdrMark = 3000;
@@ -80,17 +83,23 @@ class IRTcl112Ac {
   bool getSwingVertical(void);
   void setTurbo(const bool on);
   bool getTurbo(void);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   uint8_t remote_state[kTcl112AcStateLength];
   void stateReset();
   void checksum(const uint16_t length = kTcl112AcStateLength);
-  IRsend _irsend;
 };
 
 #endif  // IR_TCL_H_

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -136,6 +136,38 @@ void IRTecoAc::setSleep(const bool on) {
 
 bool IRTecoAc::getSleep(void) { return remote_state & kTecoSleep; }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRTecoAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kTecoCool;
+    case stdAc::opmode_t::kHeat:
+      return kTecoHeat;
+    case stdAc::opmode_t::kDry:
+      return kTecoDry;
+    case stdAc::opmode_t::kFan:
+      return kTecoFan;
+    default:
+      return kTecoAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRTecoAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kTecoFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kTecoFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kTecoFanHigh;
+    default:
+      return kTecoFanAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRTecoAc::toString(void) {

--- a/src/ir_Teco.h
+++ b/src/ir_Teco.h
@@ -10,6 +10,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Constants. Using LSB to be able to send only 35bits.
 const uint8_t kTecoAuto = 0;  // 0b000
@@ -120,16 +123,22 @@ class IRTecoAc {
   uint64_t getRaw(void);
   void setRaw(const uint64_t new_code);
 
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString(void);
 #else
   std::string toString(void);
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   // The state of the IR remote in IR code form.
   uint64_t remote_state;
-  IRsend _irsend;
 };
 
 #endif  // IR_TECO_H_

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -233,6 +233,39 @@ void IRToshibaAC::setMode(uint8_t mode) {
   }
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRToshibaAC::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kToshibaAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kToshibaAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kToshibaAcDry;
+    // No Fan mode.
+    default:
+      return kToshibaAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRToshibaAC::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kToshibaAcFanMax - 4;
+    case stdAc::fanspeed_t::kLow:
+      return kToshibaAcFanMax - 3;
+    case stdAc::fanspeed_t::kMedium:
+      return kToshibaAcFanMax - 2;
+    case stdAc::fanspeed_t::kHigh:
+      return kToshibaAcFanMax - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kToshibaAcFanMax;
+    default:
+      return kToshibaAcFanAuto;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRToshibaAC::toString() {

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -11,6 +11,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //     TTTTTTT  OOOOO   SSSSS  HH   HH IIIII BBBBB     AAA
 //       TTT   OO   OO SS      HH   HH  III  BB   B   AAAAA
@@ -65,6 +68,8 @@ class IRToshibaAC {
   uint8_t* getRaw();
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kToshibaACStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
@@ -73,13 +78,15 @@ class IRToshibaAC {
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   uint8_t remote_state[kToshibaACStateLength];
   void checksum(const uint16_t length = kToshibaACStateLength);
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kToshibaACStateLength);
   uint8_t mode_state;
-  IRsend _irsend;
 };
 
 #endif  // IR_TOSHIBA_H_

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -41,24 +41,22 @@ void IRTrotecESP::begin() { _irsend.begin(); }
 #if SEND_TROTEC
 void IRTrotecESP::send(const uint16_t repeat) {
   checksum();
-  _irsend.sendTrotec(trotec, kTrotecStateLength, repeat);
+  _irsend.sendTrotec(remote_state, kTrotecStateLength, repeat);
 }
 #endif  // SEND_TROTEC
 
 void IRTrotecESP::checksum() {
   uint8_t sum = 0;
-  uint8_t i;
 
-  for (i = 2; i < 8; i++) sum += trotec[i];
-
-  trotec[8] = sum & 0xFF;
+  for (uint8_t i = 2; i < 8; i++) sum += remote_state[i];
+  remote_state[8] = sum & 0xFF;
 }
 
 void IRTrotecESP::stateReset() {
-  for (uint8_t i = 2; i < kTrotecStateLength; i++) trotec[i] = 0x0;
+  for (uint8_t i = 2; i < kTrotecStateLength; i++) remote_state[i] = 0x0;
 
-  trotec[0] = kTrotecIntro1;
-  trotec[1] = kTrotecIntro2;
+  remote_state[0] = kTrotecIntro1;
+  remote_state[1] = kTrotecIntro2;
 
   setPower(false);
   setTemp(kTrotecDefTemp);
@@ -68,60 +66,96 @@ void IRTrotecESP::stateReset() {
 
 uint8_t* IRTrotecESP::getRaw() {
   checksum();
-  return trotec;
+  return remote_state;
 }
 
-void IRTrotecESP::setPower(bool state) {
-  if (state)
-    trotec[2] |= (kTrotecOn << 3);
+void IRTrotecESP::setPower(const bool on) {
+  if (on)
+    remote_state[2] |= kTrotecPowerBit;
   else
-    trotec[2] &= ~(kTrotecOn << 3);
+    remote_state[2] &= ~kTrotecPowerBit;
 }
 
-uint8_t IRTrotecESP::getPower() { return trotec[2] & (kTrotecOn << 3); }
+bool IRTrotecESP::getPower() { return remote_state[2] & kTrotecPowerBit; }
 
-void IRTrotecESP::setSpeed(uint8_t speed) {
-  trotec[2] = (trotec[2] & 0xcf) | (speed << 4);
+void IRTrotecESP::setSpeed(const uint8_t fan) {
+  uint8_t speed = std::min(fan, kTrotecFanHigh);
+  remote_state[2] = (remote_state[2] & 0b11001111) | (speed << 4);
 }
 
-uint8_t IRTrotecESP::getSpeed() { return trotec[2] & 0x30; }
+uint8_t IRTrotecESP::getSpeed() { return (remote_state[2] & 0b00110000) >> 4; }
 
-void IRTrotecESP::setMode(uint8_t mode) {
-  trotec[2] = (trotec[2] & 0xfc) | mode;
-}
-
-uint8_t IRTrotecESP::getMode() { return trotec[2] & 0x03; }
-
-void IRTrotecESP::setTemp(uint8_t temp) {
-  if (temp < kTrotecMinTemp)
-    temp = kTrotecMinTemp;
-  else if (temp > kTrotecMaxTemp)
-    temp = kTrotecMaxTemp;
-
-  trotec[3] = (trotec[3] & 0x80) | (temp - kTrotecMinTemp);
-}
-
-uint8_t IRTrotecESP::getTemp() { return trotec[3] & 0x7f; }
-
-void IRTrotecESP::setSleep(bool sleep) {
-  if (sleep)
-    trotec[3] |= (kTrotecSleepOn << 7);
-  else
-    trotec[3] &= ~(kTrotecSleepOn << 7);
-}
-
-bool IRTrotecESP::getSleep(void) { return trotec[3] & (kTrotecSleepOn << 7); }
-
-void IRTrotecESP::setTimer(uint8_t timer) {
-  if (timer > kTrotecMaxTimer) timer = kTrotecMaxTimer;
-
-  if (timer) {
-    trotec[5] |= (kTrotecTimerOn << 6);
-    trotec[6] = timer;
-  } else {
-    trotec[5] &= ~(kTrotecTimerOn << 6);
-    trotec[6] = 0;
+void IRTrotecESP::setMode(const uint8_t mode) {
+  switch (mode) {
+    case kTrotecAuto:
+    case kTrotecCool:
+    case kTrotecDry:
+    case kTrotecFan:
+      remote_state[2] = (remote_state[2] & 0b11111100) | mode;
+      return;
+    default:
+      this->setMode(kTrotecAuto);
   }
 }
 
-uint8_t IRTrotecESP::getTimer() { return trotec[6]; }
+uint8_t IRTrotecESP::getMode() { return remote_state[2] & 0b00000011; }
+
+void IRTrotecESP::setTemp(const uint8_t celsius) {
+  uint8_t temp = std::max(celsius, kTrotecMinTemp);
+  temp = std::min(temp, kTrotecMaxTemp);
+  remote_state[3] = (remote_state[3] & 0x80) | (temp - kTrotecMinTemp);
+}
+
+uint8_t IRTrotecESP::getTemp() {
+  return (remote_state[3] & 0b01111111) + kTrotecMinTemp;
+}
+
+void IRTrotecESP::setSleep(bool sleep) {
+  if (sleep)
+    remote_state[3] |= kTrotecSleepBit;
+  else
+    remote_state[3] &= ~kTrotecSleepBit;
+}
+
+bool IRTrotecESP::getSleep(void) { return remote_state[3] & kTrotecSleepBit; }
+
+void IRTrotecESP::setTimer(const uint8_t timer) {
+  if (timer)
+    remote_state[5] |= kTrotecTimerBit;
+  else
+    remote_state[5] &= ~kTrotecTimerBit;
+  remote_state[6] = (timer > kTrotecMaxTimer) ? kTrotecMaxTimer : timer;
+}
+
+uint8_t IRTrotecESP::getTimer() { return remote_state[6]; }
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRTrotecESP::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kTrotecCool;
+    case stdAc::opmode_t::kDry:
+      return kTrotecDry;
+    case stdAc::opmode_t::kFan:
+      return kTrotecFan;
+    // Note: No Heat mode.
+    default:
+      return kTrotecAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRTrotecESP::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kTrotecFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kTrotecFanMed;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kTrotecFanHigh;
+    default:
+      return kTrotecFanMed;
+  }
+}

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 stufisher
 
 #include "ir_Trotec.h"
+#include <algorithm>
 #include "IRremoteESP8266.h"
 #include "IRutils.h"
 

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -5,6 +5,9 @@
 
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Constants
 // Byte 0
@@ -19,8 +22,7 @@ const uint8_t kTrotecCool = 1;
 const uint8_t kTrotecDry = 2;
 const uint8_t kTrotecFan = 3;
 
-const uint8_t kTrotecOn = 1;
-const uint8_t kTrotecOff = 0;
+const uint8_t kTrotecPowerBit = 0b00001000;
 
 const uint8_t kTrotecFanLow = 1;
 const uint8_t kTrotecFanMed = 2;
@@ -31,13 +33,12 @@ const uint8_t kTrotecMinTemp = 18;
 const uint8_t kTrotecDefTemp = 25;
 const uint8_t kTrotecMaxTemp = 32;
 
-const uint8_t kTrotecSleepOn = 1;
+const uint8_t kTrotecSleepBit = 0b10000000;
 
 // Byte 5
-const uint8_t kTrotecTimerOn = 1;
+const uint8_t kTrotecTimerBit = 0b01000000;
 
 // Byte 6
-const uint8_t kTrotecMinTimer = 0;
 const uint8_t kTrotecMaxTimer = 23;
 
 // Legacy defines. (Deperecated)
@@ -50,7 +51,6 @@ const uint8_t kTrotecMaxTimer = 23;
 #define TROTEC_FAN_HIGH kTrotecFanHigh
 #define TROTEC_MIN_TEMP kTrotecMinTemp
 #define TROTEC_MAX_TEMP kTrotecMaxTemp
-#define TROTEC_MIN_TIMER kTrotecMinTimer
 #define TROTEC_MAX_TIMER kTrotecMaxTimer
 
 class IRTrotecESP {
@@ -62,31 +62,38 @@ class IRTrotecESP {
 #endif  // SEND_TROTEC
   void begin();
 
-  void setPower(bool state);
-  uint8_t getPower();
+  void setPower(const bool state);
+  bool getPower();
 
-  void setTemp(uint8_t temp);
+  void setTemp(const uint8_t celsius);
   uint8_t getTemp();
 
-  void setSpeed(uint8_t fan);
+  void setSpeed(const uint8_t fan);
   uint8_t getSpeed();
 
   uint8_t getMode();
-  void setMode(uint8_t mode);
+  void setMode(const uint8_t mode);
 
   bool getSleep();
   void setSleep(bool sleep);
 
   uint8_t getTimer();
-  void setTimer(uint8_t timer);
+  void setTimer(const uint8_t timer);
 
   uint8_t* getRaw();
 
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+#ifndef UNIT_TEST
+
  private:
-  uint8_t trotec[kTrotecStateLength];
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  uint8_t remote_state[kTrotecStateLength];
   void stateReset();
   void checksum();
-  IRsend _irsend;
 };
 
 #endif  // IR_TROTEC_H_

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -13,6 +13,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //                 VV     VV  EEEEEEE   SSSSS  TTTTTTTT  EEEEEEE  LL
 //                 VV     VV  EE       S          TT     EE       LL
@@ -100,6 +103,8 @@ const uint8_t kVestelAcOffTimerFlagOffset = kVestelAcHourOffset + 6;
 const uint8_t kVestelAcTimerFlagOffset = kVestelAcHourOffset + 7;
 const uint8_t kVestelAcMinuteOffset = 44;
 
+const uint64_t kVestelAcStateDefault = 0x0F00D9001FEF201ULL;
+const uint64_t kVestelAcTimeStateDefault = 0x201ULL;
 
 class IRVestelAc {
  public:
@@ -149,18 +154,24 @@ class IRVestelAc {
   bool isTimerActive(void);
   void setTimerActive(const bool on);
   static uint8_t calcChecksum(const uint64_t state);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
+#ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
   uint64_t remote_state;
   uint64_t remote_time_state;
   bool use_time_state;
   void checksum();
-  IRsend _irsend;
 };
 
 #endif  // IR_VESTEL_H_

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -397,6 +397,38 @@ void IRWhirlpoolAc::setCommand(const uint8_t code) {
   remote_state[kWhirlpoolAcCommandPos] = code;
 }
 
+// Convert a standard A/C mode into its native mode.
+uint8_t IRWhirlpoolAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kWhirlpoolAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kWhirlpoolAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kWhirlpoolAcDry;
+    case stdAc::opmode_t::kFan:
+      return kWhirlpoolAcFan;
+    default:
+      return kWhirlpoolAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRWhirlpoolAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kWhirlpoolAcFanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kWhirlpoolAcFanMedium;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:
+      return kWhirlpoolAcFanHigh;
+    default:
+      return kWhirlpoolAcFanAuto;
+  }
+}
+
 #ifdef ARDUINO
 String IRWhirlpoolAc::timeToString(const uint16_t minspastmidnight) {
   String result = "";

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -14,6 +14,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 //    WW      WW HH   HH IIIII RRRRRR  LL      PPPPPP   OOOOO   OOOOO  LL
 //    WW      WW HH   HH  III  RR   RR LL      PP   PP OO   OO OO   OO LL
@@ -129,19 +132,22 @@ class IRWhirlpoolAc {
               const uint16_t length = kWhirlpoolAcStateLength);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kWhirlpoolAcStateLength);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString();
 #else
   std::string toString();
 #endif
-
 #ifndef UNIT_TEST
 
  private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
 #endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kWhirlpoolAcStateLength];
-  IRsend _irsend;
   uint8_t _desiredtemp;
   void checksum(const uint16_t length = kWhirlpoolAcStateLength);
   uint16_t getTime(const uint16_t pos);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -12,6 +12,8 @@
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
+#include "ir_Teco.h"
+#include "ir_Toshiba.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -507,7 +509,6 @@ TEST(TestIRac, Tcl112) {
   ASSERT_EQ(expected, ac.toString());
 }
 
-
 TEST(TestIRac, Teco) {
   IRTecoAc ac(0);
   IRac irac(0);
@@ -530,5 +531,26 @@ TEST(TestIRac, Teco) {
   ASSERT_EQ(TECO, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTecoBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.value);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Toshiba) {
+  IRToshibaAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] = "Power: On, Mode: 2 (DRY), Temp: 29C, Fan: 2";
+
+  ac.begin();
+  irac.toshiba(&ac,
+               true,                      // Power
+               stdAc::opmode_t::kDry,     // Mode
+               29,                        // Celsius
+               stdAc::fanspeed_t::kLow);  // Fan speed
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(TOSHIBA_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kToshibaACBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -4,6 +4,7 @@
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
 #include "ir_Gree.h"
+#include "ir_Haier.h"
 #include "ir_Kelvinator.h"
 #include "IRac.h"
 #include "IRrecv.h"
@@ -194,6 +195,34 @@ TEST(TestIRac, Gree) {
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(GREE, ac._irsend.capture.decode_type);
   ASSERT_EQ(kGreeBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Haier) {
+  IRHaierAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Command: 1 (On), Mode: 3 (HEAT), Temp: 24C, Fan: 2, Swing: 1 (Up), "
+      "Sleep: On, Health: On, Current Time: 13:45, On Timer: Off, "
+      "Off Timer: Off";
+
+  ac.begin();
+  irac.haier(&ac,
+             true,                        // Power
+             stdAc::opmode_t::kCool,      // Mode
+             24,                          // Celsius
+             stdAc::fanspeed_t::kMedium,  // Fan speed
+             stdAc::swingv_t::kHigh,      // Veritcal swing
+             true,                        // Filter
+             8 * 60 + 0,                  // Sleep time
+             13 * 60 + 45);               // Clock
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HAIER_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHaierACBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -14,6 +14,7 @@
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
+#include "ir_Trotec.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -553,4 +554,22 @@ TEST(TestIRac, Toshiba) {
   ASSERT_EQ(kToshibaACBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Trotec) {
+  IRTrotecESP ac(0);
+  IRac irac(0);
+
+  ac.begin();
+  irac.trotec(&ac,
+              true,                        // Power
+              stdAc::opmode_t::kCool,      // Mode
+              18,                          // Celsius
+              stdAc::fanspeed_t::kHigh,    // Fan speed
+              8 * 60 + 17);                // Sleep
+  EXPECT_TRUE(ac.getPower());
+  EXPECT_EQ(kTrotecCool, ac.getMode());
+  EXPECT_EQ(18, ac.getTemp());
+  EXPECT_EQ(kTrotecFanHigh, ac.getSpeed());
+  EXPECT_TRUE(ac.getSleep());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -506,3 +506,29 @@ TEST(TestIRac, Tcl112) {
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }
+
+
+TEST(TestIRac, Teco) {
+  IRTecoAc ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 0 (AUTO), Temp: 21C, Fan: 2 (Med), Sleep: On, "
+      "Swing: On";
+
+  ac.begin();
+  irac.teco(&ac,
+            true,                        // Power
+            stdAc::opmode_t::kAuto,      // Mode
+            21,                          // Celsius
+            stdAc::fanspeed_t::kMedium,  // Fan speed
+            stdAc::swingv_t::kAuto,      // Veritcal swing
+            8 * 60 + 30);                // Sleep
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(TECO, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kTecoBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.value);
+  ASSERT_EQ(expected, ac.toString());
+}

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -5,6 +5,7 @@
 #include "ir_Fujitsu.h"
 #include "ir_Gree.h"
 #include "ir_Haier.h"
+#include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
 #include "IRac.h"
 #include "IRrecv.h"
@@ -251,6 +252,32 @@ TEST(TestIRac, HaierYrwo2) {
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(HAIER_AC_YRW02, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHaierACYRW02Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Hitachi) {
+  IRHitachiAc ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 2 (AUTO), Temp: 22C, Fan: 3 (UNKNOWN), "
+      "Swing (Vertical): Off, Swing (Horizontal): On";
+
+  ac.begin();
+  irac.hitachi(&ac,
+               true,                        // Power
+               stdAc::opmode_t::kAuto,      // Mode
+               22,                          // Celsius
+               stdAc::fanspeed_t::kMedium,  // Fan speed
+               stdAc::swingv_t::kOff,       // Veritcal swing
+               stdAc::swingh_t::kAuto);     // Horizontal swing
+
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HITACHI_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHitachiAcBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -9,6 +9,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_Panasonic.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -364,4 +365,58 @@ TEST(TestIRac, Mitsubishi) {
   ASSERT_EQ(kMitsubishiACBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Panasonic) {
+  IRPanasonicAc ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected_nke[] =
+      "Model: 2 (NKE), Power: On, Mode: 4 (HEAT), Temp: 28C, Fan: 2 (UNKNOWN), "
+      "Swing (Vertical): 15 (AUTO), Swing (Horizontal): 6 (Middle), Quiet: On, "
+      "Powerful: Off, Clock: 19:17, On Timer: Off, Off Timer: Off";
+
+  ac.begin();
+  irac.panasonic(&ac,
+                 kPanasonicNke,               // Model
+                 true,                        // Power
+                 stdAc::opmode_t::kHeat,      // Mode
+                 28,                          // Celsius
+                 stdAc::fanspeed_t::kMedium,  // Fan speed
+                 stdAc::swingv_t::kAuto,      // Veritcal swing
+                 stdAc::swingh_t::kLeft,      // Horizontal swing
+                 true,                        // Quiet
+                 false,                       // Turbo
+                 19 * 60 + 17);               // Clock
+  ASSERT_EQ(expected_nke, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(PANASONIC_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kPanasonicAcBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected_nke, ac.toString());
+
+  char expected_dke[] =
+      "Model: 3 (DKE), Power: On, Mode: 3 (COOL), Temp: 18C, Fan: 4 (MAX), "
+      "Swing (Vertical): 1 (Full Up), Swing (Horizontal): 6 (Middle), "
+      "Quiet: Off, Powerful: On, Clock: 19:17, On Timer: Off, Off Timer: Off";
+  ac._irsend.reset();
+  irac.panasonic(&ac,
+               kPanasonicDke,               // Model
+               true,                        // Power
+               stdAc::opmode_t::kCool,      // Mode
+               18,                          // Celsius
+               stdAc::fanspeed_t::kMax,     // Fan speed
+               stdAc::swingv_t::kHigh,      // Veritcal swing
+               stdAc::swingh_t::kMiddle,    // Horizontal swing
+               false,                       // Quiet
+               true,                        // Turbo
+               19 * 60 + 17);               // Clock
+  ASSERT_EQ(expected_dke, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(PANASONIC_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kPanasonicAcBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected_dke, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -2,6 +2,7 @@
 
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
+#include "ir_Gree.h"
 #include "ir_Kelvinator.h"
 #include "IRac.h"
 #include "IRrecv.h"
@@ -45,7 +46,6 @@ TEST(TestIRac, Coolix) {
 TEST(TestIRac, Daikin) {
   IRDaikinESP ac(0);
   IRac irac(0);
-  IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 3 (COOL), Temp: 19C, Fan: 2, Powerful: Off, "
       "Quiet: Off, Sensor: Off, Eye: Off, Mold: On, Swing (Horizontal): Off, "
@@ -144,6 +144,35 @@ TEST(TestIRac, Fujitsu) {
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state, ac._irsend.capture.bits / 8);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Gree) {
+  IRGreeAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (COOL), Temp: 22C, Fan: 2, Turbo: Off, XFan: On, "
+      "Light: On, Sleep: On, Swing Vertical Mode: Manual, "
+      "Swing Vertical Pos: 3";
+
+  ac.begin();
+  irac.gree(&ac,
+            true,                        // Power
+            stdAc::opmode_t::kCool,      // Mode
+            22,                          // Celsius
+            stdAc::fanspeed_t::kMedium,  // Fan speed
+            stdAc::swingv_t::kHigh,      // Veritcal swing
+            false,                       // Turbo
+            true,                        // Light
+            true,                        // Clean (aka Mold/XFan)
+            8 * 60 + 0);                 // Sleep time
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(GREE, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kGreeBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2019 David Conran
 
+#include "ir_Argo.h"
 #include "ir_Daikin.h"
 #include "ir_Fujitsu.h"
 #include "ir_Gree.h"
@@ -13,6 +14,27 @@
 #include "gtest/gtest.h"
 
 // Tests for IRac class.
+
+TEST(TestIRac, Argo) {
+  IRArgoAC ac(0);
+  IRac irac(0);
+
+  ac.begin();
+  irac.argo(&ac,
+            true,                        // Power
+            stdAc::opmode_t::kHeat,      // Mode
+            21,                          // Celsius
+            stdAc::fanspeed_t::kHigh,    // Fan speed
+            stdAc::swingv_t::kOff,       // Veritcal swing
+            false,                       // Turbo
+            -1);                         // Sleep
+  EXPECT_TRUE(ac.getPower());
+  EXPECT_EQ(1, ac.getMode());
+  EXPECT_EQ(21, ac.getTemp());
+  EXPECT_EQ(kArgoFlapAuto, ac.getFlap());
+  EXPECT_FALSE(ac.getMax());  // Turbo
+  EXPECT_FALSE(ac.getNight());  // Sleep
+}
 
 TEST(TestIRac, Coolix) {
   IRCoolixAC ac(0);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -227,6 +227,34 @@ TEST(TestIRac, Haier) {
   ASSERT_EQ(expected, ac.toString());
 }
 
+
+TEST(TestIRac, HaierYrwo2) {
+  IRHaierACYRW02 ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Button: 5 (Power), Mode: 2 (Cool), Temp: 23C, Fan: 4 (Med), "
+      "Turbo: 1 (High), Swing: 1 (Top), Sleep: On, Health: On";
+
+  ac.begin();
+  irac.haierYrwo2(&ac,
+             true,                        // Power
+             stdAc::opmode_t::kCool,      // Mode
+             23,                          // Celsius
+             stdAc::fanspeed_t::kMedium,  // Fan speed
+             stdAc::swingv_t::kHigh,      // Veritcal swing
+             true,                        // Turbo
+             true,                        // Filter
+             8 * 60 + 0);                 // Sleep time
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HAIER_AC_YRW02, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHaierACYRW02Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
 TEST(TestIRac, Kelvinator) {
   IRKelvinatorAC ac(0);
   IRac irac(0);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -7,6 +7,7 @@
 #include "ir_Haier.h"
 #include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
+#include "ir_Midea.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -311,5 +312,29 @@ TEST(TestIRac, Kelvinator) {
   ASSERT_EQ(KELVINATOR, ac._irsend.capture.decode_type);
   ASSERT_EQ(kKelvinatorBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Midea) {
+  IRMideaAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (DRY), Temp: 27C/81F, Fan: 2 (MED), Sleep: On";
+
+  ac.begin();
+  irac.midea(&ac,
+             true,                        // Power
+             stdAc::opmode_t::kDry,       // Mode
+             27,                          // Celsius
+             stdAc::fanspeed_t::kMedium,  // Fan speed
+             8 * 60 + 0);                 // Sleep time
+
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(MIDEA, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kMideaBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.value);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1,0 +1,152 @@
+// Copyright 2019 David Conran
+
+#include "ir_Daikin.h"
+#include "ir_Fujitsu.h"
+#include "ir_Kelvinator.h"
+#include "IRac.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for IRac class.
+
+TEST(TestIRac, Daikin) {
+  IRDaikinESP ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 3 (COOL), Temp: 19C, Fan: 2, Powerful: Off, "
+      "Quiet: Off, Sensor: Off, Eye: Off, Mold: On, Swing (Horizontal): Off, "
+      "Swing (Vertical): Off, Current Time: 0:00, On Time: Off, Off Time: Off";
+
+  ac.begin();
+  irac.daikin(&ac,
+              true,                        // Power
+              stdAc::opmode_t::kCool,      // Mode
+              19,                          // Celsius
+              stdAc::fanspeed_t::kMedium,  // Fan speed
+              stdAc::swingv_t::kOff,       // Veritcal swing
+              stdAc::swingh_t::kOff,       // Horizontal swing
+              false,                       // Quiet
+              false,                       // Turbo
+              true,                        // Filter
+              true);                       // Clean
+
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Daikin2) {
+  IRDaikin2 ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 3 (COOL), Temp: 19C, Fan: 2, Swing (V): 14 (Auto), "
+      "Swing (H): 0, Clock: 0:00, On Time: Off, Off Time: Off, "
+      "Sleep Time: Off, Beep: 1 (Quiet), Light: 1 (Bright), Mold: On, "
+      "Clean: Off, Fresh Air: Off, Eye: Off, Eye Auto: Off, Quiet: Off, "
+      "Powerful: Off, Purify: On, Econo: Off";
+
+  ac.begin();
+  irac.daikin2(&ac,
+               true,                        // Power
+               stdAc::opmode_t::kCool,      // Mode
+               19,                          // Celsius
+               stdAc::fanspeed_t::kMedium,  // Fan speed
+               stdAc::swingv_t::kOff,       // Veritcal swing
+               stdAc::swingh_t::kOff,       // Horizontal swing
+               false,                       // Quiet
+               false,                       // Turbo
+               true,                        // Light
+               false,                       // Econo
+               true,                        // Filter
+               true,                        // Clean (aka Mold)
+               -1,                          // Sleep time
+               -1);                         // Current time
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(DAIKIN2, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin2Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Fujitsu) {
+  IRFujitsuAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (COOL), Temp: 19C, Fan: 2 (MED), "
+      "Swing: Off, Command: N/A";
+
+  ac.begin();
+  irac.fujitsu(&ac,
+               ARDB1,                       // Model
+               true,                        // Power
+               stdAc::opmode_t::kCool,      // Mode
+               19,                          // Celsius
+               stdAc::fanspeed_t::kMedium,  // Fan speed
+               stdAc::swingv_t::kOff,       // Veritcal swing
+               stdAc::swingh_t::kOff,       // Horizontal swing
+               false);                      // Quiet
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kFujitsuAcBits - 8, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state, ac._irsend.capture.bits / 8);
+  ASSERT_EQ(expected, ac.toString());
+
+  ac._irsend.reset();
+  irac.fujitsu(&ac,
+               ARRAH2E,                     // Model
+               true,                        // Power
+               stdAc::opmode_t::kCool,      // Mode
+               19,                          // Celsius
+               stdAc::fanspeed_t::kMedium,  // Fan speed
+               stdAc::swingv_t::kOff,       // Veritcal swing
+               stdAc::swingh_t::kOff,       // Horizontal swing
+               false);                      // Quiet
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state, ac._irsend.capture.bits / 8);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Kelvinator) {
+  IRKelvinatorAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (COOL), Temp: 19C, Fan: 3, Turbo: Off, Quiet: Off, "
+      "XFan: On, IonFilter: On, Light: On, Swing (Horizontal): Off, "
+      "Swing (Vertical): Off";
+
+  ac.begin();
+  irac.kelvinator(&ac,
+                  true,                        // Power
+                  stdAc::opmode_t::kCool,      // Mode
+                  19,                          // Celsius
+                  stdAc::fanspeed_t::kMedium,  // Fan speed
+                  stdAc::swingv_t::kOff,       // Veritcal swing
+                  stdAc::swingh_t::kOff,       // Horizontal swing
+                  false,                       // Quiet
+                  false,                       // Turbo
+                  true,                        // Light
+                  true,                        // Filter
+                  true);                       // Clean
+
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(KELVINATOR, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kKelvinatorBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -13,6 +13,35 @@
 
 // Tests for IRac class.
 
+TEST(TestIRac, Coolix) {
+  IRCoolixAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 3 (HEAT), Fan: 1 (MAX), Temp: 21C, Zone Follow: Off, "
+      "Sensor Temp: Ignored";
+
+  ac.begin();
+  irac.coolix(&ac,
+              true,                        // Power
+              stdAc::opmode_t::kHeat,      // Mode
+              21,                          // Celsius
+              stdAc::fanspeed_t::kHigh,    // Fan speed
+              stdAc::swingv_t::kOff,       // Veritcal swing
+              stdAc::swingh_t::kOff,       // Horizontal swing
+              false,                       // Turbo
+              false,                       // Light
+              false,                       // Clean
+              -1);                         // Sleep
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(COOLIX, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kCoolixBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.value);
+  ASSERT_EQ(expected, ac.toString());
+}
+
 TEST(TestIRac, Daikin) {
   IRDaikinESP ac(0);
   IRac irac(0);
@@ -34,7 +63,6 @@ TEST(TestIRac, Daikin) {
               false,                       // Turbo
               true,                        // Filter
               true);                       // Clean
-
   ASSERT_EQ(expected, ac.toString());
 }
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -8,6 +8,7 @@
 #include "ir_Hitachi.h"
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
+#include "ir_Mitsubishi.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -336,5 +337,31 @@ TEST(TestIRac, Midea) {
   ASSERT_EQ(MIDEA, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMideaBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.value);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, Mitsubishi) {
+  IRMitsubishiAC ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On (COOL), Temp: 20C, FAN: 2, VANE: AUTO, Time: 14:30, "
+      "On timer: 00:00, Off timer: 00:00, Timer: -";
+
+  ac.begin();
+  irac.mitsubishi(&ac,
+                  true,                        // Power
+                  stdAc::opmode_t::kCool,      // Mode
+                  20,                          // Celsius
+                  stdAc::fanspeed_t::kMedium,  // Fan speed
+                  stdAc::swingv_t::kOff,       // Veritcal swing
+                  false,                       // Silent
+                  14 * 60 + 35);               // Clock
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(MITSUBISHI_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiACBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -16,6 +16,7 @@
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
 #include "ir_Vestel.h"
+#include "ir_Whirlpool.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
@@ -660,4 +661,35 @@ TEST(TestIRac, Vestel) {
       "m520s480m520s480m520s480m520s480m520s1535m520s480m520s1535m520s1535"
       "m520s480m520s1535m520s480m520s480m520s480m520s480m520s480m520s480"
       "m520s100000", ac._irsend.outputStr());
+}
+
+
+TEST(TestIRac, Whirlpool) {
+  IRWhirlpoolAc ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Model: 1 (DG11J13A), Power toggle: On, Mode: 1 (AUTO), Temp: 21C, "
+      "Fan: 3 (LOW), Swing: On, Light: On, Clock: 23:58, On Timer: Off, "
+      "Off Timer: Off, Sleep: On, Super: Off, Command: 1 (POWER)";
+
+  ac.begin();
+  irac.whirlpool(&ac,
+                 DG11J13A,
+                 true,                        // Power
+                 stdAc::opmode_t::kAuto,      // Mode
+                 21,                          // Celsius
+                 stdAc::fanspeed_t::kMedium,  // Fan speed
+                 stdAc::swingv_t::kAuto,      // Veritcal swing
+                 false,                       // Turbo
+                 true,                        // Light
+                 8 * 60 + 30,                 // Sleep
+                 23 * 60 + 58);               // Clock
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(WHIRLPOOL_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kWhirlpoolAcBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
 }

--- a/test/IRsend_test.h
+++ b/test/IRsend_test.h
@@ -17,7 +17,7 @@
 
 #ifdef UNIT_TEST
 // Used to help simulate elapsed time in unit tests.
-uint32_t _IRtimer_unittest_now = 0;
+extern uint32_t _IRtimer_unittest_now;
 #endif  // UNIT_TEST
 
 class IRsendTest : public IRsend {

--- a/test/Makefile
+++ b/test/Makefile
@@ -447,7 +447,7 @@ ir_Haier_test : $(COMMON_OBJ) ir_Haier_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Hitachi.o : $(USER_DIR)/ir_Hitachi.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Hitachi.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Hitachi.cpp
 
 ir_Hitachi_test.o : ir_Hitachi_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Hitachi_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -519,7 +519,7 @@ ir_Vestel_test : $(COMMON_OBJ) ir_Vestel_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Teco.cpp
 
 ir_Teco_test.o : ir_Teco_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Teco_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -321,7 +321,7 @@ ir_Whynter_test : $(COMMON_OBJ) ir_Whynter_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Coolix.o : $(USER_DIR)/ir_Coolix.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Coolix.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Coolix.cpp
 
 ir_Coolix_test.o : ir_Coolix_test.cpp $(USER_DIR)/ir_Coolix.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Coolix_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -81,7 +81,8 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
-	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o
+	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o \
+	ir_Trotec.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
@@ -547,3 +548,6 @@ ir_Lego_test : $(COMMON_OBJ) ir_Lego_test.o
 
 ir_Argo.o : $(USER_DIR)/ir_Argo.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Argo.cpp
+
+ir_Trotec.o : $(USER_DIR)/ir_Trotec.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Trotec.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,6 +16,7 @@ GTEST_DIR = ../lib/googletest/googletest
 
 # Where to find user code.
 USER_DIR = ../src
+INCLUDES = -I$(USER_DIR) -I.
 
 # Flags passed to the preprocessor.
 # Set Google Test's header directory as a system directory, such that
@@ -36,7 +37,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
-  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test
+  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -104,12 +105,12 @@ PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
 		$(USER_DIR)/ir_Tcl.h \
 		$(USER_DIR)/ir_Teco.h
 # Common object files
-COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o ir_GlobalCache.o \
+COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o IRac.o ir_GlobalCache.o \
              $(PROTOCOLS) gtest_main.a
 # Common dependencies
 COMMON_DEPS = $(USER_DIR)/IRrecv.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRtimer.h \
               $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteESP8266.h \
-							$(PROTOCOLS_H)
+							$(USER_DIR)/IRac.h $(PROTOCOLS_H)
 
 # Common test dependencies
 COMMON_TEST_DEPS = $(COMMON_DEPS) IRrecv_test.h IRsend_test.h
@@ -140,7 +141,7 @@ IRutils.o : $(USER_DIR)/IRutils.cpp $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteES
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/IRutils.cpp
 
 IRutils_test.o : IRutils_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c IRutils_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c IRutils_test.cpp
 
 IRutils_test : IRutils_test.o ir_NEC.o ir_Nikai.o ir_Toshiba.o $(COMMON_OBJ) gtest_main.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -152,7 +153,7 @@ IRsend.o : $(USER_DIR)/IRsend.cpp $(USER_DIR)/IRsend.h $(USER_DIR)/IRremoteESP82
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/IRsend.cpp
 
 IRsend_test.o : IRsend_test.cpp $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h IRsend_test.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c IRsend_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c IRsend_test.cpp
 
 IRsend_test : IRsend_test.o $(COMMON_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -161,16 +162,25 @@ IRrecv.o : $(USER_DIR)/IRrecv.cpp $(USER_DIR)/IRrecv.h $(USER_DIR)/IRremoteESP82
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/IRrecv.cpp
 
 IRrecv_test.o : IRrecv_test.cpp $(USER_DIR)/IRsend.h $(USER_DIR)/IRrecv.h IRsend_test.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c IRrecv_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c IRrecv_test.cpp
 
 IRrecv_test : IRrecv_test.o $(COMMON_OBJ)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+IRac.o : $(USER_DIR)/IRac.cpp $(USER_DIR)/IRac.h $(COMMON_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/IRac.cpp
+
+IRac_test.o : IRac_test.cpp $(USER_DIR)/IRac.h $(COMMON_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c IRac_test.cpp
+
+IRac_test : IRac_test.o $(COMMON_OBJ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_NEC.o : $(USER_DIR)/ir_NEC.cpp $(USER_DIR)/ir_NEC.h $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_NEC.cpp
 
 ir_NEC_test.o : ir_NEC_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_NEC_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_NEC_test.cpp
 
 ir_NEC_test : $(COMMON_OBJ) ir_NEC_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -179,7 +189,7 @@ ir_GlobalCache.o : $(USER_DIR)/ir_GlobalCache.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_GlobalCache.cpp
 
 ir_GlobalCache_test.o : ir_GlobalCache_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_GlobalCache_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_GlobalCache_test.cpp
 
 ir_GlobalCache_test : $(COMMON_OBJ) ir_GlobalCache_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -188,7 +198,7 @@ ir_Sherwood.o : $(USER_DIR)/ir_Sherwood.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sherwood.cpp
 
 ir_Sherwood_test.o : ir_Sherwood_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sherwood_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Sherwood_test.cpp
 
 ir_Sherwood_test : $(COMMON_OBJ) ir_Sherwood_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -197,7 +207,7 @@ ir_Sony.o : $(USER_DIR)/ir_Sony.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sony.cpp
 
 ir_Sony_test.o : ir_Sony_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sony_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Sony_test.cpp
 
 ir_Sony_test : $(COMMON_OBJ) ir_Sony_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -206,16 +216,16 @@ ir_Samsung.o : $(USER_DIR)/ir_Samsung.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_DEPS
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Samsung.cpp
 
 ir_Samsung_test.o : ir_Samsung_test.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Samsung_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Samsung_test.cpp
 
 ir_Samsung_test : $(COMMON_OBJ) ir_Samsung_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Kelvinator.o : $(USER_DIR)/ir_Kelvinator.cpp $(USER_DIR)/ir_Kelvinator.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Kelvinator.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Kelvinator.cpp
 
 ir_Kelvinator_test.o : ir_Kelvinator_test.cpp $(USER_DIR)/ir_Kelvinator.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Kelvinator_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Kelvinator_test.cpp
 
 ir_Kelvinator_test : $(COMMON_OBJ) ir_Kelvinator_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -224,7 +234,7 @@ ir_JVC.o : $(USER_DIR)/ir_JVC.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_JVC.cpp
 
 ir_JVC_test.o : ir_JVC_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_JVC_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_JVC_test.cpp
 
 ir_JVC_test : $(COMMON_OBJ) ir_JVC_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -233,7 +243,7 @@ ir_RCMM.o : $(USER_DIR)/ir_RCMM.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_RCMM.cpp
 
 ir_RCMM_test.o : ir_RCMM_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_RCMM_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_RCMM_test.cpp
 
 ir_RCMM_test : $(COMMON_OBJ) ir_RCMM_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -242,7 +252,7 @@ ir_LG.o : $(USER_DIR)/ir_LG.h $(USER_DIR)/ir_LG.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_LG.cpp
 
 ir_LG_test.o : ir_LG_test.cpp $(USER_DIR)/ir_LG.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_LG_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_LG_test.cpp
 
 ir_LG_test : $(COMMON_OBJ) ir_LG_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -251,16 +261,16 @@ ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(CO
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Mitsubishi.cpp
 
 ir_Mitsubishi_test.o : ir_Mitsubishi_test.cpp $(USER_DIR)/ir_Mitsubishi.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Mitsubishi_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Mitsubishi_test.cpp
 
 ir_Mitsubishi_test : $(COMMON_OBJ) ir_Mitsubishi_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Fujitsu.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp
 
 ir_Fujitsu_test.o : ir_Fujitsu_test.cpp $(USER_DIR)/ir_Fujitsu.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Fujitsu_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Fujitsu_test.cpp
 
 ir_Fujitsu_test : $(COMMON_OBJ) ir_Fujitsu_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -269,7 +279,7 @@ ir_Sharp.o : $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sharp.cpp
 
 ir_Sharp_test.o : ir_Sharp_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sharp_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Sharp_test.cpp
 
 ir_Sharp_test : $(COMMON_OBJ) ir_Sharp_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -278,7 +288,7 @@ ir_RC5_RC6.o : $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_RC5_RC6.cpp
 
 ir_RC5_RC6_test.o : ir_RC5_RC6_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_RC5_RC6_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_RC5_RC6_test.cpp
 
 ir_RC5_RC6_test : $(COMMON_OBJ) ir_RC5_RC6_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -287,7 +297,7 @@ ir_Panasonic.o : $(USER_DIR)/ir_Panasonic.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Panasonic.cpp
 
 ir_Panasonic_test.o : ir_Panasonic_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Panasonic_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Panasonic_test.cpp
 
 ir_Panasonic_test : $(COMMON_OBJ) ir_Panasonic_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -296,7 +306,7 @@ ir_Dish.o : $(USER_DIR)/ir_Dish.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Dish.cpp
 
 ir_Dish_test.o : ir_Dish_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Dish_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Dish_test.cpp
 
 ir_Dish_test : $(COMMON_OBJ) ir_Dish_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -305,7 +315,7 @@ ir_Whynter.o : $(USER_DIR)/ir_Whynter.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Whynter.cpp
 
 ir_Whynter_test.o : ir_Whynter_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Whynter_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Whynter_test.cpp
 
 ir_Whynter_test : $(COMMON_OBJ) ir_Whynter_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -314,7 +324,7 @@ ir_Coolix.o : $(USER_DIR)/ir_Coolix.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Coolix.cpp
 
 ir_Coolix_test.o : ir_Coolix_test.cpp $(USER_DIR)/ir_Coolix.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Coolix_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Coolix_test.cpp
 
 ir_Coolix_test : $(COMMON_OBJ) ir_Coolix_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -323,7 +333,7 @@ ir_Aiwa.o : $(USER_DIR)/ir_Aiwa.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Aiwa.cpp
 
 ir_Aiwa_test.o : ir_Aiwa_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Aiwa_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Aiwa_test.cpp
 
 ir_Aiwa_test : $(COMMON_OBJ) ir_Aiwa_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -332,7 +342,7 @@ ir_Denon.o : $(USER_DIR)/ir_Denon.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Denon.cpp
 
 ir_Denon_test.o : ir_Denon_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Denon_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Denon_test.cpp
 
 ir_Denon_test : $(COMMON_OBJ) ir_Denon_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -341,25 +351,25 @@ ir_Sanyo.o : $(USER_DIR)/ir_Sanyo.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sanyo.cpp
 
 ir_Sanyo_test.o : ir_Sanyo_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Sanyo_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Sanyo_test.cpp
 
 ir_Sanyo_test : $(COMMON_OBJ) ir_Sanyo_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Daikin.o : $(USER_DIR)/ir_Daikin.cpp $(USER_DIR)/ir_Daikin.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Daikin.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Daikin.cpp
 
 ir_Daikin_test.o : ir_Daikin_test.cpp $(USER_DIR)/ir_Daikin.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Daikin_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Daikin_test.cpp
 
 ir_Daikin_test : $(COMMON_OBJ) ir_Daikin_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Gree.o : $(USER_DIR)/ir_Gree.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Gree.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Gree.cpp
 
 ir_Gree_test.o : ir_Gree_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Gree_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Gree_test.cpp
 
 ir_Gree_test : $(COMMON_OBJ) ir_Gree_test.o ir_Kelvinator.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -368,7 +378,7 @@ ir_Pronto.o : $(USER_DIR)/ir_Pronto.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Pronto.cpp
 
 ir_Pronto_test.o : ir_Pronto_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Pronto_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Pronto_test.cpp
 
 ir_Pronto_test : $(COMMON_OBJ) ir_Pronto_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -377,7 +387,7 @@ ir_Nikai.o : $(USER_DIR)/ir_Nikai.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Nikai.cpp
 
 ir_Nikai_test.o : ir_Nikai_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Nikai_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Nikai_test.cpp
 
 ir_Nikai_test : $(COMMON_OBJ) ir_Nikai_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -386,7 +396,7 @@ ir_Toshiba.o : $(USER_DIR)/ir_Toshiba.cpp $(USER_DIR)/ir_Toshiba.h $(GTEST_HEADE
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Toshiba.cpp
 
 ir_Toshiba_test.o : ir_Toshiba_test.cpp $(USER_DIR)/ir_Toshiba.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Toshiba_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Toshiba_test.cpp
 
 ir_Toshiba_test : $(COMMON_OBJ) ir_Toshiba_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -395,7 +405,7 @@ ir_Midea.o : $(USER_DIR)/ir_Midea.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Midea.cpp
 
 ir_Midea_test.o : ir_Midea_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Midea_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Midea_test.cpp
 
 ir_Midea_test : $(COMMON_OBJ) ir_Midea_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -404,7 +414,7 @@ ir_Magiquest.o : $(USER_DIR)/ir_Magiquest.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Magiquest.cpp
 
 ir_Magiquest_test.o : ir_Magiquest_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Magiquest_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Magiquest_test.cpp
 
 ir_Magiquest_test : $(COMMON_OBJ) ir_Magiquest_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -413,7 +423,7 @@ ir_Lasertag.o : $(USER_DIR)/ir_Lasertag.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(GTEST_H
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lasertag.cpp
 
 ir_Lasertag_test.o : ir_Lasertag_test.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Lasertag_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Lasertag_test.cpp
 
 ir_Lasertag_test : $(COMMON_OBJ) ir_Lasertag_test.o ir_RC5_RC6.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -422,7 +432,7 @@ ir_Carrier.o : $(USER_DIR)/ir_Carrier.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Carrier.cpp
 
 ir_Carrier_test.o : ir_Carrier_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Carrier_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Carrier_test.cpp
 
 ir_Carrier_test : $(COMMON_OBJ) ir_Carrier_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -431,7 +441,7 @@ ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(COMMON_DEPS) $(GT
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Haier.cpp
 
 ir_Haier_test.o : ir_Haier_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Haier_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Haier_test.cpp
 
 ir_Haier_test : $(COMMON_OBJ) ir_Haier_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -440,7 +450,7 @@ ir_Hitachi.o : $(USER_DIR)/ir_Hitachi.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Hitachi.cpp
 
 ir_Hitachi_test.o : ir_Hitachi_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Hitachi_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Hitachi_test.cpp
 
 ir_Hitachi_test : $(COMMON_OBJ) ir_Hitachi_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -449,7 +459,7 @@ ir_GICable.o : $(USER_DIR)/ir_GICable.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_GICable.cpp
 
 ir_GICable_test.o : ir_GICable_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_GICable_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_GICable_test.cpp
 
 ir_GICable_test : $(COMMON_OBJ) ir_GICable_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -458,7 +468,7 @@ ir_Whirlpool.o : $(USER_DIR)/ir_Whirlpool.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Whirlpool.cpp
 
 ir_Whirlpool_test.o : ir_Whirlpool_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Whirlpool_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Whirlpool_test.cpp
 
 ir_Whirlpool_test : $(COMMON_OBJ) ir_Whirlpool_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -467,7 +477,7 @@ ir_Lutron.o : $(USER_DIR)/ir_Lutron.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lutron.cpp
 
 ir_Lutron_test.o : ir_Lutron_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Lutron_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Lutron_test.cpp
 
 ir_Lutron_test : $(COMMON_OBJ) ir_Lutron_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -476,7 +486,7 @@ ir_Electra.o : $(USER_DIR)/ir_Electra.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Electra.cpp
 
 ir_Electra_test.o : ir_Electra_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Electra_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Electra_test.cpp
 
 ir_Electra_test : $(COMMON_OBJ) ir_Electra_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -485,7 +495,7 @@ ir_Pioneer.o : $(USER_DIR)/ir_Pioneer.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Pioneer.cpp
 
 ir_Pioneer_test.o : ir_Pioneer_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Pioneer_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Pioneer_test.cpp
 
 ir_Pioneer_test : $(COMMON_OBJ) ir_Pioneer_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -494,7 +504,7 @@ ir_MWM.o : $(USER_DIR)/ir_MWM.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MWM.cpp
 
 ir_MWM_test.o : ir_MWM_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_MWM_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_MWM_test.cpp
 
 ir_MWM_test : $(COMMON_OBJ) ir_MWM_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -503,7 +513,7 @@ ir_Vestel.o : $(USER_DIR)/ir_Vestel.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Vestel.cpp
 
 ir_Vestel_test.o : ir_Vestel_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Vestel_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Vestel_test.cpp
 
 ir_Vestel_test : $(COMMON_OBJ) ir_Vestel_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -512,7 +522,7 @@ ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp
 
 ir_Teco_test.o : ir_Teco_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Teco_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Teco_test.cpp
 
 ir_Teco_test : $(COMMON_OBJ) ir_Teco_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -521,7 +531,7 @@ ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp
 
 ir_Tcl_test.o : ir_Tcl_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Tcl_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Tcl_test.cpp
 
 ir_Tcl_test : $(COMMON_OBJ) ir_Tcl_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -530,7 +540,7 @@ ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp
 
 ir_Lego_test.o : ir_Lego_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_Lego_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Lego_test.cpp
 
 ir_Lego_test : $(COMMON_OBJ) ir_Lego_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -528,7 +528,7 @@ ir_Teco_test : $(COMMON_OBJ) ir_Teco_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Tcl.cpp
 
 ir_Tcl_test.o : ir_Tcl_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Tcl_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -258,7 +258,7 @@ ir_LG_test : $(COMMON_OBJ) ir_LG_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Mitsubishi.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Mitsubishi.cpp
 
 ir_Mitsubishi_test.o : ir_Mitsubishi_test.cpp $(USER_DIR)/ir_Mitsubishi.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Mitsubishi_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -466,7 +466,7 @@ ir_GICable_test : $(COMMON_OBJ) ir_GICable_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Whirlpool.o : $(USER_DIR)/ir_Whirlpool.cpp $(COMMON_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Whirlpool.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Whirlpool.cpp
 
 ir_Whirlpool_test.o : ir_Whirlpool_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Whirlpool_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ INCLUDES = -I$(USER_DIR) -I.
 CPPFLAGS += -isystem $(GTEST_DIR)/include -DUNIT_TEST
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -pthread
+CXXFLAGS += -g -Wall -Wextra -pthread -std=gnu++11
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.

--- a/test/Makefile
+++ b/test/Makefile
@@ -294,7 +294,7 @@ ir_RC5_RC6_test : $(COMMON_OBJ) ir_RC5_RC6_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Panasonic.o : $(USER_DIR)/ir_Panasonic.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Panasonic.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Panasonic.cpp
 
 ir_Panasonic_test.o : ir_Panasonic_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Panasonic_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -213,7 +213,7 @@ ir_Sony_test : $(COMMON_OBJ) ir_Sony_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Samsung.o : $(USER_DIR)/ir_Samsung.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Samsung.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Samsung.cpp
 
 ir_Samsung_test.o : ir_Samsung_test.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Samsung_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -438,7 +438,7 @@ ir_Carrier_test : $(COMMON_OBJ) ir_Carrier_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(COMMON_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Haier.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Haier.cpp
 
 ir_Haier_test.o : ir_Haier_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Haier_test.cpp
@@ -510,7 +510,7 @@ ir_MWM_test : $(COMMON_OBJ) ir_MWM_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Vestel.o : $(USER_DIR)/ir_Vestel.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Vestel.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Vestel.cpp
 
 ir_Vestel_test.o : ir_Vestel_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Vestel_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -81,7 +81,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
-	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o
+	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
@@ -544,3 +544,6 @@ ir_Lego_test.o : ir_Lego_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 
 ir_Lego_test : $(COMMON_OBJ) ir_Lego_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Argo.o : $(USER_DIR)/ir_Argo.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Argo.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -393,7 +393,7 @@ ir_Nikai_test : $(COMMON_OBJ) ir_Nikai_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Toshiba.o : $(USER_DIR)/ir_Toshiba.cpp $(USER_DIR)/ir_Toshiba.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Toshiba.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Toshiba.cpp
 
 ir_Toshiba_test.o : ir_Toshiba_test.cpp $(USER_DIR)/ir_Toshiba.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Toshiba_test.cpp

--- a/test/Makefile
+++ b/test/Makefile
@@ -402,7 +402,7 @@ ir_Toshiba_test : $(COMMON_OBJ) ir_Toshiba_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Midea.o : $(USER_DIR)/ir_Midea.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Midea.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Midea.cpp
 
 ir_Midea_test.o : ir_Midea_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Midea_test.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -158,7 +158,7 @@ ir_Nikai.o : $(USER_DIR)/ir_Nikai.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Nikai.cpp
 
 ir_Toshiba.o : $(USER_DIR)/ir_Toshiba.h $(USER_DIR)/ir_Toshiba.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Toshiba.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Toshiba.cpp
 
 ir_Midea.o : $(USER_DIR)/ir_Midea.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Midea.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -203,7 +203,7 @@ ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp
 
 ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(USER_DIR)/ir_Tcl.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Tcl.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(INCLUDES) $(USER_DIR)/ir_Tcl.cpp
 
 ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -182,7 +182,7 @@ ir_GICable.o : $(USER_DIR)/ir_GICable.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_GICable.cpp
 
 ir_Whirlpool.o : $(USER_DIR)/ir_Whirlpool.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Whirlpool.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Whirlpool.cpp
 
 ir_Lutron.o : $(USER_DIR)/ir_Lutron.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lutron.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -125,7 +125,7 @@ ir_RC5_RC6.o : $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_RC5_RC6.cpp
 
 ir_Panasonic.o : $(USER_DIR)/ir_Panasonic.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Panasonic.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Panasonic.cpp
 
 ir_Dish.o : $(USER_DIR)/ir_Dish.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Dish.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -113,7 +113,7 @@ ir_LG.o : $(USER_DIR)/ir_LG.h $(USER_DIR)/ir_LG.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_LG.cpp
 
 ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Mitsubishi.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Mitsubishi.cpp
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,7 +98,7 @@ ir_Sony.o : $(USER_DIR)/ir_Sony.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sony.cpp
 
 ir_Samsung.o : $(USER_DIR)/ir_Samsung.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Samsung.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Samsung.cpp
 
 ir_Kelvinator.o : $(USER_DIR)/ir_Kelvinator.cpp $(USER_DIR)/ir_Kelvinator.h $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Kelvinator.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,6 +14,7 @@ USER_DIR = ../src
 # Where to find test code.
 TEST_DIR = ../test
 
+INCLUDES = -I$(USER_DIR) -I$(TEST_DIR)
 # Flags passed to the preprocessor.
 # Set Google Test's header directory as a system directory, such that
 # the compiler doesn't generate warnings in Google Test headers.
@@ -55,18 +56,19 @@ COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
 
 # Common dependencies
 COMMON_DEPS = $(USER_DIR)/IRrecv.h $(USER_DIR)/IRsend.h $(USER_DIR)/IRtimer.h \
-              $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteESP8266.h
+              $(USER_DIR)/IRutils.h $(USER_DIR)/IRremoteESP8266.h \
+							$(TEST_DIR)/IRsend_test.h
 # Common test dependencies
 COMMON_TEST_DEPS = $(COMMON_DEPS) $(TEST_DIR)/IRsend_test.h
 
 gc_decode.o : gc_decode.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -I$(TEST_DIR) -c gc_decode.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c gc_decode.cpp
 
 gc_decode : $(COMMON_OBJ) gc_decode.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 mode2_decode.o : mode2_decode.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -I$(TEST_DIR) -c mode2_decode.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c mode2_decode.cpp
 
 mode2_decode : $(COMMON_OBJ) mode2_decode.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
@@ -82,7 +84,6 @@ IRsend.o : $(USER_DIR)/IRsend.cpp $(USER_DIR)/IRsend.h $(USER_DIR)/IRremoteESP82
 
 IRrecv.o : $(USER_DIR)/IRrecv.cpp $(USER_DIR)/IRrecv.h $(USER_DIR)/IRremoteESP8266.h $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/IRrecv.cpp
-
 
 ir_NEC.o : $(USER_DIR)/ir_NEC.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_NEC.cpp
@@ -100,7 +101,7 @@ ir_Samsung.o : $(USER_DIR)/ir_Samsung.cpp $(USER_DIR)/ir_Samsung.h $(COMMON_DEPS
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Samsung.cpp
 
 ir_Kelvinator.o : $(USER_DIR)/ir_Kelvinator.cpp $(USER_DIR)/ir_Kelvinator.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Kelvinator.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Kelvinator.cpp
 
 ir_JVC.o : $(USER_DIR)/ir_JVC.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_JVC.cpp
@@ -115,7 +116,7 @@ ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(CO
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Mitsubishi.cpp
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Fujitsu.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp
 
 ir_Sharp.o : $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sharp.cpp
@@ -133,7 +134,7 @@ ir_Whynter.o : $(USER_DIR)/ir_Whynter.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Whynter.cpp
 
 ir_Coolix.o : $(USER_DIR)/ir_Coolix.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Coolix.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Coolix.cpp
 
 ir_Aiwa.o : $(USER_DIR)/ir_Aiwa.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Aiwa.cpp
@@ -145,10 +146,10 @@ ir_Sanyo.o : $(USER_DIR)/ir_Sanyo.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sanyo.cpp
 
 ir_Daikin.o : $(USER_DIR)/ir_Daikin.cpp $(USER_DIR)/ir_Daikin.h $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Daikin.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Daikin.cpp
 
 ir_Gree.o : $(USER_DIR)/ir_Gree.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Gree.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Gree.cpp
 
 ir_Pronto.o : $(USER_DIR)/ir_Pronto.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Pronto.cpp
@@ -172,7 +173,7 @@ ir_Carrier.o : $(USER_DIR)/ir_Carrier.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Carrier.cpp
 
 ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Haier.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Haier.cpp
 
 ir_Hitachi.o : $(USER_DIR)/ir_Hitachi.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Hitachi.cpp
@@ -196,7 +197,7 @@ ir_MWM.o : $(USER_DIR)/ir_MWM.cpp $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MWM.cpp
 
 ir_Vestel.o : $(USER_DIR)/ir_Vestel.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Vestel.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Vestel.cpp
 
 ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -176,7 +176,7 @@ ir_Haier.o : $(USER_DIR)/ir_Haier.cpp $(USER_DIR)/ir_Haier.h $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Haier.cpp
 
 ir_Hitachi.o : $(USER_DIR)/ir_Hitachi.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Hitachi.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Hitachi.cpp
 
 ir_GICable.o : $(USER_DIR)/ir_GICable.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_GICable.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -161,7 +161,7 @@ ir_Toshiba.o : $(USER_DIR)/ir_Toshiba.h $(USER_DIR)/ir_Toshiba.cpp $(COMMON_DEPS
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Toshiba.cpp
 
 ir_Midea.o : $(USER_DIR)/ir_Midea.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Midea.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Midea.cpp
 
 ir_Magiquest.o : $(USER_DIR)/ir_Magiquest.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Magiquest.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -200,10 +200,10 @@ ir_Vestel.o : $(USER_DIR)/ir_Vestel.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Vestel.cpp
 
 ir_Teco.o : $(USER_DIR)/ir_Teco.cpp $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Teco.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Teco.cpp
 
 ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(USER_DIR)/ir_Tcl.h $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(INCLUDES) $(USER_DIR)/ir_Tcl.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Tcl.cpp
 
 ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -21,7 +21,7 @@ INCLUDES = -I$(USER_DIR) -I$(TEST_DIR)
 CPPFLAGS += -DUNIT_TEST
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -pthread
+CXXFLAGS += -g -Wall -Wextra -pthread -std=gnu++11
 
 all : gc_decode mode2_decode
 


### PR DESCRIPTION
* Provide a single class/function with standardised common arguments for controlling
  all deeply supported A/C units.
* Extend unit testing for the `ac.send()` class method.
* Supports:
  - Argo
  - Coolix
  - Daikin
  - Gree
  - Fujitsu
  - Haier
  - Hitachi
  - Kelvinator
  - Midea
  - Mitsubishi
  - Panasonic
  - Samsung (inc. On/Off fixes)
  - Tcl112
  - Teco
  - Toshiba
  - Trotec (inc. some bug fixes)
  - Vestel (inc. some improvements)
  - Whirlpool
* Unit tests for the above.
* Allow unit tests to use the `c++11` standard
* Requires Arduino IDE >= **1.6.6**

Fixes #628 
Includes workaround for #604 