### PR TITLE
Add advanced aircon/climate functionality to IRMQTTServer

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -247,28 +247,28 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 #define MQTTstatus MQTTprefix "/status"  // Topic for the Last Will & Testament.
 #define MQTTclimateprefix MQTTprefix "/ac"
 
-#define MQTTcmdprefix "/cmd"
-#define MQTTstatprefix "/stat"
+#define MQTTcmdprefix "/cmd/"
+#define MQTTstatprefix "/stat/"
 
-#define MQTTwildcard "/+"
-#define MQTTprotocol "/protocol"
-#define MQTTmodel "/model"
-#define MQTTpower "/power"
-#define MQTTmode "/mode"
-#define MQTTtemp "/temp"
-#define MQTTfanspeed "/fanspeed"
-#define MQTTswingv "/swingv"
-#define MQTTswingh "/swingh"
-#define MQTTquiet "/quiet"
-#define MQTTturbo "/turbo"
-#define MQTTlight "/light"
-#define MQTTbeep "/beep"
-#define MQTTecono "/econo"
-#define MQTTsleep "/sleep"
-#define MQTTclock "/clock"
-#define MQTTfilter "/filter"
-#define MQTTclean "/clean"
-#define MQTTcelsius "/use_celsius"
+#define MQTTwildcard "+"
+#define KEY_PROTOCOL "protocol"
+#define KEY_MODEL "model"
+#define KEY_POWER "power"
+#define KEY_MODE "mode"
+#define KEY_TEMP "temp"
+#define KEY_FANSPEED "fanspeed"
+#define KEY_SWINGV "swingv"
+#define KEY_SWINGH "swingh"
+#define KEY_QUIET "quiet"
+#define KEY_TURBO "turbo"
+#define KEY_LIGHT "light"
+#define KEY_BEEP "beep"
+#define KEY_ECONO "econo"
+#define KEY_SLEEP "sleep"
+#define KEY_CLOCK "clock"
+#define KEY_FILTER "filter"
+#define KEY_CLEAN "clean"
+#define KEY_CELSIUS "use_celsius"
 
 #define MQTTdiscovery "homeassistant/climate/" HOSTNAME "/config"
 #define MQTTHomeAssistantName HOSTNAME "_aircon"
@@ -877,7 +877,7 @@ void handleAirCon() {
       "<form method='POST' action='/aircon/set' enctype='multipart/form-data'>"
       "<table style='width:33%'>"
       "<tr><td>Protocol</td><td>"
-      "<select name='type'>";
+      "<select name='" KEY_PROTOCOL "'>";
   for (uint16_t i = 0; i < 255; i++) {
     if (IRac::isProtocolSupported((decode_type_t)i)) {
       html += F("<option value='");
@@ -890,40 +890,40 @@ void handleAirCon() {
     }
   }
   html += "</select></td></tr>"
-      "<tr><td>Model</td><td>" + htmlSelectModel("model", climate.model) +
+      "<tr><td>Model</td><td>" + htmlSelectModel(KEY_MODEL, climate.model) +
           "</td></tr>"
-      "<tr><td>Power</td><td>" + htmlSelectBool("power", climate.power) +
+      "<tr><td>Power</td><td>" + htmlSelectBool(KEY_POWER, climate.power) +
           "</td></tr>"
-      "<tr><td>Mode</td><td>" + htmlSelectMode("mode", climate.mode) +
+      "<tr><td>Mode</td><td>" + htmlSelectMode(KEY_MODE, climate.mode) +
           "</td></tr>"
       "<tr><td>Temp</td><td>"
-          "<input type='number' name='degrees' min='16' max='86' step='0.5' "
-          "value='" + String(climate.degrees, 1) + "'>"
-          "<select name='use_celcius'>"
+          "<input type='number' name='" KEY_TEMP "' min='16' max='90' "
+          "step='0.5' value='" + String(climate.degrees, 1) + "'>"
+          "<select name='" KEY_CELSIUS "'>"
               "<option value='on'" +
               (climate.celsius ? " selected='selected'" : "") + ">C</option>"
               "<option value='off'" +
               (!climate.celsius ? " selected='selected'" : "") + ">F</option>"
           "</select></td></tr>"
       "<tr><td>Fan Speed</td><td>" +
-          htmlSelectFanspeed("fanspeed", climate.fanspeed) + "</td></tr>"
+          htmlSelectFanspeed(KEY_FANSPEED, climate.fanspeed) + "</td></tr>"
       "<tr><td>Swing (V)</td><td>" +
-          htmlSelectSwingv("swingv", climate.swingv) + "</td></tr>"
+          htmlSelectSwingv(KEY_SWINGV, climate.swingv) + "</td></tr>"
       "<tr><td>Swing (H)</td><td>" +
-          htmlSelectSwingh("swingh", climate.swingh) + "</td></tr>"
-      "<tr><td>Quiet</td><td>" + htmlSelectBool("quiet", climate.quiet) +
+          htmlSelectSwingh(KEY_SWINGH, climate.swingh) + "</td></tr>"
+      "<tr><td>Quiet</td><td>" + htmlSelectBool(KEY_QUIET, climate.quiet) +
           "</td></tr>"
-      "<tr><td>Turbo</td><td>" + htmlSelectBool("turbo", climate.turbo) +
+      "<tr><td>Turbo</td><td>" + htmlSelectBool(KEY_TURBO, climate.turbo) +
           "</td></tr>"
-      "<tr><td>Econo</td><td>" + htmlSelectBool("econo", climate.econo) +
+      "<tr><td>Econo</td><td>" + htmlSelectBool(KEY_ECONO, climate.econo) +
           "</td></tr>"
-      "<tr><td>Light</td><td>" + htmlSelectBool("light", climate.light) +
+      "<tr><td>Light</td><td>" + htmlSelectBool(KEY_LIGHT, climate.light) +
           "</td></tr>"
-      "<tr><td>Filter</td><td>" + htmlSelectBool("filter", climate.filter) +
+      "<tr><td>Filter</td><td>" + htmlSelectBool(KEY_FILTER, climate.filter) +
           "</td></tr>"
-      "<tr><td>Clean</td><td>" + htmlSelectBool("clean", climate.clean) +
+      "<tr><td>Clean</td><td>" + htmlSelectBool(KEY_CLEAN, climate.clean) +
           "</td></tr>"
-      "<tr><td>Beep</td><td>" + htmlSelectBool("beep", climate.beep) +
+      "<tr><td>Beep</td><td>" + htmlSelectBool(KEY_BEEP, climate.beep) +
           "</td></tr>"
       "</table>"
       "<input type='submit' value='Update'>"
@@ -931,6 +931,33 @@ void handleAirCon() {
 
   // Display the current settings.
   html += "</body></html>";
+  server.send(200, "text/html", html);
+}
+
+// Parse the URL args to find the Common A/C arguments.
+void handleAirConSet() {
+#if HTML_PASSWORD_ENABLE
+  if (!server.authenticate(kHtmlUsername, kHtmlPassword)) {
+    debug("Basic HTTP authentication failure for /aircon/set.");
+    return server.requestAuthentication();
+  }
+#endif
+  commonAcState_t result = climate;
+  debug("New common a/c received via HTTP");
+  for (uint16_t i = 0; i < server.args(); i++)
+    result = updateClimate(result, server.argName(i), "", server.arg(i));
+
+  sendClimate(climate, result, MQTTclimateprefix MQTTstatprefix,
+              true, false, false);
+  // Update the old climate state with the new one.
+  climate = result;
+  // Redirect back to the aircon page.
+  String html = F(
+      "<html><head><title>Update Aircon</title></head>"
+      "<body>"
+      "<center><h1>Aircon updated!</h1></center>");
+  html += addJsReloadUrl("/aircon", 2, false);
+  html += F("</body></html>");
   server.send(200, "text/html", html);
 }
 
@@ -1707,6 +1734,8 @@ void setup(void) {
   server.on("/ir", handleIr);
   // Setup the aircon page.
   server.on("/aircon", handleAirCon);
+  // Setup the aircon update page.
+  server.on("/aircon/set", handleAirConSet);
   // Setup the info page.
   server.on("/info", handleInfo);
   // Setup the admin page.
@@ -2385,20 +2414,20 @@ void sendMQTTDiscovery(const char *topic) {
       "{"
       "\"~\":\"" MQTTclimateprefix "\","
       "\"name\":\"" MQTTHomeAssistantName "\","
-      "\"pow_cmd_t\":\"~" MQTTcmdprefix MQTTpower "\","
-      "\"mode_cmd_t\":\"~" MQTTcmdprefix MQTTmode "\","
-      "\"mode_stat_t\":\"~" MQTTstatprefix MQTTmode "\","
+      "\"pow_cmd_t\":\"~" MQTTcmdprefix KEY_POWER "\","
+      "\"mode_cmd_t\":\"~" MQTTcmdprefix KEY_MODE "\","
+      "\"mode_stat_t\":\"~" MQTTstatprefix KEY_MODE "\","
       "\"modes\":[\"off\",\"auto\",\"cool\",\"heat\",\"dry\",\"fan_only\"],"
-      "\"temp_cmd_t\":\"~" MQTTcmdprefix MQTTtemp "\","
-      "\"temp_stat_t\":\"~" MQTTstatprefix MQTTtemp "\","
+      "\"temp_cmd_t\":\"~" MQTTcmdprefix KEY_TEMP "\","
+      "\"temp_stat_t\":\"~" MQTTstatprefix KEY_TEMP "\","
       "\"min_temp\":\"16\","
       "\"max_temp\":\"30\","
       "\"temp_step\":\"1\","
-      "\"fan_mode_cmd_t\":\"~" MQTTcmdprefix MQTTfanspeed "\","
-      "\"fan_mode_stat_t\":\"~" MQTTstatprefix MQTTfanspeed "\","
+      "\"fan_mode_cmd_t\":\"~" MQTTcmdprefix KEY_FANSPEED "\","
+      "\"fan_mode_stat_t\":\"~" MQTTstatprefix KEY_FANSPEED "\","
       "\"fan_modes\":[\"auto\",\"min\",\"low\",\"medium\",\"high\",\"max\"],"
-      "\"swing_mode_cmd_t\":\"~" MQTTcmdprefix MQTTswingv "\","
-      "\"swing_mode_stat_t\":\"~" MQTTstatprefix MQTTswingv "\","
+      "\"swing_mode_cmd_t\":\"~" MQTTcmdprefix KEY_SWINGV "\","
+      "\"swing_mode_stat_t\":\"~" MQTTstatprefix KEY_SWINGV "\","
       "\"swing_modes\":["
         "\"off\",\"auto\",\"highest\",\"high\",\"middle\",\"low\",\"lowest\""
       "]"
@@ -2424,45 +2453,45 @@ bool sendFloat(const String topic, const float_t temp, const bool retain) {
   return mqtt_client.publish(topic.c_str(), String(temp).c_str(), retain);
 }
 
-commonAcState_t updateClimate(commonAcState_t current, const String topic,
-                              const String prefix, const String message) {
+commonAcState_t updateClimate(commonAcState_t current, const String str,
+                              const String prefix, const String payload) {
   commonAcState_t result = current;
-  String umesg = message;
-  umesg.toUpperCase();
-  if (topic.endsWith(prefix + MQTTprotocol))
-    result.protocol = strToDecodeType(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTmodel))
-    result.model = IRac::strToModel(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTpower))
-    result.power = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTmode))
-    result.mode = IRac::strToOpmode(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTtemp))
-    result.degrees = umesg.toFloat();
-  else if (topic.endsWith(prefix + MQTTfanspeed))
-    result.fanspeed = IRac::strToFanspeed(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTswingv))
-    result.swingv = IRac::strToSwingV(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTswingh))
-    result.swingh = IRac::strToSwingH(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTquiet))
-    result.quiet = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTturbo))
-    result.turbo = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTecono))
-    result.econo = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTlight))
-    result.light = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTbeep))
-    result.beep = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTfilter))
-    result.filter = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTclean))
-    result.clean = IRac::strToBool(umesg.c_str());
-  else if (topic.endsWith(prefix + MQTTsleep))
-    result.sleep = umesg.toInt();
-  else if (topic.endsWith(prefix + MQTTclock))
-    result.clock = umesg.toInt();
+  String value = payload;
+  value.toUpperCase();
+  if (str.equals(prefix + KEY_PROTOCOL))
+    result.protocol = strToDecodeType(value.c_str());
+  else if (str.equals(prefix + KEY_MODEL))
+    result.model = IRac::strToModel(value.c_str());
+  else if (str.equals(prefix + KEY_POWER))
+    result.power = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_MODE))
+    result.mode = IRac::strToOpmode(value.c_str());
+  else if (str.equals(prefix + KEY_TEMP))
+    result.degrees = value.toFloat();
+  else if (str.equals(prefix + KEY_FANSPEED))
+    result.fanspeed = IRac::strToFanspeed(value.c_str());
+  else if (str.equals(prefix + KEY_SWINGV))
+    result.swingv = IRac::strToSwingV(value.c_str());
+  else if (str.equals(prefix + KEY_SWINGH))
+    result.swingh = IRac::strToSwingH(value.c_str());
+  else if (str.equals(prefix + KEY_QUIET))
+    result.quiet = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_TURBO))
+    result.turbo = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_ECONO))
+    result.econo = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_LIGHT))
+    result.light = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_BEEP))
+    result.beep = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_FILTER))
+    result.filter = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_CLEAN))
+    result.clean = IRac::strToBool(value.c_str());
+  else if (str.equals(prefix + KEY_SLEEP))
+    result.sleep = value.toInt();
+  else if (str.equals(prefix + KEY_CLOCK))
+    result.clock = value.toInt();
   return result;
 }
 
@@ -2473,74 +2502,74 @@ bool sendClimate(const commonAcState_t prev, const commonAcState_t next,
   bool success = true;
   if (prev.protocol != next.protocol || forceMQTT) {
     diff = true;
-    success &= sendString(topic_prefix + MQTTprotocol,
+    success &= sendString(topic_prefix + KEY_PROTOCOL,
                           typeToString(next.protocol), retain);
   }
   if (prev.model != next.model || forceMQTT) {
     diff = true;
-    success &= sendInt(topic_prefix + MQTTmodel, next.model, retain);
+    success &= sendInt(topic_prefix + KEY_MODEL, next.model, retain);
   }
   if (prev.power != next.power || prev.mode != next.mode || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTpower, next.power, retain);
-    success &= sendString(topic_prefix + MQTTmode,
+    success &= sendBool(topic_prefix + KEY_POWER, next.power, retain);
+    success &= sendString(topic_prefix + KEY_MODE,
                           (next.power ? opmodeToString(next.mode) : F("off")),
                           retain);
   }
   if (prev.degrees != next.degrees || forceMQTT) {
     diff = true;
-    success &= sendFloat(topic_prefix + MQTTtemp, next.degrees, retain);
+    success &= sendFloat(topic_prefix + KEY_TEMP, next.degrees, retain);
   }
   if (prev.celsius != next.celsius || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTcelsius, next.celsius, retain);
+    success &= sendBool(topic_prefix + KEY_CELSIUS, next.celsius, retain);
   }
   if (prev.fanspeed != next.fanspeed || forceMQTT) {
     diff = true;
-    success &= sendString(topic_prefix + MQTTfanspeed,
+    success &= sendString(topic_prefix + KEY_FANSPEED,
                           fanspeedToString(next.fanspeed), retain);
   }
   if (prev.swingv != next.swingv || forceMQTT) {
     diff = true;
-    success &= sendString(topic_prefix + MQTTswingv,
+    success &= sendString(topic_prefix + KEY_SWINGV,
                           swingvToString(next.swingv), retain);
   }
   if (prev.swingh != next.swingh || forceMQTT) {
     diff = true;
-    success &= sendString(topic_prefix + MQTTswingh,
+    success &= sendString(topic_prefix + KEY_SWINGH,
                           swinghToString(next.swingh), retain);
   }
   if (prev.quiet != next.quiet || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTquiet, next.quiet, retain);
+    success &= sendBool(topic_prefix + KEY_QUIET, next.quiet, retain);
   }
   if (prev.turbo != next.turbo || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTturbo, next.turbo, retain);
+    success &= sendBool(topic_prefix + KEY_TURBO, next.turbo, retain);
   }
   if (prev.econo != next.econo || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTecono, next.econo, retain);
+    success &= sendBool(topic_prefix + KEY_ECONO, next.econo, retain);
   }
   if (prev.light != next.light || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTlight, next.light, retain);
+    success &= sendBool(topic_prefix + KEY_LIGHT, next.light, retain);
   }
   if (prev.filter != next.filter || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTfilter, next.filter, retain);
+    success &= sendBool(topic_prefix + KEY_FILTER, next.filter, retain);
   }
   if (prev.clean != next.clean || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTclean, next.clean, retain);
+    success &= sendBool(topic_prefix + KEY_CLEAN, next.clean, retain);
   }
   if (prev.beep != next.beep || forceMQTT) {
     diff = true;
-    success &= sendBool(topic_prefix + MQTTbeep, next.beep, retain);
+    success &= sendBool(topic_prefix + KEY_BEEP, next.beep, retain);
   }
   if (prev.sleep != next.sleep || forceMQTT) {
     diff = true;
-    success &= sendInt(topic_prefix + MQTTsleep, next.sleep, retain);
+    success &= sendInt(topic_prefix + KEY_SLEEP, next.sleep, retain);
   }
   if (diff && !forceMQTT)
     debug("Difference in common A/C state detected.");

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -227,7 +227,9 @@
 #define REPORT_UNKNOWNS false  // Report inbound IR messages that we don't know.
 #define REPORT_RAW_UNKNOWNS false  // Report the whole buffer, recommended:
                                    // MQTT_MAX_PACKET_SIZE of 1024 or more
+#ifndef MQTT_ENABLE
 #define MQTT_ENABLE true  // Whether or not MQTT is used at all.
+#endif  // MQTT_ENABLE
 // 'kHtmlUsername' & 'kHtmlPassword' are used by the following two items:
 #define FIRMWARE_OTA true  // Allow remote update of the firmware via http.
                            // Less secure if enabled.

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -502,7 +502,7 @@ String timeSince(uint32_t const start) {
     diff = now - start;
   else
     diff = UINT32_MAX - start + now;
-  return msToHumanString(diff);
+  return msToHumanString(diff) + " ago";
 }
 
 // Return a string containing the comma separated list of sending gpios.

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1118,6 +1118,8 @@ void handleInfo() {
     "<p>IP address: " + WiFi.localIP().toString() + "<br>"
     "Booted: " + timeSince(1) + "<br>" +
     "Version: " _MY_VERSION_ "<br>"
+    "Built: " __DATE__
+      " " __TIME__ "<br>"
     "Period Offset: " + String(offset) + "us<br>"
     "IR Lib Version: " _IRREMOTEESP8266_VERSION_ "<br>"
     "ESP8266 Core Version: " + ESP.getCoreVersion() + "<br>"

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -464,6 +464,10 @@ String htmlMenu(void) {
           "Home"
         "</button>"
         "<button type='button' "
+          "onclick='window.location=\"/aircon\"'>"
+          "Aircon"
+        "</button>"
+        "<button type='button' "
           "onclick='window.location=\"/info\"'>"
           "System Info"
         "</button>"
@@ -675,6 +679,259 @@ String addJsReloadUrl(const String url, const uint16_t timeout_s,
       "//-->\n"
       "</script>\n");
   return html;
+}
+
+String boolToString(const bool value) {
+  return String(value ? "on" : "off");
+}
+
+
+String opmodeToString(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kOff:
+      return F("off");
+    case stdAc::opmode_t::kAuto:
+      return F("auto");
+    case stdAc::opmode_t::kCool:
+      return F("cool");
+    case stdAc::opmode_t::kHeat:
+      return F("heat");
+    case stdAc::opmode_t::kDry:
+      return F("dry");
+    case stdAc::opmode_t::kFan:
+      return F("fan_only");
+    default:
+      return F("unknown");
+  }
+}
+
+String fanspeedToString(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kAuto:
+      return F("auto");
+    case stdAc::fanspeed_t::kMax:
+      return F("max");
+    case stdAc::fanspeed_t::kHigh:
+      return F("high");
+    case stdAc::fanspeed_t::kMedium:
+      return F("medium");
+    case stdAc::fanspeed_t::kLow:
+      return F("low");
+    case stdAc::fanspeed_t::kMin:
+      return F("min");
+    default:
+      return F("unknown");
+  }
+}
+
+String swingvToString(const stdAc::swingv_t swingv) {
+  switch (swingv) {
+    case stdAc::swingv_t::kOff:
+      return F("off");
+    case stdAc::swingv_t::kAuto:
+      return F("auto");
+    case stdAc::swingv_t::kHighest:
+      return F("highest");
+    case stdAc::swingv_t::kHigh:
+      return F("high");
+    case stdAc::swingv_t::kMiddle:
+      return F("middle");
+    case stdAc::swingv_t::kLow:
+      return F("low");
+    case stdAc::swingv_t::kLowest:
+      return F("lowest");
+    default:
+      return F("unknown");
+  }
+}
+
+String swinghToString(const stdAc::swingh_t swingh) {
+  switch (swingh) {
+    case stdAc::swingh_t::kOff:
+      return F("off");
+    case stdAc::swingh_t::kAuto:
+      return F("auto");
+    case stdAc::swingh_t::kLeftMax:
+      return F("leftmax");
+    case stdAc::swingh_t::kLeft:
+      return F("left");
+    case stdAc::swingh_t::kMiddle:
+      return F("middle");
+    case stdAc::swingh_t::kRight:
+      return F("right");
+    case stdAc::swingh_t::kRightMax:
+      return F("rightmax");
+    default:
+      return F("unknown");
+  }
+}
+
+String htmlSelectBool(const String name, const bool def) {
+  String html = "<select name='" + name + "'>";
+  for (uint16_t i = 0; i < 2; i++) {
+    html += F("<option value='");
+    html += boolToString(i);
+    html += '\'';
+    if (i == def) html += F(" selected='selected'");
+    html += '>';
+    html += boolToString(i);
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+String htmlSelectModel(const String name, const int16_t def) {
+  String html = "<select name='" + name + "'>";
+  for (int16_t i = -1; i <= 6; i++) {
+    String num = String(i);
+    html += F("<option value='");
+    html += num;
+    html += '\'';
+    if (i == def) html += F(" selected='selected'");
+    html += '>';
+    if (i == -1)
+      html += F("Default");
+    else if (i == 0)
+      html += F("Unknown");
+    else
+      html += num;
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+String htmlSelectMode(const String name, const stdAc::opmode_t def) {
+  String html = "<select name='" + name + "'>";
+  for (int8_t i = -1; i <= 4; i++) {
+    String mode = opmodeToString((stdAc::opmode_t)i);
+    html += F("<option value='");
+    html += mode;
+    html += '\'';
+    if ((stdAc::opmode_t)i == def) html += F(" selected='selected'");
+    html += '>';
+    html += mode;
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+String htmlSelectFanspeed(const String name, const stdAc::fanspeed_t def) {
+  String html = "<select name='" + name + "'>";
+  for (int8_t i = 0; i <= 5; i++) {
+    String speed = fanspeedToString((stdAc::fanspeed_t)i);
+    html += F("<option value='");
+    html += speed;
+    html += '\'';
+    if ((stdAc::fanspeed_t)i == def) html += F(" selected='selected'");
+    html += '>';
+    html += speed;
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+String htmlSelectSwingv(const String name, const stdAc::swingv_t def) {
+  String html = "<select name='" + name + "'>";
+  for (int8_t i = -1; i <= 5; i++) {
+    String swing = swingvToString((stdAc::swingv_t)i);
+    html += F("<option value='");
+    html += swing;
+    html += '\'';
+    if ((stdAc::swingv_t)i == def) html += F(" selected='selected'");
+    html += '>';
+    html += swing;
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+String htmlSelectSwingh(const String name, const stdAc::swingh_t def) {
+  String html = "<select name='" + name + "'>";
+  for (int8_t i = -1; i <= 5; i++) {
+    String swing = swinghToString((stdAc::swingh_t)i);
+    html += F("<option value='");
+    html += swing;
+    html += '\'';
+    if ((stdAc::swingh_t)i == def) html += F(" selected='selected'");
+    html += '>';
+    html += swing;
+    html += F("</option>");
+  }
+  html += F("</select>");
+  return html;
+}
+
+// Admin web page
+void handleAirCon() {
+  String html = F(
+    "<html><head><title>AirCon control</title></head>"
+    "<body>"
+    "<center><h1>Air Conditioner Control</h1></center>");
+  html += htmlMenu();
+  html += "<h3>Current Settings</h3>"
+      "<form method='POST' action='/aircon/set' enctype='multipart/form-data'>"
+      "<table style='width:33%'>"
+      "<tr><td>Protocol</td><td>"
+      "<select name='type'>";
+  for (uint16_t i = 0; i < 255; i++) {
+    if (IRac::isProtocolSupported((decode_type_t)i)) {
+      html += F("<option value='");
+      html += String(i);
+      html += '\'';
+      if (i == climate.protocol) html += " selected='selected'";
+      html += '>';
+      html += typeToString((decode_type_t)i);
+      html += "</option>";
+    }
+  }
+  html += "</select></td></tr>"
+      "<tr><td>Model</td><td>" + htmlSelectModel("model", climate.model) +
+          "</td></tr>"
+      "<tr><td>Power</td><td>" + htmlSelectBool("power", climate.power) +
+          "</td></tr>"
+      "<tr><td>Mode</td><td>" + htmlSelectMode("mode", climate.mode) +
+          "</td></tr>"
+      "<tr><td>Temp</td><td>"
+          "<input type='number' name='degrees' min='16' max='86' step='0.5' "
+          "value='" + String(climate.degrees, 1) + "'>"
+          "<select name='use_celcius'>"
+              "<option value='on'" +
+              (climate.celsius ? " selected='selected'" : "") + ">C</option>"
+              "<option value='off'" +
+              (!climate.celsius ? " selected='selected'" : "") + ">F</option>"
+          "</select></td></tr>"
+      "<tr><td>Fan Speed</td><td>" +
+          htmlSelectFanspeed("fanspeed", climate.fanspeed) + "</td></tr>"
+      "<tr><td>Swing (V)</td><td>" +
+          htmlSelectSwingv("swingv", climate.swingv) + "</td></tr>"
+      "<tr><td>Swing (H)</td><td>" +
+          htmlSelectSwingh("swingh", climate.swingh) + "</td></tr>"
+      "<tr><td>Quiet</td><td>" + htmlSelectBool("quiet", climate.quiet) +
+          "</td></tr>"
+      "<tr><td>Turbo</td><td>" + htmlSelectBool("turbo", climate.turbo) +
+          "</td></tr>"
+      "<tr><td>Econo</td><td>" + htmlSelectBool("econo", climate.econo) +
+          "</td></tr>"
+      "<tr><td>Light</td><td>" + htmlSelectBool("light", climate.light) +
+          "</td></tr>"
+      "<tr><td>Filter</td><td>" + htmlSelectBool("filter", climate.filter) +
+          "</td></tr>"
+      "<tr><td>Clean</td><td>" + htmlSelectBool("clean", climate.clean) +
+          "</td></tr>"
+      "<tr><td>Beep</td><td>" + htmlSelectBool("beep", climate.beep) +
+          "</td></tr>"
+      "</table>"
+      "<input type='submit' value='Update'>"
+      "</form>";
+
+  // Display the current settings.
+  html += "</body></html>";
+  server.send(200, "text/html", html);
 }
 
 // Admin web page
@@ -1448,6 +1705,8 @@ void setup(void) {
   server.on("/", handleRoot);
   // Setup the page to handle web-based IR codes.
   server.on("/ir", handleIr);
+  // Setup the aircon page.
+  server.on("/aircon", handleAirCon);
   // Setup the info page.
   server.on("/info", handleInfo);
   // Setup the admin page.
@@ -1478,7 +1737,7 @@ void setup(void) {
             "<p>The firmware upload seems to have " +
             String(Update.hasError() ? "FAILED!" : "SUCCEEDED!") +
             " Rebooting! </p>" +
-            addJsReloadUrl("/", 30, true) +
+            addJsReloadUrl("/", 20, true) +
             "</body></html>");
         delay(1000);
         ESP.restart();
@@ -2147,86 +2406,6 @@ void sendMQTTDiscovery(const char *topic) {
     debug("MQTT climate discovery successful sent.");
   else
     debug("MQTT climate discovery FAILED to send.");
-}
-
-String opmodeToString(const stdAc::opmode_t mode) {
-  switch (mode) {
-    case stdAc::opmode_t::kOff:
-      return F("off");
-    case stdAc::opmode_t::kAuto:
-      return F("auto");
-    case stdAc::opmode_t::kCool:
-      return F("cool");
-    case stdAc::opmode_t::kHeat:
-      return F("heat");
-    case stdAc::opmode_t::kDry:
-      return F("dry");
-    case stdAc::opmode_t::kFan:
-      return F("fan_only");
-    default:
-      return F("unknown");
-  }
-}
-
-String fanspeedToString(const stdAc::fanspeed_t speed) {
-  switch (speed) {
-    case stdAc::fanspeed_t::kAuto:
-      return F("auto");
-    case stdAc::fanspeed_t::kMax:
-      return F("max");
-    case stdAc::fanspeed_t::kHigh:
-      return F("high");
-    case stdAc::fanspeed_t::kMedium:
-      return F("medium");
-    case stdAc::fanspeed_t::kLow:
-      return F("low");
-    case stdAc::fanspeed_t::kMin:
-      return F("min");
-    default:
-      return F("unknown");
-  }
-}
-
-String swingvToString(const stdAc::swingv_t swingv) {
-  switch (swingv) {
-    case stdAc::swingv_t::kOff:
-      return F("off");
-    case stdAc::swingv_t::kAuto:
-      return F("auto");
-    case stdAc::swingv_t::kHighest:
-      return F("highest");
-    case stdAc::swingv_t::kHigh:
-      return F("high");
-    case stdAc::swingv_t::kMiddle:
-      return F("middle");
-    case stdAc::swingv_t::kLow:
-      return F("low");
-    case stdAc::swingv_t::kLowest:
-      return F("lowest");
-    default:
-      return F("unknown");
-  }
-}
-
-String swinghToString(const stdAc::swingh_t swingh) {
-  switch (swingh) {
-    case stdAc::swingh_t::kOff:
-      return F("off");
-    case stdAc::swingh_t::kAuto:
-      return F("auto");
-    case stdAc::swingh_t::kLeftMax:
-      return F("leftmax");
-    case stdAc::swingh_t::kLeft:
-      return F("left");
-    case stdAc::swingh_t::kMiddle:
-      return F("middle");
-    case stdAc::swingh_t::kRight:
-      return F("right");
-    case stdAc::swingh_t::kRightMax:
-      return F("rightmax");
-    default:
-      return F("unknown");
-  }
 }
 
 bool sendInt(const String topic, const int32_t num, const bool retain) {

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -302,7 +302,7 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 #define MQTTstatus MQTTprefix "/status"  // Topic for the Last Will & Testament.
 #define MQTTclimateprefix MQTTprefix "/ac"
 
-#define MQTTcmdprefix "/cmnd/"
+#define MQTTcmndprefix "/cmnd/"
 #define MQTTstatprefix "/stat/"
 #define MQTTwildcard "+"
 #define MQTTdiscovery "homeassistant/climate/" HOSTNAME "/config"
@@ -1180,7 +1180,7 @@ void handleInfo() {
             timeElapsed(lastDiscovery.elapsed()) :
             String("<i>Never</i>"))) +
         "<br>"
-    "Command topics: " MQTTprefix MQTTcmdprefix
+    "Command topics: " MQTTprefix MQTTcmndprefix
       "(" KEY_PROTOCOL "|" KEY_MODEL "|" KEY_POWER "|" KEY_MODE "|" KEY_TEMP "|"
           KEY_FANSPEED "|" KEY_SWINGV "|" KEY_SWINGH "|" KEY_QUIET "|"
           KEY_TURBO "|" KEY_LIGHT "|" KEY_BEEP "|" KEY_ECONO "|" KEY_SLEEP "|"
@@ -2005,7 +2005,7 @@ bool reconnect() {
         subscribing(String(MQTTcommand "_") + String(static_cast<int>(i)));
       }
       // Climate command topics.
-      subscribing(MQTTclimateprefix MQTTcmdprefix MQTTwildcard);
+      subscribing(MQTTclimateprefix MQTTcmndprefix MQTTwildcard);
     } else {
       debug("failed, rc=" + String(mqtt_client.state()) +
             " Try again in a bit.");
@@ -2502,10 +2502,10 @@ void receivingMQTT(String const topic_name, String const callback_str) {
   mqttRecvCounter++;
 
   if (topic_name.startsWith(MQTTclimateprefix)) {
-    if (topic_name.startsWith(MQTTclimateprefix MQTTcmdprefix)) {
+    if (topic_name.startsWith(MQTTclimateprefix MQTTcmndprefix)) {
       debug("It's a climate command topic");
       commonAcState_t updated = updateClimate(
-          climate, topic_name, MQTTclimateprefix MQTTcmdprefix, callback_str);
+          climate, topic_name, MQTTclimateprefix MQTTcmndprefix, callback_str);
       sendClimate(climate, updated, MQTTclimateprefix MQTTstatprefix,
                   true, false, false);
       climate = updated;
@@ -2590,19 +2590,19 @@ void sendMQTTDiscovery(const char *topic) {
       "{"
       "\"~\":\"" MQTTclimateprefix "\","
       "\"name\":\"" MQTTHomeAssistantName "\","
-      "\"pow_cmd_t\":\"~" MQTTcmdprefix KEY_POWER "\","
-      "\"mode_cmd_t\":\"~" MQTTcmdprefix KEY_MODE "\","
+      "\"pow_cmd_t\":\"~" MQTTcmndprefix KEY_POWER "\","
+      "\"mode_cmd_t\":\"~" MQTTcmndprefix KEY_MODE "\","
       "\"mode_stat_t\":\"~" MQTTstatprefix KEY_MODE "\","
       "\"modes\":[\"off\",\"auto\",\"cool\",\"heat\",\"dry\",\"fan_only\"],"
-      "\"temp_cmd_t\":\"~" MQTTcmdprefix KEY_TEMP "\","
+      "\"temp_cmd_t\":\"~" MQTTcmndprefix KEY_TEMP "\","
       "\"temp_stat_t\":\"~" MQTTstatprefix KEY_TEMP "\","
       "\"min_temp\":\"16\","
       "\"max_temp\":\"30\","
       "\"temp_step\":\"1\","
-      "\"fan_mode_cmd_t\":\"~" MQTTcmdprefix KEY_FANSPEED "\","
+      "\"fan_mode_cmd_t\":\"~" MQTTcmndprefix KEY_FANSPEED "\","
       "\"fan_mode_stat_t\":\"~" MQTTstatprefix KEY_FANSPEED "\","
       "\"fan_modes\":[\"auto\",\"min\",\"low\",\"medium\",\"high\",\"max\"],"
-      "\"swing_mode_cmd_t\":\"~" MQTTcmdprefix KEY_SWINGV "\","
+      "\"swing_mode_cmd_t\":\"~" MQTTcmndprefix KEY_SWINGV "\","
       "\"swing_mode_stat_t\":\"~" MQTTstatprefix KEY_SWINGV "\","
       "\"swing_modes\":["
         "\"off\",\"auto\",\"highest\",\"high\",\"middle\",\"low\",\"lowest\""

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -3,7 +3,7 @@ lib_extra_dirs = ../../
 src_dir=.
 
 [common]
-build_flags = -DMQTT_MAX_PACKET_SIZE=512
+build_flags = -DMQTT_MAX_PACKET_SIZE=768
 lib_ldf_mode = chain+
 lib_deps_builtin =
 lib_deps_external =

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -29,3 +29,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:d1_mini_no_mqtt]
+platform=espressif8266
+framework=arduino
+board=d1_mini
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags} -DMQTT_ENABLE=false
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -36,6 +36,79 @@
 
 IRac::IRac(uint8_t pin) { _pin = pin; }
 
+// Is the given protocol supported by the IRac class?
+bool IRac::isProtocolSupported(const decode_type_t protocol) {
+  switch (protocol) {
+#if SEND_ARGO
+    case decode_type_t::ARGO:
+#endif
+#if SEND_COOLIX
+    case decode_type_t::COOLIX:
+#endif
+#if SEND_DAIKIN
+    case decode_type_t::DAIKIN:
+#endif
+#if SEND_DAIKIN2
+    case decode_type_t::DAIKIN2:
+#endif
+#if SEND_FUJITSU_AC
+    case decode_type_t::FUJITSU_AC:
+#endif
+#if SEND_GREE
+    case decode_type_t::GREE:
+#endif
+#if SEND_HAIER_AC
+    case decode_type_t::HAIER_AC:
+#endif
+#if SEND_HAIER_AC_YRW02
+    case decode_type_t::HAIER_AC_YRW02:
+#endif
+#if SEND_HITACHI_AC
+    case decode_type_t::HITACHI_AC:
+#endif
+#if SEND_KELVINATOR
+    case decode_type_t::KELVINATOR:
+#endif
+#if SEND_MIDEA
+    case decode_type_t::MIDEA:
+#endif
+#if SEND_MITSUBISHI_AC
+    case decode_type_t::MITSUBISHI_AC:
+#endif
+#if SEND_MITSUBISHIHEAVY
+    case decode_type_t::MITSUBISHI_HEAVY_88:
+    case decode_type_t::MITSUBISHI_HEAVY_152:
+#endif
+#if SEND_PANASONIC_AC
+    case decode_type_t::PANASONIC_AC:
+#endif
+#if SEND_SAMSUNG_AC
+    case decode_type_t::SAMSUNG_AC:
+#endif
+#if SEND_TCL112AC
+    case decode_type_t::TCL112AC:
+#endif
+#if SEND_TECO
+    case decode_type_t::TECO:
+#endif
+#if SEND_TOSHIBA_AC
+    case decode_type_t::TOSHIBA_AC:
+#endif
+#if SEND_TROTEC
+    case decode_type_t::TROTEC:
+#endif
+#if SEND_VESTEL_AC
+    case decode_type_t::VESTEL_AC:
+#endif
+#if SEND_WHIRLPOOL_AC
+    case decode_type_t::WHIRLPOOL_AC:
+#endif
+      return true;
+    default:
+      return false;
+  }
+}
+
 #if SEND_ARGO
 void IRac::argo(IRArgoAC *ac,
                 const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -654,7 +654,7 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
 //   clock:   Nr. of mins past midnight to set the clock to. (< 0 means off.)
 // Returns:
 //   boolean: True, if accepted/converted/attempted. False, if unsupported.
-bool IRac::sendAc(const decode_type_t vendor, const uint16_t model,
+bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
                   const bool power, const stdAc::opmode_t mode,
                   const float degrees, const bool celsius,
                   const stdAc::fanspeed_t fan,
@@ -883,19 +883,19 @@ bool IRac::sendAc(const decode_type_t vendor, const uint16_t model,
 
 stdAc::opmode_t IRac::strToOpmode(const char *str,
                                 const stdAc::opmode_t def) {
-  if (!strcmp(str, F("AUTO")) || !strcmp(str, F("AUTOMATIC")))
+  if (!strcmp(str, "AUTO") || !strcmp(str, "AUTOMATIC"))
     return stdAc::opmode_t::kAuto;
-  else if (!strcmp(str, F("OFF")) || !strcmp(str, F("STOP")))
+  else if (!strcmp(str, "OFF") || !strcmp(str, "STOP"))
     return stdAc::opmode_t::kOff;
-  else if (!strcmp(str, F("COOL")) || !strcmp(str, F("COOLING")))
+  else if (!strcmp(str, "COOL") || !strcmp(str, "COOLING"))
     return stdAc::opmode_t::kCool;
-  else if (!strcmp(str, F("HEAT")) || !strcmp(str, F("HEATING")))
+  else if (!strcmp(str, "HEAT") || !strcmp(str, "HEATING"))
     return stdAc::opmode_t::kHeat;
-  else if (!strcmp(str, F("DRY")) || !strcmp(str, F("DRYING")) ||
-           !strcmp(str, F("DEHUMIDIFY")))
+  else if (!strcmp(str, "DRY") || !strcmp(str, "DRYING") ||
+           !strcmp(str, "DEHUMIDIFY"))
     return stdAc::opmode_t::kDry;
-  else if (!strcmp(str, F("FAN")) || !strcmp(str, F("FANONLY")) ||
-           !strcmp(str, F("FAN_ONLY")))
+  else if (!strcmp(str, "FAN") || !strcmp(str, "FANONLY") ||
+           !strcmp(str, "FAN_ONLY"))
     return stdAc::opmode_t::kFan;
   else
     return def;
@@ -903,20 +903,20 @@ stdAc::opmode_t IRac::strToOpmode(const char *str,
 
 stdAc::fanspeed_t IRac::strToFanspeed(const char *str,
                                       const stdAc::fanspeed_t def) {
-  if (!strcmp(str, F("AUTO")) || !strcmp(str, F("AUTOMATIC")))
+  if (!strcmp(str, "AUTO") || !strcmp(str, "AUTOMATIC"))
     return stdAc::fanspeed_t::kAuto;
-  else if (!strcmp(str, F("MIN")) || !strcmp(str, F("MINIMUM")) ||
-           !strcmp(str, F("LOWEST")))
+  else if (!strcmp(str, "MIN") || !strcmp(str, "MINIMUM") ||
+           !strcmp(str, "LOWEST"))
     return stdAc::fanspeed_t::kMin;
-  else if (!strcmp(str, F("LOW")))
+  else if (!strcmp(str, "LOW"))
     return stdAc::fanspeed_t::kLow;
-  else if (!strcmp(str, F("MED")) || !strcmp(str, F("MEDIUM")) ||
-           !strcmp(str, F("MID")))
+  else if (!strcmp(str, "MED") || !strcmp(str, "MEDIUM") ||
+           !strcmp(str, "MID"))
     return stdAc::fanspeed_t::kMedium;
-  else if (!strcmp(str, F("HIGH")) || !strcmp(str, F("HI")))
+  else if (!strcmp(str, "HIGH") || !strcmp(str, "HI"))
     return stdAc::fanspeed_t::kHigh;
-  else if (!strcmp(str, F("MAX")) || !strcmp(str, F("MAXIMUM")) ||
-           !strcmp(str, F("HIGHEST")))
+  else if (!strcmp(str, "MAX") || !strcmp(str, "MAXIMUM") ||
+           !strcmp(str, "HIGHEST"))
     return stdAc::fanspeed_t::kMax;
   else
     return def;
@@ -924,26 +924,26 @@ stdAc::fanspeed_t IRac::strToFanspeed(const char *str,
 
 stdAc::swingv_t IRac::strToSwingV(const char *str,
                                   const stdAc::swingv_t def) {
-  if (!strcmp(str, F("AUTO")) || !strcmp(str, F("AUTOMATIC")) ||
-      !strcmp(str, F("ON")) || !strcmp(str, F("SWING")))
+  if (!strcmp(str, "AUTO") || !strcmp(str, "AUTOMATIC") ||
+      !strcmp(str, "ON") || !strcmp(str, "SWING"))
     return stdAc::swingv_t::kAuto;
-  else if (!strcmp(str, F("OFF")) || !strcmp(str, F("STOP")))
+  else if (!strcmp(str, "OFF") || !strcmp(str, "STOP"))
     return stdAc::swingv_t::kOff;
-  else if (!strcmp(str, F("MIN")) || !strcmp(str, F("MINIMUM")) ||
-           !strcmp(str, F("LOWEST")) || !strcmp(str, F("BOTTOM")) ||
-           !strcmp(str, F("DOWN")))
+  else if (!strcmp(str, "MIN") || !strcmp(str, "MINIMUM") ||
+           !strcmp(str, "LOWEST") || !strcmp(str, "BOTTOM") ||
+           !strcmp(str, "DOWN"))
     return stdAc::swingv_t::kLowest;
-  else if (!strcmp(str, F("LOW")))
+  else if (!strcmp(str, "LOW"))
     return stdAc::swingv_t::kLow;
-  else if (!strcmp(str, F("MID")) || !strcmp(str, F("MIDDLE")) ||
-           !strcmp(str, F("MED")) || !strcmp(str, F("MEDIUM")) ||
-           !strcmp(str, F("CENTRE")) || !strcmp(str, F("CENTER")))
+  else if (!strcmp(str, "MID") || !strcmp(str, "MIDDLE") ||
+           !strcmp(str, "MED") || !strcmp(str, "MEDIUM") ||
+           !strcmp(str, "CENTRE") || !strcmp(str, "CENTER"))
     return stdAc::swingv_t::kMiddle;
-  else if (!strcmp(str, F("HIGH")) || !strcmp(str, F("HI")))
+  else if (!strcmp(str, "HIGH") || !strcmp(str, "HI"))
     return stdAc::swingv_t::kHigh;
-  else if (!strcmp(str, F("HIGHEST")) || !strcmp(str, F("MAX")) ||
-           !strcmp(str, F("MAXIMUM")) || !strcmp(str, F("TOP")) ||
-           !strcmp(str, F("UP")))
+  else if (!strcmp(str, "HIGHEST") || !strcmp(str, "MAX") ||
+           !strcmp(str, "MAXIMUM") || !strcmp(str, "TOP") ||
+           !strcmp(str, "UP"))
     return stdAc::swingv_t::kHighest;
   else
     return def;
@@ -951,26 +951,26 @@ stdAc::swingv_t IRac::strToSwingV(const char *str,
 
 stdAc::swingh_t IRac::strToSwingH(const char *str,
                                   const stdAc::swingh_t def) {
-  if (!strcmp(str, F("AUTO")) || !strcmp(str, F("AUTOMATIC")) ||
-      !strcmp(str, F("ON")) || !strcmp(str, F("SWING")))
+  if (!strcmp(str, "AUTO") || !strcmp(str, "AUTOMATIC") ||
+      !strcmp(str, "ON") || !strcmp(str, "SWING"))
     return stdAc::swingh_t::kAuto;
-  else if (!strcmp(str, F("OFF")) || !strcmp(str, F("STOP")))
+  else if (!strcmp(str, "OFF") || !strcmp(str, "STOP"))
     return stdAc::swingh_t::kOff;
-  else if (!strcmp(str, F("LEFTMAX")) || !strcmp(str, F("LEFT MAX")) ||
-           !strcmp(str, F("MAXLEFT")) || !strcmp(str, F("MAX LEFT")) ||
-           !strcmp(str, F("FARLEFT")) || !strcmp(str, F("FAR LEFT")))
+  else if (!strcmp(str, "LEFTMAX") || !strcmp(str, "LEFT MAX") ||
+           !strcmp(str, "MAXLEFT") || !strcmp(str, "MAX LEFT") ||
+           !strcmp(str, "FARLEFT") || !strcmp(str, "FAR LEFT"))
     return stdAc::swingh_t::kLeftMax;
-  else if (!strcmp(str, F("LEFT")))
+  else if (!strcmp(str, "LEFT"))
     return stdAc::swingh_t::kLeft;
-  else if (!strcmp(str, F("MID")) || !strcmp(str, F("MIDDLE")) ||
-           !strcmp(str, F("MED")) || !strcmp(str, F("MEDIUM")) ||
-           !strcmp(str, F("CENTRE")) || !strcmp(str, F("CENTER")))
+  else if (!strcmp(str, "MID") || !strcmp(str, "MIDDLE") ||
+           !strcmp(str, "MED") || !strcmp(str, "MEDIUM") ||
+           !strcmp(str, "CENTRE") || !strcmp(str, "CENTER"))
     return stdAc::swingh_t::kMiddle;
-  else if (!strcmp(str, F("RIGHT")))
+  else if (!strcmp(str, "RIGHT"))
     return stdAc::swingh_t::kRight;
-  else if (!strcmp(str, F("RIGHTMAX")) || !strcmp(str, F("RIGHT MAX")) ||
-           !strcmp(str, F("MAXRIGHT")) || !strcmp(str, F("MAX RIGHT")) ||
-           !strcmp(str, F("FARRIGHT")) || !strcmp(str, F("FAR RIGHT")))
+  else if (!strcmp(str, "RIGHTMAX") || !strcmp(str, "RIGHT MAX") ||
+           !strcmp(str, "MAXRIGHT") || !strcmp(str, "MAX RIGHT") ||
+           !strcmp(str, "FARRIGHT") || !strcmp(str, "FAR RIGHT"))
     return stdAc::swingh_t::kRightMax;
   else
     return def;
@@ -979,28 +979,28 @@ stdAc::swingh_t IRac::strToSwingH(const char *str,
 // Assumes str is upper case or an integer >= 1.
 int16_t IRac::strToModel(const char *str, const int16_t def) {
   // Fujitsu A/C models
-  if (!strcmp(str, F("ARRAH2E"))) {
+  if (!strcmp(str, "ARRAH2E")) {
     return fujitsu_ac_remote_model_t::ARRAH2E;
-  } else if (!strcmp(str, F("ARDB1"))) {
+  } else if (!strcmp(str, "ARDB1")) {
     return fujitsu_ac_remote_model_t::ARDB1;
   // Panasonic A/C families
-  } else if (!strcmp(str, F("LKE")) || !strcmp(str, F("PANASONICLKE"))) {
+  } else if (!strcmp(str, "LKE") || !strcmp(str, "PANASONICLKE")) {
     return panasonic_ac_remote_model_t::kPanasonicLke;
-  } else if (!strcmp(str, F("NKE")) || !strcmp(str, F("PANASONICNKE"))) {
+  } else if (!strcmp(str, "NKE") || !strcmp(str, "PANASONICNKE")) {
     return panasonic_ac_remote_model_t::kPanasonicNke;
-  } else if (!strcmp(str, F("DKE")) || !strcmp(str, F("PANASONICDKE"))) {
+  } else if (!strcmp(str, "DKE") || !strcmp(str, "PANASONICDKE")) {
     return panasonic_ac_remote_model_t::kPanasonicDke;
-  } else if (!strcmp(str, F("JKE")) || !strcmp(str, F("PANASONICJKE"))) {
+  } else if (!strcmp(str, "JKE") || !strcmp(str, "PANASONICJKE")) {
     return panasonic_ac_remote_model_t::kPanasonicJke;
-  } else if (!strcmp(str, F("CKP")) || !strcmp(str, F("PANASONICCKP"))) {
+  } else if (!strcmp(str, "CKP") || !strcmp(str, "PANASONICCKP")) {
     return panasonic_ac_remote_model_t::kPanasonicCkp;
-  } else if (!strcmp(str, F("RKR")) || !strcmp(str, F("PANASONICRKR"))) {
+  } else if (!strcmp(str, "RKR") || !strcmp(str, "PANASONICRKR")) {
     return panasonic_ac_remote_model_t::kPanasonicRkr;
   // Whirlpool A/C models
-  } else if (!strcmp(str, F("DG11J13A")) || !strcmp(str, F("DG11J104")) ||
-             !strcmp(str, F("DG11J1-04"))) {
+  } else if (!strcmp(str, "DG11J13A") || !strcmp(str, "DG11J104") ||
+             !strcmp(str, "DG11J1-04")) {
     return whirlpool_ac_remote_model_t::DG11J13A;
-  } else if (!strcmp(str, F("DG11J191"))) {
+  } else if (!strcmp(str, "DG11J191")) {
     return whirlpool_ac_remote_model_t::DG11J191;
   } else {
     int16_t number = atoi(str);
@@ -1013,11 +1013,11 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
 
 // Assumes str is upper case.
 bool IRac::strToBool(const char *str, const bool def) {
-  if (!strcmp(str, F("ON")) || !strcmp(str, F("1")) || !strcmp(str, F("YES")) ||
-      !strcmp(str, F("TRUE")))
+  if (!strcmp(str, "ON") || !strcmp(str, "1") || !strcmp(str, "YES") ||
+      !strcmp(str, "TRUE"))
     return true;
-  else if (!strcmp(str, F("OFF")) || !strcmp(str, F("0")) ||
-           !strcmp(str, F("NO")) || !strcmp(str, F("FALSE")))
+  else if (!strcmp(str, "OFF") || !strcmp(str, "0") ||
+           !strcmp(str, "NO") || !strcmp(str, "FALSE"))
     return false;
   else
     return def;

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -33,6 +33,7 @@
 class IRac {
  public:
   explicit IRac(uint8_t pin);
+  static bool isProtocolSupported(const decode_type_t protocol);
   bool sendAc(const decode_type_t vendor, const int16_t model,
               const bool power, const stdAc::opmode_t mode, const float degrees,
               const bool celsius, const stdAc::fanspeed_t fan,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -33,7 +33,7 @@
 class IRac {
  public:
   explicit IRac(uint8_t pin);
-  bool sendAc(const decode_type_t vendor, const uint16_t model,
+  bool sendAc(const decode_type_t vendor, const int16_t model,
               const bool power, const stdAc::opmode_t mode, const float degrees,
               const bool celsius, const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
@@ -41,6 +41,18 @@ class IRac {
               const bool light, const bool filter, const bool clean,
               const bool beep, const int16_t sleep = -1,
               const int16_t clock = -1);
+
+  static bool strToBool(const char *str, const bool def = false);
+  static int16_t strToModel(const char *str, const int16_t def = -1);
+  static stdAc::opmode_t strToOpmode(
+    const char *str, const stdAc::opmode_t def = stdAc::opmode_t::kAuto);
+  static stdAc::fanspeed_t strToFanspeed(
+    const char *str,
+    const stdAc::fanspeed_t def = stdAc::fanspeed_t::kAuto);
+  static stdAc::swingv_t strToSwingV(
+    const char *str, const stdAc::swingv_t def = stdAc::swingv_t::kOff);
+  static stdAc::swingh_t strToSwingH(
+    const char *str, const stdAc::swingh_t def = stdAc::swingh_t::kOff);
 #ifndef UNIT_TEST
 
  private:
@@ -202,16 +214,27 @@ class IRac {
                  const bool turbo, const bool light,
                  const int16_t sleep = -1, const int16_t clock = -1);
 #endif  // SEND_WHIRLPOOL_AC
-  static bool strToBool(const char *str, const bool def = false);
-  static int16_t strToModel(const char *str, const int16_t def = -1);
-  static stdAc::opmode_t strToOpmode(
-      const char *str, const stdAc::opmode_t def = stdAc::opmode_t::kAuto);
-  static stdAc::fanspeed_t strToFanspeed(
-      const char *str,
-      const stdAc::fanspeed_t def = stdAc::fanspeed_t::kAuto);
-  static stdAc::swingv_t strToSwingV(
-      const char *str, const stdAc::swingv_t def = stdAc::swingv_t::kOff);
-  static stdAc::swingh_t strToSwingH(
-      const char *str, const stdAc::swingh_t def = stdAc::swingh_t::kOff);
 };  // IRac class
+
+// Structure to hold a common A/C state.
+typedef struct {
+  decode_type_t protocol;
+  int16_t model;
+  bool power;
+  stdAc::opmode_t mode;
+  float degrees;
+  bool celsius;
+  stdAc::fanspeed_t fanspeed;
+  stdAc::swingv_t swingv;
+  stdAc::swingh_t swingh;
+  bool quiet;
+  bool turbo;
+  bool econo;
+  bool light;
+  bool filter;
+  bool clean;
+  bool beep;
+  int16_t sleep;
+  int16_t clock;
+} commonAcState_t;
 #endif  // IRAC_H_

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -34,7 +34,7 @@ class IRac {
  public:
   explicit IRac(uint8_t pin);
   bool sendAc(const decode_type_t vendor, const uint16_t model,
-              const bool on, const stdAc::opmode_t mode, const float degrees,
+              const bool power, const stdAc::opmode_t mode, const float degrees,
               const bool celsius, const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
               const bool quiet, const bool turbo, const bool econo,
@@ -202,5 +202,16 @@ class IRac {
                  const bool turbo, const bool light,
                  const int16_t sleep = -1, const int16_t clock = -1);
 #endif  // SEND_WHIRLPOOL_AC
-};
+  static bool strToBool(const char *str, const bool def = false);
+  static int16_t strToModel(const char *str, const int16_t def = -1);
+  static stdAc::opmode_t strToOpmode(
+      const char *str, const stdAc::opmode_t def = stdAc::opmode_t::kAuto);
+  static stdAc::fanspeed_t strToFanspeed(
+      const char *str,
+      const stdAc::fanspeed_t def = stdAc::fanspeed_t::kAuto);
+  static stdAc::swingv_t strToSwingV(
+      const char *str, const stdAc::swingv_t def = stdAc::swingv_t::kOff);
+  static stdAc::swingh_t strToSwingH(
+      const char *str, const stdAc::swingh_t def = stdAc::swingh_t::kOff);
+};  // IRac class
 #endif  // IRAC_H_

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -308,6 +308,8 @@ enum decode_type_t {
   LEGOPF,
   MITSUBISHI_HEAVY_88,
   MITSUBISHI_HEAVY_152,  // 60
+  // Add new entries before this one, and update it to point to the last entry.
+  kLastDecodeType = MITSUBISHI_HEAVY_152,
 };
 
 // Message lengths & required repeat values

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -43,12 +43,12 @@ namespace stdAc {
   };
 
   enum class fanspeed_t {
-    kAuto = 0,
-    kMin =  1,
-    kLow =  2,
-    kMedium =  3,
-    kHigh = 4,
-    kMax =  5,
+    kAuto =   0,
+    kMin =    1,
+    kLow =    2,
+    kMedium = 3,
+    kHigh =   4,
+    kMax =    5,
   };
 
   enum class swingv_t {

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -34,11 +34,12 @@ const uint32_t kDefaultMessageGap = 100000;
 
 namespace stdAc {
   enum class opmode_t {
-    kAuto = 0,
-    kCool = 1,
-    kHeat = 2,
-    kDry  = 3,
-    kFan  = 4,
+    kOff  = -1,
+    kAuto =  0,
+    kCool =  1,
+    kHeat =  2,
+    kDry  =  3,
+    kFan  =  4,
   };
 
   enum class fanspeed_t {

--- a/src/IRtimer.cpp
+++ b/src/IRtimer.cpp
@@ -8,11 +8,11 @@
 #ifdef UNIT_TEST
 // Used to help simulate elapsed time in unit tests.
 uint32_t _IRtimer_unittest_now = 0;
+uint32_t _TimerMs_unittest_now = 0;
 #endif  // UNIT_TEST
 
 // This class performs a simple time in useconds since instantiated.
 // Handles when the system timer wraps around (once).
-
 IRtimer::IRtimer() { reset(); }
 
 void IRtimer::reset() {
@@ -38,4 +38,33 @@ uint32_t IRtimer::elapsed() {
 // Only used in unit testing.
 #ifdef UNIT_TEST
 void IRtimer::add(uint32_t usecs) { _IRtimer_unittest_now += usecs; }
+#endif  // UNIT_TEST
+
+// This class performs a simple time in milli-seoncds since instantiated.
+// Handles when the system timer wraps around (once).
+TimerMs::TimerMs() { reset(); }
+
+void TimerMs::reset() {
+#ifndef UNIT_TEST
+  start = millis();
+#else
+  start = _TimerMs_unittest_now;
+#endif
+}
+
+uint32_t TimerMs::elapsed() {
+#ifndef UNIT_TEST
+  uint32_t now = millis();
+#else
+  uint32_t now = _TimerMs_unittest_now;
+#endif
+  if (start <= now)      // Check if the system timer has wrapped.
+    return now - start;  // No wrap.
+  else
+    return UINT32_MAX - start + now;  // Has wrapped.
+}
+
+// Only used in unit testing.
+#ifdef UNIT_TEST
+void TimerMs::add(uint32_t msecs) { _IRtimer_unittest_now += msecs; }
 #endif  // UNIT_TEST

--- a/src/IRtimer.h
+++ b/src/IRtimer.h
@@ -20,4 +20,16 @@ class IRtimer {
   uint32_t start;
 };
 
+class TimerMs {
+ public:
+  TimerMs();
+  void reset();
+  uint32_t elapsed();
+#ifdef UNIT_TEST
+  static void add(uint32_t msecs);
+#endif  // UNIT_TEST
+
+ private:
+  uint32_t start;
+};
 #endif  // IRTIMER_H_

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -90,119 +90,119 @@ void serialPrintUint64(uint64_t input, uint8_t base) {
 // Returns:
 //  A decode_type_t enum.
 decode_type_t strToDecodeType(const char *str) {
-  if (!strcmp(str, F("AIWA_RC_T501")))
+  if (!strcmp(str, "AIWA_RC_T501"))
     return decode_type_t::AIWA_RC_T501;
-  else if (!strcmp(str, F("ARGO")))
+  else if (!strcmp(str, "ARGO"))
     return decode_type_t::ARGO;
-  else if (!strcmp(str, F("CARRIER_AC")))
+  else if (!strcmp(str, "CARRIER_AC"))
     return decode_type_t::CARRIER_AC;
-  else if (!strcmp(str, F("COOLIX")))
+  else if (!strcmp(str, "COOLIX"))
     return decode_type_t::COOLIX;
-  else if (!strcmp(str, F("DAIKIN")))
+  else if (!strcmp(str, "DAIKIN"))
     return decode_type_t::DAIKIN;
-  else if (!strcmp(str, F("DAIKIN2")))
+  else if (!strcmp(str, "DAIKIN2"))
     return decode_type_t::DAIKIN2;
-  else if (!strcmp(str, F("DENON")))
+  else if (!strcmp(str, "DENON"))
     return decode_type_t::DENON;
-  else if (!strcmp(str, F("DISH")))
+  else if (!strcmp(str, "DISH"))
     return decode_type_t::DISH;
-  else if (!strcmp(str, F("ELECTRA_AC")))
+  else if (!strcmp(str, "ELECTRA_AC"))
     return decode_type_t::ELECTRA_AC;
-  else if (!strcmp(str, F("FUJITSU_AC")))
+  else if (!strcmp(str, "FUJITSU_AC"))
     return decode_type_t::FUJITSU_AC;
-  else if (!strcmp(str, F("GICABLE")))
+  else if (!strcmp(str, "GICABLE"))
     return decode_type_t::GICABLE;
-  else if (!strcmp(str, F("GLOBALCACHE")))
+  else if (!strcmp(str, "GLOBALCACHE"))
     return decode_type_t::GLOBALCACHE;
-  else if (!strcmp(str, F("GREE")))
+  else if (!strcmp(str, "GREE"))
     return decode_type_t::GREE;
-  else if (!strcmp(str, F("HAIER_AC")))
+  else if (!strcmp(str, "HAIER_AC"))
     return decode_type_t::HAIER_AC;
-  else if (!strcmp(str, F("HAIER_AC_YRW02")))
+  else if (!strcmp(str, "HAIER_AC_YRW02"))
     return decode_type_t::HAIER_AC_YRW02;
-  else if (!strcmp(str, F("HITACHI_AC")))
+  else if (!strcmp(str, "HITACHI_AC"))
     return decode_type_t::HITACHI_AC;
-  else if (!strcmp(str, F("HITACHI_AC1")))
+  else if (!strcmp(str, "HITACHI_AC1"))
     return decode_type_t::HITACHI_AC1;
-  else if (!strcmp(str, F("HITACHI_AC2")))
+  else if (!strcmp(str, "HITACHI_AC2"))
     return decode_type_t::HITACHI_AC2;
-  else if (!strcmp(str, F("JVC")))
+  else if (!strcmp(str, "JVC"))
     return decode_type_t::JVC;
-  else if (!strcmp(str, F("KELVINATOR")))
+  else if (!strcmp(str, "KELVINATOR"))
     return decode_type_t::KELVINATOR;
-  else if (!strcmp(str, F("LEGOPF")))
+  else if (!strcmp(str, "LEGOPF"))
     return decode_type_t::LEGOPF;
-  else if (!strcmp(str, F("LG")))
+  else if (!strcmp(str, "LG"))
     return decode_type_t::LG;
-  else if (!strcmp(str, F("LG2")))
+  else if (!strcmp(str, "LG2"))
     return decode_type_t::LG2;
-  else if (!strcmp(str, F("LASERTAG")))
+  else if (!strcmp(str, "LASERTAG"))
     return decode_type_t::LASERTAG;
-  else if (!strcmp(str, F("LUTRON")))
+  else if (!strcmp(str, "LUTRON"))
     return decode_type_t::LUTRON;
-  else if (!strcmp(str, F("MAGIQUEST")))
+  else if (!strcmp(str, "MAGIQUEST"))
     return decode_type_t::MAGIQUEST;
-  else if (!strcmp(str, F("MIDEA")))
+  else if (!strcmp(str, "MIDEA"))
     return decode_type_t::MIDEA;
-  else if (!strcmp(str, F("MITSUBISHI")))
+  else if (!strcmp(str, "MITSUBISHI"))
     return decode_type_t::MITSUBISHI;
-  else if (!strcmp(str, F("MITSUBISHI2")))
+  else if (!strcmp(str, "MITSUBISHI2"))
     return decode_type_t::MITSUBISHI2;
-  else if (!strcmp(str, F("MITSUBISHI_AC")))
+  else if (!strcmp(str, "MITSUBISHI_AC"))
     return decode_type_t::MITSUBISHI_AC;
-  else if (!strcmp(str, F("MWM")))
+  else if (!strcmp(str, "MWM"))
     return decode_type_t::MWM;
-  else if (!strcmp(str, F("NEC")) || !strcmp(str, F("NEC (NON-STRICT)")))
+  else if (!strcmp(str, "NEC") || !strcmp(str, "NEC (NON-STRICT"))
     return decode_type_t::NEC;
-  else if (!strcmp(str, F("NIKAI")))
+  else if (!strcmp(str, "NIKAI"))
     return decode_type_t::NIKAI;
-  else if (!strcmp(str, F("PANASONIC")))
+  else if (!strcmp(str, "PANASONIC"))
     return decode_type_t::PANASONIC;
-  else if (!strcmp(str, F("PANASONIC_AC")))
+  else if (!strcmp(str, "PANASONIC_AC"))
     return decode_type_t::PANASONIC_AC;
-  else if (!strcmp(str, F("PIONEER")))
+  else if (!strcmp(str, "PIONEER"))
     return decode_type_t::PIONEER;
-  else if (!strcmp(str, F("PRONTO")))
+  else if (!strcmp(str, "PRONTO"))
     return decode_type_t::PRONTO;
-  else if (!strcmp(str, F("RAW")))
+  else if (!strcmp(str, "RAW"))
     return decode_type_t::RAW;
-  else if (!strcmp(str, F("RC5")))
+  else if (!strcmp(str, "RC5"))
     return decode_type_t::RC5;
-  else if (!strcmp(str, F("RC5X")))
+  else if (!strcmp(str, "RC5X"))
     return decode_type_t::RC5X;
-  else if (!strcmp(str, F("RC6")))
+  else if (!strcmp(str, "RC6"))
     return decode_type_t::RC6;
-  else if (!strcmp(str, F("RCMM")))
+  else if (!strcmp(str, "RCMM"))
     return decode_type_t::RCMM;
-  else if (!strcmp(str, F("SAMSUNG")))
+  else if (!strcmp(str, "SAMSUNG"))
     return decode_type_t::SAMSUNG;
-  else if (!strcmp(str, F("SAMSUNG36")))
+  else if (!strcmp(str, "SAMSUNG36"))
     return decode_type_t::SAMSUNG36;
-  else if (!strcmp(str, F("SAMSUNG_AC")))
+  else if (!strcmp(str, "SAMSUNG_AC"))
     return decode_type_t::SAMSUNG_AC;
-  else if (!strcmp(str, F("SANYO")))
+  else if (!strcmp(str, "SANYO"))
     return decode_type_t::SANYO;
-  else if (!strcmp(str, F("SANYO_LC7461")))
+  else if (!strcmp(str, "SANYO_LC7461"))
     return decode_type_t::SANYO_LC7461;
-  else if (!strcmp(str, F("SHARP")))
+  else if (!strcmp(str, "SHARP"))
     return decode_type_t::SHARP;
-  else if (!strcmp(str, F("SHERWOOD")))
+  else if (!strcmp(str, "SHERWOOD"))
     return decode_type_t::SHERWOOD;
-  else if (!strcmp(str, F("SONY")))
+  else if (!strcmp(str, "SONY"))
     return decode_type_t::SONY;
-  else if (!strcmp(str, F("TCL112AC")))
+  else if (!strcmp(str, "TCL112AC"))
     return decode_type_t::TCL112AC;
-  else if (!strcmp(str, F("TECO")))
+  else if (!strcmp(str, "TECO"))
     return decode_type_t::TECO;
-  else if (!strcmp(str, F("TOSHIBA_AC")))
+  else if (!strcmp(str, "TOSHIBA_AC"))
     return decode_type_t::TOSHIBA_AC;
-  else if (!strcmp(str, F("TROTEC")))
+  else if (!strcmp(str, "TROTEC"))
     return decode_type_t::TROTEC;
-  else if (!strcmp(str, F("VESTEL_AC")))
+  else if (!strcmp(str, "VESTEL_AC"))
     return decode_type_t::VESTEL_AC;
-  else if (!strcmp(str, F("WHIRLPOOL_AC")))
+  else if (!strcmp(str, "WHIRLPOOL_AC"))
     return decode_type_t::WHIRLPOOL_AC;
-  else if (!strcmp(str, F("WHYNTER")))
+  else if (!strcmp(str, "WHYNTER"))
     return decode_type_t::WHYNTER;
   else
     return decode_type_t::UNKNOWN;

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -90,7 +90,11 @@ void serialPrintUint64(uint64_t input, uint8_t base) {
 // Returns:
 //  A decode_type_t enum.
 decode_type_t strToDecodeType(const char *str) {
-  if (!strcmp(str, "AIWA_RC_T501"))
+  if (!strcmp(str, "UNKNOWN"))
+    return decode_type_t::UNKNOWN;
+  else if (!strcmp(str, "UNUSED"))
+    return decode_type_t::UNUSED;
+  else if (!strcmp(str, "AIWA_RC_T501"))
     return decode_type_t::AIWA_RC_T501;
   else if (!strcmp(str, "ARGO"))
     return decode_type_t::ARGO;
@@ -204,6 +208,11 @@ decode_type_t strToDecodeType(const char *str) {
     return decode_type_t::WHIRLPOOL_AC;
   else if (!strcmp(str, "WHYNTER"))
     return decode_type_t::WHYNTER;
+  // Handle integer values of the type by converting to a string and back again.
+  decode_type_t result = strToDecodeType(
+      typeToString((decode_type_t)atoi(str)).c_str());
+  if (result > 0)
+    return result;
   else
     return decode_type_t::UNKNOWN;
 }
@@ -222,10 +231,6 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
   std::string result = "";
 #endif
   switch (protocol) {
-    default:
-    case UNKNOWN:
-      result = F("UNKNOWN");
-      break;
     case UNUSED:
       result = F("UNUSED");
       break;
@@ -408,6 +413,10 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
       break;
     case WHYNTER:
       result = F("WHYNTER");
+      break;
+    case UNKNOWN:
+    default:
+      result = F("UNKNOWN");
       break;
   }
   if (isRepeat) result += F(" (Repeat)");

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -7,6 +7,7 @@
 
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>
+#include <string.h>
 #include <algorithm>
 #ifndef ARDUINO
 #include <string>
@@ -80,6 +81,132 @@ void serialPrintUint64(uint64_t input, uint8_t base) {
   Serial.print(uint64ToString(input, base));
 }
 #endif
+
+// Convert a c-style str to a decode_type_t
+// Note: Assumes str is upper case.
+//
+// Args:
+//   str:  An upper-case C-style string.
+// Returns:
+//  A decode_type_t enum.
+decode_type_t strToDecodeType(const char *str) {
+  if (!strcmp(str, F("AIWA_RC_T501")))
+    return decode_type_t::AIWA_RC_T501;
+  else if (!strcmp(str, F("ARGO")))
+    return decode_type_t::ARGO;
+  else if (!strcmp(str, F("CARRIER_AC")))
+    return decode_type_t::CARRIER_AC;
+  else if (!strcmp(str, F("COOLIX")))
+    return decode_type_t::COOLIX;
+  else if (!strcmp(str, F("DAIKIN")))
+    return decode_type_t::DAIKIN;
+  else if (!strcmp(str, F("DAIKIN2")))
+    return decode_type_t::DAIKIN2;
+  else if (!strcmp(str, F("DENON")))
+    return decode_type_t::DENON;
+  else if (!strcmp(str, F("DISH")))
+    return decode_type_t::DISH;
+  else if (!strcmp(str, F("ELECTRA_AC")))
+    return decode_type_t::ELECTRA_AC;
+  else if (!strcmp(str, F("FUJITSU_AC")))
+    return decode_type_t::FUJITSU_AC;
+  else if (!strcmp(str, F("GICABLE")))
+    return decode_type_t::GICABLE;
+  else if (!strcmp(str, F("GLOBALCACHE")))
+    return decode_type_t::GLOBALCACHE;
+  else if (!strcmp(str, F("GREE")))
+    return decode_type_t::GREE;
+  else if (!strcmp(str, F("HAIER_AC")))
+    return decode_type_t::HAIER_AC;
+  else if (!strcmp(str, F("HAIER_AC_YRW02")))
+    return decode_type_t::HAIER_AC_YRW02;
+  else if (!strcmp(str, F("HITACHI_AC")))
+    return decode_type_t::HITACHI_AC;
+  else if (!strcmp(str, F("HITACHI_AC1")))
+    return decode_type_t::HITACHI_AC1;
+  else if (!strcmp(str, F("HITACHI_AC2")))
+    return decode_type_t::HITACHI_AC2;
+  else if (!strcmp(str, F("JVC")))
+    return decode_type_t::JVC;
+  else if (!strcmp(str, F("KELVINATOR")))
+    return decode_type_t::KELVINATOR;
+  else if (!strcmp(str, F("LEGOPF")))
+    return decode_type_t::LEGOPF;
+  else if (!strcmp(str, F("LG")))
+    return decode_type_t::LG;
+  else if (!strcmp(str, F("LG2")))
+    return decode_type_t::LG2;
+  else if (!strcmp(str, F("LASERTAG")))
+    return decode_type_t::LASERTAG;
+  else if (!strcmp(str, F("LUTRON")))
+    return decode_type_t::LUTRON;
+  else if (!strcmp(str, F("MAGIQUEST")))
+    return decode_type_t::MAGIQUEST;
+  else if (!strcmp(str, F("MIDEA")))
+    return decode_type_t::MIDEA;
+  else if (!strcmp(str, F("MITSUBISHI")))
+    return decode_type_t::MITSUBISHI;
+  else if (!strcmp(str, F("MITSUBISHI2")))
+    return decode_type_t::MITSUBISHI2;
+  else if (!strcmp(str, F("MITSUBISHI_AC")))
+    return decode_type_t::MITSUBISHI_AC;
+  else if (!strcmp(str, F("MWM")))
+    return decode_type_t::MWM;
+  else if (!strcmp(str, F("NEC")) || !strcmp(str, F("NEC (NON-STRICT)")))
+    return decode_type_t::NEC;
+  else if (!strcmp(str, F("NIKAI")))
+    return decode_type_t::NIKAI;
+  else if (!strcmp(str, F("PANASONIC")))
+    return decode_type_t::PANASONIC;
+  else if (!strcmp(str, F("PANASONIC_AC")))
+    return decode_type_t::PANASONIC_AC;
+  else if (!strcmp(str, F("PIONEER")))
+    return decode_type_t::PIONEER;
+  else if (!strcmp(str, F("PRONTO")))
+    return decode_type_t::PRONTO;
+  else if (!strcmp(str, F("RAW")))
+    return decode_type_t::RAW;
+  else if (!strcmp(str, F("RC5")))
+    return decode_type_t::RC5;
+  else if (!strcmp(str, F("RC5X")))
+    return decode_type_t::RC5X;
+  else if (!strcmp(str, F("RC6")))
+    return decode_type_t::RC6;
+  else if (!strcmp(str, F("RCMM")))
+    return decode_type_t::RCMM;
+  else if (!strcmp(str, F("SAMSUNG")))
+    return decode_type_t::SAMSUNG;
+  else if (!strcmp(str, F("SAMSUNG36")))
+    return decode_type_t::SAMSUNG36;
+  else if (!strcmp(str, F("SAMSUNG_AC")))
+    return decode_type_t::SAMSUNG_AC;
+  else if (!strcmp(str, F("SANYO")))
+    return decode_type_t::SANYO;
+  else if (!strcmp(str, F("SANYO_LC7461")))
+    return decode_type_t::SANYO_LC7461;
+  else if (!strcmp(str, F("SHARP")))
+    return decode_type_t::SHARP;
+  else if (!strcmp(str, F("SHERWOOD")))
+    return decode_type_t::SHERWOOD;
+  else if (!strcmp(str, F("SONY")))
+    return decode_type_t::SONY;
+  else if (!strcmp(str, F("TCL112AC")))
+    return decode_type_t::TCL112AC;
+  else if (!strcmp(str, F("TECO")))
+    return decode_type_t::TECO;
+  else if (!strcmp(str, F("TOSHIBA_AC")))
+    return decode_type_t::TOSHIBA_AC;
+  else if (!strcmp(str, F("TROTEC")))
+    return decode_type_t::TROTEC;
+  else if (!strcmp(str, F("VESTEL_AC")))
+    return decode_type_t::VESTEL_AC;
+  else if (!strcmp(str, F("WHIRLPOOL_AC")))
+    return decode_type_t::WHIRLPOOL_AC;
+  else if (!strcmp(str, F("WHYNTER")))
+    return decode_type_t::WHYNTER;
+  else
+    return decode_type_t::UNKNOWN;
+}
 
 // Convert a protocol type (enum etc) to a human readable string.
 // Args:

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -24,7 +24,7 @@ String resultToSourceCode(const decode_results *results);
 String resultToTimingInfo(const decode_results *results);
 String resultToHumanReadableBasic(const decode_results *results);
 String resultToHexidecimal(const decode_results *result);
-#else
+#else  // ARDUINO
 std::string uint64ToString(uint64_t input, uint8_t base = 10);
 std::string typeToString(const decode_type_t protocol,
                          const bool isRepeat = false);
@@ -32,7 +32,7 @@ std::string resultToSourceCode(const decode_results *results);
 std::string resultToTimingInfo(const decode_results *results);
 std::string resultToHumanReadableBasic(const decode_results *results);
 std::string resultToHexidecimal(const decode_results *result);
-#endif
+#endif  // ARDUINO
 bool hasACState(const decode_type_t protocol);
 uint16_t getCorrectedRawLength(const decode_results *results);
 uint8_t sumBytes(uint8_t *start, const uint16_t length, const uint8_t init = 0);
@@ -42,5 +42,5 @@ uint16_t countBits(const uint8_t *start, const uint16_t length,
 uint16_t countBits(const uint64_t data, const uint8_t length,
                    const bool ones = true, const uint16_t init = 0);
 uint64_t invertBits(const uint64_t data, const uint16_t nbits);
-
+decode_type_t strToDecodeType(const char *str);
 #endif  // IRUTILS_H_

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -755,3 +755,83 @@ TEST(TestIRac, Whirlpool) {
   ac.setRaw(ac._irsend.capture.state);
   ASSERT_EQ(expected, ac.toString());
 }
+
+TEST(TestIRac, strToBool) {
+  EXPECT_TRUE(IRac::strToBool("ON"));
+  EXPECT_TRUE(IRac::strToBool("1"));
+  EXPECT_TRUE(IRac::strToBool("TRUE"));
+  EXPECT_TRUE(IRac::strToBool("YES"));
+  EXPECT_FALSE(IRac::strToBool("OFF"));
+  EXPECT_FALSE(IRac::strToBool("0"));
+  EXPECT_FALSE(IRac::strToBool("FALSE"));
+  EXPECT_FALSE(IRac::strToBool("NO"));
+  EXPECT_FALSE(IRac::strToBool("FOOBAR"));
+  EXPECT_TRUE(IRac::strToBool("FOOBAR", true));
+}
+
+TEST(TestIRac, strToOpmode) {
+  EXPECT_EQ(stdAc::opmode_t::kAuto, IRac::strToOpmode("AUTO"));
+  EXPECT_EQ(stdAc::opmode_t::kCool, IRac::strToOpmode("COOL"));
+  EXPECT_EQ(stdAc::opmode_t::kHeat, IRac::strToOpmode("HEAT"));
+  EXPECT_EQ(stdAc::opmode_t::kDry, IRac::strToOpmode("DRY"));
+  EXPECT_EQ(stdAc::opmode_t::kFan, IRac::strToOpmode("FAN"));
+  EXPECT_EQ(stdAc::opmode_t::kFan, IRac::strToOpmode("FAN_ONLY"));
+  EXPECT_EQ(stdAc::opmode_t::kAuto, IRac::strToOpmode("FOOBAR"));
+  EXPECT_EQ(stdAc::opmode_t::kOff, IRac::strToOpmode("OFF"));
+  EXPECT_EQ(stdAc::opmode_t::kOff, IRac::strToOpmode("FOOBAR",
+                                                     stdAc::opmode_t::kOff));
+}
+
+TEST(TestIRac, strToFanspeed) {
+  EXPECT_EQ(stdAc::fanspeed_t::kAuto, IRac::strToFanspeed("AUTO"));
+  EXPECT_EQ(stdAc::fanspeed_t::kMin, IRac::strToFanspeed("MIN"));
+  EXPECT_EQ(stdAc::fanspeed_t::kLow, IRac::strToFanspeed("LOW"));
+  EXPECT_EQ(stdAc::fanspeed_t::kMedium, IRac::strToFanspeed("MEDIUM"));
+  EXPECT_EQ(stdAc::fanspeed_t::kHigh, IRac::strToFanspeed("HIGH"));
+  EXPECT_EQ(stdAc::fanspeed_t::kMax, IRac::strToFanspeed("MAX"));
+  EXPECT_EQ(stdAc::fanspeed_t::kAuto, IRac::strToFanspeed("FOOBAR"));
+  EXPECT_EQ(stdAc::fanspeed_t::kMin,
+            IRac::strToFanspeed("FOOBAR", stdAc::fanspeed_t::kMin));
+}
+
+TEST(TestIRac, strToSwingV) {
+  EXPECT_EQ(stdAc::swingv_t::kAuto, IRac::strToSwingV("AUTO"));
+  EXPECT_EQ(stdAc::swingv_t::kLowest, IRac::strToSwingV("LOWEST"));
+  EXPECT_EQ(stdAc::swingv_t::kLow, IRac::strToSwingV("LOW"));
+  EXPECT_EQ(stdAc::swingv_t::kMiddle, IRac::strToSwingV("MIDDLE"));
+  EXPECT_EQ(stdAc::swingv_t::kHigh, IRac::strToSwingV("HIGH"));
+  EXPECT_EQ(stdAc::swingv_t::kHighest, IRac::strToSwingV("HIGHEST"));
+  EXPECT_EQ(stdAc::swingv_t::kOff, IRac::strToSwingV("OFF"));
+  EXPECT_EQ(stdAc::swingv_t::kOff, IRac::strToSwingV("FOOBAR"));
+  EXPECT_EQ(stdAc::swingv_t::kAuto,
+            IRac::strToSwingV("FOOBAR", stdAc::swingv_t::kAuto));
+}
+
+TEST(TestIRac, strToSwingH) {
+  EXPECT_EQ(stdAc::swingh_t::kAuto, IRac::strToSwingH("AUTO"));
+  EXPECT_EQ(stdAc::swingh_t::kLeftMax, IRac::strToSwingH("MAX LEFT"));
+  EXPECT_EQ(stdAc::swingh_t::kLeft, IRac::strToSwingH("LEFT"));
+  EXPECT_EQ(stdAc::swingh_t::kMiddle, IRac::strToSwingH("CENTRE"));
+  EXPECT_EQ(stdAc::swingh_t::kRight, IRac::strToSwingH("RIGHT"));
+  EXPECT_EQ(stdAc::swingh_t::kRightMax, IRac::strToSwingH("RIGHTMAX"));
+  EXPECT_EQ(stdAc::swingh_t::kOff, IRac::strToSwingH("OFF"));
+  EXPECT_EQ(stdAc::swingh_t::kOff, IRac::strToSwingH("FOOBAR"));
+  EXPECT_EQ(stdAc::swingh_t::kAuto,
+            IRac::strToSwingH("FOOBAR", stdAc::swingh_t::kAuto));
+}
+
+TEST(TestIRac, strToModel) {
+  EXPECT_EQ(panasonic_ac_remote_model_t::kPanasonicLke,
+            IRac::strToModel("LKE"));
+  EXPECT_EQ(panasonic_ac_remote_model_t::kPanasonicLke,
+            IRac::strToModel("PANASONICLKE"));
+  EXPECT_EQ(fujitsu_ac_remote_model_t::ARRAH2E,
+            IRac::strToModel("ARRAH2E"));
+  EXPECT_EQ(whirlpool_ac_remote_model_t::DG11J13A,
+            IRac::strToModel("DG11J13A"));
+  EXPECT_EQ(1, IRac::strToModel("1"));
+  EXPECT_EQ(10, IRac::strToModel("10"));
+  EXPECT_EQ(-1, IRac::strToModel("0"));
+  EXPECT_EQ(-1, IRac::strToModel("FOOBAR"));
+  EXPECT_EQ(0, IRac::strToModel("FOOBAR", 0));
+}

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -395,3 +395,9 @@ TEST(TestCountBits, Integer) {
   ASSERT_EQ(64, countBits(data, 64));
   ASSERT_EQ(0, countBits(data, 64, false));
 }
+
+TEST(TestStrToDecodeType, strToDecodeType) {
+  EXPECT_EQ(decode_type_t::NEC, strToDecodeType("NEC"));
+  EXPECT_EQ(decode_type_t::KELVINATOR, strToDecodeType("KELVINATOR"));
+  EXPECT_EQ(decode_type_t::UNKNOWN, strToDecodeType("foo"));
+}


### PR DESCRIPTION
- Allow Home Assistant (HA) to handle the most basic of settings of a generic aircon.
- Should allow all/most Common A/C (`IRac` class) features to be set via MQTT & HTTP/HTML.
- Reboot URL (/quitquitquit)
- add HA MQTT discovery message URL (/send_discovery)
- Add an "off" mode to A/C Operation mode to keep HA happy.
- Move info to it's own page and add auto-refresh.
- Move common HTML elements to functions.
- Move/document/add admin functions to their own page.
- Fix firmware update page display.
- HTML pages for displaying/setting the Climate/Common AC object.
- Set climate/aircon modes via HTTP Post to the /aircon/set URL.
- Allow integer values in strToDecodeType().
- Recovery of the climate state from the retained MQTT state, if any.
- Add a timer class for milliseconds.
  * Refactor time to human readable string(s).
- Add more stats and information to the Info page.
- General improvements and other cosmetic tweaks.
- Add some comments/documentation on how to use the new APIs.
- Crude HTML menu system.
- Bump version to `v1.0.0-beta`

* **[BUG]** Fix issues caused by having `MQTT_ENABLE` set to false.

* **[WARN]** Need to update `PubSubClient.h` to have the following (or larger) value:
`#define MQTT_MAX_PACKET_SIZE 768` otherwise HA MQTT climate discovery will not work. (too big)

Tested on my personal IR device. Seems to work as expected. I'm sure there will be bugs. :)

[TODO] Split this up and add some unit test coverage. It's too big now!