### PR TITLE
Attempt to reduce heap fragmentation by A/C toString().

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -345,6 +345,7 @@ String IRCoolixAC::toString() {
 std::string IRCoolixAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower()) {
     result += F("On");

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -426,6 +426,7 @@ String IRDaikinESP::toString(void) {
 std::string IRDaikinESP::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(230);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   result += this->getPower() ? F("On") : F("Off");
   result += F(", Mode: ");
@@ -1099,6 +1100,7 @@ String IRDaikin2::toString() {
 std::string IRDaikin2::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(310);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");
@@ -1576,6 +1578,7 @@ String IRDaikin216::toString() {
 std::string IRDaikin216::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(120);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (this->getPower())
     result += F("On");

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -361,6 +361,7 @@ String IRFujitsuAC::toString() {
 std::string IRFujitsuAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -364,6 +364,7 @@ String IRGreeAC::toString() {
 std::string IRGreeAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(150);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -372,6 +372,7 @@ String IRHaierAC::toString() {
 std::string IRHaierAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(150);  // Reserve some heap for the string to reduce fragging.
   uint8_t cmd = getCommand();
   result += F("Command: ");
   result += uint64ToString(cmd);
@@ -747,6 +748,7 @@ String IRHaierACYRW02::toString() {
 std::string IRHaierACYRW02::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(130);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -299,6 +299,7 @@ String IRHitachiAc::toString() {
 std::string IRHitachiAc::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(110);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -372,6 +372,7 @@ String IRKelvinatorAC::toString() {
 std::string IRKelvinatorAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(160);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -298,6 +298,7 @@ String IRMideaAC::toString() {
 std::string IRMideaAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(70);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -684,6 +684,7 @@ String IRMitsubishiAC::toString() {
 std::string IRMitsubishiAC::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(110);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -386,6 +386,7 @@ String IRMitsubishiHeavy152Ac::toString(void) {
 std::string IRMitsubishiHeavy152Ac::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(180);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   result += (this->getPower() ? F("On") : F("Off"));
   result += F(", Mode: ");
@@ -804,6 +805,7 @@ String IRMitsubishiHeavy88Ac::toString(void) {
 std::string IRMitsubishiHeavy88Ac::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(140);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   result += (this->getPower() ? F("On") : F("Off"));
   result += F(", Mode: ");

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -693,6 +693,7 @@ String IRPanasonicAc::toString() {
 std::string IRPanasonicAc::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(180);  // Reserve some heap for the string to reduce fragging.
   result += F("Model: ");
   result += uint64ToString(getModel());
   switch (getModel()) {

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -618,6 +618,7 @@ String IRSamsungAc::toString() {
 std::string IRSamsungAc::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   if (getPower())
     result += F("On");

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -299,6 +299,7 @@ String IRTcl112Ac::toString() {
 std::string IRTcl112Ac::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(140);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   result += (this->getPower() ? F("On") : F("Off"));
   result += F(", Mode: ");

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -176,6 +176,7 @@ String IRTecoAc::toString(void) {
 std::string IRTecoAc::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(80);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
   result += (this->getPower() ? F("On") : F("Off"));
   result += F(", Mode: ");

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -445,6 +445,7 @@ String IRVestelAc::toString() {
 std::string IRVestelAc::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
   if (isTimeCommand()) {
     result += F("Time: ");
     result += IRHaierAC::timeToString(getTime());

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -454,6 +454,7 @@ String IRWhirlpoolAc::toString() {
 std::string IRWhirlpoolAc::toString() {
   std::string result = "";
 #endif  // ARDUINO
+  result.reserve(200);  // Reserve some heap for the string to reduce fragging.
   result += F("Model: ");
   result += uint64ToString(getModel());
   switch (getModel()) {


### PR DESCRIPTION
Pre-reserve heap memory in the `.toString()` methods to avoid memory
fragmentation when joining lots of small strings together.