### PR TITLE
Experimental support for DAIKIN216 (ARC433B69)

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -652,6 +652,7 @@ void handleRoot(void) {
         "<option value='27'>Argo</option>"
         "<option value='16'>Daikin</option>"
         "<option value='53'>Daikin2</option>"
+        "<option value='61'>Daikin216 (27 bytes)</option>"
         "<option value='48'>Electra</option>"
         "<option value='33'>Fujitsu</option>"
         "<option value='24'>Gree</option>"
@@ -1352,6 +1353,9 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
     case DAIKIN2:
       stateSize = kDaikin2StateLength;
       break;
+    case DAIKIN216:
+      stateSize = kDaikin216StateLength;
+      break;
     case ELECTRA_AC:
       stateSize = kElectraAcStateLength;
       break;
@@ -1496,6 +1500,11 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       irsend->sendDaikin2(reinterpret_cast<uint8_t *>(state));
       break;
 #endif
+#if SEND_DAIKIN216
+    case DAIKIN216:
+      irsend->sendDaikin216(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif  // SEND_DAIKIN216
 #if SEND_MITSUBISHI_AC
     case MITSUBISHI_AC:
       irsend->sendMitsubishiAC(reinterpret_cast<uint8_t *>(state));
@@ -2619,6 +2628,7 @@ bool sendIRCode(IRsend *irsend, int const ir_type,
 #endif
     case DAIKIN:  // 16
     case DAIKIN2:  // 53
+    case DAIKIN216:  // 61
     case KELVINATOR:  // 18
     case MITSUBISHI_AC:  // 20
     case GREE:  // 24

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -134,6 +134,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_DAIKIN2
+#if DECODE_DAIKIN216
+  if (results->decode_type == DAIKIN216) {
+    IRDaikin216 ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_DAIKIN216
 #if DECODE_FUJITSU_AC
   if (results->decode_type == FUJITSU_AC) {
     IRFujitsuAC ac(0);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -51,6 +51,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_DAIKIN2
     case decode_type_t::DAIKIN2:
 #endif
+#if SEND_DAIKIN216
+    case decode_type_t::DAIKIN216:
+#endif
 #if SEND_FUJITSU_AC
     case decode_type_t::FUJITSU_AC:
 #endif

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -242,6 +242,23 @@ void IRac::daikin2(IRDaikin2 *ac,
 }
 #endif  // SEND_DAIKIN2
 
+#if SEND_DAIKIN216
+void IRac::daikin216(IRDaikin216 *ac,
+                     const bool on, const stdAc::opmode_t mode,
+                     const float degrees, const stdAc::fanspeed_t fan,
+                     const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                     const bool quiet) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical((int8_t)swingv >= 0);
+  ac->setSwingHorizontal((int8_t)swingh >= 0);
+  ac->setQuiet(quiet);
+  ac->send();
+}
+#endif  // SEND_DAIKIN216
+
 #if SEND_FUJITSU_AC
 void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
                    const bool on, const stdAc::opmode_t mode,
@@ -780,7 +797,15 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
               light, econo, filter, clean, beep, sleep, clock);
       break;
     }
-#endif  // SEND_DAIKIN2
+#endif  // SEND_DAIKIN216
+#if SEND_DAIKIN216
+    case DAIKIN216:
+    {
+      IRDaikin216 ac(_pin);
+      daikin216(&ac, on, mode, degC, fan, swingv, swingh, quiet);
+      break;
+    }
+#endif  // SEND_DAIKIN216
 #if SEND_FUJITSU_AC
     case FUJITSU_AC:
     {

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -91,6 +91,13 @@ class IRac {
                const bool beep, const int16_t sleep = -1,
                const int16_t clock = -1);
 #endif  // SEND_DAIKIN2
+#if SEND_DAIKIN216
+void daikin216(IRDaikin216 *ac,
+               const bool on, const stdAc::opmode_t mode,
+               const float degrees, const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+               const bool quiet);
+#endif  // SEND_DAIKIN216
 #if SEND_FUJITSU_AC
   void fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
                const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -402,6 +402,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting Daikin2 decode");
   if (decodeDaikin2(results)) return true;
 #endif
+#if DECODE_DAIKIN216
+  DPRINTLN("Attempting Daikin216 decode");
+  if (decodeDaikin216(results)) return true;
+#endif
 #if DECODE_TOSHIBA_AC
   DPRINTLN("Attempting Toshiba AC decode");
   if (decodeToshibaAC(results)) return true;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -273,6 +273,11 @@ class IRrecv {
   bool decodeDaikin2(decode_results *results, uint16_t nbits = kDaikin2Bits,
                      bool strict = true);
 #endif
+#if DECODE_DAIKIN216
+  bool decodeDaikin216(decode_results *results,
+                       const uint16_t nbits = kDaikin216Bits,
+                       const bool strict = true);
+#endif
 #if DECODE_TOSHIBA_AC
   bool decodeToshibaAC(decode_results *results,
                        uint16_t nbytes = kToshibaACBits, bool strict = true);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -222,13 +222,17 @@
 #define DECODE_MITSUBISHIHEAVY true
 #define SEND_MITSUBISHIHEAVY   true
 
+#define DECODE_DAIKIN216       true
+#define SEND_DAIKIN216         true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
      DECODE_HITACHI_AC1 || DECODE_HITACHI_AC2 || DECODE_HAIER_AC_YRW02 || \
      DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC || \
      DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || \
-     DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY)
+     DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY || \
+     DECODE_DAIKIN216)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -308,8 +312,9 @@ enum decode_type_t {
   LEGOPF,
   MITSUBISHI_HEAVY_88,
   MITSUBISHI_HEAVY_152,  // 60
+  DAIKIN216,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = MITSUBISHI_HEAVY_152,
+  kLastDecodeType = DAIKIN216,
 };
 
 // Message lengths & required repeat values
@@ -332,6 +337,9 @@ const uint16_t kDaikinDefaultRepeat = kNoRepeat;
 const uint16_t kDaikin2StateLength = 39;
 const uint16_t kDaikin2Bits = kDaikin2StateLength * 8;
 const uint16_t kDaikin2DefaultRepeat = kNoRepeat;
+const uint16_t kDaikin216StateLength = 27;
+const uint16_t kDaikin216Bits = kDaikin216StateLength * 8;
+const uint16_t kDaikin216DefaultRepeat = kNoRepeat;
 const uint16_t kDenonBits = 15;
 const uint16_t kDenonLegacyBits = 14;
 const uint16_t kDishBits = 16;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -263,6 +263,11 @@ class IRsend {
   void sendDaikin2(unsigned char data[], uint16_t nbytes = kDaikin2StateLength,
                    uint16_t repeat = kDaikin2DefaultRepeat);
 #endif
+#if SEND_DAIKIN216
+  void sendDaikin216(const unsigned char data[],
+                     const uint16_t nbytes = kDaikin216StateLength,
+                     const uint16_t repeat = kDaikin216DefaultRepeat);
+#endif
 #if SEND_AIWA_RC_T501
   void sendAiwaRCT501(uint64_t data, uint16_t nbits = kAiwaRcT501Bits,
                       uint16_t repeat = kAiwaRcT501MinRepeats);

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -106,6 +106,8 @@ decode_type_t strToDecodeType(const char *str) {
     return decode_type_t::DAIKIN;
   else if (!strcmp(str, "DAIKIN2"))
     return decode_type_t::DAIKIN2;
+  else if (!strcmp(str, "DAIKIN216"))
+    return decode_type_t::DAIKIN216;
   else if (!strcmp(str, "DENON"))
     return decode_type_t::DENON;
   else if (!strcmp(str, "DISH"))
@@ -319,6 +321,9 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case DAIKIN2:
       result = F("DAIKIN2");
       break;
+    case DAIKIN216:
+      result = F("DAIKIN216");
+      break;
     case DENON:
       result = F("DENON");
       break;
@@ -495,6 +500,7 @@ bool hasACState(const decode_type_t protocol) {
   switch (protocol) {
     case DAIKIN:
     case DAIKIN2:
+    case DAIKIN216:
     case ELECTRA_AC:
     case FUJITSU_AC:
     case GREE:

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -1429,17 +1429,17 @@ void IRDaikin216::checksum() {
 }
 
 void IRDaikin216::stateReset() {
-  for (uint8_t i = 0; i < kDaikin216StateLength; i++) remote_state[i] = 0x0;
-
+  for (uint8_t i = 0; i < kDaikin216StateLength; i++) remote_state[i] = 0x00;
   remote_state[0] =  0x11;
   remote_state[1] =  0xDA;
   remote_state[2] =  0x27;
+  remote_state[3] =  0xF0;
   // remote_state[7] is a checksum byte, it will be set by checksum().
   remote_state[8] =  0x11;
   remote_state[9] =  0xDA;
   remote_state[10] = 0x27;
+  remote_state[23] = 0xC0;
   // remote_state[26] is a checksum byte, it will be set by checksum().
-  checksum();
 }
 
 uint8_t *IRDaikin216::getRaw() {

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -631,7 +631,7 @@ bool IRrecv::decodeDaikin(decode_results *results, const uint16_t nbits,
 // Args:
 //   data: An array of kDaikin2StateLength bytes containing the IR command.
 //
-// Status: Alpha/Untested.
+// Status: BETA/Appears to work.
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/582
@@ -1366,3 +1366,194 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
   return true;
 }
 #endif  // DECODE_DAIKIN2
+
+#if SEND_DAIKIN216
+// Send a Daikin 216 bit A/C message.
+//
+// Args:
+//   data: An array of kDaikin216StateLength bytes containing the IR command.
+//
+// Status: Alpha/Untested on a real device.
+//
+// Supported devices:
+// - Daikin ARC433B69 remote.
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/689
+//   https://github.com/danny-source/Arduino_DY_IRDaikin
+void IRsend::sendDaikin216(const unsigned char data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
+  if (nbytes < kDaikin216Section1Length)
+    return;  // Not enough bytes to send a partial message.
+
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Section #1
+    sendGeneric(kDaikin216HdrMark, kDaikin216HdrSpace, kDaikin216BitMark,
+                kDaikin216OneSpace, kDaikin216BitMark, kDaikin216ZeroSpace,
+                kDaikin216BitMark, kDaikin216Gap, data,
+                kDaikin216Section1Length,
+                kDaikin216Freq, false, 0, kDutyDefault);
+    // Section #2
+    sendGeneric(kDaikin216HdrMark, kDaikin216HdrSpace, kDaikin216BitMark,
+                kDaikin216OneSpace, kDaikin216BitMark, kDaikin216ZeroSpace,
+                kDaikin216BitMark, kDaikin216Gap,
+                data + kDaikin216Section1Length,
+                nbytes - kDaikin216Section1Length,
+                kDaikin216Freq, false, 0, kDutyDefault);
+  }
+}
+#endif  // SEND_DAIKIN216
+
+// Class for handling Daikin 216 bit / 27 byte A/C messages.
+//
+// Code by crankyoldgit.
+//
+// Supported Remotes: Daikin ARC433B69 remote
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/689
+//   https://github.com/danny-source/Arduino_DY_IRDaikin
+IRDaikin216::IRDaikin216(uint16_t pin) : _irsend(pin) { stateReset(); }
+
+void IRDaikin216::begin() { _irsend.begin(); }
+
+#if SEND_DAIKIN216
+void IRDaikin216::send(const uint16_t repeat) {
+  checksum();
+  _irsend.sendDaikin216(remote_state, kDaikin216StateLength, repeat);
+}
+#endif  // SEND_DAIKIN216
+
+// Verify the checksum is valid for a given state.
+// Args:
+//   state:  The array to verify the checksum of.
+//   length: The size of the state.
+// Returns:
+//   A boolean.
+bool IRDaikin216::validChecksum(uint8_t state[], const uint16_t length) {
+  // Validate the checksum of section #1.
+  if (length <= kDaikin216Section1Length - 1 ||
+      state[kDaikin216Section1Length - 1] != sumBytes(
+          state, kDaikin216Section1Length - 1))
+    return false;
+  // Validate the checksum of section #2 (a.k.a. the rest)
+  if (length <= kDaikin216Section1Length + 1 ||
+      state[length - 1] != sumBytes(state + kDaikin216Section1Length,
+                                    length - kDaikin216Section1Length - 1))
+    return false;
+  return true;
+}
+
+// Calculate and set the checksum values for the internal state.
+void IRDaikin216::checksum() {
+  remote_state[kDaikin216Section1Length - 1] = sumBytes(
+      remote_state, kDaikin216Section1Length - 1);
+  remote_state[kDaikin216StateLength -1 ] = sumBytes(
+      remote_state + kDaikin216Section1Length, kDaikin216Section2Length - 1);
+}
+
+void IRDaikin216::stateReset() {
+  for (uint8_t i = 0; i < kDaikin216StateLength; i++) remote_state[i] = 0x0;
+
+  remote_state[0] =  0x11;
+  remote_state[1] =  0xDA;
+  remote_state[2] =  0x27;
+  // remote_state[7] is a checksum byte, it will be set by checksum().
+  remote_state[8] =  0x11;
+  remote_state[9] =  0xDA;
+  remote_state[10] = 0x27;
+  // remote_state[26] is a checksum byte, it will be set by checksum().
+  checksum();
+}
+
+uint8_t *IRDaikin216::getRaw() {
+  checksum();  // Ensure correct settings before sending.
+  return remote_state;
+}
+
+void IRDaikin216::setRaw(const uint8_t new_code[]) {
+  for (uint8_t i = 0; i < kDaikin216StateLength; i++)
+    remote_state[i] = new_code[i];
+}
+
+#if DECODE_DAIKIN216
+// Decode the supplied Daikin 216 bit A/C message.
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of bits to expect in the data portion. (kDaikin216Bits)
+//   strict:  Flag to indicate if we strictly adhere to the specification.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Supported devices:
+// - Daikin ARC433B69 remote.
+//
+// Status: BETA / Should be working.
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/689
+//   https://github.com/danny-source/Arduino_DY_IRDaikin
+bool IRrecv::decodeDaikin216(decode_results *results, const uint16_t nbits,
+                             const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1)
+    return false;
+
+  // Compliance
+  if (strict && nbits != kDaikin216Bits) return false;
+
+  uint16_t offset = kStartOffset;
+  uint16_t dataBitsSoFar = 0;
+  uint16_t i = 0;
+  match_result_t data_result;
+  uint8_t sectionSize[kDaikin216Sections] = {kDaikin216Section1Length,
+                                             kDaikin216Section2Length};
+
+  // Sections
+  // Keep reading bytes until we either run out of section or state to fill.
+  for (uint8_t section = 0, pos = 0; section < kDaikin216Sections;
+       section++) {
+    pos += sectionSize[section];
+
+    // Section Header
+    if (!matchMark(results->rawbuf[offset++], kDaikin216HdrMark)) return false;
+    if (!matchSpace(results->rawbuf[offset++], kDaikin2HdrSpace)) return false;
+
+    // Section Data
+    for (; offset <= results->rawlen - 16 && i < pos;
+         i++, dataBitsSoFar += 8, offset += data_result.used) {
+      // Read in a byte at a time.
+      data_result =
+          matchData(&(results->rawbuf[offset]), 8, kDaikin216BitMark,
+                    kDaikin216OneSpace, kDaikin216BitMark,
+                    kDaikin216ZeroSpace, kTolerance, kMarkExcess, false);
+      if (data_result.success == false) break;  // Fail
+      results->state[i] = (uint8_t)data_result.data;
+    }
+
+    // Section Footer
+    if (!matchMark(results->rawbuf[offset++], kDaikin216BitMark)) return false;
+    if (section < kDaikin216Sections - 1) {  // Inter-section gaps.
+      if (!matchSpace(results->rawbuf[offset++], kDaikin216Gap)) return false;
+    } else {  // Last section / End of message gap.
+      if (offset <= results->rawlen &&
+          !matchAtLeast(results->rawbuf[offset++], kDaikin216Gap)) return false;
+    }
+  }
+
+  // Compliance
+  if (strict) {
+    // Re-check we got the correct size/length due to the way we read the data.
+    if (dataBitsSoFar != kDaikin216Bits) return false;
+    // Validate the checksum.
+    if (!IRDaikin216::validChecksum(results->state)) return false;
+  }
+
+  // Success
+  results->decode_type = decode_type_t::DAIKIN216;
+  results->bits = dataBitsSoFar;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_DAIKIN216

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -201,6 +201,14 @@ const uint8_t kDaikin216BytePower = 13;
 const uint8_t kDaikin216ByteMode = kDaikin216BytePower;
 const uint8_t kDaikin216MaskMode = 0b01110000;
 const uint8_t kDaikin216ByteTemp = 14;
+const uint8_t kDaikin216MaskTemp = 0b01111110;
+const uint8_t kDaikin216ByteFan = 16;
+const uint8_t kDaikin216MaskFan = 0b11110000;
+const uint8_t kDaikin216ByteSwingV = 16;
+const uint8_t kDaikin216MaskSwingV = 0b00001111;
+const uint8_t kDaikin216ByteSwingH = 17;
+const uint8_t kDaikin216MaskSwingH = kDaikin216MaskSwingV;
+
 
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
@@ -267,7 +275,7 @@ class IRDaikinESP {
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikinStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
-  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString(void);
   static String renderTime(const uint16_t timemins);
@@ -358,7 +366,7 @@ class IRDaikin2 {
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikin2StateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
-  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
 #ifdef ARDUINO
   String toString();
@@ -387,7 +395,7 @@ class IRDaikin216 {
  public:
   explicit IRDaikin216(uint16_t pin);
 
-#if SEND_DAIKIN2
+#if SEND_DAIKIN216
   void send(const uint16_t repeat = kDaikin216DefaultRepeat);
 #endif
   void begin();
@@ -401,11 +409,18 @@ class IRDaikin216 {
   bool getPower(void);
   void setTemp(const uint8_t temp);
   uint8_t getTemp();
-  void setFan(const uint8_t fan);
-  uint8_t getFan(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
   static uint8_t convertMode(const stdAc::opmode_t mode);
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  void setSwingVertical(const bool on);
+  bool getSwingVertical(void);
+  void setSwingHorizontal(const bool on);
+  bool getSwingHorizontal(void);
+  void setQuiet(const bool on);
+  bool getQuiet(void);
 #ifdef ARDUINO
   String toString(void);
   static String renderTime(const uint16_t timemins);

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -185,6 +185,18 @@ const uint8_t kDaikin2SwingHAuto = 0xBE;
 const uint8_t kDaikin2SwingHSwing = 0xBF;
 const uint8_t kDaikin2MinCoolTemp = 18;  // Min temp (in C) when in Cool mode.
 
+// Another variant of the protocol for the Daikin ARC433B69 remote.
+const uint16_t kDaikin216Freq = 38000;  // Modulation Frequency in Hz.
+const uint16_t kDaikin216HdrMark = 3400;
+const uint16_t kDaikin216HdrSpace = 1800;
+const uint16_t kDaikin216BitMark = 380;
+const uint16_t kDaikin216OneSpace = 1350;
+const uint16_t kDaikin216ZeroSpace = 480;
+const uint16_t kDaikin216Gap = 29650;
+const uint16_t kDaikin216Sections = 2;
+const uint16_t kDaikin216Section1Length = 8;
+const uint16_t kDaikin216Section2Length = kDaikin216StateLength -
+                                          kDaikin216Section1Length;
 
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
@@ -364,6 +376,34 @@ class IRDaikin2 {
   void checksum();
   void clearOnTimerFlag();
   void clearSleepTimerFlag();
+};
+
+// Class to emulate a Daikin ARC433B69 remote.
+class IRDaikin216 {
+ public:
+  explicit IRDaikin216(uint16_t pin);
+
+#if SEND_DAIKIN2
+  void send(const uint16_t repeat = kDaikin216DefaultRepeat);
+#endif
+  void begin();
+
+  uint8_t* getRaw();
+  void setRaw(const uint8_t new_code[]);
+
+  static bool validChecksum(uint8_t state[],
+                            const uint16_t length = kDaikin216StateLength);
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  // # of bytes per command
+  uint8_t remote_state[kDaikin216StateLength];
+  void stateReset();
+  void checksum();
 };
 
 #endif  // IR_DAIKIN_H_

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -197,6 +197,10 @@ const uint16_t kDaikin216Sections = 2;
 const uint16_t kDaikin216Section1Length = 8;
 const uint16_t kDaikin216Section2Length = kDaikin216StateLength -
                                           kDaikin216Section1Length;
+const uint8_t kDaikin216BytePower = 13;
+const uint8_t kDaikin216ByteMode = kDaikin216BytePower;
+const uint8_t kDaikin216MaskMode = 0b01110000;
+const uint8_t kDaikin216ByteTemp = 14;
 
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
@@ -262,7 +266,7 @@ class IRDaikinESP {
               const uint16_t length = kDaikinStateLength);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikinStateLength);
-  uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
 #ifdef ARDUINO
   String toString(void);
@@ -353,7 +357,7 @@ class IRDaikin2 {
   void setCommand(uint32_t value);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikin2StateLength);
-  uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
 #ifdef ARDUINO
@@ -387,12 +391,28 @@ class IRDaikin216 {
   void send(const uint16_t repeat = kDaikin216DefaultRepeat);
 #endif
   void begin();
-
   uint8_t* getRaw();
   void setRaw(const uint8_t new_code[]);
-
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikin216StateLength);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+#ifdef ARDUINO
+  String toString(void);
+  static String renderTime(const uint16_t timemins);
+#else
+  std::string toString(void);
+  static std::string renderTime(const uint16_t timemins);
+#endif
 #ifndef UNIT_TEST
 
  private:

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -138,6 +138,32 @@ TEST(TestIRac, Daikin2) {
   ASSERT_EQ(expected, ac.toString());
 }
 
+TEST(TestIRac, Daikin216) {
+  IRDaikin216 ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 4 (HEAT), Temp: 31C, Fan: 11 (QUIET), "
+      "Swing (Horizontal): On, Swing (Vertical): On, Quiet: On";
+
+  ac.begin();
+  irac.daikin216(&ac,
+                 true,                        // Power
+                 stdAc::opmode_t::kHeat,      // Mode
+                 31,                          // Celsius
+                 stdAc::fanspeed_t::kMedium,  // Fan speed
+                 stdAc::swingv_t::kAuto,      // Veritcal swing
+                 stdAc::swingh_t::kLeft,      // Horizontal swing
+                 true);                       // Quiet
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(DAIKIN216, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin216Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
 TEST(TestIRac, Fujitsu) {
   IRFujitsuAC ac(0);
   IRac irac(0);

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1773,6 +1773,29 @@ TEST(TestDaikin216Class, ExampleStates) {
       ac.toString());
 }
 
+TEST(TestDaikin216Class, ReconstructKnownState) {
+  IRDaikin216 ac(0);
+  ac.begin();
+  // https://github.com/markszabo/IRremoteESP8266/issues/689#issue-438086949
+  uint8_t expectedState[kDaikin216StateLength] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x02,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x26, 0x00, 0xA0, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x98};
+  ac.setPower(false);
+  ac.setMode(kDaikinAuto);
+  ac.setTemp(19);
+  ac.setFan(kDaikinFanAuto);
+  ac.setSwingHorizontal(false);
+  ac.setSwingVertical(false);
+  ac.setQuiet(false);
+  EXPECT_EQ(
+      "Power: Off, Mode: 0 (AUTO), Temp: 19C, Fan: 10 (AUTO), "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, Quiet: Off",
+      ac.toString());
+
+  EXPECT_STATE_EQ(expectedState, ac.getRaw(), kDaikin216Bits);
+}
+
 // https://github.com/markszabo/IRremoteESP8266/issues/689
 TEST(TestDecodeDaikin216, RealExample) {
   IRsendTest irsend(0);

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1494,11 +1494,18 @@ TEST(TestDaikin2Class, KnownConstruction) {
   EXPECT_STATE_EQ(expectedState, ac.getRaw(), kDaikin2Bits);
 }
 
-TEST(TestUtils, Misc) {
-  ASSERT_EQ("DAIKIN", typeToString(DAIKIN));
-  ASSERT_TRUE(hasACState(DAIKIN));
-  ASSERT_EQ("DAIKIN2", typeToString(DAIKIN2));
-  ASSERT_TRUE(hasACState(DAIKIN2));
+TEST(TestUtils, Housekeeping) {
+  ASSERT_EQ("DAIKIN", typeToString(decode_type_t::DAIKIN));
+  ASSERT_EQ(decode_type_t::DAIKIN, strToDecodeType("DAIKIN"));
+  ASSERT_TRUE(hasACState(decode_type_t::DAIKIN));
+
+  ASSERT_EQ("DAIKIN2", typeToString(decode_type_t::DAIKIN2));
+  ASSERT_EQ(decode_type_t::DAIKIN2, strToDecodeType("DAIKIN2"));
+  ASSERT_TRUE(hasACState(decode_type_t::DAIKIN2));
+
+  ASSERT_EQ("DAIKIN216", typeToString(decode_type_t::DAIKIN216));
+  ASSERT_EQ(decode_type_t::DAIKIN216, strToDecodeType("DAIKIN216"));
+  ASSERT_TRUE(hasACState(decode_type_t::DAIKIN216));
 }
 
 // https://github.com/markszabo/IRremoteESP8266/issues/582#issuecomment-453863879
@@ -1585,4 +1592,80 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
       "Light: 3 (Off), Mold: On, Clean: On, Fresh Air: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
       ac.toString());
+}
+
+// https://github.com/markszabo/IRremoteESP8266/issues/689
+TEST(TestDecodeDaikin216, RealExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  // https://github.com/markszabo/IRremoteESP8266/issues/689#issue-438086949
+  uint16_t rawData[439] = {
+      3402, 1770, 382, 1340, 382, 480, 382, 478, 382, 480, 380, 1342, 382, 478,
+      356, 504, 382, 480, 380, 478, 384, 1342, 380, 480, 380, 1342, 382, 1342,
+      382, 478, 382, 1340, 382, 1340, 384, 1340, 382, 1342, 382, 1340, 380, 480,
+      382, 480, 382, 1296, 426, 480, 380, 480, 382, 480, 380, 480, 382, 480,
+      382, 478, 382, 1342, 382, 1342, 382, 1340, 356, 1368, 382, 478, 382, 480,
+      382, 478, 380, 480, 382, 480, 382, 480, 382, 478, 382, 480, 382, 478, 358,
+      504, 382, 480, 380, 480, 382, 480, 382, 480, 380, 480, 382, 478, 382, 480,
+      382, 478, 382, 480, 354, 506, 354, 506, 380, 480, 382, 480, 382, 480, 382,
+      480, 380, 1342, 382, 480, 382, 480, 382, 478, 382, 478, 382, 478, 384,
+      478, 382, 29652, 3426, 1772, 382, 1340, 382, 480, 380, 478, 382, 480, 382,
+      1342, 382, 480, 382, 480, 382, 478, 356, 506, 382, 1342, 380, 480, 382,
+      1340, 382, 1340, 382, 478, 356, 1366, 382, 1340, 384, 1340, 382, 1340,
+      382, 1342, 382, 478, 382, 478, 382, 1340, 382, 478, 382, 478, 382, 478,
+      382, 480, 382, 480, 384, 478, 358, 504, 382, 478, 382, 480, 382, 478, 382,
+      480, 382, 480, 382, 478, 382, 480, 382, 478, 382, 478, 382, 478, 382, 478,
+      384, 478, 382, 478, 360, 500, 358, 504, 382, 478, 382, 480, 382, 480, 382,
+      478, 382, 478, 382, 1340, 382, 1342, 382, 480, 380, 480, 382, 1342, 382,
+      478, 382, 480, 356, 506, 382, 478, 382, 480, 382, 480, 356, 506, 382, 478,
+      382, 480, 382, 478, 382, 480, 382, 478, 382, 480, 380, 480, 380, 480, 382,
+      1342, 382, 478, 382, 1342, 382, 480, 382, 480, 382, 478, 382, 478, 382,
+      480, 382, 478, 382, 480, 356, 504, 384, 478, 382, 480, 382, 480, 380, 480,
+      382, 478, 382, 480, 382, 480, 382, 478, 356, 504, 384, 478, 380, 480, 382,
+      480, 382, 480, 382, 478, 356, 506, 382, 478, 382, 480, 380, 480, 382, 478,
+      382, 480, 382, 478, 382, 480, 358, 504, 382, 478, 382, 478, 356, 504, 382,
+      478, 382, 480, 382, 478, 382, 478, 382, 478, 382, 480, 380, 480, 382, 480,
+      380, 480, 356, 506, 356, 504, 382, 480, 382, 478, 382, 478, 382, 478, 382,
+      478, 382, 480, 382, 478, 382, 480, 382, 480, 382, 1340, 382, 1342, 382,
+      478, 384, 478, 382, 478, 382, 480, 380, 480, 382, 478, 382, 480, 356, 506,
+      382, 478, 382, 480, 382, 478, 356, 506, 380, 480, 382, 478, 382, 478, 382,
+      478, 382, 480, 382, 480, 380, 480, 382, 1342, 382, 1340, 382, 480, 356,
+      504, 382, 1342, 382};  // UNKNOWN E0E32232
+  uint8_t expectedState[kDaikin216StateLength] = {
+      // 8 bytes
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x02,
+      // 19 bytes
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x26, 0x00, 0xA0, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x98};
+
+  irsend.begin();
+  irsend.reset();
+  irsend.sendRaw(rawData, 439, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(DAIKIN216, irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin216Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+// https://github.com/markszabo/IRremoteESP8266/issues/689
+TEST(TestDecodeDaikin216, SyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  // https://github.com/markszabo/IRremoteESP8266/issues/689#issue-438086949
+  uint8_t expectedState[kDaikin216StateLength] = {
+      // 8 bytes
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x02,
+      // 19 bytes
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x26, 0x00, 0xA0, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x98};
+
+  irsend.begin();
+  irsend.reset();
+  irsend.sendDaikin216(expectedState);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(DAIKIN216, irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin216Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
 }

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1702,7 +1702,6 @@ TEST(TestDaikin216Class, VaneSwing) {
   EXPECT_FALSE(ac.getSwingVertical());
 }
 
-
 TEST(TestDaikin216Class, FanSpeed) {
   IRDaikin216 ac(0);
   ac.begin();
@@ -1743,6 +1742,20 @@ TEST(TestDaikin216Class, FanSpeed) {
 
   ac.setFan(kDaikinFanQuiet);
   EXPECT_EQ(kDaikinFanQuiet, ac.getFan());
+}
+
+TEST(TestDaikin216Class, Quiet) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
+
+  ac.setQuiet(false);
+  EXPECT_FALSE(ac.getQuiet());
+
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
 }
 
 TEST(TestDaikin216Class, ExampleStates) {

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1594,6 +1594,89 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
       ac.toString());
 }
 
+// Tests for IRDaikin216 class.
+
+TEST(TestDaikin216Class, Power) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestDaikin216Class, Temperature) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  ac.setTemp(0);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp - 1);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp + 1);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp + 1);
+  EXPECT_EQ(kDaikinMinTemp + 1, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
+TEST(TestDaikin216Class, OperatingMode) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  ac.setMode(kDaikinAuto);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(kDaikinCool);
+  EXPECT_EQ(kDaikinCool, ac.getMode());
+
+  ac.setMode(kDaikinHeat);
+  EXPECT_EQ(kDaikinHeat, ac.getMode());
+
+  ac.setMode(kDaikinDry);
+  EXPECT_EQ(kDaikinDry, ac.getMode());
+
+  ac.setMode(kDaikinFan);
+  EXPECT_EQ(kDaikinFan, ac.getMode());
+
+  ac.setMode(kDaikinFan + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(kDaikinAuto + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+}
+
 // https://github.com/markszabo/IRremoteESP8266/issues/689
 TEST(TestDecodeDaikin216, RealExample) {
   IRsendTest irsend(0);
@@ -1646,6 +1729,12 @@ TEST(TestDecodeDaikin216, RealExample) {
   ASSERT_EQ(DAIKIN216, irsend.capture.decode_type);
   ASSERT_EQ(kDaikin216Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+
+  IRDaikin216 ac(0);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ(
+      "Power: Off, Mode: 0 (AUTO), Temp: 19C",
+      ac.toString());
 }
 
 // https://github.com/markszabo/IRremoteESP8266/issues/689

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1677,6 +1677,89 @@ TEST(TestDaikin216Class, OperatingMode) {
   EXPECT_EQ(kDaikinAuto, ac.getMode());
 }
 
+
+TEST(TestDaikin216Class, VaneSwing) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  ac.setSwingHorizontal(true);
+  ac.setSwingVertical(false);
+
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  EXPECT_FALSE(ac.getSwingVertical());
+
+  ac.setSwingVertical(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  EXPECT_TRUE(ac.getSwingVertical());
+
+  ac.setSwingHorizontal(false);
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  EXPECT_TRUE(ac.getSwingVertical());
+
+  ac.setSwingVertical(false);
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  EXPECT_FALSE(ac.getSwingVertical());
+}
+
+
+TEST(TestDaikin216Class, FanSpeed) {
+  IRDaikin216 ac(0);
+  ac.begin();
+
+  // Unexpected value should default to Auto.
+  ac.setFan(0);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  // Unexpected value should default to Auto.
+  ac.setFan(255);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanMax);
+  EXPECT_EQ(kDaikinFanMax, ac.getFan());
+
+  // Beyond Max should default to Auto.
+  ac.setFan(kDaikinFanMax + 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanMax - 1);
+  EXPECT_EQ(kDaikinFanMax - 1, ac.getFan());
+
+  ac.setFan(kDaikinFanMin);
+  EXPECT_EQ(kDaikinFanMin, ac.getFan());
+
+  ac.setFan(kDaikinFanMin + 1);
+  EXPECT_EQ(kDaikinFanMin + 1, ac.getFan());
+
+  // Beyond Min should default to Auto.
+  ac.setFan(kDaikinFanMin - 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(3);
+  EXPECT_EQ(3, ac.getFan());
+
+  ac.setFan(kDaikinFanAuto);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanQuiet);
+  EXPECT_EQ(kDaikinFanQuiet, ac.getFan());
+}
+
+TEST(TestDaikin216Class, ExampleStates) {
+  IRDaikin216 ac(0);
+  ac.begin();
+  // https://github.com/markszabo/IRremoteESP8266/pull/690#issuecomment-487770194
+  uint8_t state[kDaikin216StateLength] = {
+      0x11, 0xDA, 0x27, 0xF0, 0x00, 0x00, 0x00, 0x02,
+      0x11, 0xDA, 0x27, 0x00, 0x00, 0x21, 0xC0, 0x00, 0xA0, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x53};
+  ac.setRaw(state);
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (DRY), Temp: 32C, Fan: 10 (AUTO), "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, Quiet: Off",
+      ac.toString());
+}
+
 // https://github.com/markszabo/IRremoteESP8266/issues/689
 TEST(TestDecodeDaikin216, RealExample) {
   IRsendTest irsend(0);
@@ -1733,7 +1816,8 @@ TEST(TestDecodeDaikin216, RealExample) {
   IRDaikin216 ac(0);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: Off, Mode: 0 (AUTO), Temp: 19C",
+      "Power: Off, Mode: 0 (AUTO), Temp: 19C, Fan: 10 (AUTO), "
+      "Swing (Horizontal): Off, Swing (Vertical): Off, Quiet: Off",
       ac.toString());
 }
 


### PR DESCRIPTION
Basic support in the form of `sendDaikin216()`/`decodeDaikin216()` and `IRDaikin216` class
to support the Daikin ARC433B69 remote.
Unit tests for sending/decoding appear to work using real data.
Added to Common A/C infrastructure.

Example code updated to add new protocol.

Per #689