### PR TITLE
Implement htmlEscape() to prevent XSS etc.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -487,15 +487,6 @@ String listOfSendGpios(void) {
   return result;
 }
 
-// Quick and dirty check for any unsafe chars in a string
-// that may cause HTML shenanigans. e.g. An XSS.
-bool hasUnsafeHTMLChars(String input) {
-  static char unsafe[] = "';!-\"<>=&{}()";
-  for (uint8_t i = 0; unsafe[i]; i++)
-    if (input.indexOf(unsafe[i]) != -1) return true;
-  return false;
-}
-
 String htmlMenu(void) {
   return F(
       "<center>"
@@ -1154,12 +1145,11 @@ void handleInfo(void) {
     "Log topic: " + MqttLog + "<br>"
     "LWT topic: " + MqttLwt + "<br>"
     "QoS: " + String(QOS) + "<br>"
-    "Last MQTT command seen: (topic) '" + lastMqttCmdTopic + "' (payload) '" +
-    // lastMqttCmd is unescaped untrusted input.
+    // lastMqttCmd* is unescaped untrusted input.
     // Avoid any possible HTML/XSS when displaying it.
-    (hasUnsafeHTMLChars(lastMqttCmd) ?
-        "<i>Contains unsafe HTML characters</i>" : lastMqttCmd) +
-    "' <i>(" + timeSince(lastMqttCmdTime) + ")</i><br>"
+    "Last MQTT command seen: (topic) '" + htmlEscape(lastMqttCmdTopic) +
+         "' (payload) '" + htmlEscape(lastMqttCmd) + "' <i>(" +
+         timeSince(lastMqttCmdTime) + ")</i><br>"
     "Total published: " + String(mqttSentCounter) + "<br>"
     "Total received: " + String(mqttRecvCounter) + "<br>"
     "</p>"

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -217,6 +217,73 @@ decode_type_t strToDecodeType(const char *str) {
     return decode_type_t::UNKNOWN;
 }
 
+// Escape any special HTML (unsafe) characters in a string. e.g. anti-XSS.
+// Args:
+//   unescaped: A string containing text to make HTML safe.
+// Returns:
+//   A string that is HTML safe.
+#ifdef ARDUINO  // Arduino's & C++'s string implementations can't co-exist.
+String htmlEscape(const String unescaped) {
+  String result = "";
+#else
+std::string htmlEscape(const std::string unescaped) {
+  std::string result = "";
+#endif
+  uint16_t ulen = unescaped.length();
+  result.reserve(ulen);  // The result will be at least the size of input.
+  for (size_t i = 0; i < ulen; i++) {
+    char c = unescaped[i];
+    switch (c) {
+      // ';!-"<>=&#{}() are all unsafe.
+      case '\'':
+        result += F("&apos;");
+        break;
+      case ';':
+        result += F("&semi;");
+        break;
+      case '!':
+        result += F("&excl;");
+        break;
+      case '-':
+        result += F("&dash;");
+        break;
+      case '\"':
+        result += F("&quot;");
+        break;
+      case '<':
+        result += F("&lt;");
+        break;
+      case '>':
+        result += F("&gt;");
+        break;
+      case '=':
+        result += F("&#equals;");
+        break;
+      case '&':
+        result += F("&amp;");
+        break;
+      case '#':
+        result += F("&num;");
+        break;
+      case '{':
+        result += F("&lcub;");
+        break;
+      case '}':
+        result += F("&rcub;");
+        break;
+      case '(':
+        result += F("&lpar;");
+        break;
+      case ')':
+        result += F("&rpar;");
+        break;
+      default:
+        result += c;
+    }
+  }
+  return result;
+}
+
 // Convert a protocol type (enum etc) to a human readable string.
 // Args:
 //   protocol: Nr. (enum) of the protocol.

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -24,6 +24,7 @@ String resultToSourceCode(const decode_results *results);
 String resultToTimingInfo(const decode_results *results);
 String resultToHumanReadableBasic(const decode_results *results);
 String resultToHexidecimal(const decode_results *result);
+String htmlEscape(const String unescaped);
 #else  // ARDUINO
 std::string uint64ToString(uint64_t input, uint8_t base = 10);
 std::string typeToString(const decode_type_t protocol,
@@ -32,6 +33,7 @@ std::string resultToSourceCode(const decode_results *results);
 std::string resultToTimingInfo(const decode_results *results);
 std::string resultToHumanReadableBasic(const decode_results *results);
 std::string resultToHexidecimal(const decode_results *result);
+std::string htmlEscape(const std::string unescaped);
 #endif  // ARDUINO
 bool hasACState(const decode_type_t protocol);
 uint16_t getCorrectedRawLength(const decode_results *results);

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -401,3 +401,17 @@ TEST(TestStrToDecodeType, strToDecodeType) {
   EXPECT_EQ(decode_type_t::KELVINATOR, strToDecodeType("KELVINATOR"));
   EXPECT_EQ(decode_type_t::UNKNOWN, strToDecodeType("foo"));
 }
+
+TEST(TestUtils, htmlEscape) {
+  EXPECT_EQ("", htmlEscape(""));
+  EXPECT_EQ("No Changes", htmlEscape("No Changes"));
+  EXPECT_EQ("No\tChanges+_%^$@~`\n:\\", htmlEscape("No\tChanges+_%^$@~`\n:\\"));
+  EXPECT_EQ("&quot;With Changes&quot;", htmlEscape("\"With Changes\""));
+  EXPECT_EQ(
+      "&apos;&semi;&excl;&dash;&quot;&lt;&gt;&#equals;&amp;&num;&lcub;&rcub;"
+      "&lpar;&rpar;", htmlEscape("';!-\"<>=&#{}()"));
+  EXPECT_EQ("&quot;&quot;", htmlEscape("\"\""));
+  EXPECT_EQ(
+      "&amp;quot&semi;&amp;lt&semi;&amp;apos&semi;&amp;gt&semi;&amp;amp&semi;",
+      htmlEscape("&quot;&lt;&apos;&gt;&amp;"));
+}


### PR DESCRIPTION
* Remove old routine which blocked any string deemeds possibly bad.
* Move routine out of example code and into IRutils so we can add tests.
* Escape all the chars that could possibly cause an XSS or text to be rendered
poorly in HTML.
* Issue arose when a value of "-1" failed to display because it contained '-'.
* Added unit tests.