### PR TITLE
DAIKIN/IRDaikinESP overhaul and add Comfort mode support.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1305,7 +1305,21 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       stateSize = kToshibaACStateLength;
       break;
     case DAIKIN:
-      stateSize = kDaikinStateLength;
+      // Daikin has 2 different possible size states.
+      // (The correct size, and a legacy shorter size.)
+      // Guess which one we are being presented with based on the number of
+      // hexadecimal digits provided. i.e. Zero-pad if you need to to get
+      // the correct length/byte size.
+      // This should provide backward compatiblity with legacy messages.
+      stateSize = inputLength / 2;  // Every two hex chars is a byte.
+      // Use at least the minimum size.
+      stateSize = std::max(stateSize, kDaikinStateLengthShort);
+      // If we think it isn't a "short" message.
+      if (stateSize > kDaikinStateLengthShort)
+        // Then it has to be at least the version of the "normal" size.
+        stateSize = std::max(stateSize, kDaikinStateLength);
+      // Lastly, it should never exceed the "normal" size.
+      stateSize = std::min(stateSize, kDaikinStateLength);
       break;
     case DAIKIN2:
       stateSize = kDaikin2StateLength;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -266,8 +266,8 @@ class IRrecv {
                         uint16_t nbits = kKelvinatorBits, bool strict = true);
 #endif
 #if DECODE_DAIKIN
-  bool decodeDaikin(decode_results *results, uint16_t nbits = kDaikinRawBits,
-                    bool strict = true);
+  bool decodeDaikin(decode_results *results, const uint16_t nbits = kDaikinBits,
+                    const bool strict = true);
 #endif
 #if DECODE_DAIKIN2
   bool decodeDaikin2(decode_results *results, uint16_t nbits = kDaikin2Bits,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -324,10 +324,10 @@ const uint16_t kCoolixBits = 24;
 const uint16_t kCoolixDefaultRepeat = 1;
 const uint16_t kCarrierAcBits = 32;
 const uint16_t kCarrierAcMinRepeat = kNoRepeat;
-// Daikin has a lot of static stuff that is discarded
-const uint16_t kDaikinRawBits = 583;
-const uint16_t kDaikinStateLength = 27;
+const uint16_t kDaikinStateLength = 35;
 const uint16_t kDaikinBits = kDaikinStateLength * 8;
+const uint16_t kDaikinStateLengthShort = kDaikinStateLength - 8;
+const uint16_t kDaikinBitsShort = kDaikinStateLengthShort * 8;
 const uint16_t kDaikinDefaultRepeat = kNoRepeat;
 const uint16_t kDaikin2StateLength = 39;
 const uint16_t kDaikin2Bits = kDaikin2StateLength * 8;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -255,8 +255,9 @@ class IRsend {
                       uint16_t repeat = kKelvinatorDefaultRepeat);
 #endif
 #if SEND_DAIKIN
-  void sendDaikin(unsigned char data[], uint16_t nbytes = kDaikinStateLength,
-                  uint16_t repeat = kDaikinDefaultRepeat);
+  void sendDaikin(const unsigned char data[],
+                  const uint16_t nbytes = kDaikinStateLength,
+                  const uint16_t repeat = kDaikinDefaultRepeat);
 #endif
 #if SEND_DAIKIN2
   void sendDaikin2(unsigned char data[], uint16_t nbytes = kDaikin2StateLength,

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -34,17 +34,6 @@ Copyright 2018-2019 crankyoldgit
 //   https://github.com/markszabo/IRremoteESP8266/issues/582
 
 #if SEND_DAIKIN
-// Original header
-// static uint8_t header1[DAIKIN_HEADER1_LENGTH];
-// header1[0] = 0b00010001;
-// header1[1] = 0b11011010;
-// header1[2] = 0b00100111;
-// header1[3] = 0b00000000;
-// header1[4] = 0b11000101;
-// header1[5] = 0b00000000;
-// header1[6] = 0b00000000;
-// header1[7] = 0b11010111;
-
 // Send a Daikin A/C message.
 //
 // Args:
@@ -55,132 +44,163 @@ Copyright 2018-2019 crankyoldgit
 // Ref:
 //   IRDaikinESP.cpp
 //   https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
-void IRsend::sendDaikin(unsigned char data[], uint16_t nbytes,
-                        uint16_t repeat) {
-  if (nbytes < kDaikinStateLength)
+//   https://github.com/blafois/Daikin-IR-Reverse
+void IRsend::sendDaikin(const unsigned char data[], const uint16_t nbytes,
+                        const uint16_t repeat) {
+  if (nbytes < kDaikinStateLengthShort)
     return;  // Not enough bytes to send a proper message.
 
   for (uint16_t r = 0; r <= repeat; r++) {
+    uint16_t offset = 0;
     // Send the header, 0b00000
     sendGeneric(0, 0,  // No header for the header
                 kDaikinBitMark, kDaikinOneSpace, kDaikinBitMark,
                 kDaikinZeroSpace, kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
-                (uint64_t)0b00000, 5, 38, false, 0, 50);
-    // Leading header
-    // Do this as a constant to save RAM and keep in flash memory
-    sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
-                kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
-                kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
-                kDaikinFirstHeader64, 64, 38, false, 0, 50);
+                (uint64_t)0b00000, kDaikinHeaderLength, 38, false, 0, 50);
     // Data #1
-    sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
-                kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
-                kDaikinBitMark, kDaikinZeroSpace + kDaikinGap, data, 8, 38,
-                false, 0, 50);
+    if (nbytes < kDaikinStateLength) {  // Are we using the legacy size?
+      // Do this as a constant to save RAM and keep in flash memory
+      sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
+                  kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
+                  kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
+                  kDaikinFirstHeader64, 64, 38, false, 0, 50);
+    } else {  // We are using the newer/more correct size.
+      sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
+                  kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
+                  kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
+                  data, kDaikinSection1Length, 38, false, 0, 50);
+      offset += kDaikinSection1Length;
+    }
     // Data #2
     sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
                 kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
-                kDaikinBitMark, kDaikinZeroSpace + kDaikinGap, data + 8,
-                nbytes - 8, 38, false, 0, 50);
+                kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
+                data + offset, kDaikinSection2Length, 38, false, 0, 50);
+    offset += kDaikinSection2Length;
+    // Data #3
+    sendGeneric(kDaikinHdrMark, kDaikinHdrSpace, kDaikinBitMark,
+                kDaikinOneSpace, kDaikinBitMark, kDaikinZeroSpace,
+                kDaikinBitMark, kDaikinZeroSpace + kDaikinGap,
+                data + offset, nbytes - offset, 38, false, 0, 50);
   }
 }
 #endif  // SEND_DAIKIN
 
 IRDaikinESP::IRDaikinESP(uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRDaikinESP::begin() { _irsend.begin(); }
+void IRDaikinESP::begin(void) { _irsend.begin(); }
 
 #if SEND_DAIKIN
 void IRDaikinESP::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin(daikin, kDaikinStateLength, repeat);
+  this->checksum();
+  _irsend.sendDaikin(remote, kDaikinStateLength, repeat);
 }
 #endif  // SEND_DAIKIN
 
-// Verify the checksum is valid for a given state.
+// Verify the checksums are valid for a given state.
 // Args:
-//   state:  The array to verify the checksum of.
+//   state:  The array to verify the checksums of.
 //   length: The size of the state.
 // Returns:
 //   A boolean.
 bool IRDaikinESP::validChecksum(uint8_t state[], const uint16_t length) {
-  if (length < 8 || state[7] != sumBytes(state, 7)) return false;
-  if (length < 10 ||
-      state[length - 1] != sumBytes(state + 8, length - 9))
+  // Data #1
+  if (length < kDaikinSection1Length ||
+      state[kDaikinByteChecksum1] != sumBytes(state, kDaikinSection1Length - 1))
+    return false;
+  // Data #2
+  if (length < kDaikinSection1Length + kDaikinSection2Length ||
+      state[kDaikinByteChecksum2] != sumBytes(state + kDaikinSection1Length,
+                                              kDaikinSection2Length - 1))
+    return false;
+  // Data #3
+  if (length < kDaikinSection1Length + kDaikinSection2Length + 2 ||
+      state[length - 1] != sumBytes(state + kDaikinSection1Length +
+                                    kDaikinSection2Length,
+                                    length - (kDaikinSection1Length +
+                                              kDaikinSection2Length) - 1))
     return false;
   return true;
 }
 
 // Calculate and set the checksum values for the internal state.
-void IRDaikinESP::checksum() {
-  daikin[7] = sumBytes(daikin, 7);
-  daikin[26] = sumBytes(daikin + 8, 17);
+void IRDaikinESP::checksum(void) {
+  remote[kDaikinByteChecksum1] = sumBytes(remote, kDaikinSection1Length - 1);
+  remote[kDaikinByteChecksum2] = sumBytes(remote + kDaikinSection1Length,
+                                          kDaikinSection2Length - 1);
+  remote[kDaikinByteChecksum3] = sumBytes(remote + kDaikinSection1Length +
+                                          kDaikinSection2Length,
+                                          kDaikinSection3Length - 1);
 }
 
-void IRDaikinESP::stateReset() {
-  for (uint8_t i = 0; i < kDaikinStateLength; i++) daikin[i] = 0x0;
+void IRDaikinESP::stateReset(void) {
+  for (uint8_t i = 0; i < kDaikinStateLength; i++) remote[i] = 0x0;
 
-  daikin[0] = 0x11;
-  daikin[1] = 0xDA;
-  daikin[2] = 0x27;
-  daikin[4] = 0x42;
-  // daikin[7] is a checksum byte, it will be set by checksum().
-  daikin[8] = 0x11;
-  daikin[9] = 0xDA;
-  daikin[10] = 0x27;
-  daikin[13] = 0x49;
-  daikin[14] = 0x1E;
-  daikin[16] = 0xB0;
-  daikin[19] = 0x06;
-  daikin[20] = 0x60;
-  daikin[23] = 0xC0;
-  // daikin[26] is a checksum byte, it will be set by checksum().
-  checksum();
+  remote[0] = 0x11;
+  remote[1] = 0xDA;
+  remote[2] = 0x27;
+  remote[4] = 0xC5;
+  // remote[7] is a checksum byte, it will be set by checksum().
+
+  remote[8] = 0x11;
+  remote[9] = 0xDA;
+  remote[10] = 0x27;
+  remote[12] = 0x42;
+  // remote[15] is a checksum byte, it will be set by checksum().
+  remote[16] = 0x11;
+  remote[17] = 0xDA;
+  remote[18] = 0x27;
+  remote[21] = 0x49;
+  remote[22] = 0x1E;
+  remote[24] = 0xB0;
+  remote[27] = 0x06;
+  remote[28] = 0x60;
+  remote[31] = 0xC0;
+  // remote[34] is a checksum byte, it will be set by checksum().
+  this->checksum();
 }
 
-uint8_t *IRDaikinESP::getRaw() {
-  checksum();  // Ensure correct settings before sending.
-  return daikin;
+uint8_t *IRDaikinESP::getRaw(void) {
+  this->checksum();  // Ensure correct settings before sending.
+  return remote;
 }
 
-void IRDaikinESP::setRaw(uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikinStateLength; i++) daikin[i] = new_code[i];
+void IRDaikinESP::setRaw(const uint8_t new_code[], const uint16_t length) {
+  uint8_t offset = 0;
+  if (length == kDaikinStateLengthShort) {  // Handle the "short" length case.
+    offset = kDaikinStateLength - kDaikinStateLengthShort;
+    this->stateReset();
+  }
+  for (uint8_t i = 0; i < length && i < kDaikinStateLength; i++)
+    remote[i + offset] = new_code[i];
 }
 
-void IRDaikinESP::on() {
-  // state = ON;
-  setBit(kDaikinBytePower, kDaikinBitPower);
-}
+void IRDaikinESP::on(void) { remote[kDaikinBytePower] |= kDaikinBitPower; }
 
-void IRDaikinESP::off() {
-  // state = OFF;
-  clearBit(kDaikinBytePower, kDaikinBitPower);
-}
+void IRDaikinESP::off(void) { remote[kDaikinBytePower] &= ~kDaikinBitPower; }
 
-void IRDaikinESP::setPower(bool state) {
-  if (state)
-    on();
+void IRDaikinESP::setPower(const bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
-bool IRDaikinESP::getPower() {
-  return (getBit(kDaikinBytePower, kDaikinBitPower) > 0);
+bool IRDaikinESP::getPower(void) {
+  return remote[kDaikinBytePower] & kDaikinBitPower;
 }
 
 // Set the temp in deg C
-void IRDaikinESP::setTemp(uint8_t temp) {
-  if (temp < kDaikinMinTemp)
-    temp = kDaikinMinTemp;
-  else if (temp > kDaikinMaxTemp)
-    temp = kDaikinMaxTemp;
-  daikin[14] = temp * 2;
+void IRDaikinESP::setTemp(const uint8_t temp) {
+  uint8_t degrees = std::max(temp, kDaikinMinTemp);
+  degrees = std::min(degrees, kDaikinMaxTemp);
+  remote[kDaikinByteTemp] = degrees << 1;
 }
 
-uint8_t IRDaikinESP::getTemp() { return daikin[14] / 2; }
+uint8_t IRDaikinESP::getTemp(void) { return remote[kDaikinByteTemp] >> 1; }
 
 // Set the speed of the fan, 1-5 or kDaikinFanAuto or kDaikinFanQuiet
-void IRDaikinESP::setFan(uint8_t fan) {
+void IRDaikinESP::setFan(const uint8_t fan) {
   // Set the fan speed bits, leave low 4 bits alone
   uint8_t fanset;
   if (fan == kDaikinFanQuiet || fan == kDaikinFanAuto)
@@ -189,229 +209,210 @@ void IRDaikinESP::setFan(uint8_t fan) {
     fanset = kDaikinFanAuto;
   else
     fanset = 2 + fan;
-  daikin[16] &= 0x0F;
-  daikin[16] |= (fanset << 4);
+  remote[kDaikinByteFan] &= 0x0F;
+  remote[kDaikinByteFan] |= (fanset << 4);
 }
 
-uint8_t IRDaikinESP::getFan() {
-  uint8_t fan = daikin[16] >> 4;
+uint8_t IRDaikinESP::getFan(void) {
+  uint8_t fan = remote[kDaikinByteFan] >> 4;
   if (fan != kDaikinFanQuiet && fan != kDaikinFanAuto) fan -= 2;
   return fan;
 }
 
-uint8_t IRDaikinESP::getMode() {
-  /*
-  kDaikinCool
-  kDaikinHeat
-  kDaikinFan
-  kDaikinAuto
-  kDaikinDry
-  */
-  return daikin[13] >> 4;
-}
+uint8_t IRDaikinESP::getMode(void) { return remote[kDaikinBytePower] >> 4; }
 
-void IRDaikinESP::setMode(uint8_t mode) {
+void IRDaikinESP::setMode(const uint8_t mode) {
   switch (mode) {
+    case kDaikinAuto:
     case kDaikinCool:
     case kDaikinHeat:
     case kDaikinFan:
     case kDaikinDry:
+      remote[kDaikinBytePower] &= 0b10001111;
+      remote[kDaikinBytePower] |= (mode << 4);
       break;
     default:
-      mode = kDaikinAuto;
+      this->setMode(kDaikinAuto);
   }
-  mode <<= 4;
-  daikin[13] &= 0b10001111;
-  daikin[13] |= mode;
 }
 
-void IRDaikinESP::setSwingVertical(bool state) {
-  if (state)
-    daikin[16] |= 0x0F;
+void IRDaikinESP::setSwingVertical(const bool on) {
+  if (on)
+    remote[kDaikinByteFan] |= 0x0F;
   else
-    daikin[16] &= 0xF0;
+    remote[kDaikinByteFan] &= 0xF0;
 }
 
-bool IRDaikinESP::getSwingVertical() { return daikin[16] & 0x01; }
+bool IRDaikinESP::getSwingVertical(void) {
+  return remote[kDaikinByteFan] & 0x0F;
+}
 
-void IRDaikinESP::setSwingHorizontal(bool state) {
-  if (state)
-    daikin[17] |= 0x0F;
+void IRDaikinESP::setSwingHorizontal(const bool on) {
+  if (on)
+    remote[kDaikinByteSwingH] |= 0x0F;
   else
-    daikin[17] &= 0xF0;
+    remote[kDaikinByteSwingH] &= 0xF0;
 }
 
-bool IRDaikinESP::getSwingHorizontal() { return daikin[17] & 0x01; }
+bool IRDaikinESP::getSwingHorizontal(void) {
+  return remote[kDaikinByteSwingH] & 0x0F;
+}
 
-void IRDaikinESP::setQuiet(bool state) {
-  if (state) {
-    setBit(kDaikinByteSilent, kDaikinBitSilent);
+void IRDaikinESP::setQuiet(const bool on) {
+  if (on) {
+    remote[kDaikinByteSilent] |= kDaikinBitSilent;
     // Powerful & Quiet mode being on are mutually exclusive.
-    setPowerful(false);
+    this->setPowerful(false);
   } else {
-    clearBit(kDaikinByteSilent, kDaikinBitSilent);
+    remote[kDaikinByteSilent] &= ~kDaikinBitSilent;
   }
 }
 
-bool IRDaikinESP::getQuiet() {
-  return (getBit(kDaikinByteSilent, kDaikinBitSilent) > 0);
+bool IRDaikinESP::getQuiet(void) {
+  return remote[kDaikinByteSilent] & kDaikinBitSilent;
 }
 
-void IRDaikinESP::setPowerful(bool state) {
-  if (state) {
-    setBit(kDaikinBytePowerful, kDaikinBitPowerful);
+void IRDaikinESP::setPowerful(const bool on) {
+  if (on) {
+    remote[kDaikinBytePowerful] |= kDaikinBitPowerful;
     // Powerful, Quiet, & Econo mode being on are mutually exclusive.
-    setQuiet(false);
-    setEcono(false);
+    this->setQuiet(false);
+    this->setEcono(false);
   } else {
-    clearBit(kDaikinBytePowerful, kDaikinBitPowerful);
+    remote[kDaikinBytePowerful] &= ~kDaikinBitPowerful;
   }
 }
 
-bool IRDaikinESP::getPowerful() {
-  return (getBit(kDaikinBytePowerful, kDaikinBitPowerful) > 0);
+bool IRDaikinESP::getPowerful(void) {
+  return remote[kDaikinBytePowerful] & kDaikinBitPowerful;
 }
 
-void IRDaikinESP::setSensor(bool state) {
-  if (state)
-    setBit(kDaikinByteSensor, kDaikinBitSensor);
+void IRDaikinESP::setSensor(const bool on) {
+  if (on)
+    remote[kDaikinByteSensor] |= kDaikinBitSensor;
   else
-    clearBit(kDaikinByteSensor, kDaikinBitSensor);
+    remote[kDaikinByteSensor] &= ~kDaikinBitSensor;
 }
 
-bool IRDaikinESP::getSensor() {
-  return (getBit(kDaikinByteSensor, kDaikinBitSensor) > 0);
+bool IRDaikinESP::getSensor(void) {
+  return remote[kDaikinByteSensor] & kDaikinBitSensor;
 }
 
-void IRDaikinESP::setEcono(bool state) {
-  if (state) {
-    setBit(kDaikinByteEcono, kDaikinBitEcono);
+void IRDaikinESP::setEcono(const bool on) {
+  if (on) {
+    remote[kDaikinByteEcono] |= kDaikinBitEcono;
     // Powerful & Econo mode being on are mutually exclusive.
-    setPowerful(false);
+    this->setPowerful(false);
   } else {
-    clearBit(kDaikinByteEcono, kDaikinBitEcono);
+    remote[kDaikinByteEcono] &= ~kDaikinBitEcono;
   }
 }
 
-bool IRDaikinESP::getEcono() {
-  return (getBit(kDaikinByteEcono, kDaikinBitEcono) > 0);
+bool IRDaikinESP::getEcono(void) {
+  return remote[kDaikinByteEcono] & kDaikinBitEcono;
 }
 
-void IRDaikinESP::setEye(bool state) {
-  if (state)
-    setBit(kDaikinByteEye, kDaikinBitEye);
+void IRDaikinESP::setEye(const bool on) {
+  if (on)
+    remote[kDaikinByteEye] |= kDaikinBitEye;
   else
-    clearBit(kDaikinByteEye, kDaikinBitEye);
+    remote[kDaikinByteEye] &= ~kDaikinBitEye;
 }
 
-bool IRDaikinESP::getEye() {
-  return (getBit(kDaikinByteEye, kDaikinBitEye) > 0);
+bool IRDaikinESP::getEye(void) {
+  return remote[kDaikinByteEye] & kDaikinBitEye;
 }
 
-void IRDaikinESP::setMold(bool state) {
-  if (state)
-    setBit(kDaikinByteMold, kDaikinBitMold);
+void IRDaikinESP::setMold(const bool on) {
+  if (on)
+    remote[kDaikinByteMold] |= kDaikinBitMold;
   else
-    clearBit(kDaikinByteMold, kDaikinBitMold);
+    remote[kDaikinByteMold] &= ~kDaikinBitMold;
 }
 
-bool IRDaikinESP::getMold() {
-  return (getBit(kDaikinByteMold, kDaikinBitMold) > 0);
+bool IRDaikinESP::getMold(void) {
+  return remote[kDaikinByteMold] & kDaikinBitMold;
 }
 
-void IRDaikinESP::setBit(uint8_t byte, uint8_t bitmask) {
-  daikin[byte] |= bitmask;
+void IRDaikinESP::setComfort(const bool on) {
+  if (on)
+    remote[kDaikinByteComfort] |= kDaikinBitComfort;
+  else
+    remote[kDaikinByteComfort] &= ~kDaikinBitComfort;
 }
 
-void IRDaikinESP::clearBit(uint8_t byte, uint8_t bitmask) {
-  bitmask = ~bitmask;
-  daikin[byte] &= bitmask;
-}
-
-uint8_t IRDaikinESP::getBit(uint8_t byte, uint8_t bitmask) {
-  return daikin[byte] & bitmask;
+bool IRDaikinESP::getComfort(void) {
+  return remote[kDaikinByteComfort] & kDaikinBitComfort;
 }
 
 // starttime: Number of minutes after midnight.
-void IRDaikinESP::enableOnTimer(uint16_t starttime) {
-  setBit(kDaikinByteOnTimer, kDaikinBitOnTimer);
-  daikin[18] = (uint8_t)(starttime & 0x00FF);
+void IRDaikinESP::enableOnTimer(const uint16_t starttime) {
+  remote[kDaikinByteOnTimer] |= kDaikinBitOnTimer;
+  remote[kDaikinByteOnTimerMinsLow] = starttime;
   // only keep 4 bits
-  daikin[19] &= 0xF0;
-  daikin[19] |= (uint8_t)((starttime >> 8) & 0x0F);
+  remote[kDaikinByteOnTimerMinsHigh] &= 0xF0;
+  remote[kDaikinByteOnTimerMinsHigh] |= ((starttime >> 8) & 0x0F);
 }
 
-void IRDaikinESP::disableOnTimer() {
-  enableOnTimer(kDaikinUnusedTime);
-  clearBit(kDaikinByteOnTimer, kDaikinBitOnTimer);
+void IRDaikinESP::disableOnTimer(void) {
+  this->enableOnTimer(kDaikinUnusedTime);
+  remote[kDaikinByteOnTimer] &= ~kDaikinBitOnTimer;
 }
 
-uint16_t IRDaikinESP::getOnTime() {
-  uint16_t ret;
-  ret = daikin[19] & 0x0F;
-  ret = ret << 8;
-  ret += daikin[18];
-  return ret;
+uint16_t IRDaikinESP::getOnTime(void) {
+  return ((remote[kDaikinByteOnTimerMinsHigh] & 0x0F) << 8) +
+      remote[kDaikinByteOnTimerMinsLow];
 }
 
-bool IRDaikinESP::getOnTimerEnabled() {
-  return getBit(kDaikinByteOnTimer, kDaikinBitOnTimer);
+bool IRDaikinESP::getOnTimerEnabled(void) {
+  return remote[kDaikinByteOnTimer] & kDaikinBitOnTimer;
 }
 
 // endtime: Number of minutes after midnight.
-void IRDaikinESP::enableOffTimer(uint16_t endtime) {
-  setBit(kDaikinByteOffTimer, kDaikinBitOffTimer);
-  daikin[20] = (uint8_t)((endtime >> 4) & 0xFF);
-  daikin[19] &= 0x0F;
-  daikin[19] |= (uint8_t)((endtime & 0x000F) << 4);
+void IRDaikinESP::enableOffTimer(const uint16_t endtime) {
+  remote[kDaikinByteOffTimer] |= kDaikinBitOffTimer;
+  remote[kDaikinByteOffTimerMinsHigh] = endtime >> 4;
+  remote[kDaikinByteOffTimerMinsLow] &= 0x0F;
+  remote[kDaikinByteOffTimerMinsLow] |= ((endtime & 0x0F) << 4);
 }
 
-void IRDaikinESP::disableOffTimer() {
-  enableOffTimer(kDaikinUnusedTime);
-  clearBit(kDaikinByteOffTimer, kDaikinBitOffTimer);
+void IRDaikinESP::disableOffTimer(void) {
+  this->enableOffTimer(kDaikinUnusedTime);
+  remote[kDaikinByteOffTimer] &= ~kDaikinBitOffTimer;
 }
 
-uint16_t IRDaikinESP::getOffTime() {
-  uint16_t ret, tmp;
-  ret = daikin[20];
-  ret <<= 4;
-  tmp = daikin[19] & 0xF0;
-  tmp >>= 4;
-  ret += tmp;
-  return ret;
+uint16_t IRDaikinESP::getOffTime(void) {
+  return (remote[kDaikinByteOffTimerMinsHigh] << 4) +
+      ((remote[kDaikinByteOffTimerMinsLow] & 0xF0) >> 4);
 }
 
-bool IRDaikinESP::getOffTimerEnabled() {
-  return getBit(kDaikinByteOffTimer, kDaikinBitOffTimer);
+bool IRDaikinESP::getOffTimerEnabled(void) {
+  return remote[kDaikinByteOffTimer] & kDaikinBitOffTimer;
 }
 
-void IRDaikinESP::setCurrentTime(uint16_t numMins) {
-  if (numMins > 24 * 60) numMins = 0;  // If > 23:59, set to 00:00
-  daikin[5] = (uint8_t)(numMins & 0x00FF);
+void IRDaikinESP::setCurrentTime(const uint16_t mins_since_midnight) {
+  uint16_t mins = mins_since_midnight;
+  if (mins > 24 * 60) mins = 0;  // If > 23:59, set to 00:00
+  remote[kDaikinByteClockMinsLow] = mins;
   // only keep 4 bits
-  daikin[6] &= 0xF0;
-  daikin[6] |= (uint8_t)((numMins >> 8) & 0x0F);
+  remote[kDaikinByteClockMinsHigh] &= 0xF0;
+  remote[kDaikinByteClockMinsHigh] |= ((mins >> 8) & 0x0F);
 }
 
-uint16_t IRDaikinESP::getCurrentTime() {
-  uint16_t ret;
-  ret = daikin[6] & 0x0F;
-  ret <<= 8;
-  ret += daikin[5];
-  return ret;
+uint16_t IRDaikinESP::getCurrentTime(void) {
+  return ((remote[kDaikinByteClockMinsHigh] & 0x0F) << 8) +
+      remote[kDaikinByteClockMinsLow];
 }
 
 #ifdef ARDUINO
-String IRDaikinESP::renderTime(uint16_t timemins) {
+String IRDaikinESP::renderTime(const uint16_t timemins) {
   String ret;
 #else   // ARDUINO
-std::string IRDaikinESP::renderTime(uint16_t timemins) {
+std::string IRDaikinESP::renderTime(const uint16_t timemins) {
   std::string ret;
 #endif  // ARDUINO
-  uint16_t hours, mins;
-  hours = timemins / 60;
-  ret = uint64ToString(hours) + ':';
-  mins = timemins - (hours * 60);
+  ret = uint64ToString(timemins / 60) + ':';
+  uint8_t mins = timemins % 60;
   if (mins < 10) ret += '0';
   ret += uint64ToString(mins);
   return ret;
@@ -419,20 +420,17 @@ std::string IRDaikinESP::renderTime(uint16_t timemins) {
 
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRDaikinESP::toString() {
+String IRDaikinESP::toString(void) {
   String result = "";
 #else   // ARDUINO
-std::string IRDaikinESP::toString() {
+std::string IRDaikinESP::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getPower() ? F("On") : F("Off");
   result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
+  result += uint64ToString(this->getMode());
+  switch (this->getMode()) {
     case kDaikinAuto:
       result += F(" (AUTO)");
       break;
@@ -452,10 +450,10 @@ std::string IRDaikinESP::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Temp: ");
-  result += uint64ToString(getTemp());
+  result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
-  result += uint64ToString(getFan());
-  switch (getFan()) {
+  result += uint64ToString(this->getFan());
+  switch (this->getFan()) {
     case kDaikinFanAuto:
       result += F(" (AUTO)");
       break;
@@ -470,138 +468,34 @@ std::string IRDaikinESP::toString() {
       break;
   }
   result += F(", Powerful: ");
-  if (getPowerful())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getPowerful() ? F("On") : F("Off");
   result += F(", Quiet: ");
-  if (getQuiet())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getQuiet() ? F("On") : F("Off");
   result += F(", Sensor: ");
-  if (getSensor())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getSensor() ? F("On") : F("Off");
   result += F(", Eye: ");
-  if (getEye())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getEye() ? F("On") : F("Off");
   result += F(", Mold: ");
-  if (getMold())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getMold() ? F("On") : F("Off");
+  result += F(", Comfort: ");
+  result += this->getComfort() ? F("On") : F("Off");
   result += F(", Swing (Horizontal): ");
-  if (getSwingHorizontal())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getSwingHorizontal() ? F("On") : F("Off");
   result += F(", Swing (Vertical): ");
-  if (getSwingVertical())
-    result += F("On");
-  else
-  result += F("Off");
+  result += this->getSwingVertical() ? F("On") : F("Off");
   result += F(", Current Time: ");
-  result += renderTime(getCurrentTime());
+  result += this->renderTime(this->getCurrentTime());
   result += F(", On Time: ");
-  if (getOnTimerEnabled())
-    result += renderTime(getOnTime());
+  if (this->getOnTimerEnabled())
+    result += this->renderTime(this->getOnTime());
   else
     result += F("Off");
   result += F(", Off Time: ");
-  if (getOffTimerEnabled())
-    result += renderTime(getOffTime());
+  if (this->getOffTimerEnabled())
+    result += this->renderTime(this->getOffTime());
   else
     result += F("Off");
-
   return result;
-}
-
-#if DAIKIN_DEBUG
-// Print what we have
-void IRDaikinESP::printState() {
-#ifdef ARDUINO
-  String strbits;
-#else   // ARDUINO
-  std::string strbits;
-#endif  // ARDUINO
-  DPRINTLN("Raw Bits:");
-  for (uint8_t i = 0; i < kDaikinStateLength; i++) {
-    strbits = uint64ToString(daikin[i], BIN);
-    while (strbits.length() < 8) strbits = '0' + strbits;
-    DPRINT(strbits);
-    DPRINT(" ");
-  }
-  DPRINTLN("");
-  DPRINTLN(toString());
-}
-#endif  // DAIKIN_DEBUG
-
-/*
- * Return most important bits to allow replay
- * layout is:
- *      0:      Power
- *      1-3:    Mode
- *      4-7:    Fan speed/mode
- *      8-14:   Target Temperature
- *      15:     Econo
- *      16:     Powerful
- *      17:     Quiet
- *      18:     Sensor
- *      19:     Swing Vertical
- *      20-31:  Current time (mins since midnight)
- * */
-uint32_t IRDaikinESP::getCommand() {
-  uint32_t ret = 0;
-  uint32_t tmp = 0;
-  if (getPower()) ret |= 0b00000000000000000000000000000001;
-  tmp = getMode();
-  tmp = tmp << 1;
-  ret |= tmp;
-
-  tmp = getFan();
-  tmp <<= 4;
-  ret |= tmp;
-
-  tmp = getTemp();
-  tmp <<= 8;
-  ret |= tmp;
-
-  if (getEcono()) ret |= 0b00000000000000001000000000000000;
-  if (getPowerful()) ret |= 0b00000000000000010000000000000000;
-  if (getQuiet()) ret |= 0b00000000000000100000000000000000;
-  if (getSensor()) ret |= 0b00000000000001000000000000000000;
-  if (getSwingVertical()) ret |= 0b00000000000010000000000000000000;
-  ret |= (getCurrentTime() << 20);
-  return ret;
-}
-
-void IRDaikinESP::setCommand(uint32_t value) {
-  uint32_t tmp = 0;
-  if (value & 0b00000000000000000000000000000001) setPower(true);
-  tmp = value & 0b00000000000000000000000000001110;
-  tmp >>= 1;
-  setMode(tmp);
-
-  tmp = value & 0b00000000000000000000000011110000;
-  tmp >>= 4;
-  setFan(tmp);
-
-  tmp = value & 0b00000000000000000111111100000000;
-  tmp >>= 8;
-  setTemp(tmp);
-
-  if (value & 0b00000000000000001000000000000000) setEcono(true);
-  if (value & 0b00000000000000010000000000000000) setPowerful(true);
-  if (value & 0b00000000000000100000000000000000) setQuiet(true);
-  if (value & 0b00000000000001000000000000000000) setSensor(true);
-  if (value & 0b00000000000010000000000000000000) setSwingVertical(true);
-
-  value >>= 20;
-  setCurrentTime(value);
 }
 
 // Convert a standard A/C mode into its native mode.
@@ -621,7 +515,7 @@ uint8_t IRDaikinESP::convertMode(const stdAc::opmode_t mode) {
 }
 
 // Convert a standard A/C Fan speed into its native fan speed.
-uint8_t IRDaikinESP::convertFan(stdAc::fanspeed_t speed) {
+uint8_t IRDaikinESP::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
       return kDaikinFanQuiet;
@@ -639,112 +533,73 @@ uint8_t IRDaikinESP::convertFan(stdAc::fanspeed_t speed) {
 }
 
 #if DECODE_DAIKIN
-void addbit(bool val, unsigned char data[]) {
-  uint8_t curbit = data[kDaikinCurBit];
-  uint8_t curindex = data[kDaikinCurIndex];
-  if (val) {
-    unsigned char bit = 1;
-    bit = bit << curbit;
-    data[curindex] |= bit;
-  }
-  curbit++;
-  if (curbit == 8) {
-    curbit = 0;
-    curindex++;
-  }
-  data[kDaikinCurBit] = curbit;
-  data[kDaikinCurIndex] = curindex;
-}
-
-bool checkheader(decode_results *results, uint16_t *offset) {
-  if (!IRrecv::matchMark(results->rawbuf[(*offset)++], kDaikinBitMark,
-                         kDaikinTolerance, kDaikinMarkExcess))
-    return false;
-  if (!IRrecv::matchSpace(results->rawbuf[(*offset)++],
-                          kDaikinZeroSpace + kDaikinGap, kDaikinTolerance,
-                          kDaikinMarkExcess))
-    return false;
-  if (!IRrecv::matchMark(results->rawbuf[(*offset)++], kDaikinHdrMark,
-                         kDaikinTolerance, kDaikinMarkExcess))
-    return false;
-  if (!IRrecv::matchSpace(results->rawbuf[(*offset)++], kDaikinHdrSpace,
-                          kDaikinTolerance, kDaikinMarkExcess))
-    return false;
-
-  return true;
-}
-
-bool readbits(decode_results *results, uint16_t *offset,
-              unsigned char daikin_code[], uint16_t countbits) {
-  for (uint16_t i = 0; i < countbits && *offset < results->rawlen - 1;
-       i++, (*offset)++) {
-    if (!IRrecv::matchMark(results->rawbuf[(*offset)++], kDaikinBitMark,
-                           kDaikinTolerance, kDaikinMarkExcess))
-      return false;
-    if (IRrecv::matchSpace(results->rawbuf[*offset], kDaikinOneSpace,
-                           kDaikinTolerance, kDaikinMarkExcess))
-      addbit(1, daikin_code);
-    else if (IRrecv::matchSpace(results->rawbuf[*offset], kDaikinZeroSpace,
-                                kDaikinTolerance, kDaikinMarkExcess))
-      addbit(0, daikin_code);
-    else
-      return false;
-  }
-  return true;
-}
-
 // Decode the supplied Daikin A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
-//   nbits:   Nr. of bits to expect in the data portion. (kDaikinRawBits)
+//   nbits:   Nr. of bits to expect in the data portion. (kDaikinBits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: BETA / Should be working.
 //
-// Notes:
-//   If DAIKIN_DEBUG enabled, will print all the set options and values.
-//
 // Ref:
 //   https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
-bool IRrecv::decodeDaikin(decode_results *results, uint16_t nbits,
-                          bool strict) {
-  if (results->rawlen < kDaikinRawBits) return false;
+bool IRrecv::decodeDaikin(decode_results *results, const uint16_t nbits,
+                          const bool strict) {
+  // Is there enough data to match successfully?
+  if (results->rawlen < (2 * (nbits + kDaikinHeaderLength) +
+                         kDaikinSections * (kHeader + kFooter) + kFooter - 1))
+    return false;
 
   // Compliance
-  if (strict && nbits != kDaikinRawBits) return false;
+  if (strict && nbits != kDaikinBits) return false;
 
   uint16_t offset = kStartOffset;
-  unsigned char daikin_code[kDaikinStateLength + 2];
-  for (uint8_t i = 0; i < kDaikinStateLength + 2; i++) daikin_code[i] = 0;
+  match_result_t data_result;
+  uint16_t dataBitsSoFar = 0;
+  uint16_t i = 0;
 
-  // Header (#1)
-  for (uint8_t i = 0; i < 10; i++) {
-    if (!matchMark(results->rawbuf[offset++], kDaikinBitMark)) return false;
+  // Header #1 - Doesn't count as data.
+  data_result = matchData(&(results->rawbuf[offset]), kDaikinHeaderLength,
+                          kDaikinBitMark, kDaikinOneSpace,
+                          kDaikinBitMark, kDaikinZeroSpace,
+                          kDaikinTolerance, kDaikinMarkExcess, false);
+  offset += data_result.used;
+  if (data_result.success == false) return false;  // Fail
+  if (data_result.data) return false;  // The header bits should be zero.
+
+  // Read the Data sections.
+  // Keep reading bytes until we either run out of section or state to fill.
+  const uint8_t kSectionSize[kDaikinSections] = {
+      kDaikinSection1Length, kDaikinSection2Length, kDaikinSection3Length};
+  for (uint8_t section = 0, pos = 0; section < kDaikinSections;
+       section++) {
+    pos += kSectionSize[section];
+    // Section Footer
+    if (!matchMark(results->rawbuf[offset++], kDaikinBitMark,
+                   kDaikinTolerance, kDaikinMarkExcess)) return false;
+    if (!matchSpace(results->rawbuf[offset++], kDaikinZeroSpace + kDaikinGap,
+                    kDaikinTolerance, kDaikinMarkExcess)) return false;
+    // Section Header
+    if (!matchMark(results->rawbuf[offset++], kDaikinHdrMark,
+                  kDaikinTolerance, kDaikinMarkExcess)) return false;
+    if (!matchSpace(results->rawbuf[offset++], kDaikinHdrSpace,
+                   kDaikinTolerance, kDaikinMarkExcess)) return false;
+
+    // Section Data
+    for (; offset <= results->rawlen - 16 && i < pos;
+         i++, dataBitsSoFar += 8, offset += data_result.used) {
+      // Read in a byte at a time.
+      data_result =
+          matchData(&(results->rawbuf[offset]), 8,
+                    kDaikinBitMark, kDaikinOneSpace,
+                    kDaikinBitMark, kDaikinZeroSpace,
+                    kDaikinTolerance, kDaikinMarkExcess, false);
+      if (data_result.success == false) break;  // Fail
+      results->state[i] = (uint8_t)data_result.data;
+    }
   }
-  if (!checkheader(results, &offset)) return false;
-
-  // Data (#1)
-  if (!readbits(results, &offset, daikin_code, 8 * 8)) return false;
-
-  // Ignore everything that has just been captured as it is not needed.
-  // Some remotes may not send this portion, my remote did, but it's not
-  // required.
-  for (uint8_t i = 0; i < kDaikinStateLength + 2; i++) daikin_code[i] = 0;
-
-  // Header (#2)
-  if (!checkheader(results, &offset)) return false;
-
-  // Data (#2)
-  if (!readbits(results, &offset, daikin_code, 8 * 8)) return false;
-
-  // Header (#3)
-  if (!checkheader(results, &offset)) return false;
-
-  // Data (#3), read up everything else
-  if (!readbits(results, &offset, daikin_code, kDaikinBits - (8 * 8)))
-    return false;
 
   // Footer
   if (!matchMark(results->rawbuf[offset++], kDaikinBitMark)) return false;
@@ -754,24 +609,18 @@ bool IRrecv::decodeDaikin(decode_results *results, uint16_t nbits,
 
   // Compliance
   if (strict) {
-    if (!IRDaikinESP::validChecksum(daikin_code)) return false;
+    // Re-check we got the correct size/length due to the way we read the data.
+    if (dataBitsSoFar != kDaikinBits) return false;
+    // Validate the checksum.
+    if (!IRDaikinESP::validChecksum(results->state)) return false;
   }
 
   // Success
-#if DAIKIN_DEBUG
-  IRDaikinESP dako = IRDaikinESP(0);
-  dako.setRaw(daikin_code);
-#ifdef ARDUINO
-  yield();
-#endif  // ARDUINO
-  dako.printState();
-#endif  // DAIKIN_DEBUG
-
-  // Copy across the bits to state
-  for (uint8_t i = 0; i < kDaikinStateLength; i++)
-    results->state[i] = daikin_code[i];
-  results->bits = kDaikinStateLength * 8;
   results->decode_type = DAIKIN;
+  results->bits = dataBitsSoFar;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
   return true;
 }
 #endif  // DECODE_DAIKIN

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -83,8 +83,9 @@ TEST(TestIRac, Daikin) {
   IRac irac(0);
   char expected[] =
       "Power: On, Mode: 3 (COOL), Temp: 19C, Fan: 2, Powerful: Off, "
-      "Quiet: Off, Sensor: Off, Eye: Off, Mold: On, Swing (Horizontal): Off, "
-      "Swing (Vertical): Off, Current Time: 0:00, On Time: Off, Off Time: Off";
+      "Quiet: Off, Sensor: Off, Eye: Off, Mold: On, Comfort: Off, "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, "
+      "Current Time: 0:00, On Time: Off, Off Time: Off";
 
   ac.begin();
   irac.daikin(&ac,

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -10,10 +10,11 @@
 
 // Test sending typical data only.
 TEST(TestSendDaikin, SendDataOnly) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(0);
   irsend.begin();
 
   uint8_t daikin_code[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
       0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00, 0xB0, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
@@ -22,7 +23,8 @@ TEST(TestSendDaikin, SendDataOnly) {
   irsend.sendDaikin(daikin_code);
   EXPECT_EQ(
       "m428s428m428s428m428s428m428s428m428s428"
-      "m428s29428m3650s1623"
+      "m428s29428"
+      "m3650s1623"
       "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
       "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
       "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
@@ -31,7 +33,8 @@ TEST(TestSendDaikin, SendDataOnly) {
       "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
       "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
       "m428s1280m428s1280m428s1280m428s428m428s1280m428s428m428s1280m428s1280"
-      "m428s29428m3650s1623"
+      "m428s29428"
+      "m3650s1623"
       "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
       "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
       "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
@@ -40,7 +43,8 @@ TEST(TestSendDaikin, SendDataOnly) {
       "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
       "m428s428m428s428m428s428m428s428m428s428m428s428m428s428m428s428"
       "m428s428m428s428m428s428m428s428m428s428m428s1280m428s428m428s428"
-      "m428s29428m3650s1623"
+      "m428s29428"
+      "m3650s1623"
       "m428s1280m428s428m428s428m428s428m428s1280m428s428m428s428m428s428"
       "m428s428m428s1280m428s428m428s1280m428s1280m428s428m428s1280m428s1280"
       "m428s1280m428s1280m428s1280m428s428m428s428m428s1280m428s428m428s428"
@@ -66,17 +70,17 @@ TEST(TestSendDaikin, SendDataOnly) {
 
 // Test sending with repeats.
 TEST(TestSendDaikin, SendWithRepeats) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(0);
   irsend.begin();
 
   irsend.reset();
-  uint8_t daikin_code[kDaikinStateLength] = {
+  uint8_t daikin_code[kDaikinStateLengthShort] = {
       0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00, 0xB0, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3};
   irsend.reset();
 
-  irsend.sendDaikin(daikin_code, kDaikinStateLength, 1);
+  irsend.sendDaikin(daikin_code, kDaikinStateLengthShort, 1);
   EXPECT_EQ(
       "m428s428m428s428m428s428m428s428m428s428"
       "m428s29428m3650s1623"
@@ -166,21 +170,21 @@ TEST(TestSendDaikin, SendUnexpectedSizes) {
   IRsendTest irsend(4);
   irsend.begin();
 
-  uint8_t daikin_short_code[kDaikinStateLength - 1] = {
+  uint8_t daikin_short_code[kDaikinStateLengthShort - 1] = {
       0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00, 0xB0, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00};
 
   irsend.reset();
-  irsend.sendDaikin(daikin_short_code, kDaikinStateLength - 1);
+  irsend.sendDaikin(daikin_short_code, kDaikinStateLengthShort - 1);
   ASSERT_EQ("", irsend.outputStr());
 
-  uint8_t daikin_long_code[kDaikinStateLength + 1] = {
+  uint8_t daikin_long_code[kDaikinStateLengthShort + 1] = {
       0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x20, 0x11, 0xDA,
       0x27, 0x00, 0x00, 0x41, 0x1E, 0x00, 0xB0, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE3, 0x11};
   irsend.reset();
-  irsend.sendDaikin(daikin_long_code, kDaikinStateLength + 1);
+  irsend.sendDaikin(daikin_long_code, kDaikinStateLengthShort + 1);
   ASSERT_EQ(
       "m428s428m428s428m428s428m428s428m428s428"
       "m428s29428m3650s1623"
@@ -229,367 +233,382 @@ TEST(TestSendDaikin, SendUnexpectedSizes) {
 // Tests for IRDaikinESP class.
 
 TEST(TestDaikinClass, Power) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.on();
-  EXPECT_TRUE(irdaikin.getPower());
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
 
-  irdaikin.off();
-  EXPECT_FALSE(irdaikin.getPower());
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
 
-  irdaikin.setPower(true);
-  EXPECT_TRUE(irdaikin.getPower());
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
 
-  irdaikin.setPower(false);
-  EXPECT_FALSE(irdaikin.getPower());
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
 }
 
 TEST(TestDaikinClass, Temperature) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setTemp(0);
-  EXPECT_EQ(kDaikinMinTemp, irdaikin.getTemp());
+  ac.setTemp(0);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
-  irdaikin.setTemp(255);
-  EXPECT_EQ(kDaikinMaxTemp, irdaikin.getTemp());
+  ac.setTemp(255);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  irdaikin.setTemp(kDaikinMinTemp);
-  EXPECT_EQ(kDaikinMinTemp, irdaikin.getTemp());
+  ac.setTemp(kDaikinMinTemp);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
-  irdaikin.setTemp(kDaikinMaxTemp);
-  EXPECT_EQ(kDaikinMaxTemp, irdaikin.getTemp());
+  ac.setTemp(kDaikinMaxTemp);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  irdaikin.setTemp(kDaikinMinTemp - 1);
-  EXPECT_EQ(kDaikinMinTemp, irdaikin.getTemp());
+  ac.setTemp(kDaikinMinTemp - 1);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
 
-  irdaikin.setTemp(kDaikinMaxTemp + 1);
-  EXPECT_EQ(kDaikinMaxTemp, irdaikin.getTemp());
+  ac.setTemp(kDaikinMaxTemp + 1);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
 
-  irdaikin.setTemp(kDaikinMinTemp + 1);
-  EXPECT_EQ(kDaikinMinTemp + 1, irdaikin.getTemp());
+  ac.setTemp(kDaikinMinTemp + 1);
+  EXPECT_EQ(kDaikinMinTemp + 1, ac.getTemp());
 
-  irdaikin.setTemp(21);
-  EXPECT_EQ(21, irdaikin.getTemp());
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
 
-  irdaikin.setTemp(25);
-  EXPECT_EQ(25, irdaikin.getTemp());
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
 
-  irdaikin.setTemp(29);
-  EXPECT_EQ(29, irdaikin.getTemp());
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
 }
 
 TEST(TestDaikinClass, OperatingMode) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setMode(kDaikinAuto);
-  EXPECT_EQ(kDaikinAuto, irdaikin.getMode());
+  ac.setMode(kDaikinAuto);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
 
-  irdaikin.setMode(kDaikinCool);
-  EXPECT_EQ(kDaikinCool, irdaikin.getMode());
+  ac.setMode(kDaikinCool);
+  EXPECT_EQ(kDaikinCool, ac.getMode());
 
-  irdaikin.setMode(kDaikinHeat);
-  EXPECT_EQ(kDaikinHeat, irdaikin.getMode());
+  ac.setMode(kDaikinHeat);
+  EXPECT_EQ(kDaikinHeat, ac.getMode());
 
-  irdaikin.setMode(kDaikinDry);
-  EXPECT_EQ(kDaikinDry, irdaikin.getMode());
+  ac.setMode(kDaikinDry);
+  EXPECT_EQ(kDaikinDry, ac.getMode());
 
-  irdaikin.setMode(kDaikinFan);
-  EXPECT_EQ(kDaikinFan, irdaikin.getMode());
+  ac.setMode(kDaikinFan);
+  EXPECT_EQ(kDaikinFan, ac.getMode());
 
-  irdaikin.setMode(kDaikinFan + 1);
-  EXPECT_EQ(kDaikinAuto, irdaikin.getMode());
+  ac.setMode(kDaikinFan + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
 
-  irdaikin.setMode(kDaikinAuto + 1);
-  EXPECT_EQ(kDaikinAuto, irdaikin.getMode());
+  ac.setMode(kDaikinAuto + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
 
-  irdaikin.setMode(255);
-  EXPECT_EQ(kDaikinAuto, irdaikin.getMode());
+  ac.setMode(255);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
 }
 
 TEST(TestDaikinClass, VaneSwing) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setSwingHorizontal(true);
-  irdaikin.setSwingVertical(false);
+  ac.setSwingHorizontal(true);
+  ac.setSwingVertical(false);
 
-  irdaikin.setSwingHorizontal(true);
-  EXPECT_TRUE(irdaikin.getSwingHorizontal());
-  EXPECT_FALSE(irdaikin.getSwingVertical());
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  EXPECT_FALSE(ac.getSwingVertical());
 
-  irdaikin.setSwingVertical(true);
-  EXPECT_TRUE(irdaikin.getSwingHorizontal());
-  EXPECT_TRUE(irdaikin.getSwingVertical());
+  ac.setSwingVertical(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  EXPECT_TRUE(ac.getSwingVertical());
 
-  irdaikin.setSwingHorizontal(false);
-  EXPECT_FALSE(irdaikin.getSwingHorizontal());
-  EXPECT_TRUE(irdaikin.getSwingVertical());
+  ac.setSwingHorizontal(false);
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  EXPECT_TRUE(ac.getSwingVertical());
 
-  irdaikin.setSwingVertical(false);
-  EXPECT_FALSE(irdaikin.getSwingHorizontal());
-  EXPECT_FALSE(irdaikin.getSwingVertical());
+  ac.setSwingVertical(false);
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  EXPECT_FALSE(ac.getSwingVertical());
 }
 
 TEST(TestDaikinClass, QuietMode) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setQuiet(true);
-  EXPECT_TRUE(irdaikin.getQuiet());
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
 
-  irdaikin.setQuiet(false);
-  EXPECT_FALSE(irdaikin.getQuiet());
+  ac.setQuiet(false);
+  EXPECT_FALSE(ac.getQuiet());
 
-  irdaikin.setQuiet(true);
-  EXPECT_TRUE(irdaikin.getQuiet());
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
 
   // Setting Econo mode should NOT change out of quiet mode.
-  irdaikin.setEcono(true);
-  EXPECT_TRUE(irdaikin.getQuiet());
-  irdaikin.setEcono(false);
-  EXPECT_TRUE(irdaikin.getQuiet());
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getQuiet());
+  ac.setEcono(false);
+  EXPECT_TRUE(ac.getQuiet());
 
   // But setting Powerful mode should exit out of quiet mode.
-  irdaikin.setPowerful(true);
-  EXPECT_FALSE(irdaikin.getQuiet());
+  ac.setPowerful(true);
+  EXPECT_FALSE(ac.getQuiet());
 }
 
 TEST(TestDaikinClass, PowerfulMode) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setPowerful(true);
-  EXPECT_TRUE(irdaikin.getPowerful());
+  ac.setPowerful(true);
+  EXPECT_TRUE(ac.getPowerful());
 
-  irdaikin.setPowerful(false);
-  EXPECT_FALSE(irdaikin.getPowerful());
+  ac.setPowerful(false);
+  EXPECT_FALSE(ac.getPowerful());
 
-  irdaikin.setPowerful(true);
-  EXPECT_TRUE(irdaikin.getPowerful());
+  ac.setPowerful(true);
+  EXPECT_TRUE(ac.getPowerful());
 
-  irdaikin.setQuiet(true);
-  EXPECT_FALSE(irdaikin.getPowerful());
+  ac.setQuiet(true);
+  EXPECT_FALSE(ac.getPowerful());
 
-  irdaikin.setPowerful(true);
-  irdaikin.setEcono(true);
-  EXPECT_FALSE(irdaikin.getPowerful());
+  ac.setPowerful(true);
+  ac.setEcono(true);
+  EXPECT_FALSE(ac.getPowerful());
 }
 
 TEST(TestDaikinClass, EconoMode) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setEcono(true);
-  EXPECT_TRUE(irdaikin.getEcono());
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
 
-  irdaikin.setEcono(false);
-  EXPECT_FALSE(irdaikin.getEcono());
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
 
-  irdaikin.setEcono(true);
-  EXPECT_TRUE(irdaikin.getEcono());
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
 
   // Setting Quiet mode should NOT change out of Econo mode.
-  irdaikin.setQuiet(true);
-  EXPECT_TRUE(irdaikin.getEcono());
-  irdaikin.setQuiet(false);
-  EXPECT_TRUE(irdaikin.getEcono());
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getEcono());
+  ac.setQuiet(false);
+  EXPECT_TRUE(ac.getEcono());
 
   // But setting Powerful mode should exit out of Econo mode.
-  irdaikin.setPowerful(true);
-  EXPECT_FALSE(irdaikin.getEcono());
+  ac.setPowerful(true);
+  EXPECT_FALSE(ac.getEcono());
 }
 
 TEST(TestDaikinClass, FanSpeed) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
   // Unexpected value should default to Auto.
-  irdaikin.setFan(0);
-  EXPECT_EQ(kDaikinFanAuto, irdaikin.getFan());
+  ac.setFan(0);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
 
   // Unexpected value should default to Auto.
-  irdaikin.setFan(255);
-  EXPECT_EQ(kDaikinFanAuto, irdaikin.getFan());
+  ac.setFan(255);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanMax);
-  EXPECT_EQ(kDaikinFanMax, irdaikin.getFan());
+  ac.setFan(kDaikinFanMax);
+  EXPECT_EQ(kDaikinFanMax, ac.getFan());
 
   // Beyond Max should default to Auto.
-  irdaikin.setFan(kDaikinFanMax + 1);
-  EXPECT_EQ(kDaikinFanAuto, irdaikin.getFan());
+  ac.setFan(kDaikinFanMax + 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanMax - 1);
-  EXPECT_EQ(kDaikinFanMax - 1, irdaikin.getFan());
+  ac.setFan(kDaikinFanMax - 1);
+  EXPECT_EQ(kDaikinFanMax - 1, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanMin);
-  EXPECT_EQ(kDaikinFanMin, irdaikin.getFan());
+  ac.setFan(kDaikinFanMin);
+  EXPECT_EQ(kDaikinFanMin, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanMin + 1);
-  EXPECT_EQ(kDaikinFanMin + 1, irdaikin.getFan());
+  ac.setFan(kDaikinFanMin + 1);
+  EXPECT_EQ(kDaikinFanMin + 1, ac.getFan());
 
   // Beyond Min should default to Auto.
-  irdaikin.setFan(kDaikinFanMin - 1);
-  EXPECT_EQ(kDaikinFanAuto, irdaikin.getFan());
+  ac.setFan(kDaikinFanMin - 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
 
-  irdaikin.setFan(3);
-  EXPECT_EQ(3, irdaikin.getFan());
+  ac.setFan(3);
+  EXPECT_EQ(3, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanAuto);
-  EXPECT_EQ(kDaikinFanAuto, irdaikin.getFan());
+  ac.setFan(kDaikinFanAuto);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
 
-  irdaikin.setFan(kDaikinFanQuiet);
-  EXPECT_EQ(kDaikinFanQuiet, irdaikin.getFan());
+  ac.setFan(kDaikinFanQuiet);
+  EXPECT_EQ(kDaikinFanQuiet, ac.getFan());
 }
 
 TEST(TestDaikinClass, CurrentTime) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setCurrentTime(0);  // 00:00
-  EXPECT_EQ(0, irdaikin.getCurrentTime());
+  ac.setCurrentTime(0);  // 00:00
+  EXPECT_EQ(0, ac.getCurrentTime());
 
-  irdaikin.setCurrentTime(754);  // 12:34
-  EXPECT_EQ(754, irdaikin.getCurrentTime());
+  ac.setCurrentTime(754);  // 12:34
+  EXPECT_EQ(754, ac.getCurrentTime());
 
-  irdaikin.setCurrentTime(1439);  // 23:59
-  EXPECT_EQ(1439, irdaikin.getCurrentTime());
+  ac.setCurrentTime(1439);  // 23:59
+  EXPECT_EQ(1439, ac.getCurrentTime());
 }
 
 TEST(TestDaikinClass, OnOffTimers) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
   // Both timers turned off.
-  irdaikin.disableOnTimer();
-  irdaikin.disableOffTimer();
-  EXPECT_FALSE(irdaikin.getOnTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOnTime());
-  EXPECT_FALSE(irdaikin.getOffTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOffTime());
+  ac.disableOnTimer();
+  ac.disableOffTimer();
+  EXPECT_FALSE(ac.getOnTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOnTime());
+  EXPECT_FALSE(ac.getOffTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOffTime());
 
   // Turn on just the On Timer.
-  irdaikin.enableOnTimer(123);
-  EXPECT_TRUE(irdaikin.getOnTimerEnabled());
-  EXPECT_EQ(123, irdaikin.getOnTime());
-  EXPECT_FALSE(irdaikin.getOffTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOffTime());
+  ac.enableOnTimer(123);
+  EXPECT_TRUE(ac.getOnTimerEnabled());
+  EXPECT_EQ(123, ac.getOnTime());
+  EXPECT_FALSE(ac.getOffTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOffTime());
 
   // Now turn on the Off Timer.
-  irdaikin.enableOffTimer(754);
-  EXPECT_TRUE(irdaikin.getOffTimerEnabled());
-  EXPECT_EQ(754, irdaikin.getOffTime());
-  EXPECT_TRUE(irdaikin.getOnTimerEnabled());
-  EXPECT_EQ(123, irdaikin.getOnTime());
+  ac.enableOffTimer(754);
+  EXPECT_TRUE(ac.getOffTimerEnabled());
+  EXPECT_EQ(754, ac.getOffTime());
+  EXPECT_TRUE(ac.getOnTimerEnabled());
+  EXPECT_EQ(123, ac.getOnTime());
 
   // Turn off the just the On Timer.
-  irdaikin.disableOnTimer();
-  EXPECT_FALSE(irdaikin.getOnTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOnTime());
-  EXPECT_TRUE(irdaikin.getOffTimerEnabled());
-  EXPECT_EQ(754, irdaikin.getOffTime());
+  ac.disableOnTimer();
+  EXPECT_FALSE(ac.getOnTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOnTime());
+  EXPECT_TRUE(ac.getOffTimerEnabled());
+  EXPECT_EQ(754, ac.getOffTime());
 
   // Now turn off the Off Timer.
-  irdaikin.disableOffTimer();
-  EXPECT_FALSE(irdaikin.getOffTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOffTime());
-  EXPECT_FALSE(irdaikin.getOnTimerEnabled());
-  EXPECT_EQ(kDaikinUnusedTime, irdaikin.getOnTime());
+  ac.disableOffTimer();
+  EXPECT_FALSE(ac.getOffTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOffTime());
+  EXPECT_FALSE(ac.getOnTimerEnabled());
+  EXPECT_EQ(kDaikinUnusedTime, ac.getOnTime());
 
   // Use some canary values around the timers to ensure no accidental
   // bit flips happen. i.e. Neighbouring bytes in the state.
   // (Found some during testing on systems with different endian-ness)
   // Tests here to make sure it never happens again.
-  irdaikin.setSwingHorizontal(true);
-  irdaikin.setPowerful(true);
-  irdaikin.disableOffTimer();
-  irdaikin.disableOnTimer();
-  ASSERT_TRUE(irdaikin.getSwingHorizontal());
-  ASSERT_TRUE(irdaikin.getPowerful());
-  irdaikin.enableOnTimer(123);
-  irdaikin.enableOffTimer(456);
-  ASSERT_TRUE(irdaikin.getSwingHorizontal());
-  ASSERT_TRUE(irdaikin.getPowerful());
-  irdaikin.disableOffTimer();
-  irdaikin.disableOnTimer();
-  ASSERT_TRUE(irdaikin.getSwingHorizontal());
-  ASSERT_TRUE(irdaikin.getPowerful());
+  ac.setSwingHorizontal(true);
+  ac.setPowerful(true);
+  ac.disableOffTimer();
+  ac.disableOnTimer();
+  ASSERT_TRUE(ac.getSwingHorizontal());
+  ASSERT_TRUE(ac.getPowerful());
+  ac.enableOnTimer(123);
+  ac.enableOffTimer(456);
+  ASSERT_TRUE(ac.getSwingHorizontal());
+  ASSERT_TRUE(ac.getPowerful());
+  ac.disableOffTimer();
+  ac.disableOnTimer();
+  ASSERT_TRUE(ac.getSwingHorizontal());
+  ASSERT_TRUE(ac.getPowerful());
 
-  irdaikin.setSwingHorizontal(false);
-  irdaikin.setPowerful(false);
-  irdaikin.disableOffTimer();
-  irdaikin.disableOnTimer();
-  ASSERT_FALSE(irdaikin.getSwingHorizontal());
-  ASSERT_FALSE(irdaikin.getPowerful());
-  irdaikin.enableOnTimer(123);
-  irdaikin.enableOffTimer(456);
-  ASSERT_FALSE(irdaikin.getSwingHorizontal());
-  ASSERT_FALSE(irdaikin.getPowerful());
-  irdaikin.disableOffTimer();
-  irdaikin.disableOnTimer();
-  ASSERT_FALSE(irdaikin.getSwingHorizontal());
-  ASSERT_FALSE(irdaikin.getPowerful());
+  ac.setSwingHorizontal(false);
+  ac.setPowerful(false);
+  ac.disableOffTimer();
+  ac.disableOnTimer();
+  ASSERT_FALSE(ac.getSwingHorizontal());
+  ASSERT_FALSE(ac.getPowerful());
+  ac.enableOnTimer(123);
+  ac.enableOffTimer(456);
+  ASSERT_FALSE(ac.getSwingHorizontal());
+  ASSERT_FALSE(ac.getPowerful());
+  ac.disableOffTimer();
+  ac.disableOnTimer();
+  ASSERT_FALSE(ac.getSwingHorizontal());
+  ASSERT_FALSE(ac.getPowerful());
 }
 
 // Test Eye mode.
 TEST(TestDaikinClass, EyeSetting) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
   // The Eye setting is stored in the same byte as Econo mode.
   // Econo mode tests are there to make sure it isn't harmed and vice-versa.
-  irdaikin.setEcono(false);
-  irdaikin.setEye(false);
-  ASSERT_FALSE(irdaikin.getEye());
-  EXPECT_FALSE(irdaikin.getEcono());
+  ac.setEcono(false);
+  ac.setEye(false);
+  ASSERT_FALSE(ac.getEye());
+  EXPECT_FALSE(ac.getEcono());
 
-  irdaikin.setEye(true);
-  ASSERT_TRUE(irdaikin.getEye());
-  EXPECT_FALSE(irdaikin.getEcono());
+  ac.setEye(true);
+  ASSERT_TRUE(ac.getEye());
+  EXPECT_FALSE(ac.getEcono());
 
-  irdaikin.setEcono(false);
-  ASSERT_TRUE(irdaikin.getEye());
-  EXPECT_FALSE(irdaikin.getEcono());
+  ac.setEcono(false);
+  ASSERT_TRUE(ac.getEye());
+  EXPECT_FALSE(ac.getEcono());
 
-  irdaikin.setEcono(true);
-  ASSERT_TRUE(irdaikin.getEye());
-  EXPECT_TRUE(irdaikin.getEcono());
+  ac.setEcono(true);
+  ASSERT_TRUE(ac.getEye());
+  EXPECT_TRUE(ac.getEcono());
 
-  irdaikin.setEye(false);
-  ASSERT_FALSE(irdaikin.getEye());
-  EXPECT_TRUE(irdaikin.getEcono());
+  ac.setEye(false);
+  ASSERT_FALSE(ac.getEye());
+  EXPECT_TRUE(ac.getEcono());
 }
 
 // Test Mold mode.
 TEST(TestDaikinClass, MoldSetting) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setMold(false);
-  ASSERT_FALSE(irdaikin.getMold());
+  ac.setMold(false);
+  ASSERT_FALSE(ac.getMold());
 
-  irdaikin.setMold(true);
-  ASSERT_TRUE(irdaikin.getMold());
+  ac.setMold(true);
+  ASSERT_TRUE(ac.getMold());
 
-  irdaikin.setMold(false);
-  ASSERT_FALSE(irdaikin.getMold());
+  ac.setMold(false);
+  ASSERT_FALSE(ac.getMold());
+}
+
+// Test Comfort mode.
+TEST(TestDaikinClass, ComfortSetting) {
+  IRDaikinESP ac(0);
+  ac.begin();
+
+  ac.setComfort(false);
+  ASSERT_FALSE(ac.getComfort());
+
+  ac.setComfort(true);
+  ASSERT_TRUE(ac.getComfort());
+
+  ac.setComfort(false);
+  ASSERT_FALSE(ac.getComfort());
 }
 
 // Test Sensor mode.
 TEST(TestDaikinClass, SensorSetting) {
-  IRDaikinESP irdaikin(0);
-  irdaikin.begin();
+  IRDaikinESP ac(0);
+  ac.begin();
 
-  irdaikin.setSensor(false);
-  ASSERT_FALSE(irdaikin.getSensor());
+  ac.setSensor(false);
+  ASSERT_FALSE(ac.getSensor());
 
-  irdaikin.setSensor(true);
-  ASSERT_TRUE(irdaikin.getSensor());
+  ac.setSensor(true);
+  ASSERT_TRUE(ac.getSensor());
 
-  irdaikin.setSensor(false);
-  ASSERT_FALSE(irdaikin.getSensor());
+  ac.setSensor(false);
+  ASSERT_FALSE(ac.getSensor());
 }
 
 TEST(TestDaikinClass, RenderTime) {
@@ -600,28 +619,37 @@ TEST(TestDaikinClass, RenderTime) {
 }
 
 TEST(TestDaikinClass, SetAndGetRaw) {
-  IRDaikinESP irdaikin(0);
-  uint8_t initialState[kDaikinStateLength] = {
+  IRDaikinESP ac(0);
+  uint8_t shortState[kDaikinStateLengthShort] = {
+      0x11, 0xDA, 0x27, 0x00, 0x42, 0x00, 0x00, 0x54, 0x11,
+      0xDA, 0x27, 0x00, 0x00, 0x49, 0x1E, 0x00, 0xB0, 0x00,
+      0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x4F};
+  uint8_t longState[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
       0x11, 0xDA, 0x27, 0x00, 0x42, 0x00, 0x00, 0x54, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x49, 0x1E, 0x00, 0xB0, 0x00,
       0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x4F};
   uint8_t expectedState[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
       0x11, 0xDA, 0x27, 0x00, 0x42, 0x00, 0x00, 0x54, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x48, 0x2A, 0x00, 0xB0, 0x00,
-      0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x02, 0x5A};
+      0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x02, 0x5C};
 
-  EXPECT_STATE_EQ(initialState, irdaikin.getRaw(), kDaikinBits);
+  EXPECT_STATE_EQ(longState, ac.getRaw(), kDaikinBits);
   // toggle the power state.
-  irdaikin.setPower(!irdaikin.getPower());
-  irdaikin.setTemp(21);
-  irdaikin.setMold(true);
-  EXPECT_STATE_EQ(expectedState, irdaikin.getRaw(), kDaikinBits);
-  irdaikin.setRaw(initialState);
-  EXPECT_STATE_EQ(initialState, irdaikin.getRaw(), kDaikinBits);
+  ac.setPower(!ac.getPower());
+  ac.setTemp(21);
+  ac.setMold(true);
+  EXPECT_STATE_EQ(expectedState, ac.getRaw(), kDaikinBits);
+  ac.setRaw(longState);
+  EXPECT_STATE_EQ(longState, ac.getRaw(), kDaikinBits);
+  ac.setRaw(shortState, kDaikinStateLengthShort);
+  EXPECT_STATE_EQ(longState, ac.getRaw(), kDaikinBits);
 }
 
 TEST(TestDaikinClass, ChecksumValidation) {
   uint8_t daikin_code[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
       0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x02, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x41, 0x1E, 0x00, 0xB0, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0xE1};
@@ -640,65 +668,71 @@ TEST(TestDaikinClass, ChecksumValidation) {
   EXPECT_FALSE(IRDaikinESP::validChecksum(daikin_code));
   daikin_code[10] ^= 0xFF;
   EXPECT_TRUE(IRDaikinESP::validChecksum(daikin_code));
+  // Change something in the 3rd block.
+  daikin_code[20] ^= 0xFF;
+  EXPECT_FALSE(IRDaikinESP::validChecksum(daikin_code));
+  daikin_code[20] ^= 0xFF;
+  EXPECT_TRUE(IRDaikinESP::validChecksum(daikin_code));
 }
 
 // Test human readable output.
 TEST(TestDaikinClass, HumanReadable) {
-  IRDaikinESP irdaikin(0);
+  IRDaikinESP ac(0);
 
   EXPECT_EQ(
       "Power: On, Mode: 4 (HEAT), Temp: 15C, Fan: 11 (QUIET), "
       "Powerful: Off, Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, "
-      "Swing (Horizontal): Off, Swing (Vertical): Off, "
+      "Comfort: Off, Swing (Horizontal): Off, Swing (Vertical): Off, "
       "Current Time: 0:00, On Time: Off, Off Time: Off",
-      irdaikin.toString());
-  irdaikin.setMode(kDaikinAuto);
-  irdaikin.setTemp(25);
-  irdaikin.setFan(kDaikinFanAuto);
-  irdaikin.setQuiet(true);
-  irdaikin.setSensor(true);
-  irdaikin.setEye(true);
-  irdaikin.setMold(true);
-  irdaikin.setSwingVertical(true);
-  irdaikin.setSwingHorizontal(true);
-  irdaikin.setCurrentTime(9 * 60 + 15);
-  irdaikin.enableOnTimer(8 * 60 + 0);
-  irdaikin.enableOffTimer(17 * 60 + 30);
-  irdaikin.off();
+      ac.toString());
+  ac.setMode(kDaikinAuto);
+  ac.setTemp(25);
+  ac.setFan(kDaikinFanAuto);
+  ac.setQuiet(true);
+  ac.setSensor(true);
+  ac.setEye(true);
+  ac.setMold(true);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  ac.setCurrentTime(9 * 60 + 15);
+  ac.enableOnTimer(8 * 60 + 0);
+  ac.enableOffTimer(17 * 60 + 30);
+  ac.setComfort(true);
+  ac.off();
   EXPECT_EQ(
       "Power: Off, Mode: 0 (AUTO), Temp: 25C, Fan: 10 (AUTO), "
-      "Powerful: Off, Quiet: On, Sensor: On, Eye: On, Mold: On, "
+      "Powerful: Off, Quiet: On, Sensor: On, Eye: On, Mold: On, Comfort: On, "
       "Swing (Horizontal): On, Swing (Vertical): On, "
       "Current Time: 9:15, On Time: 8:00, Off Time: 17:30",
-      irdaikin.toString());
+      ac.toString());
 }
 
 // Test general message construction after tweaking some settings.
 TEST(TestDaikinClass, MessageConstuction) {
-  IRDaikinESP irdaikin(0);
+  IRDaikinESP ac(0);
   IRsendTest irsend(4);
-  irdaikin.begin();
+  ac.begin();
   irsend.begin();
 
-  irdaikin.setFan(kDaikinFanMin);
-  irdaikin.setMode(kDaikinCool);
-  irdaikin.setTemp(27);
-  irdaikin.setSwingVertical(false);
-  irdaikin.setSwingHorizontal(true);
-  irdaikin.setQuiet(false);
-  irdaikin.setPower(true);
+  ac.setFan(kDaikinFanMin);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(27);
+  ac.setSwingVertical(false);
+  ac.setSwingHorizontal(true);
+  ac.setQuiet(false);
+  ac.setPower(true);
 
   // Check everything for kicks.
-  EXPECT_EQ(kDaikinFanMin, irdaikin.getFan());
-  EXPECT_EQ(kDaikinCool, irdaikin.getMode());
-  EXPECT_EQ(27, irdaikin.getTemp());
-  EXPECT_FALSE(irdaikin.getSwingVertical());
-  EXPECT_TRUE(irdaikin.getSwingHorizontal());
-  EXPECT_FALSE(irdaikin.getQuiet());
-  EXPECT_TRUE(irdaikin.getPower());
+  EXPECT_EQ(kDaikinFanMin, ac.getFan());
+  EXPECT_EQ(kDaikinCool, ac.getMode());
+  EXPECT_EQ(27, ac.getTemp());
+  EXPECT_FALSE(ac.getSwingVertical());
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  EXPECT_FALSE(ac.getQuiet());
+  EXPECT_TRUE(ac.getPower());
 
   irsend.reset();
-  irsend.sendDaikin(irdaikin.getRaw());
+  irsend.sendDaikin(ac.getRaw());
   EXPECT_EQ(
       "m428s428m428s428m428s428m428s428m428s428"
       "m428s29428m3650s1623"
@@ -747,16 +781,17 @@ TEST(TestDaikinClass, MessageConstuction) {
 
 // Test decoding a message captured from a real IR remote.
 TEST(TestDecodeDaikin, RealExample) {
-  IRDaikinESP irdaikin(0);
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRDaikinESP ac(0);
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
   irsend.begin();
 
   uint8_t expectedState[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
       0x11, 0xDA, 0x27, 0x00, 0x42, 0x3A, 0x05, 0x93, 0x11,
       0xDA, 0x27, 0x00, 0x00, 0x3F, 0x3A, 0x00, 0xA0, 0x00,
       0x0A, 0x25, 0x17, 0x01, 0x00, 0xC0, 0x00, 0x00, 0x32};
-  uint16_t rawData[kDaikinRawBits] = {
+  uint16_t rawData[583] = {
       416,  446,  416, 446,  416, 446,  418, 446,  416, 446,  416, 25434,
       3436, 1768, 390, 1336, 390, 446,  416, 446,  416, 446,  416, 1336,
       390,  446,  416, 446,  416, 446,  416, 446,  416, 1336, 390, 448,
@@ -808,33 +843,78 @@ TEST(TestDecodeDaikin, RealExample) {
       390,  1336, 390, 446,  416, 446,  416};  // Captured by @sillyfrog
 
   irsend.reset();
-  irsend.sendRaw(rawData, kDaikinRawBits, 38000);
+  irsend.sendRaw(rawData, 583, 38000);
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(DAIKIN, irsend.capture.decode_type);
   ASSERT_EQ(kDaikinBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
+      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, "
+      "Current Time: 22:18, On Time: 21:30, Off Time: 6:10", ac.toString());
 }
 
 // Decoding a message we entirely constructed based solely on a given state.
-TEST(TestDecodeDaikin, SyntheticExample) {
-  IRDaikinESP irdaikin(0);
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+TEST(TestDecodeDaikin, ShortSyntheticExample) {
+  IRDaikinESP ac(0);
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  uint8_t shortState[kDaikinStateLengthShort] = {
+      0x11, 0xDA, 0x27, 0x00, 0x42, 0x3A, 0x05, 0x93, 0x11,
+      0xDA, 0x27, 0x00, 0x00, 0x3F, 0x3A, 0x00, 0xA0, 0x00,
+      0x0A, 0x25, 0x17, 0x01, 0x00, 0xC0, 0x00, 0x00, 0x32};
+
+  uint8_t longState[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
+      0x11, 0xDA, 0x27, 0x00, 0x42, 0x3A, 0x05, 0x93, 0x11,
+      0xDA, 0x27, 0x00, 0x00, 0x3F, 0x3A, 0x00, 0xA0, 0x00,
+      0x0A, 0x25, 0x17, 0x01, 0x00, 0xC0, 0x00, 0x00, 0x32};
+  irsend.reset();
+  irsend.sendDaikin(shortState, kDaikinStateLengthShort);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(DAIKIN, irsend.capture.decode_type);
+  ASSERT_EQ(kDaikinBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(longState, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
+      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, "
+      "Current Time: 22:18, On Time: 21:30, Off Time: 6:10", ac.toString());
+}
+
+// Decoding a message we entirely constructed based solely on a given state.
+TEST(TestDecodeDaikin, LongSyntheticExample) {
+  IRDaikinESP ac(0);
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
   irsend.begin();
 
   uint8_t expectedState[kDaikinStateLength] = {
-      0x11, 0xDA, 0x27, 0x00, 0x42, 0x3A, 0x05, 0x93, 0x11,
-      0xDA, 0x27, 0x00, 0x00, 0x3F, 0x3A, 0x00, 0xA0, 0x00,
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7,
+      0x11, 0xDA, 0x27, 0x00, 0x42, 0x3A, 0x05, 0x93,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x3F, 0x3A, 0x00, 0xA0, 0x00,
       0x0A, 0x25, 0x17, 0x01, 0x00, 0xC0, 0x00, 0x00, 0x32};
 
   irsend.reset();
   irsend.sendDaikin(expectedState);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_TRUE(irrecv.decodeDaikin(&irsend.capture));
   ASSERT_EQ(DAIKIN, irsend.capture.decode_type);
   ASSERT_EQ(kDaikinBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
+      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, "
+      "Current Time: 22:18, On Time: 21:30, Off Time: 6:10", ac.toString());
 }
 
 // Test decoding a message captured from a real IR remote.


### PR DESCRIPTION
* Enlarge the expected state size by 8 bytes.
  - Very first data section needed, because it has the "Comfort" setting in it.
  - Try to handle backward compatiblity with the old shorter size.
  - Add special case handling in IRMQTTServer to handle short size messages
    using the old size.
  - Update unit tests accordingly.
* Add set/getComfort() support.
  - Unit tests.
  - Fixes #675

* Refactor sendDaikin()/decodeDaikin() and IRDaikinESP class.
  - **[Bug]** Fix checksum calculation.
    - It was not including the last data byte of the last section.
  - Remove a lot of dead code.
  - Reduce function calls, and optimise for less stack usage.
  - Rewrote most decodeDaikin() from scratch.
    * Use common routines instead of special ones.
    * Use a loop to reduce code size a bit.
    * Get rid of the horrible raw bits kludge.

* Code passes the existing unit tests after being suitably updated.
  - Except for the "off by one" bug found. ;-)

Fixes #675.