### PR TITLE
Fix the byte array version of sendGree()

### DIFF
--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -59,7 +59,7 @@ void IRsend::sendGree(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
     // Footer #1
     sendGeneric(0, 0,  // No Header
                 kGreeBitMark, kGreeOneSpace, kGreeBitMark, kGreeZeroSpace,
-                kGreeBitMark, kGreeMsgSpace, 0b010, 3, 38, true, 0, false);
+                kGreeBitMark, kGreeMsgSpace, 0b010, 3, 38, false, 0, 50);
 
     // Block #2
     sendGeneric(0, 0,  // No Header for Block #2


### PR DESCRIPTION
As reported in #684 by @enriqueolivieri the duty cycle setting for the middle data footer was wrong.
I guess everyone was using the `uint64t` version of `sendGree()`.

Unit tests don't and won't catch this as they don't care about duty cycles for the tests we typically conduct.