### PR TITLE
First draft of support for Mitsubishi Heavy Industries A/Cs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   - arduino --verify --board $BD $PWD/examples/TurnOnToshibaAC/TurnOnToshibaAC.ino
   - arduino --verify --board $BD $PWD/examples/ControlSamsungAC/ControlSamsungAC.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnPanasonicAC/TurnOnPanasonicAC.ino
+  - arduino --verify --board $BD $PWD/examples/TurnOnMitsubishiHeavyAc/TurnOnMitsubishiHeavyAc.ino
 
   # Also check the tools programs compile.
   - (cd tools; make all)

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -624,6 +624,8 @@ void handleRoot() {
         "<option value='42'>Hitachi2 (53 bytes)</option>"
         "<option selected='selected' value='18'>Kelvinator</option>"  // Default
         "<option value='20'>Mitsubishi</option>"
+        "<option value='59'>Mitsubishi Heavy (11 bytes)</option>"
+        "<option value='60'>Mitsubishi Heavy (19 bytes)</option>"
         "<option value='52'>MWM</option>"
         "<option value='46'>Samsung</option>"
         "<option value='57'>TCL112</option>"
@@ -720,6 +722,12 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       break;
     case MITSUBISHI_AC:
       stateSize = kMitsubishiACStateLength;
+      break;
+    case MITSUBISHI_HEAVY_88:
+      stateSize = kMitsubishiHeavy88StateLength;
+      break;
+    case MITSUBISHI_HEAVY_152:
+      stateSize = kMitsubishiHeavy152StateLength;
       break;
     case PANASONIC_AC:
       stateSize = kPanasonicAcStateLength;
@@ -857,6 +865,14 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       irsend->sendMitsubishiAC(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
+#if SEND_MITSUBISHIHEAVY
+    case MITSUBISHI_HEAVY_88:  // 59
+      irsend->sendMitsubishiHeavy88(reinterpret_cast<uint8_t *>(state));
+      break;
+    case MITSUBISHI_HEAVY_152:  // 60
+      irsend->sendMitsubishiHeavy152(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif  // SEND_MITSUBISHIHEAVY
 #if SEND_TROTEC
     case TROTEC:
       irsend->sendTrotec(reinterpret_cast<uint8_t *>(state));

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -156,6 +156,11 @@ void dumpACInfo(decode_results *results) {
   }
 #endif  // DECODE_MITSUBISHI_AC
 #if DECODE_MITSUBISHIHEAVY
+  if (results->decode_type == MITSUBISHI_HEAVY_88) {
+    IRMitsubishiHeavy88Ac ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
   if (results->decode_type == MITSUBISHI_HEAVY_152) {
     IRMitsubishiHeavy152Ac ac(0);
     ac.setRaw(results->state);

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -35,6 +35,7 @@
 #include <ir_Kelvinator.h>
 #include <ir_Midea.h>
 #include <ir_Mitsubishi.h>
+#include <ir_MitsubishiHeavy.h>
 #include <ir_Panasonic.h>
 #include <ir_Samsung.h>
 #include <ir_Tcl.h>
@@ -154,6 +155,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_MITSUBISHI_AC
+#if DECODE_MITSUBISHIHEAVY
+  if (results->decode_type == MITSUBISHI_HEAVY_152) {
+    IRMitsubishiHeavy152Ac ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_MITSUBISHIHEAVY
 #if DECODE_TOSHIBA_AC
   if (results->decode_type == TOSHIBA_AC) {
     IRToshibaAC ac(0);

--- a/examples/TurnOnMitsubishiHeavyAc/TurnOnMitsubishiHeavyAc.ino
+++ b/examples/TurnOnMitsubishiHeavyAc/TurnOnMitsubishiHeavyAc.ino
@@ -1,0 +1,72 @@
+/* Copyright 2019 David Conran
+*
+* An IR LED circuit *MUST* be connected to the ESP8266 on a pin
+* as specified by kIrLed below.
+*
+* TL;DR: The IR LED needs to be driven by a transistor for a good result.
+*
+* Suggested circuit:
+*     https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
+*
+* Common mistakes & tips:
+*   * Don't just connect the IR LED directly to the pin, it won't
+*     have enough current to drive the IR LED effectively.
+*   * Make sure you have the IR LED polarity correct.
+*     See: https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity
+*   * Typical digital camera/phones can be used to see if the IR LED is flashed.
+*     Replace the IR LED with a normal LED if you don't have a digital camera
+*     when debugging.
+*   * Avoid using the following pins unless you really know what you are doing:
+*     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
+*     * Pin 1/TX/TXD0: Any serial transmissions from the ESP8266 will interfere.
+*     * Pin 3/RX/RXD0: Any serial transmissions to the ESP8266 will interfere.
+*   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
+*     for your first time. e.g. ESP-12 etc.
+*/
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include <IRremoteESP8266.h>
+#include <IRsend.h>
+#include <ir_MitsubishiHeavy.h>
+
+const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
+IRMitsubishiHeavy152Ac ac(kIrLed);  // Set the GPIO used for sending messages.
+
+void printState() {
+  // Display the settings.
+  Serial.println("Mitsubishi Heavy A/C remote is in the following state:");
+  Serial.printf("  %s\n", ac.toString().c_str());
+  // Display the encoded IR sequence.
+  unsigned char* ir_code = ac.getRaw();
+  Serial.print("IR Code: 0x");
+  for (uint8_t i = 0; i < kMitsubishiHeavy152StateLength; i++)
+    Serial.printf("%02X", ir_code[i]);
+  Serial.println();
+}
+
+void setup() {
+  ac.begin();
+  Serial.begin(115200);
+  delay(200);
+
+  // Set up what we want to send. See ir_MitsubishiHeavy.(cpp|h) for all the
+  // options.
+  Serial.println("Default state of the remote.");
+  printState();
+  Serial.println("Setting desired state for A/C.");
+  ac.setPower(true);  // Turn it on.
+  ac.setFan(kMitsubishiHeavy152FanMed);  // Medium Fan
+  ac.setMode(kMitsubishiHeavyCool);  // Cool mode
+  ac.setTemp(26);  // Celsius
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);  // Swing vertically
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHMiddle);  // Swing Horizontally
+}
+
+void loop() {
+  // Now send the IR signal.
+  Serial.println("Sending IR command to A/C ...");
+  ac.send();
+  printState();
+  delay(5000);
+}

--- a/examples/TurnOnMitsubishiHeavyAc/platformio.ini
+++ b/examples/TurnOnMitsubishiHeavyAc/platformio.ini
@@ -1,0 +1,17 @@
+[platformio]
+lib_extra_dirs = ../../
+src_dir=.
+
+[common]
+build_flags =
+lib_deps_builtin =
+lib_deps_external =
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -23,6 +23,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
@@ -363,6 +364,61 @@ void IRac::mitsubishi(IRMitsubishiAC *ac,
   ac->send();
 }
 #endif  // SEND_MITSUBISHI_AC
+
+#if SEND_MITSUBISHIHEAVY
+void IRac::mitsubishiHeavy88(IRMitsubishiHeavy88Ac *ac,
+                             const bool on, const stdAc::opmode_t mode,
+                             const float degrees,
+                             const stdAc::fanspeed_t fan,
+                             const stdAc::swingv_t swingv,
+                             const stdAc::swingh_t swingh,
+                             const bool turbo, const bool econo,
+                             const bool clean) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(ac->convertSwingV(swingv));
+  ac->setSwingHorizontal(ac->convertSwingH(swingh));
+  // No Quiet setting available.
+  ac->setTurbo(turbo);
+  // No Light setting available.
+  ac->setEcono(econo);
+  // No Filter setting available.
+  ac->setClean(clean);
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+
+void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
+                              const bool on, const stdAc::opmode_t mode,
+                              const float degrees,
+                              const stdAc::fanspeed_t fan,
+                              const stdAc::swingv_t swingv,
+                              const stdAc::swingh_t swingh,
+                              const bool quiet, const bool turbo,
+                              const bool econo, const bool filter,
+                              const bool clean, const int16_t sleep) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(ac->convertSwingV(swingv));
+  ac->setSwingHorizontal(ac->convertSwingH(swingh));
+  ac->setSilent(quiet);
+  ac->setTurbo(turbo);
+  // No Light setting available.
+  ac->setEcono(econo);
+  ac->setClean(clean);
+  ac->setFilter(filter);
+  // No Beep setting available.
+  ac->setNight(sleep >= 0);  // Sleep is either on/off, so convert to boolean.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_MITSUBISHIHEAVY
 
 #if SEND_PANASONIC_AC
 void IRac::panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,
@@ -723,6 +779,24 @@ bool IRac::sendAc(const decode_type_t vendor, const uint16_t model,
       break;
     }
 #endif  // SEND_MITSUBISHI_AC
+#if SEND_MITSUBISHIHEAVY
+    case MITSUBISHI_HEAVY_88:
+    {
+      IRMitsubishiHeavy88Ac ac(_pin);
+      ac.begin();
+      mitsubishiHeavy88(&ac, on, mode, degC, fan, swingv, swingh,
+                        turbo, econo, clean);
+      break;
+    }
+    case MITSUBISHI_HEAVY_152:
+    {
+      IRMitsubishiHeavy152Ac ac(_pin);
+      ac.begin();
+      mitsubishiHeavy152(&ac, on, mode, degC, fan, swingv, swingh,
+                         quiet, turbo, econo, filter, clean, sleep);
+      break;
+    }
+#endif  // SEND_MITSUBISHIHEAVY
 #if SEND_PANASONIC_AC
     case PANASONIC_AC:
     {

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -20,6 +20,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
@@ -132,6 +133,22 @@ class IRac {
                   const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                   const bool quiet, const int16_t clock = -1);
 #endif  // SEND_MITSUBISHI_AC
+#if SEND_MITSUBISHIHEAVY
+  void mitsubishiHeavy88(IRMitsubishiHeavy88Ac *ac,
+                         const bool on, const stdAc::opmode_t mode,
+                         const float degrees, const stdAc::fanspeed_t fan,
+                         const stdAc::swingv_t swingv,
+                         const stdAc::swingh_t swingh,
+                         const bool turbo, const bool econo, const bool clean);
+  void mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
+                          const bool on, const stdAc::opmode_t mode,
+                          const float degrees, const stdAc::fanspeed_t fan,
+                          const stdAc::swingv_t swingv,
+                          const stdAc::swingh_t swingh,
+                          const bool quiet, const bool turbo, const bool econo,
+                          const bool filter, const bool clean,
+                          const int16_t sleep = -1);
+#endif  // SEND_MITSUBISHIHEAVY
 #if SEND_PANASONIC_AC
   void panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,
                  const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -513,6 +513,12 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting LEGOPF decode");
   if (decodeLegoPf(results)) return true;
 #endif
+#if DECODE_MITSUBISHIHEAVY
+  DPRINTLN("Attempting MITSUBISHIHEAVY (152 bit) decode");
+  if (decodeMitsubishiHeavy(results, kMitsubishiHeavy152Bits)) return true;
+  DPRINTLN("Attempting MITSUBISHIHEAVY (88 bit) decode");
+  if (decodeMitsubishiHeavy(results, kMitsubishiHeavy88Bits)) return true;
+#endif
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -181,6 +181,10 @@ class IRrecv {
                           uint16_t nbits = kMitsubishiACBits,
                           bool strict = false);
 #endif
+#if DECODE_MITSUBISHIHEAVY
+  bool decodeMitsubishiHeavy(decode_results *results, const uint16_t nbits,
+                             const bool strict = true);
+#endif
 #if (DECODE_RC5 || DECODE_R6 || DECODE_LASERTAG || DECODE_MWM)
   int16_t getRClevel(decode_results *results, uint16_t *offset, uint16_t *used,
                      uint16_t bitTime, uint8_t tolerance = kTolerance,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -219,13 +219,16 @@
 #define DECODE_LEGOPF          true
 #define SEND_LEGOPF            true
 
+#define DECODE_MITSUBISHIHEAVY true
+#define SEND_MITSUBISHIHEAVY   true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
      DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2 || DECODE_HAIER_AC_YRW02 || \
      DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC || \
      DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || \
-     DECODE_VESTEL_AC || DECODE_TCL112AC)
+     DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -303,6 +306,8 @@ enum decode_type_t {
   SAMSUNG36,
   TCL112AC,
   LEGOPF,
+  MITSUBISHI_HEAVY_88,
+  MITSUBISHI_HEAVY_152,  // 60
 };
 
 // Message lengths & required repeat values
@@ -375,6 +380,12 @@ const uint16_t kMitsubishiMinRepeat = kSingleRepeat;
 const uint16_t kMitsubishiACStateLength = 18;
 const uint16_t kMitsubishiACBits = kMitsubishiACStateLength * 8;
 const uint16_t kMitsubishiACMinRepeat = kSingleRepeat;
+const uint16_t kMitsubishiHeavy88StateLength = 11;
+const uint16_t kMitsubishiHeavy88Bits = kMitsubishiHeavy88StateLength * 8;
+const uint16_t kMitsubishiHeavy88MinRepeat = kNoRepeat;
+const uint16_t kMitsubishiHeavy152StateLength = 19;
+const uint16_t kMitsubishiHeavy152Bits = kMitsubishiHeavy152StateLength * 8;
+const uint16_t kMitsubishiHeavy152MinRepeat = kNoRepeat;
 const uint16_t kNikaiBits = 24;
 const uint16_t kNECBits = 32;
 const uint16_t kPanasonicBits = 48;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -231,6 +231,16 @@ class IRsend {
                         uint16_t nbytes = kMitsubishiACStateLength,
                         uint16_t repeat = kMitsubishiACMinRepeat);
 #endif
+#if SEND_MITSUBISHIHEAVY
+  void sendMitsubishiHeavy88(
+      const unsigned char data[],
+      const uint16_t nbytes = kMitsubishiHeavy88StateLength,
+      const uint16_t repeat = kMitsubishiHeavy88MinRepeat);
+  void sendMitsubishiHeavy152(
+      const unsigned char data[],
+      const uint16_t nbytes = kMitsubishiHeavy152StateLength,
+      const uint16_t repeat = kMitsubishiHeavy152MinRepeat);
+#endif
 #if SEND_FUJITSU_AC
   void sendFujitsuAC(unsigned char data[], uint16_t nbytes,
                      uint16_t repeat = kFujitsuAcMinRepeat);

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -193,10 +193,10 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
       result = F("MITSUBISHI_AC");
       break;
     case MITSUBISHI_HEAVY_88:
-      result = "MITSUBISHI_HEAVY_88";
+      result = F("MITSUBISHI_HEAVY_88");
       break;
     case MITSUBISHI_HEAVY_152:
-      result = "MITSUBISHI_HEAVY_152";
+      result = F("MITSUBISHI_HEAVY_152");
       break;
     case MWM:
       result = F("MWM");
@@ -361,15 +361,16 @@ std::string resultToSourceCode(const decode_results *results) {
     }
     output += uint64ToString(usecs, 10);
     if (i < results->rawlen - 1)
-      output += ", ";               // ',' not needed on the last one
-    if (i % 2 == 0) output += " ";  // Extra if it was even.
+      output += F(", ");            // ',' not needed on the last one
+    if (i % 2 == 0) output += ' ';  // Extra if it was even.
   }
 
   // End declaration
-  output += "};";
+  output += F("};");
 
   // Comment
-  output += "  // " + typeToString(results->decode_type, results->repeat);
+  output += F("  // ");
+  output += typeToString(results->decode_type, results->repeat);
   // Only display the value if the decode type doesn't have an A/C state.
   if (!hasACState(results->decode_type))
     output += ' ' + uint64ToString(results->value, 16);
@@ -387,7 +388,7 @@ std::string resultToSourceCode(const decode_results *results) {
         output += F("0x");
         if (results->state[i] < 0x10) output += '0';
         output += uint64ToString(results->state[i], 16);
-        if (i < nbytes - 1) output += ", ";
+        if (i < nbytes - 1) output += F(", ");
       }
       output += F("};\n");
 #endif  // DECODE_AC
@@ -432,15 +433,16 @@ std::string resultToTimingInfo(const decode_results *results) {
     if (i % 2 == 0)
       output += '-';  // even
     else
-      output += "   +";  // odd
+      output += F("   +");  // odd
     value = uint64ToString(results->rawbuf[i] * kRawTick);
     // Space pad the value till it is at least 6 chars long.
-    while (value.length() < 6) value = " " + value;
+    while (value.length() < 6) value = ' ' + value;
     output += value;
-    if (i < results->rawlen - 1) output += ", ";  // ',' not needed for last one
-    if (!(i % 8)) output += F("\n");                 // Newline every 8 entries.
+    if (i < results->rawlen - 1)
+      output += F(", ");  // ',' not needed for last one
+    if (!(i % 8)) output += '\n';  // Newline every 8 entries.
   }
-  output += F("\n");
+  output += '\n';
   return output;
 }
 
@@ -478,7 +480,7 @@ std::string resultToHumanReadableBasic(const decode_results *results) {
   // Show Encoding standard
   output += F("Encoding  : ");
   output += typeToString(results->decode_type, results->repeat);
-  output += F("\n");
+  output += '\n';
 
   // Show Code & length
   output += F("Code      : ");

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -192,6 +192,12 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case MITSUBISHI_AC:
       result = F("MITSUBISHI_AC");
       break;
+    case MITSUBISHI_HEAVY_88:
+      result = "MITSUBISHI_HEAVY_88";
+      break;
+    case MITSUBISHI_HEAVY_152:
+      result = "MITSUBISHI_HEAVY_152";
+      break;
     case MWM:
       result = F("MWM");
       break;
@@ -296,6 +302,8 @@ bool hasACState(const decode_type_t protocol) {
     case HITACHI_AC2:
     case KELVINATOR:
     case MITSUBISHI_AC:
+    case MITSUBISHI_HEAVY_88:
+    case MITSUBISHI_HEAVY_152:
     case MWM:
     case PANASONIC_AC:
     case SAMSUNG_AC:

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -303,6 +303,81 @@ bool IRMitsubishiHeavy152Ac::validChecksum(const uint8_t *state,
   return true;
 }
 
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRMitsubishiHeavy152Ac::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kMitsubishiHeavyCool;
+    case stdAc::opmode_t::kHeat:
+      return kMitsubishiHeavyHeat;
+    case stdAc::opmode_t::kDry:
+      return kMitsubishiHeavyDry;
+    case stdAc::opmode_t::kFan:
+      return kMitsubishiHeavyFan;
+    default:
+      return kMitsubishiHeavyAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRMitsubishiHeavy152Ac::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kMitsubishiHeavy152FanEcono;  // Assumes Econo is slower than Low.
+    case stdAc::fanspeed_t::kLow:
+      return kMitsubishiHeavy152FanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kMitsubishiHeavy152FanMed;
+    case stdAc::fanspeed_t::kHigh:
+      return kMitsubishiHeavy152FanHigh;
+    case stdAc::fanspeed_t::kMax:
+      return kMitsubishiHeavy152FanMax;
+    default:
+      return kMitsubishiHeavy152FanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRMitsubishiHeavy152Ac::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kAuto:
+      return kMitsubishiHeavy152SwingVAuto;
+    case stdAc::swingv_t::kHighest:
+      return kMitsubishiHeavy152SwingVHighest;
+    case stdAc::swingv_t::kHigh:
+      return kMitsubishiHeavy152SwingVHigh;
+    case stdAc::swingv_t::kMiddle:
+      return kMitsubishiHeavy152SwingVMiddle;
+    case stdAc::swingv_t::kLow:
+      return kMitsubishiHeavy152SwingVLow;
+    case stdAc::swingv_t::kLowest:
+      return kMitsubishiHeavy152SwingVLowest;
+    default:
+      return kMitsubishiHeavy152SwingVOff;
+  }
+}
+
+// Convert a standard A/C horizontal swing into its native setting.
+uint8_t IRMitsubishiHeavy152Ac::convertSwingH(const stdAc::swingh_t position) {
+  switch (position) {
+    case stdAc::swingh_t::kAuto:
+      return kMitsubishiHeavy152SwingHAuto;
+    case stdAc::swingh_t::kLeftMax:
+      return kMitsubishiHeavy152SwingHLeftMax;
+    case stdAc::swingh_t::kLeft:
+      return kMitsubishiHeavy152SwingHLeft;
+    case stdAc::swingh_t::kMiddle:
+      return kMitsubishiHeavy152SwingHMiddle;
+    case stdAc::swingh_t::kRight:
+    return kMitsubishiHeavy152SwingHRight;
+    case stdAc::swingh_t::kRightMax:
+      return kMitsubishiHeavy152SwingHRightMax;
+    default:
+      return kMitsubishiHeavy152SwingHOff;
+  }
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRMitsubishiHeavy152Ac::toString(void) {
@@ -655,6 +730,70 @@ void IRMitsubishiHeavy88Ac::checksum(void) {
 bool IRMitsubishiHeavy88Ac::validChecksum(const uint8_t *state,
                                            const uint16_t length) {
   return IRMitsubishiHeavy152Ac::validChecksum(state, length);
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRMitsubishiHeavy88Ac::convertMode(const stdAc::opmode_t mode) {
+  return IRMitsubishiHeavy152Ac::convertMode(mode);
+}
+
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRMitsubishiHeavy88Ac::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kMitsubishiHeavy88FanEcono;  // Assumes Econo is slower than Low.
+    case stdAc::fanspeed_t::kLow:
+      return kMitsubishiHeavy88FanLow;
+    case stdAc::fanspeed_t::kMedium:
+      return kMitsubishiHeavy88FanMed;
+    case stdAc::fanspeed_t::kHigh:
+      return kMitsubishiHeavy88FanHigh;
+    case stdAc::fanspeed_t::kMax:
+      return kMitsubishiHeavy88FanTurbo;
+    default:
+      return kMitsubishiHeavy88FanAuto;
+  }
+}
+
+// Convert a standard A/C vertical swing into its native setting.
+uint8_t IRMitsubishiHeavy88Ac::convertSwingV(const stdAc::swingv_t position) {
+  switch (position) {
+    case stdAc::swingv_t::kAuto:
+      return kMitsubishiHeavy88SwingVAuto;
+    case stdAc::swingv_t::kHighest:
+      return kMitsubishiHeavy88SwingVHighest;
+    case stdAc::swingv_t::kHigh:
+      return kMitsubishiHeavy88SwingVHigh;
+    case stdAc::swingv_t::kMiddle:
+      return kMitsubishiHeavy88SwingVMiddle;
+    case stdAc::swingv_t::kLow:
+      return kMitsubishiHeavy88SwingVLow;
+    case stdAc::swingv_t::kLowest:
+      return kMitsubishiHeavy88SwingVLowest;
+    default:
+      return kMitsubishiHeavy88SwingVOff;
+  }
+}
+
+// Convert a standard A/C horizontal swing into its native setting.
+uint8_t IRMitsubishiHeavy88Ac::convertSwingH(const stdAc::swingh_t position) {
+  switch (position) {
+    case stdAc::swingh_t::kAuto:
+      return kMitsubishiHeavy88SwingHAuto;
+    case stdAc::swingh_t::kLeftMax:
+      return kMitsubishiHeavy88SwingHLeftMax;
+    case stdAc::swingh_t::kLeft:
+      return kMitsubishiHeavy88SwingHLeft;
+    case stdAc::swingh_t::kMiddle:
+      return kMitsubishiHeavy88SwingHMiddle;
+    case stdAc::swingh_t::kRight:
+    return kMitsubishiHeavy88SwingHRight;
+    case stdAc::swingh_t::kRightMax:
+      return kMitsubishiHeavy88SwingHRightMax;
+    default:
+      return kMitsubishiHeavy88SwingHOff;
+  }
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -1,0 +1,534 @@
+// Copyright 2019 David Conran
+// Mitsubishi Heavy Industries A/C remote emulation.
+
+// Code to emulate Mitsubishi Heavy Industries A/C IR remote control units,
+// which should control at least the following A/C units:
+//   Remote Control RLA502A700B:
+//     Model SRKxxZM-S
+//     Model SRKxxZMXA-S
+//   Remote Control RKX502A001C:
+//     Model SRKxxZJ-S
+
+// Note: This code was *heavily* influenced by @ToniA's great work & code,
+//       but it has been written from scratch.
+//       Nothing was copied other than constants and message analysis.
+
+#include "ir_MitsubishiHeavy.h"
+#include <algorithm>
+#include "IRremoteESP8266.h"
+#include "IRutils.h"
+#ifndef ARDUINO
+#include <string>
+#endif
+
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/660
+//   https://github.com/ToniA/Raw-IR-decoder-for-Arduino/blob/master/MitsubishiHeavy.cpp
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp
+
+// Constants
+const uint16_t kMitsubishiHeavyHdrMark = 3140;
+const uint16_t kMitsubishiHeavyHdrSpace = 1630;
+const uint16_t kMitsubishiHeavyBitMark = 370;
+const uint16_t kMitsubishiHeavyOneSpace = 420;
+const uint16_t kMitsubishiHeavyZeroSpace = 1220;
+const uint32_t kMitsubishiHeavyGap = kDefaultMessageGap;  // Just a guess.
+
+#if SEND_MITSUBISHIHEAVY
+// Send a MitsubishiHeavy 88 bit A/C message.
+//
+// Args:
+//   data:   Contents of the message to be sent.
+//   nbits:  Nr. of bits of data to be sent. Typically kMitsubishiHeavy88Bits.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: BETA / Appears to be working. Needs testing against a real device.
+void IRsend::sendMitsubishiHeavy88(const unsigned char data[],
+                                   const uint16_t nbytes,
+                                   const uint16_t repeat) {
+  if (nbytes < kMitsubishiHeavy88StateLength)
+    return;  // Not enough bytes to send a proper message.
+  sendGeneric(kMitsubishiHeavyHdrMark, kMitsubishiHeavyHdrSpace,
+              kMitsubishiHeavyBitMark, kMitsubishiHeavyOneSpace,
+              kMitsubishiHeavyBitMark, kMitsubishiHeavyZeroSpace,
+              kMitsubishiHeavyBitMark, kMitsubishiHeavyGap,
+              data, nbytes, 38000, false, repeat, kDutyDefault);
+}
+
+// Send a MitsubishiHeavy 152 bit A/C message.
+//
+// Args:
+//   data:   Contents of the message to be sent.
+//   nbits:  Nr. of bits of data to be sent. Typically kMitsubishiHeavy152Bits.
+//   repeat: Nr. of additional times the message is to be sent.
+//
+// Status: BETA / Appears to be working. Needs testing against a real device.
+void IRsend::sendMitsubishiHeavy152(const unsigned char data[],
+                                    const uint16_t nbytes,
+                                    const uint16_t repeat) {
+  if (nbytes < kMitsubishiHeavy152StateLength)
+    return;  // Not enough bytes to send a proper message.
+  sendMitsubishiHeavy88(data, nbytes, repeat);
+}
+#endif  // SEND_MITSUBISHIHEAVY
+
+// Class for decoding and constructing MitsubishiHeavy152 AC messages.
+IRMitsubishiHeavy152Ac::IRMitsubishiHeavy152Ac(
+    const uint16_t pin) : _irsend(pin) { stateReset(); }
+
+void IRMitsubishiHeavy152Ac::begin() { _irsend.begin(); }
+
+#if SEND_MITSUBISHIHEAVY
+void IRMitsubishiHeavy152Ac::send(const uint16_t repeat) {
+  _irsend.sendMitsubishiHeavy152(this->getRaw(), kMitsubishiHeavy152StateLength,
+                                 repeat);
+}
+#endif  // SEND_MITSUBISHIHEAVY
+
+void IRMitsubishiHeavy152Ac::stateReset(void) {
+  for (uint8_t i = 0; i < kMitsubishiHeavySigLength; i++)
+    remote_state[i] = kMitsubishiHeavyZmsSig[i];
+
+  for (uint8_t i = kMitsubishiHeavySigLength;
+       i < kMitsubishiHeavy152StateLength - 3; i += 2)
+    remote_state[i] = 0;
+  remote_state[17] = 0x80;
+}
+
+uint8_t *IRMitsubishiHeavy152Ac::getRaw(void) {
+  checksum();
+  return remote_state;
+}
+
+void IRMitsubishiHeavy152Ac::setRaw(const uint8_t *data) {
+  for (uint8_t i = 0; i < kMitsubishiHeavy152StateLength; i++) {
+    remote_state[i] = data[i];
+  }
+}
+
+void IRMitsubishiHeavy152Ac::on(void) {
+  remote_state[5] |= kMitsubishiHeavyPowerBit;
+}
+
+void IRMitsubishiHeavy152Ac::off(void) {
+  remote_state[5] &= ~kMitsubishiHeavyPowerBit;
+}
+
+void IRMitsubishiHeavy152Ac::setPower(const bool on) {
+  if (on)
+    this->on();
+  else
+    this->off();
+}
+
+bool IRMitsubishiHeavy152Ac::getPower(void) {
+  return remote_state[5] & kMitsubishiHeavyPowerBit;
+}
+
+void IRMitsubishiHeavy152Ac::setTemp(const uint8_t temp) {
+  uint8_t newtemp = temp;
+  newtemp = std::min(newtemp, kMitsubishiHeavyMaxTemp);
+  newtemp = std::max(newtemp, kMitsubishiHeavyMinTemp);
+
+  remote_state[7] &= ~kMitsubishiHeavyTempMask;
+  remote_state[7] |= newtemp - kMitsubishiHeavyMinTemp;
+}
+
+uint8_t IRMitsubishiHeavy152Ac::getTemp(void) {
+  return (remote_state[7] & kMitsubishiHeavyTempMask) + kMitsubishiHeavyMinTemp;
+}
+
+// Set the speed of the fan
+void IRMitsubishiHeavy152Ac::setFan(const uint8_t speed) {
+  uint8_t newspeed = speed;
+  switch (speed) {
+    case kMitsubishiHeavy152FanLow:
+    case kMitsubishiHeavy152FanMed:
+    case kMitsubishiHeavy152FanHigh:
+    case kMitsubishiHeavy152FanMax:
+    case kMitsubishiHeavy152FanEcono:
+    case kMitsubishiHeavy152FanTurbo:
+      break;
+    default:
+      newspeed = kMitsubishiHeavy152FanAuto;
+  }
+  remote_state[9] &= ~kMitsubishiHeavyFanMask;
+  remote_state[9] |= newspeed;
+}
+
+uint8_t IRMitsubishiHeavy152Ac::getFan(void) {
+  return remote_state[9] & kMitsubishiHeavyFanMask;
+}
+
+void IRMitsubishiHeavy152Ac::setMode(const uint8_t mode) {
+  uint8_t newmode = mode;
+  switch (mode) {
+    case kMitsubishiHeavyCool:
+    case kMitsubishiHeavyDry:
+    case kMitsubishiHeavyFan:
+    case kMitsubishiHeavyHeat:
+      break;
+    default:
+      newmode = kMitsubishiHeavyAuto;
+  }
+  remote_state[5] &= ~kMitsubishiHeavyModeMask;
+  remote_state[5] |= newmode;
+}
+
+uint8_t IRMitsubishiHeavy152Ac::getMode(void) {
+  return remote_state[5] & kMitsubishiHeavyModeMask;
+}
+
+void IRMitsubishiHeavy152Ac::setSwingVertical(const uint8_t pos) {
+  uint8_t newpos = std::min(pos, kMitsubishiHeavy152SwingVOff);
+  remote_state[11] &= ~kMitsubishiHeavySwingVMask;
+  remote_state[11] |= (newpos << 5);
+}
+
+uint8_t IRMitsubishiHeavy152Ac::getSwingVertical(void) {
+  return remote_state[11] >> 5;
+}
+
+void IRMitsubishiHeavy152Ac::setSwingHorizontal(const uint8_t pos) {
+  uint8_t newpos = std::min(pos, kMitsubishiHeavy152SwingHOff);
+  remote_state[13] &= ~kMitsubishiHeavySwingHMask;
+  remote_state[13] |= (newpos & kMitsubishiHeavySwingHMask);
+}
+
+uint8_t IRMitsubishiHeavy152Ac::getSwingHorizontal(void) {
+  return remote_state[13] & kMitsubishiHeavySwingHMask;
+}
+
+void IRMitsubishiHeavy152Ac::setNight(const bool on) {
+  if (on)
+    remote_state[15] |= kMitsubishiHeavyNightBit;
+  else
+    remote_state[15] &= ~kMitsubishiHeavyNightBit;
+}
+
+bool IRMitsubishiHeavy152Ac::getNight(void) {
+  return remote_state[15] & kMitsubishiHeavyNightBit;
+}
+
+void IRMitsubishiHeavy152Ac::set3D(const bool on) {
+  if (on)
+    remote_state[11] |= kMitsubishiHeavy3DMask;
+  else
+    remote_state[11] &= ~kMitsubishiHeavy3DMask;
+}
+
+bool IRMitsubishiHeavy152Ac::get3D(void) {
+  return (remote_state[11] & kMitsubishiHeavy3DMask) == kMitsubishiHeavy3DMask;
+}
+
+void IRMitsubishiHeavy152Ac::setSilent(const bool on) {
+  if (on)
+    remote_state[15] |= kMitsubishiHeavySilentBit;
+  else
+    remote_state[15] &= ~kMitsubishiHeavySilentBit;
+}
+
+bool IRMitsubishiHeavy152Ac::getSilent(void) {
+  return remote_state[15] & kMitsubishiHeavySilentBit;
+}
+
+void IRMitsubishiHeavy152Ac::setFilter(const bool on) {
+  if (on)
+    remote_state[5] |= kMitsubishiHeavyFilterBit;
+  else
+    remote_state[5] &= ~kMitsubishiHeavyFilterBit;
+}
+
+bool IRMitsubishiHeavy152Ac::getFilter(void) {
+  return remote_state[5] & kMitsubishiHeavyFilterBit;
+}
+
+void IRMitsubishiHeavy152Ac::setClean(const bool on) {
+  this->setFilter(on);
+  if (on)
+    remote_state[5] |= kMitsubishiHeavyCleanBit;
+  else
+    remote_state[5] &= ~kMitsubishiHeavyCleanBit;
+}
+
+bool IRMitsubishiHeavy152Ac::getClean(void) {
+  return remote_state[5] & kMitsubishiHeavyCleanBit && this->getFilter();
+}
+
+void IRMitsubishiHeavy152Ac::setTurbo(const bool on) {
+  if (on)
+    this->setFan(kMitsubishiHeavy152FanTurbo);
+  else if (this->getTurbo()) this->setFan(kMitsubishiHeavy152FanAuto);
+}
+
+bool IRMitsubishiHeavy152Ac::getTurbo(void) {
+  return this->getFan() == kMitsubishiHeavy152FanTurbo;
+}
+
+void IRMitsubishiHeavy152Ac::setEcono(const bool on) {
+  if (on)
+    this->setFan(kMitsubishiHeavy152FanEcono);
+  else if (this->getEcono()) this->setFan(kMitsubishiHeavy152FanAuto);
+}
+
+bool IRMitsubishiHeavy152Ac::getEcono(void) {
+  return this->getFan() == kMitsubishiHeavy152FanEcono;
+}
+
+// Verify the given state has a ZM-S signature.
+bool IRMitsubishiHeavy152Ac::checkZmsSig(const uint8_t *state) {
+  for (uint8_t i = 0; i < kMitsubishiHeavySigLength; i++)
+    if (state[i] != kMitsubishiHeavyZmsSig[i]) return false;
+  return true;
+}
+
+// Verify the given state has a ZJ-S signature.
+bool IRMitsubishiHeavy152Ac::checkZjsSig(const uint8_t *state) {
+  for (uint8_t i = 0; i < kMitsubishiHeavySigLength; i++)
+    if (state[i] != kMitsubishiHeavyZjsSig[i]) return false;
+  return true;
+}
+
+// Protocol technically has no checksum, but does has inverted byte pairs.
+void IRMitsubishiHeavy152Ac::checksum(void) {
+  for (uint8_t i = kMitsubishiHeavySigLength - 2;
+       i < kMitsubishiHeavy152StateLength;
+       i += 2) {
+    remote_state[i + 1] = ~remote_state[i];
+  }
+}
+
+// Protocol technically has no checksum, but does has inverted byte pairs.
+bool IRMitsubishiHeavy152Ac::validChecksum(const uint8_t *state,
+                                           const uint16_t length) {
+  // Assume anything too short is fine.
+  if (length < kMitsubishiHeavySigLength) return true;
+  // Check all the byte pairs.
+  for (uint16_t i = kMitsubishiHeavySigLength - 2;
+       i < length;
+       i += 2) {
+    // XOR of a byte and it's self inverted should be 0xFF;
+    if ((state[i] ^ state[i + 1]) != 0xFF) return false;
+  }
+  return true;
+}
+
+// Convert the internal state into a human readable string.
+#ifdef ARDUINO
+String IRMitsubishiHeavy152Ac::toString(void) {
+  String result = "";
+#else
+std::string IRMitsubishiHeavy152Ac::toString(void) {
+  std::string result = "";
+#endif  // ARDUINO
+  result += "Power: ";
+  result += (this->getPower() ? "On" : "Off");
+  result += ", Mode: " + uint64ToString(this->getMode());
+  switch (this->getMode()) {
+    case kMitsubishiHeavyAuto:
+      result += " (Auto)";
+      break;
+    case kMitsubishiHeavyCool:
+      result += " (Cool)";
+      break;
+    case kMitsubishiHeavyHeat:
+      result += " (Heat)";
+      break;
+    case kMitsubishiHeavyDry:
+      result += " (Dry)";
+      break;
+    case kMitsubishiHeavyFan:
+      result += " (Fan)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Temp: " + uint64ToString(this->getTemp()) + "C";
+  result += ", Fan: " + uint64ToString(this->getFan());
+  switch (this->getFan()) {
+    case kMitsubishiHeavy152FanAuto:
+      result += " (Auto)";
+      break;
+    case kMitsubishiHeavy152FanHigh:
+      result += " (High)";
+      break;
+    case kMitsubishiHeavy152FanLow:
+      result += " (Low)";
+      break;
+    case kMitsubishiHeavy152FanMed:
+      result += " (Med)";
+      break;
+    case kMitsubishiHeavy152FanMax:
+      result += " (Max)";
+      break;
+    case kMitsubishiHeavy152FanEcono:
+      result += " (Econo)";
+      break;
+    case kMitsubishiHeavy152FanTurbo:
+      result += " (Turbo)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Swing (V): " + uint64ToString(this->getSwingVertical());
+  switch (this->getSwingVertical()) {
+    case kMitsubishiHeavy152SwingVAuto:
+      result += " (Auto)";
+      break;
+    case kMitsubishiHeavy152SwingVHighest:
+      result += " (Highest)";
+      break;
+    case kMitsubishiHeavy152SwingVHigh:
+      result += " (High)";
+      break;
+    case kMitsubishiHeavy152SwingVMiddle:
+      result += " (Middle)";
+      break;
+    case kMitsubishiHeavy152SwingVLow:
+      result += " (Low)";
+      break;
+    case kMitsubishiHeavy152SwingVLowest:
+      result += " (Lowest)";
+      break;
+    case kMitsubishiHeavy152SwingVOff:
+      result += " (Off)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Swing (H): " + uint64ToString(this->getSwingHorizontal());
+  switch (this->getSwingHorizontal()) {
+    case kMitsubishiHeavy152SwingHAuto:
+      result += " (Auto)";
+      break;
+    case kMitsubishiHeavy152SwingHLeftMax:
+      result += " (Max Left)";
+      break;
+    case kMitsubishiHeavy152SwingHLeft:
+      result += " (Left)";
+      break;
+    case kMitsubishiHeavy152SwingHMiddle:
+      result += " (Middle)";
+      break;
+    case kMitsubishiHeavy152SwingHRight:
+      result += " (Right)";
+      break;
+    case kMitsubishiHeavy152SwingHRightMax:
+      result += " (Max Right)";
+      break;
+    case kMitsubishiHeavy152SwingHLeftRight:
+      result += " (Left Right)";
+      break;
+    case kMitsubishiHeavy152SwingHRightLeft:
+      result += " (Right Left)";
+      break;
+    case kMitsubishiHeavy152SwingHOff:
+      result += " (Off)";
+      break;
+    default:
+      result += " (UNKNOWN)";
+  }
+  result += ", Silent: ";
+  result += (this->getSilent() ? "On" : "Off");
+  result += ", Turbo: ";
+  result += (this->getTurbo() ? "On" : "Off");
+  result += ", Econo: ";
+  result += (this->getEcono() ? "On" : "Off");
+  result += ", Night: ";
+  result += (this->getNight() ? "On" : "Off");
+  result += ", Filter: ";
+  result += (this->getFilter() ? "On" : "Off");
+  result += ", 3D: ";
+  result += (this->get3D() ? "On" : "Off");
+  result += ", Clean: ";
+  result += (this->getClean() ? "On" : "Off");
+  return result;
+}
+
+#if DECODE_MITSUBISHIHEAVY
+// Decode the supplied MitsubishiHeavy message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect.
+//            Typically kMitsubishiHeavy88Bits or kMitsubishiHeavy152Bits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: BETA / Appears to be working. Needs testing against a real device.
+bool IRrecv::decodeMitsubishiHeavy(decode_results* results,
+                                   const uint16_t nbits, const bool strict) {
+  // Check if can possibly be a valid MitsubishiHeavy message.
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1) return false;
+  if (strict) {
+    switch (nbits) {
+      case kMitsubishiHeavy88Bits:
+      case kMitsubishiHeavy152Bits:
+        break;
+      default:
+        return false;  // Not what is expected
+    }
+  }
+
+  uint16_t actualBits = 0;
+  uint16_t offset = kStartOffset;
+  match_result_t data_result;
+
+  // Header
+  if (!matchMark(results->rawbuf[offset++], kMitsubishiHeavyHdrMark))
+    return false;
+  if (!matchSpace(results->rawbuf[offset++], kMitsubishiHeavyHdrSpace))
+    return false;
+  // Data
+  // Keep reading bytes until we either run out of section or state to fill.
+  for (uint16_t i = 0;
+       offset <= results->rawlen - 16 && actualBits < nbits;
+       i++, actualBits += 8, offset += data_result.used) {
+    data_result = matchData(&(results->rawbuf[offset]), 8,
+                            kMitsubishiHeavyBitMark, kMitsubishiHeavyOneSpace,
+                            kMitsubishiHeavyBitMark, kMitsubishiHeavyZeroSpace,
+                            kTolerance, 0, false);
+    if (data_result.success == false) {
+      DPRINT("DEBUG: offset = ");
+      DPRINTLN(offset + data_result.used);
+      return false;  // Fail
+    }
+    results->state[i] = data_result.data;
+  }
+  // Footer.
+  if (!matchMark(results->rawbuf[offset++], kMitsubishiHeavyBitMark))
+    return false;
+  if (offset < results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset], kMitsubishiHeavyGap)) return false;
+
+  // Compliance
+  if (actualBits < nbits) return false;
+  if (strict && actualBits != nbits) return false;  // Not as we expected.
+  switch (actualBits) {
+    case kMitsubishiHeavy88Bits:
+      if (strict && !(
+          IRMitsubishiHeavy152Ac::checkZjsSig(results->state) &&
+          IRMitsubishiHeavy152Ac::validChecksum(results->state,
+                                                kMitsubishiHeavy88StateLength)))
+        return false;
+      results->decode_type = MITSUBISHI_HEAVY_88;
+      break;
+    case kMitsubishiHeavy152Bits:
+      if (strict && !(IRMitsubishiHeavy152Ac::checkZmsSig(results->state) &&
+                      IRMitsubishiHeavy152Ac::validChecksum(results->state)))
+        return false;
+      results->decode_type = MITSUBISHI_HEAVY_152;
+      break;
+    default:
+      return false;
+  }
+
+  // Success
+  results->bits = actualBits;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_MITSUBISHIHEAVY

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -311,127 +311,132 @@ String IRMitsubishiHeavy152Ac::toString(void) {
 std::string IRMitsubishiHeavy152Ac::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
-  result += "Power: ";
-  result += (this->getPower() ? "On" : "Off");
-  result += ", Mode: " + uint64ToString(this->getMode());
+  result += F("Power: ");
+  result += (this->getPower() ? F("On") : F("Off"));
+  result += F(", Mode: ");
+  result += uint64ToString(this->getMode());
   switch (this->getMode()) {
     case kMitsubishiHeavyAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavyCool:
-      result += " (Cool)";
+      result += F(" (Cool)");
       break;
     case kMitsubishiHeavyHeat:
-      result += " (Heat)";
+      result += F(" (Heat)");
       break;
     case kMitsubishiHeavyDry:
-      result += " (Dry)";
+      result += F(" (Dry)");
       break;
     case kMitsubishiHeavyFan:
-      result += " (Fan)";
+      result += F(" (Fan)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Temp: " + uint64ToString(this->getTemp()) + "C";
-  result += ", Fan: " + uint64ToString(this->getFan());
+  result += F(", Temp: ");
+  result += uint64ToString(this->getTemp()) + 'C';
+  result += F(", Fan: ");
+  result += uint64ToString(this->getFan());
   switch (this->getFan()) {
     case kMitsubishiHeavy152FanAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy152FanHigh:
-      result += " (High)";
+      result += F(" (High)");
       break;
     case kMitsubishiHeavy152FanLow:
-      result += " (Low)";
+      result += F(" (Low)");
       break;
     case kMitsubishiHeavy152FanMed:
-      result += " (Med)";
+      result += F(" (Med)");
       break;
     case kMitsubishiHeavy152FanMax:
-      result += " (Max)";
+      result += F(" (Max)");
       break;
     case kMitsubishiHeavy152FanEcono:
-      result += " (Econo)";
+      result += F(" (Econo)");
       break;
     case kMitsubishiHeavy152FanTurbo:
-      result += " (Turbo)";
+      result += F(" (Turbo)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Swing (V): " + uint64ToString(this->getSwingVertical());
+  result += F(", Swing (V): ");
+  result += uint64ToString(this->getSwingVertical());
   switch (this->getSwingVertical()) {
     case kMitsubishiHeavy152SwingVAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy152SwingVHighest:
-      result += " (Highest)";
+      result += F(" (Highest)");
       break;
     case kMitsubishiHeavy152SwingVHigh:
-      result += " (High)";
+      result += F(" (High)");
       break;
     case kMitsubishiHeavy152SwingVMiddle:
-      result += " (Middle)";
+      result += F(" (Middle)");
       break;
     case kMitsubishiHeavy152SwingVLow:
-      result += " (Low)";
+      result += F(" (Low)");
       break;
     case kMitsubishiHeavy152SwingVLowest:
-      result += " (Lowest)";
+      result += F(" (Lowest)");
       break;
     case kMitsubishiHeavy152SwingVOff:
-      result += " (Off)";
+      result += F(" (Off)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Swing (H): " + uint64ToString(this->getSwingHorizontal());
+  result += F(", Swing (H): ");
+  result += uint64ToString(this->getSwingHorizontal());
   switch (this->getSwingHorizontal()) {
     case kMitsubishiHeavy152SwingHAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy152SwingHLeftMax:
-      result += " (Max Left)";
+      result += F(" (Max Left)");
       break;
     case kMitsubishiHeavy152SwingHLeft:
-      result += " (Left)";
+      result += F(" (Left)");
       break;
     case kMitsubishiHeavy152SwingHMiddle:
-      result += " (Middle)";
+      result += F(" (Middle)");
       break;
     case kMitsubishiHeavy152SwingHRight:
-      result += " (Right)";
+      result += F(" (Right)");
       break;
     case kMitsubishiHeavy152SwingHRightMax:
-      result += " (Max Right)";
+      result += F(" (Max Right)");
       break;
     case kMitsubishiHeavy152SwingHLeftRight:
-      result += " (Left Right)";
+      result += F(" (Left Right)");
       break;
     case kMitsubishiHeavy152SwingHRightLeft:
-      result += " (Right Left)";
+      result += F(" (Right Left)");
       break;
     case kMitsubishiHeavy152SwingHOff:
-      result += " (Off)";
+      result += F(" (Off)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Silent: ";
-  result += (this->getSilent() ? "On" : "Off");
-  result += ", Turbo: ";
-  result += (this->getTurbo() ? "On" : "Off");
-  result += ", Econo: ";
-  result += (this->getEcono() ? "On" : "Off");
-  result += ", Night: ";
-  result += (this->getNight() ? "On" : "Off");
-  result += ", Filter: ";
-  result += (this->getFilter() ? "On" : "Off");
-  result += ", 3D: ";
-  result += (this->get3D() ? "On" : "Off");
-  result += ", Clean: ";
-  result += (this->getClean() ? "On" : "Off");
+  result += F(", Silent: ");
+  result += (this->getSilent() ? F("On") : F("Off"));
+  result += F(", Turbo: ");
+  result += (this->getTurbo() ? F("On") : F("Off"));
+  result += F(", Econo: ");
+  result += (this->getEcono() ? F("On") : F("Off"));
+  result += F(", Night: ");
+  result += (this->getNight() ? F("On") : F("Off"));
+  result += F(", Filter: ");
+  result += (this->getFilter() ? F("On") : F("Off"));
+  result += F(", 3D: ");
+  result += (this->get3D() ? F("On") : F("Off"));
+  result += F(", Clean: ");
+  result += (this->getClean() ? F("On") : F("Off"));
   return result;
 }
 
@@ -660,121 +665,126 @@ String IRMitsubishiHeavy88Ac::toString(void) {
 std::string IRMitsubishiHeavy88Ac::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
-  result += "Power: ";
-  result += (this->getPower() ? "On" : "Off");
-  result += ", Mode: " + uint64ToString(this->getMode());
+  result += F("Power: ");
+  result += (this->getPower() ? F("On") : F("Off"));
+  result += F(", Mode: ");
+  result += uint64ToString(this->getMode());
   switch (this->getMode()) {
     case kMitsubishiHeavyAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavyCool:
-      result += " (Cool)";
+      result += F(" (Cool)");
       break;
     case kMitsubishiHeavyHeat:
-      result += " (Heat)";
+      result += F(" (Heat)");
       break;
     case kMitsubishiHeavyDry:
-      result += " (Dry)";
+      result += F(" (Dry)");
       break;
     case kMitsubishiHeavyFan:
-      result += " (Fan)";
+      result += F(" (Fan)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Temp: " + uint64ToString(this->getTemp()) + "C";
-  result += ", Fan: " + uint64ToString(this->getFan());
+  result += F(", Temp: ");
+  result += uint64ToString(this->getTemp()) + 'C';
+  result += F(", Fan: ");
+  result += uint64ToString(this->getFan());
   switch (this->getFan()) {
     case kMitsubishiHeavy88FanAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy88FanHigh:
-      result += " (High)";
+      result += F(" (High)");
       break;
     case kMitsubishiHeavy88FanLow:
-      result += " (Low)";
+      result += F(" (Low)");
       break;
     case kMitsubishiHeavy88FanMed:
-      result += " (Med)";
+      result += F(" (Med)");
       break;
     case kMitsubishiHeavy88FanEcono:
-      result += " (Econo)";
+      result += F(" (Econo)");
       break;
     case kMitsubishiHeavy88FanTurbo:
-      result += " (Turbo)";
+      result += F(" (Turbo)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Swing (V): " + uint64ToString(this->getSwingVertical());
+  result += F(", Swing (V): ");
+  result += uint64ToString(this->getSwingVertical());
   switch (this->getSwingVertical()) {
     case kMitsubishiHeavy88SwingVAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy88SwingVHighest:
-      result += " (Highest)";
+      result += F(" (Highest)");
       break;
     case kMitsubishiHeavy88SwingVHigh:
-      result += " (High)";
+      result += F(" (High)");
       break;
     case kMitsubishiHeavy88SwingVMiddle:
-      result += " (Middle)";
+      result += F(" (Middle)");
       break;
     case kMitsubishiHeavy88SwingVLow:
-      result += " (Low)";
+      result += F(" (Low)");
       break;
     case kMitsubishiHeavy88SwingVLowest:
-      result += " (Lowest)";
+      result += F(" (Lowest)");
       break;
     case kMitsubishiHeavy88SwingVOff:
-      result += " (Off)";
+      result += F(" (Off)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Swing (H): " + uint64ToString(this->getSwingHorizontal());
+  result += F(", Swing (H): ");
+  result += uint64ToString(this->getSwingHorizontal());
   switch (this->getSwingHorizontal()) {
     case kMitsubishiHeavy88SwingHAuto:
-      result += " (Auto)";
+      result += F(" (Auto)");
       break;
     case kMitsubishiHeavy88SwingHLeftMax:
-      result += " (Max Left)";
+      result += F(" (Max Left)");
       break;
     case kMitsubishiHeavy88SwingHLeft:
-      result += " (Left)";
+      result += F(" (Left)");
       break;
     case kMitsubishiHeavy88SwingHMiddle:
-      result += " (Middle)";
+      result += F(" (Middle)");
       break;
     case kMitsubishiHeavy88SwingHRight:
-      result += " (Right)";
+      result += F(" (Right)");
       break;
     case kMitsubishiHeavy88SwingHRightMax:
-      result += " (Max Right)";
+      result += F(" (Max Right)");
       break;
     case kMitsubishiHeavy88SwingHLeftRight:
-      result += " (Left Right)";
+      result += F(" (Left Right)");
       break;
     case kMitsubishiHeavy88SwingHRightLeft:
-      result += " (Right Left)";
+      result += F(" (Right Left)");
       break;
     case kMitsubishiHeavy88SwingH3D:
-      result += " (3D)";
+      result += F(" (3D)");
       break;
     case kMitsubishiHeavy88SwingHOff:
-      result += " (Off)";
+      result += F(" (Off)");
       break;
     default:
-      result += " (UNKNOWN)";
+      result += F(" (UNKNOWN)");
   }
-  result += ", Turbo: ";
-  result += (this->getTurbo() ? "On" : "Off");
-  result += ", Econo: ";
-  result += (this->getEcono() ? "On" : "Off");
-  result += ", 3D: ";
-  result += (this->get3D() ? "On" : "Off");
-  result += ", Clean: ";
-  result += (this->getClean() ? "On" : "Off");
+  result += F(", Turbo: ");
+  result += (this->getTurbo() ? F("On") : F("Off"));
+  result += F(", Econo: ");
+  result += (this->getEcono() ? F("On") : F("Off"));
+  result += F(", 3D: ");
+  result += (this->get3D() ? F("On") : F("Off"));
+  result += F(", Clean: ");
+  result += (this->getClean() ? F("On") : F("Off"));
   return result;
 }
 

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -10,9 +10,9 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
-// #ifdef UNIT_TEST
-// #include "IRsend_test.h"
-// #endif  // UNIT_TEST
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
 
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/660
@@ -172,17 +172,22 @@ class IRMitsubishiHeavy152Ac {
   static bool validChecksum(
       const uint8_t *state,
       const uint16_t length = kMitsubishiHeavy152StateLength);
-
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertSwingV(const stdAc::swingv_t position);
+  static uint8_t convertSwingH(const stdAc::swingh_t position);
 #ifdef ARDUINO
   String toString(void);
-#else
+#else  // ARDUINO
   std::string toString(void);
-#endif
+#endif  // ARDUINO
 #ifndef UNIT_TEST
 
  private:
-#endif  // UNIT_TEST
   IRsend _irsend;
+#else  // UNIT_TEST
+  IRsendTest _irsend;
+#endif  // UNIT_TEST
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kMitsubishiHeavy152StateLength];
   void checksum();
@@ -236,17 +241,22 @@ class IRMitsubishiHeavy88Ac {
   static bool validChecksum(
       const uint8_t *state,
       const uint16_t length = kMitsubishiHeavy88StateLength);
-
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertSwingV(const stdAc::swingv_t position);
+  static uint8_t convertSwingH(const stdAc::swingh_t position);
 #ifdef ARDUINO
   String toString(void);
-#else
+#else  // ARDUINO
   std::string toString(void);
-#endif
+#endif  // ARDUINO
 #ifndef UNIT_TEST
 
  private:
-#endif  // UNIT_TEST
   IRsend _irsend;
+#else  // UNIT_TEST
+  IRsendTest _irsend;
+#endif  // UNIT_TEST
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kMitsubishiHeavy152StateLength];
   void checksum();

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -1,0 +1,159 @@
+// Copyright 2019 David Conran
+
+#ifndef IR_MITSUBISHIHEAVY_H_
+#define IR_MITSUBISHIHEAVY_H_
+
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+// #ifdef UNIT_TEST
+// #include "IRsend_test.h"
+// #endif  // UNIT_TEST
+
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/660
+//   https://github.com/ToniA/Raw-IR-decoder-for-Arduino/blob/master/MitsubishiHeavy.cpp
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp
+
+// Constants.
+const uint8_t kMitsubishiHeavyAuto = 0;  // 0b000
+const uint8_t kMitsubishiHeavyCool = 1;  // 0b001
+const uint8_t kMitsubishiHeavyDry =  2;  // 0b010
+const uint8_t kMitsubishiHeavyFan =  3;  // 0b011
+const uint8_t kMitsubishiHeavyHeat = 4;  // 0b100
+const uint8_t kMitsubishiHeavy88FanAuto =  0;  // 0b000
+const uint8_t kMitsubishiHeavy88FanLow =   2;  // 0b010
+const uint8_t kMitsubishiHeavy88FanMed =   3;  // 0b011
+const uint8_t kMitsubishiHeavy88FanHigh =  4;  // 0b100
+const uint8_t kMitsubishiHeavy88FanTurbo = 6;  // 0b110
+const uint8_t kMitsubishiHeavy88FanEcono = 7;  // 0b111
+const uint8_t kMitsubishiHeavy152FanAuto =  0x0;  // 0b0000
+const uint8_t kMitsubishiHeavy152FanLow =   0x1;  // 0b0001
+const uint8_t kMitsubishiHeavy152FanMed =   0x2;  // 0b0010
+const uint8_t kMitsubishiHeavy152FanHigh =  0x3;  // 0b0011
+const uint8_t kMitsubishiHeavy152FanMax =   0x4;  // 0b0100
+const uint8_t kMitsubishiHeavy152FanEcono = 0x6;  // 0b0110
+const uint8_t kMitsubishiHeavy152FanTurbo = 0x8;  // 0b1000
+const uint8_t kMitsubishiHeavyMinTemp = 17;   // 17C
+const uint8_t kMitsubishiHeavyMaxTemp = 31;   // 31C
+// Byte 5.
+const uint8_t kMitsubishiHeavyFilterBit =  0b01000000;
+const uint8_t kMitsubishiHeavyCleanBit =   0b00100000;
+const uint8_t kMitsubishiHeavyPowerBit =   0b00001000;
+const uint8_t kMitsubishiHeavyModeMask =   0b00000111;
+// Byte 7.
+const uint8_t kMitsubishiHeavyTempMask =   0b00001111;
+// Byte 9.
+const uint8_t kMitsubishiHeavyFanMask =    0b00001111;
+// Byte 11.
+const uint8_t kMitsubishiHeavy3DMask =     0b00010010;
+const uint8_t kMitsubishiHeavySwingVMask = 0b11100000;
+const uint8_t kMitsubishiHeavy152SwingVAuto =    0;  // 0b000
+const uint8_t kMitsubishiHeavy152SwingVHighest = 1;  // 0b001
+const uint8_t kMitsubishiHeavy152SwingVHigh =    2;  // 0b010
+const uint8_t kMitsubishiHeavy152SwingVMiddle =  3;  // 0b011
+const uint8_t kMitsubishiHeavy152SwingVLow =     4;  // 0b100
+const uint8_t kMitsubishiHeavy152SwingVLowest =  5;  // 0b101
+const uint8_t kMitsubishiHeavy152SwingVOff =     6;  // 0b110
+// Byte 13.
+const uint8_t kMitsubishiHeavySwingHMask = 0b00001111;
+const uint8_t kMitsubishiHeavy152SwingHAuto =      0;  // 0b0000
+const uint8_t kMitsubishiHeavy152SwingHLeftMax =   1;  // 0b0001
+const uint8_t kMitsubishiHeavy152SwingHLeft =      2;  // 0b0010
+const uint8_t kMitsubishiHeavy152SwingHMiddle =    3;  // 0b0011
+const uint8_t kMitsubishiHeavy152SwingHRight =     4;  // 0b0100
+const uint8_t kMitsubishiHeavy152SwingHRightMax =  5;  // 0b0101
+const uint8_t kMitsubishiHeavy152SwingHRightLeft = 6;  // 0b0110
+const uint8_t kMitsubishiHeavy152SwingHLeftRight = 7;  // 0b0111
+const uint8_t kMitsubishiHeavy152SwingHOff =       8;  // 0b1000
+// Byte 15.
+const uint8_t kMitsubishiHeavyNightBit =   0b01000000;
+const uint8_t kMitsubishiHeavySilentBit =  0b10000000;
+
+const uint8_t kMitsubishiHeavySigLength = 5;
+const uint8_t kMitsubishiHeavyZjsSig[kMitsubishiHeavySigLength] = {
+    0xAD, 0x51, 0x3C, 0xD9, 0x26};
+const uint8_t kMitsubishiHeavyZmsSig[kMitsubishiHeavySigLength] = {
+    0xAD, 0x51, 0x3C, 0xE5, 0x1A};
+
+
+// Classes
+class IRMitsubishiHeavy152Ac {
+ public:
+  explicit IRMitsubishiHeavy152Ac(const uint16_t pin);
+
+  void stateReset(void);
+#if SEND_MITSUBISHIHEAVY
+  void send(const uint16_t repeat = kMitsubishiHeavy152MinRepeat);
+#endif  // SEND_MITSUBISHIHEAVY
+  void begin(void);
+  void on(void);
+  void off(void);
+
+  void setPower(const bool on);
+  bool getPower(void);
+
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp(void);
+
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+
+  void setSwingVertical(const uint8_t pos);
+  uint8_t getSwingVertical(void);
+  void setSwingHorizontal(const uint8_t pos);
+  uint8_t getSwingHorizontal(void);
+
+  void setNight(const bool on);
+  bool getNight(void);
+
+  void set3D(const bool on);
+  bool get3D(void);
+
+  void setSilent(const bool on);
+  bool getSilent(void);
+
+  void setFilter(const bool on);
+  bool getFilter(void);
+
+  void setClean(const bool on);
+  bool getClean(void);
+
+  void setTurbo(const bool on);
+  bool getTurbo(void);
+
+  void setEcono(const bool on);
+  bool getEcono(void);
+
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t* data);
+
+  static bool checkZmsSig(const uint8_t *state);
+  static bool checkZjsSig(const uint8_t *state);
+  static bool validChecksum(
+      const uint8_t *state,
+      const uint16_t length = kMitsubishiHeavy152StateLength);
+
+#ifdef ARDUINO
+  String toString(void);
+#else
+  std::string toString(void);
+#endif
+#ifndef UNIT_TEST
+
+ private:
+#endif  // UNIT_TEST
+  IRsend _irsend;
+  // The state of the IR remote in IR code form.
+  uint8_t remote_state[kMitsubishiHeavy152StateLength];
+  void checksum();
+};
+
+#endif  // IR_MITSUBISHIHEAVY_H_

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -20,17 +20,28 @@
 //   https://github.com/ToniA/arduino-heatpumpir/blob/master/MitsubishiHeavyHeatpumpIR.cpp
 
 // Constants.
-const uint8_t kMitsubishiHeavyAuto = 0;  // 0b000
-const uint8_t kMitsubishiHeavyCool = 1;  // 0b001
-const uint8_t kMitsubishiHeavyDry =  2;  // 0b010
-const uint8_t kMitsubishiHeavyFan =  3;  // 0b011
-const uint8_t kMitsubishiHeavyHeat = 4;  // 0b100
-const uint8_t kMitsubishiHeavy88FanAuto =  0;  // 0b000
-const uint8_t kMitsubishiHeavy88FanLow =   2;  // 0b010
-const uint8_t kMitsubishiHeavy88FanMed =   3;  // 0b011
-const uint8_t kMitsubishiHeavy88FanHigh =  4;  // 0b100
-const uint8_t kMitsubishiHeavy88FanTurbo = 6;  // 0b110
-const uint8_t kMitsubishiHeavy88FanEcono = 7;  // 0b111
+const uint8_t kMitsubishiHeavySigLength = 5;
+
+
+// ZMS (152 bit)
+const uint8_t kMitsubishiHeavyZmsSig[kMitsubishiHeavySigLength] = {
+    0xAD, 0x51, 0x3C, 0xE5, 0x1A};
+// Byte[5]
+const uint8_t kMitsubishiHeavyFilterBit =     0b01000000;
+const uint8_t kMitsubishiHeavyCleanBit =      0b00100000;
+const uint8_t kMitsubishiHeavyPowerBit =      0b00001000;  // Byte 9 on ZJS
+const uint8_t kMitsubishiHeavyModeMask =      0b00000111;  // Byte 9 on ZJS
+const uint8_t kMitsubishiHeavyAuto = 0;         // 0b000
+const uint8_t kMitsubishiHeavyCool = 1;         // 0b001
+const uint8_t kMitsubishiHeavyDry =  2;         // 0b010
+const uint8_t kMitsubishiHeavyFan =  3;         // 0b011
+const uint8_t kMitsubishiHeavyHeat = 4;         // 0b100
+// Byte[7]
+const uint8_t kMitsubishiHeavyTempMask =      0b00001111;
+const uint8_t kMitsubishiHeavyMinTemp = 17;   // 17C
+const uint8_t kMitsubishiHeavyMaxTemp = 31;   // 31C
+// Byte[9]
+const uint8_t kMitsubishiHeavyFanMask =       0b00001111;  // ~Byte 7 on ZJS.
 const uint8_t kMitsubishiHeavy152FanAuto =  0x0;  // 0b0000
 const uint8_t kMitsubishiHeavy152FanLow =   0x1;  // 0b0001
 const uint8_t kMitsubishiHeavy152FanMed =   0x2;  // 0b0010
@@ -38,20 +49,9 @@ const uint8_t kMitsubishiHeavy152FanHigh =  0x3;  // 0b0011
 const uint8_t kMitsubishiHeavy152FanMax =   0x4;  // 0b0100
 const uint8_t kMitsubishiHeavy152FanEcono = 0x6;  // 0b0110
 const uint8_t kMitsubishiHeavy152FanTurbo = 0x8;  // 0b1000
-const uint8_t kMitsubishiHeavyMinTemp = 17;   // 17C
-const uint8_t kMitsubishiHeavyMaxTemp = 31;   // 31C
-// Byte 5.
-const uint8_t kMitsubishiHeavyFilterBit =  0b01000000;
-const uint8_t kMitsubishiHeavyCleanBit =   0b00100000;
-const uint8_t kMitsubishiHeavyPowerBit =   0b00001000;
-const uint8_t kMitsubishiHeavyModeMask =   0b00000111;
-// Byte 7.
-const uint8_t kMitsubishiHeavyTempMask =   0b00001111;
-// Byte 9.
-const uint8_t kMitsubishiHeavyFanMask =    0b00001111;
-// Byte 11.
-const uint8_t kMitsubishiHeavy3DMask =     0b00010010;
-const uint8_t kMitsubishiHeavySwingVMask = 0b11100000;
+// Byte[11]
+const uint8_t kMitsubishiHeavy3DMask =        0b00010010;
+const uint8_t kMitsubishiHeavy152SwingVMask = 0b11100000;
 const uint8_t kMitsubishiHeavy152SwingVAuto =    0;  // 0b000
 const uint8_t kMitsubishiHeavy152SwingVHighest = 1;  // 0b001
 const uint8_t kMitsubishiHeavy152SwingVHigh =    2;  // 0b010
@@ -59,8 +59,8 @@ const uint8_t kMitsubishiHeavy152SwingVMiddle =  3;  // 0b011
 const uint8_t kMitsubishiHeavy152SwingVLow =     4;  // 0b100
 const uint8_t kMitsubishiHeavy152SwingVLowest =  5;  // 0b101
 const uint8_t kMitsubishiHeavy152SwingVOff =     6;  // 0b110
-// Byte 13.
-const uint8_t kMitsubishiHeavySwingHMask = 0b00001111;
+// Byte[13]
+const uint8_t kMitsubishiHeavy152SwingHMask = 0b00001111;
 const uint8_t kMitsubishiHeavy152SwingHAuto =      0;  // 0b0000
 const uint8_t kMitsubishiHeavy152SwingHLeftMax =   1;  // 0b0001
 const uint8_t kMitsubishiHeavy152SwingHLeft =      2;  // 0b0010
@@ -70,15 +70,48 @@ const uint8_t kMitsubishiHeavy152SwingHRightMax =  5;  // 0b0101
 const uint8_t kMitsubishiHeavy152SwingHRightLeft = 6;  // 0b0110
 const uint8_t kMitsubishiHeavy152SwingHLeftRight = 7;  // 0b0111
 const uint8_t kMitsubishiHeavy152SwingHOff =       8;  // 0b1000
-// Byte 15.
+// Byte[15]
 const uint8_t kMitsubishiHeavyNightBit =   0b01000000;
 const uint8_t kMitsubishiHeavySilentBit =  0b10000000;
 
-const uint8_t kMitsubishiHeavySigLength = 5;
+
+// ZJS (88 bit)
 const uint8_t kMitsubishiHeavyZjsSig[kMitsubishiHeavySigLength] = {
     0xAD, 0x51, 0x3C, 0xD9, 0x26};
-const uint8_t kMitsubishiHeavyZmsSig[kMitsubishiHeavySigLength] = {
-    0xAD, 0x51, 0x3C, 0xE5, 0x1A};
+// Byte [5]
+const uint8_t kMitsubishiHeavy88CleanBit =                  0b00100000;
+const uint8_t kMitsubishiHeavy88SwingHMask =                0b11001100;
+const uint8_t kMitsubishiHeavy88SwingHAuto =      0x80;  // 0b10000000
+const uint8_t kMitsubishiHeavy88SwingHLeftMax =   0x04;  // 0b00000100
+const uint8_t kMitsubishiHeavy88SwingHLeft =      0x44;  // 0b01000100
+const uint8_t kMitsubishiHeavy88SwingHMiddle =    0x84;  // 0b10000100
+const uint8_t kMitsubishiHeavy88SwingHRight =     0xC4;  // 0b11000100
+const uint8_t kMitsubishiHeavy88SwingHRightMax =  0x08;  // 0b00001000
+const uint8_t kMitsubishiHeavy88SwingHRightLeft = 0x88;  // 0b10001000
+const uint8_t kMitsubishiHeavy88SwingHLeftRight = 0x48;  // 0b01001000
+const uint8_t kMitsubishiHeavy88SwingHOff =       0x00;  // 0b00000000
+const uint8_t kMitsubishiHeavy88SwingH3D =        0xC8;  // 0b11001000
+// Byte[7]
+const uint8_t kMitsubishiHeavy88FanMask =         0b11100000;
+const uint8_t kMitsubishiHeavy88FanAuto =  0;  // 0b000
+const uint8_t kMitsubishiHeavy88FanLow =   2;  // 0b010
+const uint8_t kMitsubishiHeavy88FanMed =   3;  // 0b011
+const uint8_t kMitsubishiHeavy88FanHigh =  4;  // 0b100
+const uint8_t kMitsubishiHeavy88FanTurbo = 6;  // 0b110
+const uint8_t kMitsubishiHeavy88FanEcono = 7;  // 0b111
+const uint8_t kMitsubishiHeavy88SwingVMaskByte5 = 0b00000010;
+const uint8_t kMitsubishiHeavy88SwingVMaskByte7 = 0b00011000;
+const uint8_t kMitsubishiHeavy88SwingVMask =
+    kMitsubishiHeavy88SwingVMaskByte5 | kMitsubishiHeavy88SwingVMaskByte7;
+                                          // i.e. 0b00011010
+const uint8_t kMitsubishiHeavy88SwingVAuto =      0b00010000;  // 0x10
+const uint8_t kMitsubishiHeavy88SwingVHighest =   0b00011000;  // 0x18
+const uint8_t kMitsubishiHeavy88SwingVHigh =      0b00000010;  // 0x02
+const uint8_t kMitsubishiHeavy88SwingVMiddle =    0b00001010;  // 0x0A
+const uint8_t kMitsubishiHeavy88SwingVLow =       0b00010010;  // 0x12
+const uint8_t kMitsubishiHeavy88SwingVLowest =    0b00011010;  // 0x1A
+const uint8_t kMitsubishiHeavy88SwingVOff =       0b00000000;  // 0x00
+// Byte[9] is Power & Mode & Temp.
 
 
 // Classes
@@ -136,7 +169,6 @@ class IRMitsubishiHeavy152Ac {
   void setRaw(const uint8_t* data);
 
   static bool checkZmsSig(const uint8_t *state);
-  static bool checkZjsSig(const uint8_t *state);
   static bool validChecksum(
       const uint8_t *state,
       const uint16_t length = kMitsubishiHeavy152StateLength);
@@ -156,4 +188,67 @@ class IRMitsubishiHeavy152Ac {
   void checksum();
 };
 
+class IRMitsubishiHeavy88Ac {
+ public:
+  explicit IRMitsubishiHeavy88Ac(const uint16_t pin);
+
+  void stateReset(void);
+#if SEND_MITSUBISHIHEAVY
+  void send(const uint16_t repeat = kMitsubishiHeavy88MinRepeat);
+#endif  // SEND_MITSUBISHIHEAVY
+  void begin(void);
+  void on(void);
+  void off(void);
+
+  void setPower(const bool on);
+  bool getPower(void);
+
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp(void);
+
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+
+  void setSwingVertical(const uint8_t pos);
+  uint8_t getSwingVertical(void);
+  void setSwingHorizontal(const uint8_t pos);
+  uint8_t getSwingHorizontal(void);
+
+  void setTurbo(const bool on);
+  bool getTurbo(void);
+
+  void setEcono(const bool on);
+  bool getEcono(void);
+
+  void set3D(const bool on);
+  bool get3D(void);
+
+  void setClean(const bool on);
+  bool getClean(void);
+
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t* data);
+
+  static bool checkZjsSig(const uint8_t *state);
+  static bool validChecksum(
+      const uint8_t *state,
+      const uint16_t length = kMitsubishiHeavy88StateLength);
+
+#ifdef ARDUINO
+  String toString(void);
+#else
+  std::string toString(void);
+#endif
+#ifndef UNIT_TEST
+
+ private:
+#endif  // UNIT_TEST
+  IRsend _irsend;
+  // The state of the IR remote in IR code form.
+  uint8_t remote_state[kMitsubishiHeavy152StateLength];
+  void checksum();
+};
 #endif  // IR_MITSUBISHIHEAVY_H_

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -9,6 +9,7 @@
 #include "ir_Kelvinator.h"
 #include "ir_Midea.h"
 #include "ir_Mitsubishi.h"
+#include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
 #include "ir_Tcl.h"
@@ -370,6 +371,67 @@ TEST(TestIRac, Mitsubishi) {
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(MITSUBISHI_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishiACBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, MitsubishiHeavy88) {
+  IRMitsubishiHeavy88Ac ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (Cool), Temp: 21C, Fan: 3 (Med), "
+      "Swing (V): 16 (Auto), Swing (H): 0 (Off), Turbo: Off, Econo: Off, "
+      "3D: Off, Clean: On";
+
+  ac.begin();
+  irac.mitsubishiHeavy88(&ac,
+                         true,                        // Power
+                         stdAc::opmode_t::kCool,      // Mode
+                         21,                          // Celsius
+                         stdAc::fanspeed_t::kMedium,  // Fan speed
+                         stdAc::swingv_t::kAuto,      // Veritcal swing
+                         stdAc::swingh_t::kOff,       // Horizontal swing
+                         false,                       // Turbo
+                         false,                       // Econo
+                         true);                       // Clean
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_88, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy88Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
+TEST(TestIRac, MitsubishiHeavy152) {
+  IRMitsubishiHeavy152Ac ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 6 (Econo), "
+      "Swing (V): 6 (Off), Swing (H): 0 (Auto), Silent: On, Turbo: Off, "
+      "Econo: On, Night: On, Filter: On, 3D: Off, Clean: Off";
+
+  ac.begin();
+  irac.mitsubishiHeavy152(&ac,
+                          true,                        // Power
+                          stdAc::opmode_t::kCool,      // Mode
+                          20,                          // Celsius
+                          stdAc::fanspeed_t::kLow,     // Fan speed
+                          stdAc::swingv_t::kOff,       // Veritcal swing
+                          stdAc::swingh_t::kAuto,      // Horizontal swing
+                          true,                        // Silent
+                          false,                       // Turbo
+                          true,                        // Econo
+                          true,                        // Filter
+                          false,                       // Clean
+                          8 * 60);                     // Sleep
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_152, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy152Bits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,12 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
+<<<<<<< HEAD
   ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test
+=======
+  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test \
+	ir_MitsubishiHeavy_test
+>>>>>>> First draft of support for Mitsubishi Heavy Industries A/Cs.
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -81,8 +86,13 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
+<<<<<<< HEAD
 	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o \
 	ir_Trotec.o
+=======
+	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o \
+	ir_MitsubishiHeavy.o
+>>>>>>> First draft of support for Mitsubishi Heavy Industries A/Cs.
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
@@ -95,6 +105,7 @@ PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
 		$(USER_DIR)/ir_Daikin.h \
 		$(USER_DIR)/ir_Kelvinator.h \
 		$(USER_DIR)/ir_Mitsubishi.h \
+		$(USER_DIR)/ir_MitsubishiHeavy.h \
 		$(USER_DIR)/ir_NEC.h \
 		$(USER_DIR)/ir_Samsung.h \
 		$(USER_DIR)/ir_Trotec.h \
@@ -265,6 +276,15 @@ ir_Mitsubishi_test.o : ir_Mitsubishi_test.cpp $(USER_DIR)/ir_Mitsubishi.h $(COMM
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Mitsubishi_test.cpp
 
 ir_Mitsubishi_test : $(COMMON_OBJ) ir_Mitsubishi_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_MitsubishiHeavy.o : $(USER_DIR)/ir_MitsubishiHeavy.h $(USER_DIR)/ir_MitsubishiHeavy.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
+
+ir_MitsubishiHeavy_test.o : ir_MitsubishiHeavy_test.cpp $(USER_DIR)/ir_MitsubishiHeavy.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_MitsubishiHeavy_test.cpp
+
+ir_MitsubishiHeavy_test : $(COMMON_OBJ) ir_MitsubishiHeavy_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -270,10 +270,10 @@ ir_Mitsubishi_test : $(COMMON_OBJ) ir_Mitsubishi_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_MitsubishiHeavy.o : $(USER_DIR)/ir_MitsubishiHeavy.h $(USER_DIR)/ir_MitsubishiHeavy.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
 
 ir_MitsubishiHeavy_test.o : ir_MitsubishiHeavy_test.cpp $(USER_DIR)/ir_MitsubishiHeavy.h $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -I$(USER_DIR) -c ir_MitsubishiHeavy_test.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_MitsubishiHeavy_test.cpp
 
 ir_MitsubishiHeavy_test : $(COMMON_OBJ) ir_MitsubishiHeavy_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,12 +37,8 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
         ir_Toshiba_test ir_Midea_test ir_Magiquest_test ir_Lasertag_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
-<<<<<<< HEAD
-  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test
-=======
-  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test \
+  ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test \
 	ir_MitsubishiHeavy_test
->>>>>>> First draft of support for Mitsubishi Heavy Industries A/Cs.
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -86,13 +82,8 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Kelvinator.o ir_Daikin.o ir_Gree.o ir_Pronto.o ir_Nikai.o ir_Toshiba.o \
 	ir_Midea.o ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
-<<<<<<< HEAD
 	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o \
-	ir_Trotec.o
-=======
-	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o \
-	ir_MitsubishiHeavy.o
->>>>>>> First draft of support for Mitsubishi Heavy Industries A/Cs.
+	ir_Trotec.o ir_MitsubishiHeavy.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \

--- a/test/ir_MitsubishiHeavy_test.cpp
+++ b/test/ir_MitsubishiHeavy_test.cpp
@@ -355,7 +355,6 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
       ac.toString());
 }
 
-
 TEST(TestMitsubishiHeavy152AcClass, ReconstructKnownExample) {
   IRMitsubishiHeavy152Ac ac(0);
 
@@ -388,6 +387,307 @@ TEST(TestMitsubishiHeavy152AcClass, ReconstructKnownExample) {
       0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
       0xFF, 0x80, 0x7F};
   EXPECT_STATE_EQ(expected, ac.getRaw(), kMitsubishiHeavy152Bits);
+}
+
+// Tests for IRMitsubishiHeavy88Ac class.
+
+TEST(TestMitsubishiHeavy88AcClass, Power) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, Temperature) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setMode(kMitsubishiHeavyCool);
+
+  ac.setTemp(0);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMinTemp);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMaxTemp);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMinTemp - 1);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMaxTemp + 1);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(19);
+  EXPECT_EQ(19, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, OperatingMode) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setMode(kMitsubishiHeavyAuto);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyCool);
+  EXPECT_EQ(kMitsubishiHeavyCool, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyHeat);
+  EXPECT_EQ(kMitsubishiHeavyHeat, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyDry);
+  EXPECT_EQ(kMitsubishiHeavyDry, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyFan);
+  EXPECT_EQ(kMitsubishiHeavyFan, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyHeat + 1);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, Turbo) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setTurbo(true);
+  EXPECT_TRUE(ac.getTurbo());
+
+  ac.setTurbo(false);
+  EXPECT_FALSE(ac.getTurbo());
+
+  ac.setTurbo(true);
+  EXPECT_TRUE(ac.getTurbo());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, Econo) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, 3D) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.set3D(true);
+  EXPECT_TRUE(ac.get3D());
+
+  ac.set3D(false);
+  EXPECT_FALSE(ac.get3D());
+
+  ac.set3D(true);
+  EXPECT_TRUE(ac.get3D());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, Clean) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setClean(true);
+  EXPECT_TRUE(ac.getClean());
+
+  ac.setClean(false);
+  EXPECT_FALSE(ac.getClean());
+
+  ac.setClean(true);
+  EXPECT_TRUE(ac.getClean());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, FanSpeed) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  ac.setFan(kMitsubishiHeavy88FanLow);
+  EXPECT_EQ(kMitsubishiHeavy88FanLow, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanAuto);
+  EXPECT_EQ(kMitsubishiHeavy88FanAuto, ac.getFan());
+
+
+  ac.setFan(255);
+  EXPECT_EQ(kMitsubishiHeavy88FanAuto, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanHigh);
+  EXPECT_EQ(kMitsubishiHeavy88FanHigh, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanHigh + 1);
+  EXPECT_EQ(kMitsubishiHeavy88FanAuto, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanHigh - 1);
+  EXPECT_EQ(kMitsubishiHeavy88FanHigh - 1, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanLow + 1);
+  EXPECT_EQ(kMitsubishiHeavy88FanLow + 1, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanEcono);
+  EXPECT_EQ(kMitsubishiHeavy88FanEcono, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy88FanTurbo);
+  EXPECT_EQ(kMitsubishiHeavy88FanTurbo, ac.getFan());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, VerticalSwing) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVAuto);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVAuto, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVHighest);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVHighest, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVOff);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVOff, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVHighest + 1);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVOff, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVOff + 1);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVOff, ac.getSwingVertical());
+
+  // Out of bounds.
+  ac.setSwingVertical(255);
+  EXPECT_EQ(kMitsubishiHeavy88SwingVOff, ac.getSwingVertical());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, HorizontalSwing) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHAuto);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHAuto, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftMax);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHLeftMax, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftMax + 1);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHOff, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHRightMax);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHRightMax, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHRightMax - 1);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHOff, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHOff);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHOff, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHOff + 1);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHOff, ac.getSwingHorizontal());
+
+  // Out of bounds.
+  ac.setSwingHorizontal(255);
+  EXPECT_EQ(kMitsubishiHeavy88SwingHOff, ac.getSwingHorizontal());
+}
+
+TEST(TestMitsubishiHeavy88AcClass, Checksums) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.begin();
+
+  EXPECT_TRUE(ac.validChecksum(ac.getRaw()));
+
+  uint8_t expected[kMitsubishiHeavy88StateLength] = {
+      0xAD, 0x51, 0x3C, 0xD9, 0x26, 0x48, 0xB7, 0x00, 0xFF, 0x8A, 0x75};
+  EXPECT_TRUE(IRMitsubishiHeavy88Ac::validChecksum(expected));
+
+  // Screw up the "checksum" to test it fails.
+  expected[kMitsubishiHeavy88StateLength - 1] = 0x55;
+  EXPECT_FALSE(IRMitsubishiHeavy88Ac::validChecksum(expected));
+  // getting the after getRaw() should repair it.
+  ac.setRaw(expected);
+  EXPECT_TRUE(ac.validChecksum(ac.getRaw()));
+  EXPECT_TRUE(IRMitsubishiHeavy88Ac::validChecksum(ac.getRaw()));
+}
+
+TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
+  IRMitsubishiHeavy88Ac ac(0);
+
+  EXPECT_EQ(
+      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Swing (V): 0 (Off), Swing (H): 0 (Off), "
+      "Turbo: Off, Econo: Off, 3D: Off, Clean: Off",
+      ac.toString());
+  ac.on();
+  ac.setMode(kMitsubishiHeavyCool);
+  ac.setTemp(kMitsubishiHeavyMinTemp);
+  ac.setFan(kMitsubishiHeavy88FanHigh);
+  ac.setTurbo(false);
+  ac.setEcono(false);
+  ac.set3D(true);
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Cool), Temp: 17C, Fan: 4 (High), "
+      "Swing (V): 16 (Auto), Swing (H): 200 (3D), "
+      "Turbo: Off, Econo: Off, 3D: On, Clean: Off",
+      ac.toString());
+
+  ac.setMode(kMitsubishiHeavyHeat);
+  ac.setTemp(kMitsubishiHeavyMaxTemp);
+  ac.setTurbo(true);
+  ac.setEcono(false);
+  ac.set3D(false);
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVLowest);
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftMax);
+
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (Heat), Temp: 31C, Fan: 6 (Turbo), "
+      "Swing (V): 26 (Lowest), Swing (H): 4 (Max Left), Turbo: On, Econo: Off, "
+      "3D: Off, Clean: Off",
+      ac.toString());
+
+  ac.setClean(true);
+  ac.setEcono(true);
+  ac.setMode(kMitsubishiHeavyAuto);
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVOff);
+
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (Auto), Temp: 31C, Fan: 7 (Econo), "
+      "Swing (V): 0 (Off), Swing (H): 4 (Max Left), Turbo: Off, Econo: On, "
+      "3D: Off, Clean: On",
+      ac.toString());
+
+  ac.setClean(false);
+  ac.setTemp(25);
+  ac.setEcono(false);
+  ac.setMode(kMitsubishiHeavyDry);
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftRight);
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Swing (V): 0 (Off), Swing (H): 72 (Left Right), Turbo: Off, Econo: Off, "
+      "3D: Off, Clean: Off",
+      ac.toString());
 }
 
 // Tests for decodeMitsubishiHeavy().
@@ -529,10 +829,11 @@ TEST(TestDecodeMitsubishiHeavy, ZmsRealExample2) {
 TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
+  IRMitsubishiHeavy88Ac ac(0);
   irsend.begin();
 
   uint8_t expected[kMitsubishiHeavy88StateLength] = {
-      0xAD, 0x51, 0x3C, 0xD9, 0x26, 0xEE, 0x11, 0xF8, 0x07, 0xFF, 0x00};
+      0xAD, 0x51, 0x3C, 0xD9, 0x26, 0x48, 0xB7, 0x00, 0xFF, 0x8A, 0x75};
 
   irsend.reset();
   irsend.sendMitsubishiHeavy88(expected);
@@ -541,4 +842,10 @@ TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
   ASSERT_EQ(MITSUBISHI_HEAVY_88, irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishiHeavy88Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Swing (V): 0 (Off), Swing (H): 72 (Left Right), Turbo: Off, Econo: Off, "
+      "3D: Off, Clean: Off",
+      ac.toString());
 }

--- a/test/ir_MitsubishiHeavy_test.cpp
+++ b/test/ir_MitsubishiHeavy_test.cpp
@@ -1,0 +1,544 @@
+// Copyright 2019 David Conran
+
+#include "ir_MitsubishiHeavy.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// General housekeeping
+TEST(TestMitsubishiHeavy, Housekeeping) {
+  ASSERT_EQ("MITSUBISHI_HEAVY_88", typeToString(MITSUBISHI_HEAVY_88));
+  ASSERT_TRUE(hasACState(MITSUBISHI_HEAVY_88));
+  ASSERT_EQ("MITSUBISHI_HEAVY_152", typeToString(MITSUBISHI_HEAVY_152));
+  ASSERT_TRUE(hasACState(MITSUBISHI_HEAVY_152));
+}
+
+// Tests for IRMitsubishiHeavy152Ac class.
+
+TEST(TestMitsubishiHeavy152AcClass, Power) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Temperature) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setMode(kMitsubishiHeavyCool);
+
+  ac.setTemp(0);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMinTemp);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMaxTemp);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMinTemp - 1);
+  EXPECT_EQ(kMitsubishiHeavyMinTemp, ac.getTemp());
+
+  ac.setTemp(kMitsubishiHeavyMaxTemp + 1);
+  EXPECT_EQ(kMitsubishiHeavyMaxTemp, ac.getTemp());
+
+  ac.setTemp(19);
+  EXPECT_EQ(19, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, OperatingMode) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setMode(kMitsubishiHeavyAuto);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyCool);
+  EXPECT_EQ(kMitsubishiHeavyCool, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyHeat);
+  EXPECT_EQ(kMitsubishiHeavyHeat, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyDry);
+  EXPECT_EQ(kMitsubishiHeavyDry, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyFan);
+  EXPECT_EQ(kMitsubishiHeavyFan, ac.getMode());
+
+  ac.setMode(kMitsubishiHeavyHeat + 1);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kMitsubishiHeavyAuto, ac.getMode());
+}
+
+
+TEST(TestMitsubishiHeavy152AcClass, Filter) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setFilter(true);
+  EXPECT_TRUE(ac.getFilter());
+
+  ac.setFilter(false);
+  EXPECT_FALSE(ac.getFilter());
+
+  ac.setFilter(true);
+  EXPECT_TRUE(ac.getFilter());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Turbo) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setTurbo(true);
+  EXPECT_TRUE(ac.getTurbo());
+
+  ac.setTurbo(false);
+  EXPECT_FALSE(ac.getTurbo());
+
+  ac.setTurbo(true);
+  EXPECT_TRUE(ac.getTurbo());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Econo) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, 3D) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.set3D(true);
+  EXPECT_TRUE(ac.get3D());
+
+  ac.set3D(false);
+  EXPECT_FALSE(ac.get3D());
+
+  ac.set3D(true);
+  EXPECT_TRUE(ac.get3D());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Night) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setNight(true);
+  EXPECT_TRUE(ac.getNight());
+
+  ac.setNight(false);
+  EXPECT_FALSE(ac.getNight());
+
+  ac.setNight(true);
+  EXPECT_TRUE(ac.getNight());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Clean) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setClean(true);
+  EXPECT_TRUE(ac.getClean());
+
+  ac.setClean(false);
+  EXPECT_FALSE(ac.getClean());
+
+  ac.setClean(true);
+  EXPECT_TRUE(ac.getClean());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, FanSpeed) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  ac.setFan(kMitsubishiHeavy152FanLow);
+  EXPECT_EQ(kMitsubishiHeavy152FanLow, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanAuto);
+  EXPECT_EQ(kMitsubishiHeavy152FanAuto, ac.getFan());
+
+
+  ac.setFan(255);
+  EXPECT_EQ(kMitsubishiHeavy152FanAuto, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanMax);
+  EXPECT_EQ(kMitsubishiHeavy152FanMax, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanMax + 1);
+  EXPECT_EQ(kMitsubishiHeavy152FanAuto, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanMax - 1);
+  EXPECT_EQ(kMitsubishiHeavy152FanMax - 1, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanLow + 1);
+  EXPECT_EQ(kMitsubishiHeavy152FanLow + 1, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanEcono);
+  EXPECT_EQ(kMitsubishiHeavy152FanEcono, ac.getFan());
+
+  ac.setFan(kMitsubishiHeavy152FanTurbo);
+  EXPECT_EQ(kMitsubishiHeavy152FanTurbo, ac.getFan());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, VerticalSwing) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVAuto, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVHighest);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVHighest, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVHighest + 1);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVHighest + 1, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVOff);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVOff, ac.getSwingVertical());
+
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVOff + 1);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVOff, ac.getSwingVertical());
+
+  // Out of bounds.
+  ac.setSwingVertical(255);
+  EXPECT_EQ(kMitsubishiHeavy152SwingVOff, ac.getSwingVertical());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, HorizontalSwing) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHAuto);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHAuto, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftMax);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHLeftMax, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftMax + 1);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHLeftMax + 1, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHRightMax);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHRightMax, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHRightMax - 1);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHRightMax - 1, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHOff);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHOff, ac.getSwingHorizontal());
+
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHOff + 1);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHOff, ac.getSwingHorizontal());
+
+  // Out of bounds.
+  ac.setSwingHorizontal(255);
+  EXPECT_EQ(kMitsubishiHeavy152SwingHOff, ac.getSwingHorizontal());
+}
+
+TEST(TestMitsubishiHeavy152AcClass, Checksums) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.begin();
+
+  EXPECT_TRUE(ac.validChecksum(ac.getRaw()));
+
+  uint8_t expected[kMitsubishiHeavy152StateLength] = {
+      0xAD, 0x51, 0x3C, 0xE5, 0x1A, 0x0C, 0xF3, 0x07,
+      0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x80, 0x7F};
+  EXPECT_TRUE(IRMitsubishiHeavy152Ac::validChecksum(expected));
+
+  // Screw up the "checksum" to test it fails.
+  expected[kMitsubishiHeavy152StateLength - 1] = 0x55;
+  EXPECT_FALSE(IRMitsubishiHeavy152Ac::validChecksum(expected));
+  // getting the after getRaw() should repair it.
+  ac.setRaw(expected);
+  EXPECT_TRUE(ac.validChecksum(ac.getRaw()));
+  EXPECT_TRUE(IRMitsubishiHeavy152Ac::validChecksum(ac.getRaw()));
+}
+
+TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
+  IRMitsubishiHeavy152Ac ac(0);
+
+  EXPECT_EQ(
+      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+  ac.on();
+  ac.setMode(kMitsubishiHeavyCool);
+  ac.setTemp(kMitsubishiHeavyMinTemp);
+  ac.setFan(kMitsubishiHeavy152FanMax);
+  ac.setFilter(true);
+  ac.setNight(true);
+  ac.setTurbo(false);
+  ac.setSilent(true);
+  ac.setEcono(false);
+  ac.set3D(true);
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Cool), Temp: 17C, Fan: 4 (Max), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: On, Turbo: Off, "
+      "Econo: Off, Night: On, Filter: On, 3D: On, Clean: Off",
+      ac.toString());
+
+  ac.setMode(kMitsubishiHeavyHeat);
+  ac.setTemp(kMitsubishiHeavyMaxTemp);
+  ac.setFilter(true);
+  ac.setNight(false);
+  ac.setTurbo(true);
+  ac.setEcono(false);
+  ac.setSilent(false);
+  ac.set3D(false);
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVLowest);
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftMax);
+
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (Heat), Temp: 31C, Fan: 8 (Turbo), "
+      "Swing (V): 5 (Lowest), Swing (H): 1 (Max Left), Silent: Off, Turbo: On, "
+      "Econo: Off, Night: Off, Filter: On, 3D: Off, Clean: Off",
+      ac.toString());
+
+  ac.setClean(true);
+  ac.setEcono(true);
+  ac.setMode(kMitsubishiHeavyAuto);
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVOff);
+
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (Auto), Temp: 31C, Fan: 6 (Econo), "
+      "Swing (V): 6 (Off), Swing (H): 1 (Max Left), Silent: Off, "
+      "Turbo: Off, Econo: On, Night: Off, Filter: On, 3D: Off, Clean: On",
+      ac.toString());
+
+  ac.setClean(false);
+  ac.setTemp(25);
+  ac.setEcono(false);
+  ac.setMode(kMitsubishiHeavyDry);
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftRight);
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Swing (V): 6 (Off), Swing (H): 7 (Left Right), Silent: Off, "
+      "Turbo: Off, Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+}
+
+
+TEST(TestMitsubishiHeavy152AcClass, ReconstructKnownExample) {
+  IRMitsubishiHeavy152Ac ac(0);
+
+  EXPECT_EQ(
+      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+  ac.on();
+  ac.setMode(kMitsubishiHeavyHeat);
+  ac.setTemp(24);
+  ac.setFan(kMitsubishiHeavy152FanMax);
+  ac.setFilter(true);
+  ac.setNight(false);
+  ac.setTurbo(false);
+  ac.setSilent(false);
+  ac.setEcono(false);
+  ac.set3D(false);
+  ac.setClean(false);
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHAuto);
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+
+  uint8_t expected[kMitsubishiHeavy152StateLength] = {
+      0xAD, 0x51, 0x3C, 0xE5, 0x1A, 0x0C, 0xF3, 0x07,
+      0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x80, 0x7F};
+  EXPECT_STATE_EQ(expected, ac.getRaw(), kMitsubishiHeavy152Bits);
+}
+
+// Tests for decodeMitsubishiHeavy().
+
+// Decode a real MitsubishiHeavy 152Bit message.
+TEST(TestDecodeMitsubishiHeavy, ZmsRealExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  IRMitsubishiHeavy152Ac ac(0);
+  irsend.begin();
+
+  uint8_t expected[kMitsubishiHeavy152StateLength] = {
+      0xAD, 0x51, 0x3C, 0xE5, 0x1A, 0x0C, 0xF3, 0x07,
+      0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x80, 0x7F};
+
+  // Ref: https://github.com/markszabo/IRremoteESP8266/issues/660#issuecomment-480571466
+  uint16_t rawData[307] = {
+      3136, 1638, 364, 428, 366, 1224, 362, 432, 364, 430, 364, 1226, 362, 432,
+      364, 1224, 366, 428, 366, 430, 366, 1224, 362, 1228, 362, 1228, 362, 432,
+      364, 1224, 364, 432, 364, 1226, 364, 1224, 366, 1226, 364, 428, 364, 430,
+      364, 430, 364, 432, 366, 1226, 364, 1224, 364, 430, 364, 1226, 364, 428,
+      364, 1224, 368, 1224, 364, 428, 364, 430, 366, 430, 364, 1158, 430, 432,
+      366, 1222, 366, 430, 366, 430, 364, 1226, 364, 1224, 364, 1224, 364, 1224,
+      366, 1224, 364, 430, 364, 430, 364, 1228, 362, 1226, 364, 1226, 366, 1222,
+      366, 430, 364, 430, 364, 1224, 366, 1224, 364, 430, 364, 430, 364, 432,
+      364, 430, 364, 428, 364, 430, 364, 430, 366, 1226, 362, 1154, 434, 1228,
+      364, 1226, 362, 1226, 364, 1226, 364, 1228, 362, 1226, 362, 432, 364, 430,
+      364, 428, 364, 430, 364, 430, 364, 1228, 362, 1228, 362, 432, 364, 1224,
+      368, 1224, 364, 1226, 362, 1226, 364, 1226, 366, 428, 366, 430, 364, 1224,
+      364, 430, 366, 430, 366, 430, 364, 430, 364, 430, 364, 1226, 364, 1226,
+      366, 1224, 366, 1224, 366, 1226, 364, 1224, 366, 1224, 366, 1224, 366,
+      428, 364, 430, 366, 428, 364, 430, 364, 430, 366, 428, 364, 430, 364, 432,
+      364, 1226, 364, 1226, 364, 1226, 364, 1228, 364, 1222, 370, 1222, 362,
+      1228, 362, 1226, 362, 430, 364, 430, 364, 430, 364, 432, 364, 428, 364,
+      432, 364, 428, 364, 430, 366, 1226, 362, 1224, 364, 1226, 364, 1226, 364,
+      1226, 362, 1226, 366, 1224, 366, 1224, 364, 430, 364, 432, 364, 428, 364,
+      432, 364, 428, 364, 430, 366, 430, 364, 430, 364, 1226, 362, 1226, 364,
+      1224, 366, 1226, 362, 1228, 364, 1224, 366, 1224, 364, 430, 364, 432, 364,
+      428, 364, 430, 364, 430, 364, 430, 366, 430, 364, 430, 338, 1252, 362
+    };  // UNKNOWN 5138D49D
+
+  irsend.reset();
+  irsend.sendRaw(rawData, 307, 38000);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_152, irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy152Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+}
+
+// Decode a Synthetic MitsubishiHeavy 152Bit message.
+TEST(TestDecodeMitsubishiHeavy, ZmsSyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  IRMitsubishiHeavy152Ac ac(0);
+  irsend.begin();
+
+  uint8_t expected[kMitsubishiHeavy152StateLength] = {
+      0xAD, 0x51, 0x3C, 0xE5, 0x1A, 0x0C, 0xF3, 0x07,
+      0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x80, 0x7F};
+
+  irsend.reset();
+  irsend.sendMitsubishiHeavy152(expected);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_152, irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy152Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+}
+
+// Decode a real MitsubishiHeavy 152Bit message.
+TEST(TestDecodeMitsubishiHeavy, ZmsRealExample2) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  IRMitsubishiHeavy152Ac ac(0);
+  irsend.begin();
+
+  uint8_t expected[kMitsubishiHeavy152StateLength] = {
+      0xAD, 0x51, 0x3C, 0xE5, 0x1A, 0x04, 0xFB, 0x07,
+      0xF8, 0x04, 0xFB, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x80, 0x7F};
+
+  // Ref: https://github.com/markszabo/IRremoteESP8266/issues/660#issuecomment-480571466
+  uint16_t rawData[307] = {
+      3196, 1580, 398, 390, 404, 1190, 400, 390, 402, 390, 402, 1192, 402, 388,
+      402, 1192, 400, 390, 402, 392, 402, 1192, 400, 1188, 400, 1188, 400, 390,
+      404, 1192, 398, 392, 400, 1192, 402, 1188, 400, 1190, 402, 388, 402, 392,
+      404, 392, 402, 392, 404, 1188, 400, 1190, 398, 392, 404, 1188, 398, 392,
+      402, 1192, 398, 1190, 400, 390, 404, 390, 402, 392, 404, 1188, 398, 392,
+      404, 1190, 400, 392, 400, 394, 402, 1192, 398, 1190, 398, 1192, 398, 1190,
+      400, 1190, 398, 392, 402, 1192, 398, 1190, 398, 1190, 398, 1192, 396,
+      1192, 398, 396, 400, 394, 398, 1194, 396, 394, 400, 394, 398, 396, 398,
+      396, 400, 402, 390, 394, 402, 392, 398, 396, 398, 1194, 396, 1194, 398,
+      1192, 398, 1192, 396, 1194, 396, 1192, 396, 1196, 398, 1190, 398, 392,
+      402, 392, 402, 394, 398, 394, 400, 394, 400, 1192, 398, 1192, 400, 390,
+      402, 1190, 398, 1190, 398, 1192, 402, 1188, 398, 1190, 400, 390, 402, 392,
+      402, 1190, 400, 390, 404, 390, 402, 394, 402, 392, 402, 390, 404, 1190,
+      400, 1188, 400, 1190, 400, 1190, 402, 1188, 402, 1188, 400, 1188, 402,
+      1190, 400, 388, 402, 394, 404, 392, 404, 388, 404, 390, 404, 392, 402,
+      394, 402, 390, 402, 1190, 402, 1186, 402, 1190, 400, 1190, 398, 1190, 402,
+      1186, 402, 1190, 400, 1188, 400, 390, 404, 392, 404, 390, 402, 392, 402,
+      392, 400, 394, 402, 392, 402, 394, 400, 1192, 400, 1190, 400, 1188, 400,
+      1192, 400, 1186, 402, 1190, 400, 1190, 400, 1188, 402, 388, 402, 390, 404,
+      392, 402, 392, 402, 392, 402, 392, 404, 392, 402, 392, 404, 1190, 400,
+      1190, 398, 1190, 400, 1190, 400, 1190, 400, 1188, 400, 1188, 400, 392,
+      402, 392, 404, 390, 402, 392, 402, 392, 402, 392, 402, 390, 402, 392, 402,
+      1192, 398};  // UNKNOWN A650F2C1
+
+  irsend.reset();
+  irsend.sendRaw(rawData, 307, 38000);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_152, irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy152Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: Off, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
+      "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
+      ac.toString());
+}
+
+// Decode a Synthetic MitsubishiHeavy 88 Bit message.
+TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  uint8_t expected[kMitsubishiHeavy88StateLength] = {
+      0xAD, 0x51, 0x3C, 0xD9, 0x26, 0xEE, 0x11, 0xF8, 0x07, 0xFF, 0x00};
+
+  irsend.reset();
+  irsend.sendMitsubishiHeavy88(expected);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI_HEAVY_88, irsend.capture.decode_type);
+  ASSERT_EQ(kMitsubishiHeavy88Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -49,7 +49,8 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Pronto.o ir_GlobalCache.o ir_Nikai.o ir_Toshiba.o ir_Midea.o \
             ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o ir_Hitachi.o \
             ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o ir_Pioneer.o \
-            ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o
+            ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o \
+						ir_MitsubishiHeavy.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -114,6 +115,9 @@ ir_LG.o : $(USER_DIR)/ir_LG.h $(USER_DIR)/ir_LG.cpp $(COMMON_DEPS)
 
 ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Mitsubishi.cpp
+
+ir_MitsubishiHeavy.o : $(USER_DIR)/ir_MitsubishiHeavy.h $(USER_DIR)/ir_MitsubishiHeavy.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -117,7 +117,7 @@ ir_Mitsubishi.o : $(USER_DIR)/ir_Mitsubishi.h $(USER_DIR)/ir_Mitsubishi.cpp $(CO
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Mitsubishi.cpp
 
 ir_MitsubishiHeavy.o : $(USER_DIR)/ir_MitsubishiHeavy.h $(USER_DIR)/ir_MitsubishiHeavy.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_MitsubishiHeavy.cpp
 
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp


### PR DESCRIPTION
- Full support (send/receive/decode/class) for 152 bit (ZMS) & 88 bit (ZJS) protocol.
- Unit test coverage for all added code.
  * Can accept and fully decode supplied real examples (ZMS).
  * Can accept and fully decode synthetic examples (ZJS).
- Updated example code to handle new A/C types.

For #660