### PR TITLE
Add limited support for Sharp A/C

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -155,7 +155,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.0.0"
+#define _MY_VERSION_ "v1.0.1"
 
 const uint8_t kSendTableSize = sizeof(gpioTable);
 // JSON stuff

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -667,6 +667,7 @@ void handleRoot(void) {
         "<option value='60'>Mitsubishi Heavy (19 bytes)</option>"
         "<option value='52'>MWM</option>"
         "<option value='46'>Samsung</option>"
+        "<option value='62'>Sharp</option>"
         "<option value='57'>TCL112</option>"
         "<option value='32'>Toshiba</option>"
         "<option value='28'>Trotec</option>"
@@ -1430,6 +1431,9 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       // Lastly, it should never exceed the maximum "extended" size.
       stateSize = std::min(stateSize, kSamsungAcExtendedStateLength);
       break;
+    case SHARP_AC:
+      stateSize = kSharpAcStateLength;
+      break;
     case MWM:
       // MWM has variable size states, so make a best guess
       // which one we are being presented with based on the number of
@@ -1501,7 +1505,7 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       break;
 #endif
 #if SEND_DAIKIN216
-    case DAIKIN216:
+    case DAIKIN216:  // 61
       irsend->sendDaikin216(reinterpret_cast<uint8_t *>(state));
       break;
 #endif  // SEND_DAIKIN216
@@ -1573,6 +1577,11 @@ bool parseStringAndSendAirCon(IRsend *irsend, const uint16_t irType,
       irsend->sendSamsungAC(reinterpret_cast<uint8_t *>(state), stateSize);
       break;
 #endif
+#if SEND_SHARP_AC
+    case SHARP_AC:  // 62
+      irsend->sendSharpAc(reinterpret_cast<uint8_t *>(state));
+      break;
+#endif  // SEND_SHARP_AC
 #if SEND_ELECTRA_AC
     case ELECTRA_AC:
       irsend->sendElectraAC(reinterpret_cast<uint8_t *>(state));
@@ -2643,6 +2652,7 @@ bool sendIRCode(IRsend *irsend, int const ir_type,
     case HITACHI_AC2:  // 42
     case WHIRLPOOL_AC:  // 45
     case SAMSUNG_AC:  // 46
+    case SHARP_AC:  // 62
     case ELECTRA_AC:  // 48
     case PANASONIC_AC:  // 49
     case MWM:  // 52

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -38,6 +38,7 @@
 #include <ir_MitsubishiHeavy.h>
 #include <ir_Panasonic.h>
 #include <ir_Samsung.h>
+#include <ir_Sharp.h>
 #include <ir_Tcl.h>
 #include <ir_Teco.h>
 #include <ir_Toshiba.h>
@@ -216,6 +217,13 @@ void dumpACInfo(decode_results *results) {
     description = ac.toString();
   }
 #endif  // DECODE_SAMSUNG_AC
+#if DECODE_SHARP_AC
+  if (results->decode_type == SHARP_AC) {
+    IRSharpAc ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_SHARP_AC
 #if DECODE_COOLIX
   if (results->decode_type == COOLIX) {
     IRCoolixAC ac(0);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -27,6 +27,7 @@
 #include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
+#include "ir_Sharp.h"
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
@@ -87,6 +88,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #endif
 #if SEND_SAMSUNG_AC
     case decode_type_t::SAMSUNG_AC:
+#endif
+#if SEND_SHARP_AC
+    case decode_type_t::SHARP_AC:
 #endif
 #if SEND_TCL112AC
     case decode_type_t::TCL112AC:
@@ -570,6 +574,31 @@ void IRac::samsung(IRSamsungAc *ac,
 }
 #endif  // SEND_SAMSUNG_AC
 
+#if SEND_SHARP_AC
+void IRac::sharp(IRSharpAc *ac,
+                 const bool on, const stdAc::opmode_t mode,
+                 const float degrees, const stdAc::fanspeed_t fan) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  // No Vertical swing setting available.
+  // No Horizontal swing setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Econo setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  // Do setMode() again as it can affect fan speed and temp.
+  ac->setMode(ac->convertMode(mode));
+  ac->send();
+}
+#endif  // SEND_SHARP_AC
+
 #if SEND_TCL112AC
 void IRac::tcl112(IRTcl112Ac *ac,
                   const bool on, const stdAc::opmode_t mode,
@@ -914,6 +943,15 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
       break;
     }
 #endif  // SEND_SAMSUNG_AC
+#if SEND_SHARP_AC
+    case SHARP_AC:
+    {
+      IRSharpAc ac(_pin);
+      ac.begin();
+      sharp(&ac, on, mode, degC, fan);
+      break;
+    }
+#endif  // SEND_SHARP_AC
 #if SEND_TCL112AC
     case TCL112AC:
     {

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -23,6 +23,7 @@
 #include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
+#include "ir_Sharp.h"
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
@@ -183,6 +184,11 @@ void daikin216(IRDaikin216 *ac,
                const bool quiet, const bool turbo, const bool clean,
                const bool beep, const bool dopower = true);
 #endif  // SEND_SAMSUNG_AC
+#if SEND_SHARP_AC
+  void sharp(IRSharpAc *ac,
+             const bool on, const stdAc::opmode_t mode,
+             const float degrees, const stdAc::fanspeed_t fan);
+#endif  // SEND_SHARP_AC
 #if SEND_TCL112AC
   void tcl112(IRTcl112Ac *ac,
               const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -523,6 +523,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting MITSUBISHIHEAVY (88 bit) decode");
   if (decodeMitsubishiHeavy(results, kMitsubishiHeavy88Bits)) return true;
 #endif
+#if DECODE_SHARP_AC
+  DPRINTLN("Attempting SHARP_AC decode");
+  if (decodeSharpAc(results)) return true;
+#endif
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -249,6 +249,11 @@ class IRrecv {
   bool decodeSharp(decode_results *results, uint16_t nbits = kSharpBits,
                    bool strict = true, bool expansion = true);
 #endif
+#if DECODE_SHARP_AC
+  bool decodeSharpAc(decode_results *results,
+                     const uint16_t nbits = kSharpAcBits,
+                     const bool strict = true);
+#endif
 #if DECODE_AIWA_RC_T501
   bool decodeAiwaRCT501(decode_results *results,
                         uint16_t nbits = kAiwaRcT501Bits, bool strict = true);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -117,6 +117,9 @@
 #define DECODE_SHARP           true
 #define SEND_SHARP             true
 
+#define DECODE_SHARP_AC        true
+#define SEND_SHARP_AC          true
+
 #define DECODE_DENON           true
 #define SEND_DENON             true
 
@@ -232,7 +235,7 @@
      DECODE_WHIRLPOOL_AC || DECODE_SAMSUNG_AC || DECODE_ELECTRA_AC || \
      DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || \
      DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY || \
-     DECODE_DAIKIN216)
+     DECODE_DAIKIN216 || DECODE_SHARP_AC)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -313,8 +316,9 @@ enum decode_type_t {
   MITSUBISHI_HEAVY_88,
   MITSUBISHI_HEAVY_152,  // 60
   DAIKIN216,
+  SHARP_AC,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = DAIKIN216,
+  kLastDecodeType = SHARP_AC,
 };
 
 // Message lengths & required repeat values
@@ -428,6 +432,9 @@ const uint16_t kSanyoLC7461Bits = (kSanyoLC7461AddressBits +
 const uint8_t  kSharpAddressBits = 5;
 const uint8_t  kSharpCommandBits = 8;
 const uint16_t kSharpBits = kSharpAddressBits + kSharpCommandBits + 2;  // 15
+const uint16_t kSharpAcStateLength = 13;
+const uint16_t kSharpAcBits = kSharpAcStateLength * 8;  // 104
+const uint16_t kSharpAcDefaultRepeat = kNoRepeat;
 const uint8_t  kSherwoodBits = kNECBits;
 const uint16_t kSherwoodMinRepeat = kSingleRepeat;
 const uint16_t kSony12Bits = 12;

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -160,6 +160,11 @@ class IRsend {
   void sendSharpRaw(uint64_t data, uint16_t nbits = kSharpBits,
                     uint16_t repeat = kNoRepeat);
 #endif
+#if SEND_SHARP_AC
+  void sendSharpAc(const unsigned char data[],
+                   const uint16_t nbytes = kSharpAcStateLength,
+                   const uint16_t repeat = kSharpAcDefaultRepeat);
+#endif  // SEND_SHARP_AC
 #if SEND_JVC
   void sendJVC(uint64_t data, uint16_t nbits = kJvcBits,
                uint16_t repeat = kNoRepeat);

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -192,6 +192,8 @@ decode_type_t strToDecodeType(const char *str) {
     return decode_type_t::SANYO_LC7461;
   else if (!strcmp(str, "SHARP"))
     return decode_type_t::SHARP;
+  else if (!strcmp(str, "SHARP_AC"))
+    return decode_type_t::SHARP_AC;
   else if (!strcmp(str, "SHERWOOD"))
     return decode_type_t::SHERWOOD;
   else if (!strcmp(str, "SONY"))
@@ -459,6 +461,9 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
     case SHARP:
       result = F("SHARP");
       break;
+    case SHARP_AC:
+      result = F("SHARP_AC");
+      break;
     case SHERWOOD:
       result = F("SHERWOOD");
       break;
@@ -516,6 +521,7 @@ bool hasACState(const decode_type_t protocol) {
     case MWM:
     case PANASONIC_AC:
     case SAMSUNG_AC:
+    case SHARP_AC:
     case TCL112AC:
     case TOSHIBA_AC:
     case WHIRLPOOL_AC:

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -1,7 +1,11 @@
 // Copyright 2009 Ken Shirriff
-// Copyright 2017 David Conran
+// Copyright 2017, 2019 David Conran
 
+#include "ir_Sharp.h"
 #include <algorithm>
+#ifndef ARDUINO
+#include <string>
+#endif
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRutils.h"
@@ -265,3 +269,326 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t nbits, bool strict,
   return true;
 }
 #endif  // (DECODE_SHARP || DECODE_DENON)
+
+#if SEND_SHARP_AC
+// Send a Sharp A/C message.
+//
+// Args:
+//   data: An array of kSharpAcStateLength bytes containing the IR command.
+//   nbytes: Nr. of bytes of data to send. i.e. length of `data`.
+//   repeat: Nr. of times the message should be repeated.
+//
+// Status: Alpha / Untested.
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/638
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+void IRsend::sendSharpAc(const unsigned char data[], const uint16_t nbytes,
+                         const uint16_t repeat) {
+  if (nbytes < kSharpAcStateLength)
+    return;  // Not enough bytes to send a proper message.
+
+  sendGeneric(kSharpAcHdrMark, kSharpAcHdrSpace,
+              kSharpAcBitMark, kSharpAcOneSpace,
+              kSharpAcBitMark, kSharpAcZeroSpace,
+              kSharpAcBitMark, kSharpAcGap,
+              data, nbytes, 38000, false, repeat, 50);
+}
+#endif  // SEND_SHARP_AC
+
+IRSharpAc::IRSharpAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+
+void IRSharpAc::begin(void) { _irsend.begin(); }
+
+#if SEND_SHARP_AC
+void IRSharpAc::send(const uint16_t repeat) {
+  this->checksum();
+  _irsend.sendSharpAc(remote, kSharpAcStateLength, repeat);
+}
+#endif  // SEND_SHARP_AC
+
+// Calculate the checksum for a given state.
+// Args:
+//   state:  The array to verify the checksums of.
+//   length: The size of the state.
+// Returns:
+//   The 4 bit checksum.
+uint8_t IRSharpAc::calcChecksum(uint8_t state[], const uint16_t length) {
+  uint8_t xorsum = xorBytes(state, length - 1);
+  xorsum ^= (state[length - 1] & 0xF);
+  xorsum ^= xorsum >> 4;
+  return xorsum & 0xF;
+}
+
+// Verify the checksums are valid for a given state.
+// Args:
+//   state:  The array to verify the checksums of.
+//   length: The size of the state.
+// Returns:
+//   A boolean.
+bool IRSharpAc::validChecksum(uint8_t state[], const uint16_t length) {
+  return (state[length - 1] >> 4) == calcChecksum(state, length);
+}
+
+// Calculate and set the checksum values for the internal state.
+void IRSharpAc::checksum(void) {
+  remote[kSharpAcStateLength - 1] &= 0x0F;
+  remote[kSharpAcStateLength - 1] |= calcChecksum(remote) << 4;
+}
+
+void IRSharpAc::stateReset(void) {
+  static const uint8_t reset[kSharpAcStateLength] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0x00, 0x01, 0x00, 0x00, 0x08, 0x80, 0x00, 0xE0,
+      0x01};
+  for (uint8_t i = 0; i < kSharpAcStateLength; i++) remote[i] = reset[i];
+}
+
+uint8_t *IRSharpAc::getRaw(void) {
+  this->checksum();  // Ensure correct settings before sending.
+  return remote;
+}
+
+void IRSharpAc::setRaw(const uint8_t new_code[], const uint16_t length) {
+  for (uint8_t i = 0; i < length && i < kSharpAcStateLength; i++)
+    remote[i] = new_code[i];
+}
+
+void IRSharpAc::on(void) { remote[kSharpAcBytePower] |= kSharpAcBitPower; }
+
+void IRSharpAc::off(void) { remote[kSharpAcBytePower] &= ~kSharpAcBitPower; }
+
+void IRSharpAc::setPower(const bool on) {
+  if (on)
+    this->on();
+  else
+    this->off();
+}
+
+bool IRSharpAc::getPower(void) {
+  return remote[kSharpAcBytePower] & kSharpAcBitPower;
+}
+
+// Set the temp in deg C
+void IRSharpAc::setTemp(const uint8_t temp) {
+  switch (this->getMode()) {
+    // Auto & Dry don't allow temp changes and have a special temp.
+    case kSharpAcAuto:
+    case kSharpAcDry:
+      remote[kSharpAcByteTemp] = 0;
+      remote[kSharpAcByteManual] = 0;  // When in Dry/Auto this byte is 0.
+      return;
+    default:
+      remote[kSharpAcByteTemp] = 0xC0;
+      remote[kSharpAcByteManual] |= kSharpAcBitTempManual;
+  }
+  uint8_t degrees = std::max(temp, kSharpAcMinTemp);
+  degrees = std::min(degrees, kSharpAcMaxTemp);
+  remote[kSharpAcByteTemp] &= ~kSharpAcMaskTemp;
+  remote[kSharpAcByteTemp] |= (degrees - kSharpAcMinTemp);
+}
+
+uint8_t IRSharpAc::getTemp(void) {
+  return (remote[kSharpAcByteTemp] & kSharpAcMaskTemp) + kSharpAcMinTemp;
+}
+
+uint8_t IRSharpAc::getMode(void) {
+  return remote[kSharpAcByteMode] & kSharpAcMaskMode;
+}
+
+void IRSharpAc::setMode(const uint8_t mode) {
+  const uint8_t special = 0x20;  // Non-auto modes have this bit set.
+  remote[kSharpAcBytePower] |= special;
+  switch (mode) {
+    case kSharpAcAuto:
+      remote[kSharpAcBytePower] &= ~special;  // Auto has this bit cleared.
+      // FALLTHRU
+    case kSharpAcDry:
+      this->setTemp(0);  // Dry/Auto have no temp setting.
+      // FALLTHRU
+    case kSharpAcCool:
+    case kSharpAcHeat:
+      remote[kSharpAcByteMode] &= ~kSharpAcMaskMode;
+      remote[kSharpAcByteMode] |= mode;
+
+      break;
+    default:
+      this->setMode(kSharpAcAuto);
+  }
+}
+
+// Set the speed of the fan
+void IRSharpAc::setFan(const uint8_t speed) {
+  remote[kSharpAcByteManual] |= kSharpAcBitFanManual;  // Manual fan mode.
+  switch (speed) {
+    case kSharpAcFanAuto:
+      // Clear the manual fan bit.
+      remote[kSharpAcByteManual] &= ~kSharpAcBitFanManual;
+      // FALLTHRU
+    case kSharpAcFanMin:
+    case kSharpAcFanMed:
+    case kSharpAcFanHigh:
+    case kSharpAcFanMax:
+      remote[kSharpAcByteFan] &= ~kSharpAcMaskFan;
+      remote[kSharpAcByteFan] |= (speed << 4);
+      break;
+    default:
+      this->setFan(kSharpAcFanAuto);
+  }
+}
+
+uint8_t IRSharpAc::getFan(void) {
+  return (remote[kSharpAcByteFan] & kSharpAcMaskFan) >> 4;
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRSharpAc::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kSharpAcCool;
+    case stdAc::opmode_t::kHeat:
+      return kSharpAcHeat;
+    case stdAc::opmode_t::kDry:
+      return kSharpAcDry;
+    // No Fan mode.
+    default:
+      return kSharpAcAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRSharpAc::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:
+      return kSharpAcFanMin;
+    case stdAc::fanspeed_t::kMedium:
+      return kSharpAcFanMed;
+    case stdAc::fanspeed_t::kHigh:
+      return kSharpAcFanHigh;
+    case stdAc::fanspeed_t::kMax:
+      return kSharpAcFanMax;
+    default:
+      return kSharpAcFanAuto;
+  }
+}
+
+// Convert the internal state into a human readable string.
+#ifdef ARDUINO
+String IRSharpAc::toString(void) {
+  String result = "";
+#else   // ARDUINO
+std::string IRSharpAc::toString(void) {
+  std::string result = "";
+#endif  // ARDUINO
+  result.reserve(60);  // Reserve some heap for the string to reduce fragging.
+  result += F("Power: ");
+  result += this->getPower() ? F("On") : F("Off");
+  result += F(", Mode: ");
+  result += uint64ToString(this->getMode());
+  switch (this->getMode()) {
+    case kSharpAcAuto:
+      result += F(" (AUTO)");
+      break;
+    case kSharpAcCool:
+      result += F(" (COOL)");
+      break;
+    case kSharpAcHeat:
+      result += F(" (HEAT)");
+      break;
+    case kSharpAcDry:
+      result += F(" (DRY)");
+      break;
+    default:
+      result += F(" (UNKNOWN)");
+  }
+  result += F(", Temp: ");
+  result += uint64ToString(this->getTemp());
+  result += F("C, Fan: ");
+  result += uint64ToString(this->getFan());
+  switch (this->getFan()) {
+    case kSharpAcFanAuto:
+      result += F(" (AUTO)");
+      break;
+    case kSharpAcFanMin:
+      result += F(" (MIN)");
+      break;
+    case kSharpAcFanMed:
+      result += F(" (MED)");
+      break;
+    case kSharpAcFanHigh:
+      result += F(" (HIGH)");
+      break;
+    case kSharpAcFanMax:
+      result += F(" (MAX)");
+      break;
+  }
+  return result;
+}
+
+#if DECODE_SHARP_AC
+// Decode the supplied Sharp A/C message.
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of bits to expect in the data portion. (kSharpAcBits)
+//   strict:  Flag to indicate if we strictly adhere to the specification.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: BETA / Should be working.
+//
+// Ref:
+//   https://github.com/markszabo/IRremoteESP8266/issues/638
+//   https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+bool IRrecv::decodeSharpAc(decode_results *results, const uint16_t nbits,
+                           const bool strict) {
+  // Is there enough data to match successfully?
+  DPRINTLN(2 * nbits + kHeader + kFooter - 1);
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
+    return false;
+
+  // Compliance
+  if (strict && nbits != kSharpAcBits) return false;
+
+  uint16_t offset = kStartOffset;
+  match_result_t data_result;
+  uint16_t dataBitsSoFar = 0;
+  // Header
+  if (!matchMark(results->rawbuf[offset++], kSharpAcHdrMark)) return false;
+  if (!matchSpace(results->rawbuf[offset++], kSharpAcHdrSpace)) return false;
+
+  // Data
+  // Keep reading bytes until we either run out of state to fill.
+  for (uint16_t i = 0; offset <= results->rawlen - 16 && i < nbits;
+       i++, dataBitsSoFar += 8, offset += data_result.used) {
+    // Read in a byte at a time.
+    data_result =
+        matchData(&(results->rawbuf[offset]), 8,
+                  kSharpAcBitMark, kSharpAcOneSpace,
+                  kSharpAcBitMark, kSharpAcZeroSpace,
+                  kTolerance, kMarkExcess, false);
+    if (data_result.success == false) break;  // Fail
+    results->state[i] = (uint8_t)data_result.data;
+  }
+
+  // Footer
+  if (!matchMark(results->rawbuf[offset++], kSharpAcBitMark)) return false;
+  if (offset < results->rawlen &&
+      !matchAtLeast(results->rawbuf[offset], kSharpAcGap))
+    return false;
+
+  // Compliance
+  if (strict) {
+    // Re-check we got the correct size/length due to the way we read the data.
+    if (dataBitsSoFar != kSharpAcBits) return false;
+    if (!IRSharpAc::validChecksum(results->state)) return false;
+  }
+
+  // Success
+  results->decode_type = SHARP_AC;
+  results->bits = dataBitsSoFar;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_SHARP_AC

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -542,7 +542,6 @@ std::string IRSharpAc::toString(void) {
 bool IRrecv::decodeSharpAc(decode_results *results, const uint16_t nbits,
                            const bool strict) {
   // Is there enough data to match successfully?
-  DPRINTLN(2 * nbits + kHeader + kFooter - 1);
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;
 
@@ -557,7 +556,7 @@ bool IRrecv::decodeSharpAc(decode_results *results, const uint16_t nbits,
   if (!matchSpace(results->rawbuf[offset++], kSharpAcHdrSpace)) return false;
 
   // Data
-  // Keep reading bytes until we either run out of state to fill.
+  // Keep reading bytes until we run out of state to fill.
   for (uint16_t i = 0; offset <= results->rawlen - 16 && i < nbits;
        i++, dataBitsSoFar += 8, offset += data_result.used) {
     // Read in a byte at a time.

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -1,0 +1,124 @@
+// Copyright 2019 crankyoldgit
+#ifndef IR_SHARP_H_
+#define IR_SHARP_H_
+
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
+#include "IRrecv.h"
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
+
+// Constants
+const uint16_t kSharpAcHdrMark = 3800;
+const uint16_t kSharpAcHdrSpace = 1900;
+const uint16_t kSharpAcBitMark = 470;
+const uint16_t kSharpAcZeroSpace = 500;
+const uint16_t kSharpAcOneSpace = 1400;
+const uint32_t kSharpAcGap = kDefaultMessageGap;
+
+const uint8_t kSharpAcAuto = 0b000;
+const uint8_t kSharpAcDry = 0b011;
+const uint8_t kSharpAcCool = 0b010;
+const uint8_t kSharpAcHeat = 0b001;
+const uint8_t kSharpAcMinTemp = 15;  // Celsius
+const uint8_t kSharpAcMaxTemp = 30;  // Celsius
+const uint8_t kSharpAcFanAuto = 0b010;  // 2
+const uint8_t kSharpAcFanMin =  0b100;  // 4 (FAN1)
+const uint8_t kSharpAcFanMed =  0b011;  // 3 (FAN2)
+const uint8_t kSharpAcFanHigh = 0b101;  // 5 (FAN3)
+const uint8_t kSharpAcFanMax =  0b111;  // 7 (FAN4)
+const uint8_t kSharpAcByteTemp = 4;
+const uint8_t kSharpAcMaskTemp = 0b00001111;
+const uint8_t kSharpAcBytePower = 5;
+const uint8_t kSharpAcBitPower = 0b00010000;
+const uint8_t kSharpAcByteMode = 6;
+const uint8_t kSharpAcMaskMode = 0b00000011;
+const uint8_t kSharpAcByteFan = kSharpAcByteMode;
+const uint8_t kSharpAcMaskFan = 0b01110000;
+const uint8_t kSharpAcByteManual = 10;
+const uint8_t kSharpAcBitFanManual = 0b00000001;
+const uint8_t kSharpAcBitTempManual = 0b00000100;
+
+
+class IRSharpAc {
+ public:
+  explicit IRSharpAc(uint16_t pin);
+
+#if SEND_SHARP_AC
+  void send(const uint16_t repeat = kSharpAcDefaultRepeat);
+#endif  // SEND_SHARP_AC
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  void setSwingVertical(const bool on);
+  bool getSwingVertical(void);
+  void setSwingHorizontal(const bool on);
+  bool getSwingHorizontal(void);
+  bool getQuiet(void);
+  void setQuiet(const bool on);
+  bool getPowerful(void);
+  void setPowerful(const bool on);
+  void setSensor(const bool on);
+  bool getSensor(void);
+  void setEcono(const bool on);
+  bool getEcono(void);
+  void setEye(const bool on);
+  bool getEye(void);
+  void setMold(const bool on);
+  bool getMold(void);
+  void setComfort(const bool on);
+  bool getComfort(void);
+  void enableOnTimer(const uint16_t starttime);
+  void disableOnTimer(void);
+  uint16_t getOnTime(void);
+  bool getOnTimerEnabled();
+  void enableOffTimer(const uint16_t endtime);
+  void disableOffTimer(void);
+  uint16_t getOffTime(void);
+  bool getOffTimerEnabled(void);
+  void setCurrentTime(const uint16_t mins_since_midnight);
+  uint16_t getCurrentTime(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[],
+              const uint16_t length = kSharpAcStateLength);
+  static bool validChecksum(uint8_t state[],
+                            const uint16_t length = kSharpAcStateLength);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+#ifdef ARDUINO
+  String toString(void);
+  static String renderTime(const uint16_t timemins);
+#else
+  std::string toString(void);
+  static std::string renderTime(const uint16_t timemins);
+#endif
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  // # of bytes per command
+  uint8_t remote[kSharpAcStateLength];
+  void stateReset(void);
+  void checksum(void);
+  static uint8_t calcChecksum(uint8_t state[],
+                              const uint16_t length = kSharpAcStateLength);
+};
+
+#endif  // IR_SHARP_H_

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -12,6 +12,7 @@
 #include "ir_MitsubishiHeavy.h"
 #include "ir_Panasonic.h"
 #include "ir_Samsung.h"
+#include "ir_Sharp.h"
 #include "ir_Tcl.h"
 #include "ir_Teco.h"
 #include "ir_Toshiba.h"
@@ -572,6 +573,27 @@ TEST(TestIRac, Samsung) {
   ASSERT_EQ(expected_on, ac.toString());
 }
 
+TEST(TestIRac, Sharp) {
+  IRSharpAc ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 2 (COOL), Temp: 28C, Fan: 3 (MED)";
+
+  ac.begin();
+  irac.sharp(&ac,
+             true,                         // Power
+             stdAc::opmode_t::kCool,       // Mode
+             28,                           // Celsius
+             stdAc::fanspeed_t::kMedium);  // Fan speed
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(SHARP_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kSharpAcBits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
 TEST(TestIRac, Tcl112) {
   IRTcl112Ac ac(0);
   IRac irac(0);

--- a/test/Makefile
+++ b/test/Makefile
@@ -98,6 +98,7 @@ PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
 		$(USER_DIR)/ir_Mitsubishi.h \
 		$(USER_DIR)/ir_MitsubishiHeavy.h \
 		$(USER_DIR)/ir_NEC.h \
+		$(USER_DIR)/ir_Sharp.h \
 		$(USER_DIR)/ir_Samsung.h \
 		$(USER_DIR)/ir_Trotec.h \
 		$(USER_DIR)/ir_Fujitsu.h \
@@ -288,7 +289,7 @@ ir_Fujitsu_test : $(COMMON_OBJ) ir_Fujitsu_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Sharp.o : $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sharp.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Sharp.cpp
 
 ir_Sharp_test.o : ir_Sharp_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Sharp_test.cpp

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -122,8 +122,8 @@ ir_MitsubishiHeavy.o : $(USER_DIR)/ir_MitsubishiHeavy.h $(USER_DIR)/ir_Mitsubish
 ir_Fujitsu.o : $(USER_DIR)/ir_Fujitsu.h $(USER_DIR)/ir_Fujitsu.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Fujitsu.cpp
 
-ir_Sharp.o : $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Sharp.cpp
+ir_Sharp.o : $(USER_DIR)/ir_Sharp.h $(USER_DIR)/ir_Sharp.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Sharp.cpp
 
 ir_RC5_RC6.o : $(USER_DIR)/ir_RC5_RC6.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_RC5_RC6.cpp


### PR DESCRIPTION
* Add `sendSharpAc()`/`decodeSharpAc()`
* Supports power, mode, temp & fan speed settings only.
* Add common A/C support for Sharp A/C.
* Unit tests.
* Update example code.

Fixes #638