### PR TITLE
 IRMQTTServer: Convert IR A/C messages to Common A/C format.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -94,6 +94,26 @@ const uint16_t kMinUnknownSize = 2 * 10;
 #define REPORT_RAW_UNKNOWNS false  // Report the whole buffer, recommended:
                                    // MQTT_MAX_PACKET_SIZE of 1024 or more
 
+// Should we use and report individual A/C settings we capture via IR if we
+// can understand the individual settings of the remote.
+// e.g. Aquire the A/C settings from an actual A/C IR remote and override
+//      any local settings set via MQTT/HTTP etc.
+#define USE_DECODED_AC_SETTINGS true  // `false` to disable. `true` to enable.
+// Should we allow or ignore an A/C IR remote to override the A/C protocol/model
+// as set via MQTT or HTTP?
+// e.g. If `true`, you can use any fully supported A/C remote to control
+//      another brand's or model's A/C unit. `false` means change to the new
+//      protocol/model if we support it via `USE_DECODED_AC_SETTINGS`.
+#define IGNORE_DECODED_AC_PROTOCOL true
+// Do we (re-)send the captured & decoded A/C message via the IR_LED?
+// `false` if you don't want to repeat the captured message.
+// e.g. Useful if the IR demodulator is located in the path between the remote
+//      and the A/C unit so the command isn't sent twice.
+// `true` if want it sent anyway.
+// e.g. The IR demodulator is in a completely different location than than the
+//      actual a/c unit.
+#define REPLAY_DECODED_AC_MESSAGE false
+
 // ------------------------ Advanced Usage Only --------------------------------
 // Change if you need multiple independent send gpio/topics.
 const uint8_t gpioTable[] = {
@@ -155,7 +175,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.0.1"
+#define _MY_VERSION_ "v1.1.0-alpha"
 
 const uint8_t kSendTableSize = sizeof(gpioTable);
 // JSON stuff
@@ -185,7 +205,7 @@ void receivingMQTT(String const topic_name, String const callback_str);
 void callback(char* topic, byte* payload, unsigned int length);
 void sendMQTTDiscovery(const char *topic);
 void doBroadcast(TimerMs *timer, const uint32_t interval,
-                 const commonAcState_t state, const bool retain,
+                 const stdAc::state_t state, const bool retain,
                  const bool force);
 #endif  // MQTT_ENABLE
 bool isSerialGpioUsedByIr(void);
@@ -249,10 +269,12 @@ bool sendInt(const String topic, const int32_t num, const bool retain);
 bool sendBool(const String topic, const bool on, const bool retain);
 bool sendString(const String topic, const String str, const bool retain);
 bool sendFloat(const String topic, const float_t temp, const bool retain);
-commonAcState_t updateClimate(commonAcState_t current, const String str,
+stdAc::state_t updateClimate(stdAc::state_t current, const String str,
                               const String prefix, const String payload);
-bool cmpClimate(const commonAcState_t a, const commonAcState_t b);
-bool sendClimate(const commonAcState_t prev, const commonAcState_t next,
+bool cmpClimate(const stdAc::state_t a, const stdAc::state_t b);
+bool sendClimate(const stdAc::state_t prev, const stdAc::state_t next,
                  const String topic_prefix, const bool retain,
-                 const bool forceMQTT, const bool forceIR);
+                 const bool forceMQTT, const bool forceIR,
+                 const bool enableIR = true);
+bool decodeCommonAc(const decode_results *decode);
 #endif  // EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3242,6 +3242,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_VESTEL_AC
+#if DECODE_WHIRLPOOL_AC
+    case decode_type_t::WHIRLPOOL_AC: {
+      IRWhirlpoolAc ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_WHIRLPOOL_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2670,7 +2670,7 @@ bool sendIRCode(IRsend *irsend, int const ir_type,
 #if SEND_DENON
     case DENON:  // 17
       if (bits == 0)
-        bits = DENON_BITS;
+        bits = kDenonBits;
       irsend->sendDenon(code, bits, repeat);
       break;
 #endif
@@ -3186,6 +3186,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_PANASONIC_AC
+#if DECODE_SAMSUNG_AC
+    case decode_type_t::SAMSUNG_AC: {
+      IRSamsungAc ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_SAMSUNG_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3234,6 +3234,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_TROTEC
+#if DECODE_VESTEL_AC
+    case decode_type_t::VESTEL_AC: {
+      IRVestelAc ac(IR_LED);
+      ac.setRaw(decode->value);  // Uses value instead of state.
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_VESTEL_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3202,6 +3202,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_SHARP_AC
+#if DECODE_TCL112AC
+    case decode_type_t::TCL112AC: {
+      IRTcl112Ac ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_TCL112AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3068,6 +3068,14 @@ bool decodeCommonAc(const decode_results *decode) {
   stdAc::state_t state = climate;
   debug("Converting inbound IR A/C message to common A/C");
   switch (decode->decode_type) {
+#if DECODE_FUJITSU_AC
+    case decode_type_t::FUJITSU_AC: {
+      IRFujitsuAC ac(IR_LED);
+      ac.setRaw(decode->state, decode->bits / 8);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_FUJITSU_AC
 #if DECODE_KELVINATOR
     case decode_type_t::KELVINATOR: {
       IRKelvinatorAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3164,6 +3164,20 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_MITSUBISHI_AC
+#if DECODE_MITSUBISHIHEAVY
+    case decode_type_t::MITSUBISHI_HEAVY_88: {
+      IRMitsubishiHeavy88Ac ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+    case decode_type_t::MITSUBISHI_HEAVY_152: {
+      IRMitsubishiHeavy152Ac ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_MITSUBISHIHEAVY
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3068,6 +3068,14 @@ bool decodeCommonAc(const decode_results *decode) {
   stdAc::state_t state = climate;
   debug("Converting inbound IR A/C message to common A/C");
   switch (decode->decode_type) {
+#if DECODE_COOLIX
+    case decode_type_t::COOLIX: {
+      IRCoolixAC ac(IR_LED);
+      ac.setRaw(decode->value);  // Uses value instead of state.
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_COOLIX
 #if DECODE_DAIKIN
     case decode_type_t::DAIKIN: {
       IRDaikinESP ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3148,6 +3148,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_KELVINATOR
+#if DECODE_MIDEA
+    case decode_type_t::MIDEA: {
+      IRMideaAC ac(IR_LED);
+      ac.setRaw(decode->value);  // Uses value instead of state.
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_MIDEA
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3068,6 +3068,14 @@ bool decodeCommonAc(const decode_results *decode) {
   stdAc::state_t state = climate;
   debug("Converting inbound IR A/C message to common A/C");
   switch (decode->decode_type) {
+#if DECODE_ARGO
+    case decode_type_t::ARGO: {
+      IRArgoAC ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_ARGO
 #if DECODE_COOLIX
     case decode_type_t::COOLIX: {
       IRCoolixAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3178,6 +3178,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_MITSUBISHIHEAVY
+#if DECODE_PANASONIC_AC
+    case decode_type_t::PANASONIC_AC: {
+      IRPanasonicAc ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_PANASONIC_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3218,6 +3218,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_TECO
+#if DECODE_TOSHIBA_AC
+    case decode_type_t::TOSHIBA_AC: {
+      IRToshibaAC ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_TOSHIBA_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3132,6 +3132,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_HAIER_AC_YRW02
+#if (DECODE_HITACHI_AC || DECODE_HITACHI_AC2)
+    case decode_type_t::HITACHI_AC: {
+      IRHitachiAc ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // (DECODE_HITACHI_AC || DECODE_HITACHI_AC2)
 #if DECODE_KELVINATOR
     case decode_type_t::KELVINATOR: {
       IRKelvinatorAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3210,6 +3210,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_TCL112AC
+#if DECODE_TECO
+    case decode_type_t::TECO: {
+      IRTecoAc ac(IR_LED);
+      ac.setRaw(decode->value);  // Uses value instead of state.
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_TECO
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3226,6 +3226,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_TOSHIBA_AC
+#if DECODE_TROTEC
+    case decode_type_t::TROTEC: {
+      IRTrotecESP ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_TROTEC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3068,6 +3068,30 @@ bool decodeCommonAc(const decode_results *decode) {
   stdAc::state_t state = climate;
   debug("Converting inbound IR A/C message to common A/C");
   switch (decode->decode_type) {
+#if DECODE_DAIKIN
+    case decode_type_t::DAIKIN: {
+      IRDaikinESP ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_DAIKIN
+#if DECODE_DAIKIN2
+    case decode_type_t::DAIKIN2: {
+      IRDaikin2 ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_DAIKIN2
+#if DECODE_DAIKIN216
+    case decode_type_t::DAIKIN216: {
+      IRDaikin216 ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_DAIKIN216
 #if DECODE_FUJITSU_AC
     case decode_type_t::FUJITSU_AC: {
       IRFujitsuAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3124,6 +3124,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_HAIER_AC
+#if DECODE_HAIER_AC_YRW02
+    case decode_type_t::HAIER_AC_YRW02: {
+      IRHaierACYRW02 ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_HAIER_AC_YRW02
 #if DECODE_KELVINATOR
     case decode_type_t::KELVINATOR: {
       IRKelvinatorAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3156,6 +3156,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_MIDEA
+#if DECODE_MITSUBISHI_AC
+    case decode_type_t::MITSUBISHI_AC: {
+      IRMitsubishiAC ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_MITSUBISHI_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3116,6 +3116,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_GREE
+#if DECODE_HAIER_AC
+    case decode_type_t::HAIER_AC: {
+      IRHaierAC ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_HAIER_AC
 #if DECODE_KELVINATOR
     case decode_type_t::KELVINATOR: {
       IRKelvinatorAC ac(IR_LED);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3194,6 +3194,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_SAMSUNG_AC
+#if DECODE_SHARP_AC
+    case decode_type_t::SHARP_AC: {
+      IRSharpAc ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_SHARP_AC
     default:
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3108,6 +3108,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_FUJITSU_AC
+#if DECODE_GREE
+    case decode_type_t::GREE: {
+      IRGreeAC ac(IR_LED);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_GREE
 #if DECODE_KELVINATOR
     case decode_type_t::KELVINATOR: {
       IRKelvinatorAC ac(IR_LED);

--- a/examples/TurnOnArgoAC/TurnOnArgoAC.ino
+++ b/examples/TurnOnArgoAC/TurnOnArgoAC.ino
@@ -44,7 +44,7 @@ void loop() {
   // Set up what we want to send. See ir_Argo.cpp for all the options.
   ac.setPower(true);
   ac.setFan(kArgoFan1);
-  ac.setCoolMode(kArgoCoolAuto);
+  ac.setMode(kArgoAuto);
   ac.setTemp(25);
 
 #if SEND_ARGO

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -312,6 +312,7 @@ void IRac::gree(IRGreeAC *ac,
   ac->setXFan(clean);
   ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
   // No Horizontal Swing setting available.
+  // No Econo setting available.
   // No Filter setting available.
   // No Beep setting available.
   // No Quiet setting available.

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -122,19 +122,7 @@ void IRac::argo(IRArgoAC *ac,
                 const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                 const bool turbo, const int16_t sleep) {
   ac->setPower(on);
-  switch (mode) {
-    case stdAc::opmode_t::kCool:
-      ac->setCoolMode(kArgoCoolOn);
-      break;
-    case stdAc::opmode_t::kHeat:
-      ac->setHeatMode(kArgoHeatOn);
-      break;
-    case stdAc::opmode_t::kDry:
-      ac->setCoolMode(kArgoCoolHum);
-      break;
-    default:  // No idea how to set Fan mode.
-      ac->setCoolMode(kArgoCoolAuto);
-  }
+  ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
   ac->setFlap(ac->convertSwingV(swingv));

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -229,26 +229,4 @@ void daikin216(IRDaikin216 *ac,
                  const int16_t sleep = -1, const int16_t clock = -1);
 #endif  // SEND_WHIRLPOOL_AC
 };  // IRac class
-
-// Structure to hold a common A/C state.
-typedef struct {
-  decode_type_t protocol;
-  int16_t model;
-  bool power;
-  stdAc::opmode_t mode;
-  float degrees;
-  bool celsius;
-  stdAc::fanspeed_t fanspeed;
-  stdAc::swingv_t swingv;
-  stdAc::swingh_t swingh;
-  bool quiet;
-  bool turbo;
-  bool econo;
-  bool light;
-  bool filter;
-  bool clean;
-  bool beep;
-  int16_t sleep;
-  int16_t clock;
-} commonAcState_t;
 #endif  // IRAC_H_

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -335,7 +335,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
 #if DECODE_DENON
   // Denon needs to precede Panasonic as it is a special case of Panasonic.
   DPRINTLN("Attempting Denon decode");
-  if (decodeDenon(results, DENON_48_BITS) || decodeDenon(results, DENON_BITS) ||
+  if (decodeDenon(results, kDenon48Bits) || decodeDenon(results, kDenonBits) ||
       decodeDenon(results, kDenonLegacyBits))
     return true;
 #endif

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -364,8 +364,9 @@ class IRrecv {
                       bool strict = true);
 #endif
 #if DECODE_TCL112AC
-  bool decodeTcl112Ac(decode_results *results, uint16_t nbits = kTcl112AcBits,
-                      bool strict = true);
+  bool decodeTcl112Ac(decode_results *results,
+                      const uint16_t nbits = kTcl112AcBits,
+                      const bool strict = true);
 #endif
 #if DECODE_TECO
   bool decodeTeco(decode_results *results, uint16_t nbits = kTecoBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -317,12 +317,14 @@ class IRrecv {
                           bool strict = true);
 #endif
 #if (DECODE_HITACHI_AC || DECODE_HITACHI_AC2)
-  bool decodeHitachiAC(decode_results *results, uint16_t nbits = kHitachiAcBits,
-                       bool strict = true);
+  bool decodeHitachiAC(decode_results *results,
+                       const uint16_t nbits = kHitachiAcBits,
+                       const bool strict = true);
 #endif
 #if DECODE_HITACHI_AC1
   bool decodeHitachiAC1(decode_results *results,
-                        uint16_t nbits = kHitachiAc1Bits, bool strict = true);
+                        const uint16_t nbits = kHitachiAc1Bits,
+                        const bool strict = true);
 #endif
 #if DECODE_GICABLE
   bool decodeGICable(decode_results *results, uint16_t nbits = kGicableBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -218,8 +218,9 @@ class IRrecv {
                  bool strict = true);
 #endif
 #if DECODE_SAMSUNG
-  bool decodeSAMSUNG(decode_results *results, uint16_t nbits = kSamsungBits,
-                     bool strict = true);
+  bool decodeSAMSUNG(decode_results *results,
+                     const uint16_t nbits = kSamsungBits,
+                     const bool strict = true);
 #endif
 #if DECODE_SAMSUNG
   bool decodeSamsung36(decode_results *results,
@@ -227,8 +228,9 @@ class IRrecv {
                        const bool strict = true);
 #endif
 #if DECODE_SAMSUNG_AC
-  bool decodeSamsungAC(decode_results *results, uint16_t nbits = kSamsungAcBits,
-                       bool strict = true);
+  bool decodeSamsungAC(decode_results *results,
+                       const uint16_t nbits = kSamsungAcBits,
+                       const bool strict = true);
 #endif
 #if DECODE_WHYNTER
   bool decodeWhynter(decode_results *results, uint16_t nbits = kWhynterBits,
@@ -239,7 +241,7 @@ class IRrecv {
                     bool strict = true);
 #endif
 #if DECODE_DENON
-  bool decodeDenon(decode_results *results, uint16_t nbits = DENON_BITS,
+  bool decodeDenon(decode_results *results, uint16_t nbits = kDenonBits,
                    bool strict = true);
 #endif
 #if DECODE_DISH

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -369,8 +369,8 @@ class IRrecv {
                       const bool strict = true);
 #endif
 #if DECODE_TECO
-  bool decodeTeco(decode_results *results, uint16_t nbits = kTecoBits,
-                  bool strict = false);
+  bool decodeTeco(decode_results *results, const uint16_t nbits = kTecoBits,
+                  const bool strict = false);
 #endif
 #if DECODE_LEGOPF
   bool decodeLegoPf(decode_results *results, const uint16_t nbits = kLegoPfBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -361,8 +361,9 @@ class IRrecv {
                  bool strict = true);
 #endif
 #if DECODE_VESTEL_AC
-  bool decodeVestelAc(decode_results *results, uint16_t nbits = kVestelAcBits,
-                      bool strict = true);
+  bool decodeVestelAc(decode_results *results,
+                      const uint16_t nbits = kVestelAcBits,
+                      const bool strict = true);
 #endif
 #if DECODE_TCL112AC
   bool decodeTcl112Ac(decode_results *results,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -249,8 +249,8 @@ class IRrecv {
                   bool strict = true);
 #endif
 #if (DECODE_SHARP || DECODE_DENON)
-  bool decodeSharp(decode_results *results, uint16_t nbits = kSharpBits,
-                   bool strict = true, bool expansion = true);
+  bool decodeSharp(decode_results *results, const uint16_t nbits = kSharpBits,
+                   const bool strict = true, const bool expansion = true);
 #endif
 #if DECODE_SHARP_AC
   bool decodeSharpAc(decode_results *results,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -336,7 +336,8 @@ class IRrecv {
 #endif
 #if DECODE_WHIRLPOOL_AC
   bool decodeWhirlpoolAC(decode_results *results,
-                         uint16_t nbits = kWhirlpoolAcBits, bool strict = true);
+                         const uint16_t nbits = kWhirlpoolAcBits,
+                         const bool strict = true);
 #endif
 #if DECODE_LUTRON
   bool decodeLutron(decode_results *results, uint16_t nbits = kLutronBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -288,7 +288,8 @@ class IRrecv {
 #endif
 #if DECODE_TOSHIBA_AC
   bool decodeToshibaAC(decode_results *results,
-                       uint16_t nbytes = kToshibaACBits, bool strict = true);
+                       const uint16_t nbytes = kToshibaACBits,
+                       const bool strict = true);
 #endif
 #if DECODE_MIDEA
   bool decodeMidea(decode_results *results, uint16_t nbits = kMideaBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -204,9 +204,10 @@ class IRrecv {
                   bool strict = false);
 #endif
 #if (DECODE_PANASONIC || DECODE_DENON)
-  bool decodePanasonic(decode_results *results, uint16_t nbits = kPanasonicBits,
-                       bool strict = false,
-                       uint32_t manufacturer = kPanasonicManufacturer);
+  bool decodePanasonic(decode_results *results,
+                       const uint16_t nbits = kPanasonicBits,
+                       const bool strict = false,
+                       const uint32_t manufacturer = kPanasonicManufacturer);
 #endif
 #if DECODE_LG
   bool decodeLG(decode_results *results, uint16_t nbits = kLgBits,
@@ -344,7 +345,8 @@ class IRrecv {
 #endif
 #if DECODE_PANASONIC_AC
   bool decodePanasonicAC(decode_results *results,
-                         uint16_t nbits = kPanasonicAcBits, bool strict = true);
+                         const uint16_t nbits = kPanasonicAcBits,
+                         const bool strict = true);
 #endif
 #if DECODE_PIONEER
   bool decodePioneer(decode_results *results,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -345,6 +345,7 @@ const uint16_t kDaikin216StateLength = 27;
 const uint16_t kDaikin216Bits = kDaikin216StateLength * 8;
 const uint16_t kDaikin216DefaultRepeat = kNoRepeat;
 const uint16_t kDenonBits = 15;
+const uint16_t kDenon48Bits = 48;
 const uint16_t kDenonLegacyBits = 14;
 const uint16_t kDishBits = 16;
 const uint16_t kDishMinRepeat = 3;
@@ -466,7 +467,7 @@ const uint8_t  kVestelAcBits = 56;
 #define CARRIER_AC_BITS               kCarrierAcBits
 #define DAIKIN_COMMAND_LENGTH         kDaikinStateLength
 #define DENON_BITS                    kDenonBits
-#define DENON_48_BITS                 kPanasonicBits
+#define DENON_48_BITS                 kDenon48Bits
 #define DENON_LEGACY_BITS             kDenonLegacyBits
 #define DISH_BITS                     kDishBits
 #define FUJITSU_AC_MIN_REPEAT         kFujitsuAcMinRepeat

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -353,19 +353,19 @@ class IRsend {
                         const uint16_t repeat = kHaierAcYrw02DefaultRepeat);
 #endif
 #if SEND_HITACHI_AC
-  void sendHitachiAC(unsigned char data[],
-                     uint16_t nbytes = kHitachiAcStateLength,
-                     uint16_t repeat = kHitachiAcDefaultRepeat);
+  void sendHitachiAC(const unsigned char data[],
+                     const uint16_t nbytes = kHitachiAcStateLength,
+                     const uint16_t repeat = kHitachiAcDefaultRepeat);
 #endif
 #if SEND_HITACHI_AC1
-  void sendHitachiAC1(unsigned char data[],
-                      uint16_t nbytes = kHitachiAc1StateLength,
-                      uint16_t repeat = kNoRepeat);
+  void sendHitachiAC1(const unsigned char data[],
+                      const uint16_t nbytes = kHitachiAc1StateLength,
+                      const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_HITACHI_AC2
-  void sendHitachiAC2(unsigned char data[],
-                      uint16_t nbytes = kHitachiAc2StateLength,
-                      uint16_t repeat = kNoRepeat);
+  void sendHitachiAC2(const unsigned char data[],
+                      const uint16_t nbytes = kHitachiAc2StateLength,
+                      const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_GICABLE
   void sendGICable(uint64_t data, uint16_t nbits = kGicableBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -343,13 +343,14 @@ class IRsend {
                      uint16_t repeat = kCarrierAcMinRepeat);
 #endif
 #if (SEND_HAIER_AC || SEND_HAIER_AC_YRW02)
-  void sendHaierAC(unsigned char data[], uint16_t nbytes = kHaierACStateLength,
-                   uint16_t repeat = kHaierAcDefaultRepeat);
+  void sendHaierAC(const unsigned char data[],
+                   const uint16_t nbytes = kHaierACStateLength,
+                   const uint16_t repeat = kHaierAcDefaultRepeat);
 #endif
 #if SEND_HAIER_AC_YRW02
-  void sendHaierACYRW02(unsigned char data[],
-                        uint16_t nbytes = kHaierACYRW02StateLength,
-                        uint16_t repeat = kHaierAcYrw02DefaultRepeat);
+  void sendHaierACYRW02(const unsigned char data[],
+                        const uint16_t nbytes = kHaierACYRW02StateLength,
+                        const uint16_t repeat = kHaierAcYrw02DefaultRepeat);
 #endif
 #if SEND_HITACHI_AC
   void sendHitachiAC(unsigned char data[],

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -70,6 +70,28 @@ namespace stdAc {
     kRight =    4,
     kRightMax = 5,
   };
+
+  // Structure to hold a common A/C state.
+  typedef struct {
+    decode_type_t protocol;
+    int16_t model;
+    bool power;
+    stdAc::opmode_t mode;
+    float degrees;
+    bool celsius;
+    stdAc::fanspeed_t fanspeed;
+    stdAc::swingv_t swingv;
+    stdAc::swingh_t swingh;
+    bool quiet;
+    bool turbo;
+    bool econo;
+    bool light;
+    bool filter;
+    bool clean;
+    bool beep;
+    int16_t sleep;
+    int16_t clock;
+  } state_t;
 };  // namespace stdAc
 
 // Classes

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -311,8 +311,9 @@ class IRsend {
   void sendPronto(uint16_t data[], uint16_t len, uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_ARGO
-  void sendArgo(unsigned char data[], uint16_t nbytes = kArgoStateLength,
-                uint16_t repeat = kArgoDefaultRepeat);
+  void sendArgo(const unsigned char data[],
+                const uint16_t nbytes = kArgoStateLength,
+                const uint16_t repeat = kArgoDefaultRepeat);
 #endif
 #if SEND_TROTEC
   void sendTrotec(const unsigned char data[],

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -174,13 +174,14 @@ class IRsend {
   uint32_t encodeLG(uint16_t address, uint16_t command);
 #endif
 #if (SEND_SHARP || SEND_DENON)
-  uint32_t encodeSharp(uint16_t address, uint16_t command,
-                       uint16_t expansion = 1, uint16_t check = 0,
-                       bool MSBfirst = false);
-  void sendSharp(uint16_t address, uint16_t command,
-                 uint16_t nbits = kSharpBits, uint16_t repeat = kNoRepeat);
-  void sendSharpRaw(uint64_t data, uint16_t nbits = kSharpBits,
-                    uint16_t repeat = kNoRepeat);
+  uint32_t encodeSharp(const uint16_t address, const uint16_t command,
+                       const uint16_t expansion = 1, const uint16_t check = 0,
+                       const bool MSBfirst = false);
+  void sendSharp(const uint16_t address, const uint16_t command,
+                 const uint16_t nbits = kSharpBits,
+                 const uint16_t repeat = kNoRepeat);
+  void sendSharpRaw(const uint64_t data, const uint16_t nbits = kSharpBits,
+                    const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_SHARP_AC
   void sendSharpAc(const unsigned char data[],

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -411,8 +411,8 @@ class IRsend {
                     const uint16_t repeat = kTcl112AcDefaultRepeat);
 #endif
 #if SEND_TECO
-  void sendTeco(uint64_t data, uint16_t nbits = kTecoBits,
-                uint16_t repeat = kNoRepeat);
+  void sendTeco(const uint64_t data, const uint16_t nbits = kTecoBits,
+                const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_LEGOPF
   void sendLegoPf(const uint64_t data, const uint16_t nbits = kLegoPfBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -153,9 +153,9 @@ class IRsend {
                     uint16_t repeat = kSherwoodMinRepeat);
 #endif
 #if SEND_SAMSUNG
-  void sendSAMSUNG(uint64_t data, uint16_t nbits = kSamsungBits,
-                   uint16_t repeat = kNoRepeat);
-  uint32_t encodeSAMSUNG(uint8_t customer, uint8_t command);
+  void sendSAMSUNG(const uint64_t data, const uint16_t nbits = kSamsungBits,
+                   const uint16_t repeat = kNoRepeat);
+  uint32_t encodeSAMSUNG(const uint8_t customer, const uint8_t command);
 #endif
 #if SEND_SAMSUNG36
   void sendSamsung36(const uint64_t data, const uint16_t nbits = kSamsung36Bits,
@@ -193,7 +193,7 @@ class IRsend {
   uint16_t encodeJVC(uint8_t address, uint8_t command);
 #endif
 #if SEND_DENON
-  void sendDenon(uint64_t data, uint16_t nbits = DENON_BITS,
+  void sendDenon(uint64_t data, uint16_t nbits = kDenonBits,
                  uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_SANYO

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -315,8 +315,9 @@ class IRsend {
                 uint16_t repeat = kArgoDefaultRepeat);
 #endif
 #if SEND_TROTEC
-  void sendTrotec(unsigned char data[], uint16_t nbytes = kTrotecStateLength,
-                  uint16_t repeat = kTrotecDefaultRepeat);
+  void sendTrotec(const unsigned char data[],
+                  const uint16_t nbytes = kTrotecStateLength,
+                  const uint16_t repeat = kTrotecDefaultRepeat);
 #endif
 #if SEND_NIKAI
   void sendNikai(uint64_t data, uint16_t nbits = kNikaiBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -210,13 +210,14 @@ class IRsend {
                 uint16_t repeat = kDishMinRepeat);
 #endif
 #if (SEND_PANASONIC || SEND_DENON)
-  void sendPanasonic64(uint64_t data, uint16_t nbits = kPanasonicBits,
-                       uint16_t repeat = kNoRepeat);
-  void sendPanasonic(uint16_t address, uint32_t data,
-                     uint16_t nbits = kPanasonicBits,
-                     uint16_t repeat = kNoRepeat);
-  uint64_t encodePanasonic(uint16_t manufacturer, uint8_t device,
-                           uint8_t subdevice, uint8_t function);
+  void sendPanasonic64(const uint64_t data,
+                       const uint16_t nbits = kPanasonicBits,
+                       const uint16_t repeat = kNoRepeat);
+  void sendPanasonic(const uint16_t address, const uint32_t data,
+                     const uint16_t nbits = kPanasonicBits,
+                     const uint16_t repeat = kNoRepeat);
+  uint64_t encodePanasonic(const uint16_t manufacturer, const uint8_t device,
+                           const uint8_t subdevice, const uint8_t function);
 #endif
 #if SEND_RC5
   void sendRC5(uint64_t data, uint16_t nbits = kRC5XBits,
@@ -386,9 +387,9 @@ class IRsend {
                      uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_PANASONIC_AC
-  void sendPanasonicAC(unsigned char data[],
-                       uint16_t nbytes = kPanasonicAcStateLength,
-                       uint16_t repeat = kPanasonicAcDefaultRepeat);
+  void sendPanasonicAC(const unsigned char data[],
+                       const uint16_t nbytes = kPanasonicAcStateLength,
+                       const uint16_t repeat = kPanasonicAcDefaultRepeat);
 #endif
 #if SEND_PIONEER
   void sendPioneer(const uint64_t data, const uint16_t nbits = kPioneerBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -323,9 +323,9 @@ class IRsend {
                  uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_TOSHIBA_AC
-  void sendToshibaAC(unsigned char data[],
-                     uint16_t nbytes = kToshibaACStateLength,
-                     uint16_t repeat = kToshibaACMinRepeat);
+  void sendToshibaAC(const unsigned char data[],
+                     const uint16_t nbytes = kToshibaACStateLength,
+                     const uint16_t repeat = kToshibaACMinRepeat);
 #endif
 #if SEND_MIDEA
   void sendMidea(uint64_t data, uint16_t nbits = kMideaBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -375,9 +375,9 @@ class IRsend {
                    uint16_t repeat = kGicableMinRepeat);
 #endif
 #if SEND_WHIRLPOOL_AC
-  void sendWhirlpoolAC(unsigned char data[],
-                       uint16_t nbytes = kWhirlpoolAcStateLength,
-                       uint16_t repeat = kWhirlpoolAcDefaultRepeat);
+  void sendWhirlpoolAC(const unsigned char data[],
+                       const uint16_t nbytes = kWhirlpoolAcStateLength,
+                       const uint16_t repeat = kWhirlpoolAcDefaultRepeat);
 #endif
 #if SEND_LUTRON
   void sendLutron(uint64_t data, uint16_t nbits = kLutronBits,

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -33,19 +33,41 @@
 
 // Constants. Store MSB left.
 
-const uint8_t kArgoCoolOn = 0;  // 0b000
-const uint8_t kArgoCoolOff = 3;  // 0b110
-const uint8_t kArgoCoolAuto = 2;  // 0b010
-const uint8_t kArgoCoolHum = 1;  // 0b100
-const uint8_t kArgoHeatOn = 0;  // 0b001
-const uint8_t kArgoHeatAuto = 1;  // 0b101
-const uint8_t kArgoHeatBlink = 2;  // 0b011  // ??no idea what mode that is
-const uint8_t kArgoMinTemp = 10;  // Celsius offset +4
-const uint8_t kArgoMaxTemp = 32;  // Celsius
+// byte[2]
+const uint8_t kArgoHeatBit =      0b00100000;
+const uint8_t kArgoModeMask =     0b00111000;
+const uint8_t kArgoTempLowMask =  0b11000000;
+const uint8_t kArgoCool =           0b000;  // 0b000 (LSB) 0
+const uint8_t kArgoDry =            0b001;  // 0b100 (LSB) 1
+const uint8_t kArgoAuto =           0b010;  // 0b010 (LSB) 2
+const uint8_t kArgoOff =            0b011;  // 0b110 (LSB) 3
+const uint8_t kArgoHeat =           0b100;  // 0b001 (LSB) 4
+const uint8_t kArgoHeatAuto =       0b101;  // 0b101 (LSB) 5
+// ?no idea what mode that is
+const uint8_t kArgoHeatBlink = 0b110;  // 0b011 (LSB) 6
+
+// byte[3]
+const uint8_t kArgoTempHighMask =    0b00000111;
+const uint8_t kArgoFanMask =         0b00011000;
+const uint8_t kArgoRoomTempLowMask = 0b11100000;
 const uint8_t kArgoFanAuto = 0;  // 0b00
 const uint8_t kArgoFan3 = 3;  // 0b11
 const uint8_t kArgoFan2 = 2;  // 0b01
 const uint8_t kArgoFan1 = 1;  // 0b10
+
+// byte[4]
+const uint8_t kArgoRoomTempHighMask = 0b00000011;
+
+// byte[9]
+const uint8_t kArgoPowerBit = 0b00100000;
+const uint8_t kArgoMaxBit =   0b00001000;
+const uint8_t kArgoNightBit = 0b00000100;
+const uint8_t kArgoIFeelBit = 0b10000000;
+
+const uint8_t kArgoTempOffset = 4;
+const uint8_t kArgoMinTemp = 10;  // Celsius offset +4
+const uint8_t kArgoMaxTemp = 32;  // Celsius
+
 const uint8_t kArgoFlapAuto = 0;  // 0b000
 const uint8_t kArgoFlap1 = 1;  // 0b100
 const uint8_t kArgoFlap2 = 2;  // 0b010
@@ -81,49 +103,51 @@ const uint8_t kArgoFlapFull = 7;  // 0b111
 
 class IRArgoAC {
  public:
-  explicit IRArgoAC(uint16_t pin);
+  explicit IRArgoAC(const uint16_t pin);
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
 #endif  // SEND_ARGO
-  void begin();
-  void on();
-  void off();
+  void begin(void);
+  void on(void);
+  void off(void);
 
-  void setPower(bool state);
-  uint8_t getPower();
+  void setPower(const bool on);
+  bool getPower(void);
 
-  void setTemp(uint8_t temp);
-  uint8_t getTemp();
+  void setTemp(const uint8_t degrees);
+  uint8_t getTemp(void);
 
-  void setFan(uint8_t fan);
-  uint8_t getFan();
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
 
-  void setFlap(uint8_t flap);
-  uint8_t getFlap();
+  void setFlap(const uint8_t flap);
+  uint8_t getFlap(void);
 
-  void setCoolMode(uint8_t mode);
-  uint8_t getCoolMode();
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
 
-  void setHeatMode(uint8_t mode);
-  uint8_t getHeatMode();
-  uint8_t getMode();
+  void setMax(const bool on);
+  bool getMax(void);
 
-  void setMax(bool state);
-  bool getMax();
+  void setNight(const bool on);
+  bool getNight(void);
 
-  void setNight(bool state);
-  bool getNight();
+  void setiFeel(const bool on);
+  bool getiFeel(void);
 
-  void setiFeel(bool state);
-  bool getiFeel();
+  void setTime(void);
+  void setRoomTemp(const uint8_t degrees);
+  uint8_t getRoomTemp(void);
 
-  void setTime();
-  void setRoomTemp(uint8_t temp);
-
-  uint8_t* getRaw();
-  uint8_t convertFan(const stdAc::fanspeed_t speed);
-  uint8_t convertSwingV(const stdAc::swingv_t position);
+  uint8_t* getRaw(void);
+  void setRaw(const char state[]);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifndef UNIT_TEST
 
  private:
@@ -133,20 +157,13 @@ class IRArgoAC {
 #endif
   // # of bytes per command
   uint8_t argo[kArgoStateLength];  // Defined in IRremoteESP8266.h
-  void stateReset();
-  void checksum();
+  void stateReset(void);
+  void checksum(void);
 
   // Attributes
-  uint8_t set_temp;
-  uint8_t fan_mode;
   uint8_t flap_mode;
-  uint8_t ac_state;
-  uint8_t ac_mode;  // heat 1, cool 0
   uint8_t heat_mode;
   uint8_t cool_mode;
-  uint8_t night_mode;  // on/off
-  uint8_t max_mode;  // on/off
-  uint8_t ifeel_mode;  // on/off
 };
 
 #endif  // IR_ARGO_H_

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -337,6 +337,54 @@ uint8_t IRCoolixAC::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRCoolixAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kCoolixCool: return stdAc::opmode_t::kCool;
+    case kCoolixHeat: return stdAc::opmode_t::kHeat;
+    case kCoolixDry: return stdAc::opmode_t::kDry;
+    case kCoolixFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRCoolixAC::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kCoolixFanMax: return stdAc::fanspeed_t::kMax;
+    case kCoolixFanMed: return stdAc::fanspeed_t::kMedium;
+    case kCoolixFanMin: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRCoolixAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::COOLIX;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwing() ? stdAc::swingv_t::kAuto :
+                                     stdAc::swingv_t::kOff;
+  result.swingh = this->getSwing() ? stdAc::swingh_t::kAuto :
+                                     stdAc::swingh_t::kOff;
+  result.turbo = this->getTurbo();
+  result.sleep = this->getSleep() ? 0 : -1;
+  result.light = this->getLed();
+  result.clean = this->getClean();
+  // Not supported.
+  result.quiet = false;
+  result.econo = false;
+  result.filter = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRCoolixAC::toString() {

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -125,6 +125,9 @@ class IRCoolixAC {
   void setRaw(const uint32_t new_code);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString();
 #else

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -417,6 +417,91 @@ uint8_t IRDaikinESP::getCurrentDay(void) {
   return ((remote[kDaikinByteClockMinsHigh] & 0x38) >> 3);
 }
 
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRDaikinESP::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool:
+      return kDaikinCool;
+    case stdAc::opmode_t::kHeat:
+      return kDaikinHeat;
+    case stdAc::opmode_t::kDry:
+      return kDaikinDry;
+    case stdAc::opmode_t::kFan:
+      return kDaikinFan;
+    default:
+      return kDaikinAuto;
+  }
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRDaikinESP::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+      return kDaikinFanQuiet;
+    case stdAc::fanspeed_t::kLow:
+      return kDaikinFanMin;
+    case stdAc::fanspeed_t::kMedium:
+      return kDaikinFanMin + 1;
+    case stdAc::fanspeed_t::kHigh:
+      return kDaikinFanMax - 1;
+    case stdAc::fanspeed_t::kMax:
+      return kDaikinFanMax;
+    default:
+      return kDaikinFanAuto;
+  }
+}
+
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRDaikinESP::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kDaikinCool: return stdAc::opmode_t::kCool;
+    case kDaikinHeat: return stdAc::opmode_t::kHeat;
+    case kDaikinDry: return stdAc::opmode_t::kDry;
+    case kDaikinFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRDaikinESP::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kDaikinFanMax: return stdAc::fanspeed_t::kMax;
+    case kDaikinFanMax - 1: return stdAc::fanspeed_t::kHigh;
+    case kDaikinFanMin + 1: return stdAc::fanspeed_t::kMedium;
+    case kDaikinFanMin: return stdAc::fanspeed_t::kLow;
+    case kDaikinFanQuiet: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRDaikinESP::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::DAIKIN;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  result.swingh = this->getSwingHorizontal() ? stdAc::swingh_t::kAuto :
+                                               stdAc::swingh_t::kOff;
+  result.quiet = this->getQuiet();
+  result.turbo = this->getPowerful();
+  result.clean = this->getMold();
+  result.econo = this->getEcono();
+  // Not supported.
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 #ifdef ARDUINO
 String IRDaikinESP::renderTime(const uint16_t timemins) {
   String ret;
@@ -529,40 +614,6 @@ std::string IRDaikinESP::toString(void) {
   else
     result += F("Off");
   return result;
-}
-
-// Convert a standard A/C mode into its native mode.
-uint8_t IRDaikinESP::convertMode(const stdAc::opmode_t mode) {
-  switch (mode) {
-    case stdAc::opmode_t::kCool:
-      return kDaikinCool;
-    case stdAc::opmode_t::kHeat:
-      return kDaikinHeat;
-    case stdAc::opmode_t::kDry:
-      return kDaikinDry;
-    case stdAc::opmode_t::kFan:
-      return kDaikinFan;
-    default:
-      return kDaikinAuto;
-  }
-}
-
-// Convert a standard A/C Fan speed into its native fan speed.
-uint8_t IRDaikinESP::convertFan(const stdAc::fanspeed_t speed) {
-  switch (speed) {
-    case stdAc::fanspeed_t::kMin:
-      return kDaikinFanQuiet;
-    case stdAc::fanspeed_t::kLow:
-      return kDaikinFanMin;
-    case stdAc::fanspeed_t::kMedium:
-      return kDaikinFanMin + 1;
-    case stdAc::fanspeed_t::kHigh:
-      return kDaikinFanMax - 1;
-    case stdAc::fanspeed_t::kMax:
-      return kDaikinFanMax;
-    default:
-      return kDaikinFanAuto;
-  }
 }
 
 #if DECODE_DAIKIN
@@ -1124,6 +1175,53 @@ uint8_t IRDaikin2::convertSwingV(const stdAc::swingv_t position) {
   }
 }
 
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRDaikin2::toCommonSwingV(const uint8_t setting) {
+  switch (setting) {
+    case kDaikin2SwingVHigh: return stdAc::swingv_t::kHighest;
+    case kDaikin2SwingVHigh + 1: return stdAc::swingv_t::kHigh;
+    case kDaikin2SwingVHigh + 2:
+    case kDaikin2SwingVHigh + 3: return stdAc::swingv_t::kMiddle;
+    case kDaikin2SwingVLow - 1: return stdAc::swingv_t::kLow;
+    case kDaikin2SwingVLow: return stdAc::swingv_t::kLowest;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert a native horizontal swing to it's common equivalent.
+stdAc::swingh_t IRDaikin2::toCommonSwingH(const uint8_t setting) {
+  switch (setting) {
+    case kDaikin2SwingHSwing:
+    case kDaikin2SwingHAuto: return stdAc::swingh_t::kAuto;
+    default: return stdAc::swingh_t::kOff;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRDaikin2::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::DAIKIN2;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = IRDaikinESP::toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = IRDaikinESP::toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getSwingVertical());
+  result.swingh = this->toCommonSwingH(this->getSwingHorizontal());
+  result.quiet = this->getQuiet();
+  result.light = this->getLight();
+  result.turbo = this->getPowerful();
+  result.clean = this->getMold();
+  result.econo = this->getEcono();
+  result.filter = this->getPurify();
+  result.beep = this->getBeep();
+  result.sleep = this->getSleepTimerEnabled() ? this->getSleepTime() : -1;
+  // Not supported.
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRDaikin2::toString() {
@@ -1617,6 +1715,33 @@ void IRDaikin216::setPowerful(const bool on) {
 
 bool IRDaikin216::getPowerful() {
   return remote_state[kDaikin216BytePowerful] & kDaikinBitPowerful;
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRDaikin216::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::DAIKIN216;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = IRDaikinESP::toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = IRDaikinESP::toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  result.swingh = this->getSwingHorizontal() ? stdAc::swingh_t::kAuto :
+                                               stdAc::swingh_t::kOff;
+  result.quiet = this->getQuiet();
+  result.turbo = this->getPowerful();
+  // Not supported.
+  result.light = false;
+  result.clean = false;
+  result.econo = false;
+  result.filter = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -280,6 +280,9 @@ class IRDaikinESP {
                             const uint16_t length = kDaikinStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
   static String renderTime(const uint16_t timemins);
@@ -372,6 +375,9 @@ class IRDaikin2 {
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t setting);
+  static stdAc::swingh_t toCommonSwingH(const uint8_t setting);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString();
   static String renderTime(uint16_t timemins);
@@ -427,6 +433,7 @@ class IRDaikin216 {
   bool getQuiet(void);
   void setPowerful(const bool on);
   bool getPowerful(void);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
   static String renderTime(const uint16_t timemins);

--- a/src/ir_Denon.cpp
+++ b/src/ir_Denon.cpp
@@ -43,7 +43,7 @@ const uint64_t kDenonManufacturer = 0x2A4CULL;
 //
 // Args:
 //   data:   Contents of the message to be sent.
-//   nbits:  Nr. of bits of data to be sent. Typically DENON_BITS.
+//   nbits:  Nr. of bits of data to be sent. Typically kDenonBits.
 //   repeat: Nr. of additional times the message is to be sent.
 //
 // Status: BETA / Should be working.
@@ -70,7 +70,7 @@ void IRsend::sendDenon(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
-//   nbits:   Expected nr. of data bits. (Typically DENON_BITS)
+//   nbits:   Expected nr. of data bits. (Typically kDenonBits)
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
@@ -82,8 +82,8 @@ bool IRrecv::decodeDenon(decode_results *results, uint16_t nbits, bool strict) {
   // Compliance
   if (strict) {
     switch (nbits) {
-      case DENON_BITS:
-      case DENON_48_BITS:
+      case kDenonBits:
+      case kDenon48Bits:
       case kDenonLegacyBits:
         break;
       default:

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -50,13 +50,14 @@ void IRsend::sendFujitsuAC(unsigned char data[], uint16_t nbytes,
 // Code to emulate Fujitsu A/C IR remote control unit.
 
 // Initialise the object.
-IRFujitsuAC::IRFujitsuAC(uint16_t pin, fujitsu_ac_remote_model_t model)
+IRFujitsuAC::IRFujitsuAC(const uint16_t pin,
+                         const fujitsu_ac_remote_model_t model)
     : _irsend(pin) {
   setModel(model);
   stateReset();
 }
 
-void IRFujitsuAC::setModel(fujitsu_ac_remote_model_t model) {
+void IRFujitsuAC::setModel(const fujitsu_ac_remote_model_t model) {
   _model = model;
   switch (model) {
     case ARDB1:
@@ -69,8 +70,10 @@ void IRFujitsuAC::setModel(fujitsu_ac_remote_model_t model) {
   }
 }
 
+fujitsu_ac_remote_model_t IRFujitsuAC::getModel(void) { return _model; }
+
 // Reset the state of the remote to a known good state/sequence.
-void IRFujitsuAC::stateReset() {
+void IRFujitsuAC::stateReset(void) {
   _temp = 24;
   _fanSpeed = kFujitsuAcFanHigh;
   _mode = kFujitsuAcModeCool;
@@ -80,7 +83,7 @@ void IRFujitsuAC::stateReset() {
 }
 
 // Configure the pin for output.
-void IRFujitsuAC::begin() { _irsend.begin(); }
+void IRFujitsuAC::begin(void) { _irsend.begin(); }
 
 #if SEND_FUJITSU_AC
 // Send the current desired state to the IR LED.
@@ -90,7 +93,7 @@ void IRFujitsuAC::send(const uint16_t repeat) {
 }
 #endif  // SEND_FUJITSU_AC
 
-void IRFujitsuAC::buildState() {
+void IRFujitsuAC::buildState(void) {
   remote_state[0] = 0x14;
   remote_state[1] = 0x63;
   remote_state[2] = 0x00;
@@ -158,7 +161,7 @@ void IRFujitsuAC::buildState() {
   }
 }
 
-uint8_t IRFujitsuAC::getStateLength() {
+uint8_t IRFujitsuAC::getStateLength(void) {
   buildState();  // Force an update of the internal state.
   if ((_model == ARRAH2E && remote_state[5] != 0xFE) ||
       (_model == ARDB1 && remote_state[5] != 0xFC))
@@ -168,7 +171,7 @@ uint8_t IRFujitsuAC::getStateLength() {
 }
 
 // Return a pointer to the internal state date of the remote.
-uint8_t* IRFujitsuAC::getRaw() {
+uint8_t* IRFujitsuAC::getRaw(void) {
   buildState();
   return remote_state;
 }
@@ -220,9 +223,9 @@ bool IRFujitsuAC::setRaw(const uint8_t newState[], const uint16_t length) {
 }
 
 // Set the requested power state of the A/C to off.
-void IRFujitsuAC::off() { _cmd = kFujitsuAcCmdTurnOff; }
+void IRFujitsuAC::off(void) { _cmd = kFujitsuAcCmdTurnOff; }
 
-void IRFujitsuAC::stepHoriz() {
+void IRFujitsuAC::stepHoriz(void) {
   switch (_model) {
     case ARDB1:
       break;  // This remote doesn't have a horizontal option.
@@ -231,10 +234,10 @@ void IRFujitsuAC::stepHoriz() {
   }
 }
 
-void IRFujitsuAC::stepVert() { _cmd = kFujitsuAcCmdStepVert; }
+void IRFujitsuAC::stepVert(void) { _cmd = kFujitsuAcCmdStepVert; }
 
 // Set the requested command of the A/C.
-void IRFujitsuAC::setCmd(uint8_t cmd) {
+void IRFujitsuAC::setCmd(const uint8_t cmd) {
   switch (cmd) {
     case kFujitsuAcCmdTurnOff:
     case kFujitsuAcCmdTurnOn:
@@ -252,54 +255,55 @@ void IRFujitsuAC::setCmd(uint8_t cmd) {
   }
 }
 
-uint8_t IRFujitsuAC::getCmd() { return _cmd; }
+uint8_t IRFujitsuAC::getCmd(void) { return _cmd; }
 
-bool IRFujitsuAC::getPower() { return _cmd != kFujitsuAcCmdTurnOff; }
+bool IRFujitsuAC::getPower(void) { return _cmd != kFujitsuAcCmdTurnOff; }
 
 // Set the temp. in deg C
-void IRFujitsuAC::setTemp(uint8_t temp) {
-  temp = std::max((uint8_t)kFujitsuAcMinTemp, temp);
-  temp = std::min((uint8_t)kFujitsuAcMaxTemp, temp);
-  _temp = temp;
+void IRFujitsuAC::setTemp(const uint8_t temp) {
+  _temp = std::max((uint8_t)kFujitsuAcMinTemp, temp);
+  _temp = std::min((uint8_t)kFujitsuAcMaxTemp, _temp);
 }
 
-uint8_t IRFujitsuAC::getTemp() { return _temp; }
+uint8_t IRFujitsuAC::getTemp(void) { return _temp; }
 
 // Set the speed of the fan
-void IRFujitsuAC::setFanSpeed(uint8_t fanSpeed) {
+void IRFujitsuAC::setFanSpeed(const uint8_t fanSpeed) {
   if (fanSpeed > kFujitsuAcFanQuiet)
-    fanSpeed = kFujitsuAcFanHigh;  // Set the fan to maximum if out of range.
-  _fanSpeed = fanSpeed;
+    _fanSpeed = kFujitsuAcFanHigh;  // Set the fan to maximum if out of range.
+  else
+    _fanSpeed = fanSpeed;
 }
-uint8_t IRFujitsuAC::getFanSpeed() { return _fanSpeed; }
+uint8_t IRFujitsuAC::getFanSpeed(void) { return _fanSpeed; }
 
 // Set the requested climate operation mode of the a/c unit.
-void IRFujitsuAC::setMode(uint8_t mode) {
+void IRFujitsuAC::setMode(const uint8_t mode) {
   if (mode > kFujitsuAcModeHeat)
-    mode = kFujitsuAcModeHeat;  // Set the mode to maximum if out of range.
-  _mode = mode;
+    _mode = kFujitsuAcModeHeat;  // Set the mode to maximum if out of range.
+  else
+    _mode = mode;
 }
 
-uint8_t IRFujitsuAC::getMode() { return _mode; }
+uint8_t IRFujitsuAC::getMode(void) { return _mode; }
 
 // Set the requested swing operation mode of the a/c unit.
-void IRFujitsuAC::setSwing(uint8_t swingMode) {
+void IRFujitsuAC::setSwing(const uint8_t swingMode) {
+  _swingMode = swingMode;
   switch (_model) {
     case ARDB1:
       // Set the mode to max if out of range
-      if (swingMode > kFujitsuAcSwingVert) swingMode = kFujitsuAcSwingVert;
+      if (swingMode > kFujitsuAcSwingVert) _swingMode = kFujitsuAcSwingVert;
       break;
     case ARRAH2E:
     default:
       // Set the mode to max if out of range
-      if (swingMode > kFujitsuAcSwingBoth) swingMode = kFujitsuAcSwingBoth;
+      if (swingMode > kFujitsuAcSwingBoth) _swingMode = kFujitsuAcSwingBoth;
   }
-  _swingMode = swingMode;
 }
 
-uint8_t IRFujitsuAC::getSwing() { return _swingMode; }
+uint8_t IRFujitsuAC::getSwing(void) { return _swingMode; }
 
-bool IRFujitsuAC::validChecksum(uint8_t state[], uint16_t length) {
+bool IRFujitsuAC::validChecksum(uint8_t state[], const uint16_t length) {
   uint8_t sum = 0;
   uint8_t sum_complement = 0;
   uint8_t checksum = state[length - 1];
@@ -353,12 +357,62 @@ uint8_t IRFujitsuAC::convertFan(stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRFujitsuAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kFujitsuAcModeCool: return stdAc::opmode_t::kCool;
+    case kFujitsuAcModeHeat: return stdAc::opmode_t::kHeat;
+    case kFujitsuAcModeDry: return stdAc::opmode_t::kDry;
+    case kFujitsuAcModeFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRFujitsuAC::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kFujitsuAcFanHigh: return stdAc::fanspeed_t::kMax;
+    case kFujitsuAcFanMed: return stdAc::fanspeed_t::kMedium;
+    case kFujitsuAcFanLow: return stdAc::fanspeed_t::kLow;
+    case kFujitsuAcFanQuiet: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRFujitsuAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::FUJITSU_AC;
+  result.model = this->getModel();
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFanSpeed());
+  uint8_t swing = this->getSwing();
+  result.swingv = (swing & kFujitsuAcSwingVert) ? stdAc::swingv_t::kAuto :
+                                                  stdAc::swingv_t::kOff;
+  result.swingh = (swing & kFujitsuAcSwingHoriz) ? stdAc::swingh_t::kAuto :
+                                                   stdAc::swingh_t::kOff;
+  result.quiet = (this->getFanSpeed() == kFujitsuAcFanQuiet);
+  // Not supported.
+  result.turbo = false;
+  result.light = false;
+  result.filter = false;
+  result.clean = false;
+  result.econo = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRFujitsuAC::toString() {
+String IRFujitsuAC::toString(void) {
   String result = "";
 #else
-std::string IRFujitsuAC::toString() {
+std::string IRFujitsuAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -76,38 +76,43 @@ enum fujitsu_ac_remote_model_t {
 
 class IRFujitsuAC {
  public:
-  explicit IRFujitsuAC(uint16_t pin, fujitsu_ac_remote_model_t model = ARRAH2E);
+  explicit IRFujitsuAC(const uint16_t pin,
+                       const fujitsu_ac_remote_model_t model = ARRAH2E);
 
-  void setModel(fujitsu_ac_remote_model_t model);
-  void stateReset();
+  void setModel(const fujitsu_ac_remote_model_t model);
+  fujitsu_ac_remote_model_t getModel(void);
+  void stateReset(void);
 #if SEND_FUJITSU_AC
   void send(const uint16_t repeat = kFujitsuAcMinRepeat);
 #endif  // SEND_FUJITSU_AC
-  void begin();
-  void off();
-  void stepHoriz();
-  void stepVert();
-  void setCmd(uint8_t cmd);
-  uint8_t getCmd();
-  void setTemp(uint8_t temp);
-  uint8_t getTemp();
-  void setFanSpeed(uint8_t fan);
-  uint8_t getFanSpeed();
-  void setMode(uint8_t mode);
-  uint8_t getMode();
-  void setSwing(uint8_t mode);
-  uint8_t getSwing();
-  uint8_t* getRaw();
+  void begin(void);
+  void off(void);
+  void stepHoriz(void);
+  void stepVert(void);
+  void setCmd(const uint8_t cmd);
+  uint8_t getCmd(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp(void);
+  void setFanSpeed(const uint8_t fan);
+  uint8_t getFanSpeed(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  void setSwing(const uint8_t mode);
+  uint8_t getSwing(void);
+  uint8_t* getRaw(void);
   bool setRaw(const uint8_t newState[], const uint16_t length);
-  uint8_t getStateLength();
-  static bool validChecksum(uint8_t* state, uint16_t length);
-  bool getPower();
+  uint8_t getStateLength(void);
+  static bool validChecksum(uint8_t* state, const uint16_t length);
+  bool getPower(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(stdAc::fanspeed_t speed);
+  stdAc::opmode_t toCommonMode(const uint8_t mode);
+  stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -125,7 +130,7 @@ class IRFujitsuAC {
   fujitsu_ac_remote_model_t _model;
   uint8_t _state_length;
   uint8_t _state_length_short;
-  void buildState();
+  void buildState(void);
   void buildFromState(const uint16_t length);
 };
 

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -106,8 +106,8 @@ class IRFujitsuAC {
   bool getPower(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(stdAc::fanspeed_t speed);
-  stdAc::opmode_t toCommonMode(const uint8_t mode);
-  stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -112,7 +112,7 @@ void IRsend::sendGree(uint64_t data, uint16_t nbits, uint16_t repeat) {
 
 IRGreeAC::IRGreeAC(uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRGreeAC::stateReset() {
+void IRGreeAC::stateReset(void) {
   // This resets to a known-good state to Power Off, Fan Auto, Mode Auto, 25C.
   for (uint8_t i = 0; i < kGreeStateLength; i++) remote_state[i] = 0x0;
   remote_state[1] = 0x09;
@@ -122,11 +122,11 @@ void IRGreeAC::stateReset() {
   remote_state[7] = 0x50;
 }
 
-void IRGreeAC::fixup() {
+void IRGreeAC::fixup(void) {
   checksum();  // Calculate the checksums
 }
 
-void IRGreeAC::begin() { _irsend.begin(); }
+void IRGreeAC::begin(void) { _irsend.begin(); }
 
 #if SEND_GREE
 void IRGreeAC::send(const uint16_t repeat) {
@@ -135,12 +135,12 @@ void IRGreeAC::send(const uint16_t repeat) {
 }
 #endif  // SEND_GREE
 
-uint8_t* IRGreeAC::getRaw() {
+uint8_t* IRGreeAC::getRaw(void) {
   fixup();  // Ensure correct settings before sending.
   return remote_state;
 }
 
-void IRGreeAC::setRaw(uint8_t new_code[]) {
+void IRGreeAC::setRaw(const uint8_t new_code[]) {
   for (uint8_t i = 0; i < kGreeStateLength; i++) {
     remote_state[i] = new_code[i];
   }
@@ -167,24 +167,24 @@ bool IRGreeAC::validChecksum(const uint8_t state[], const uint16_t length) {
     return false;
 }
 
-void IRGreeAC::on() {
+void IRGreeAC::on(void) {
   remote_state[0] |= kGreePower1Mask;
   remote_state[2] |= kGreePower2Mask;
 }
 
-void IRGreeAC::off() {
+void IRGreeAC::off(void) {
   remote_state[0] &= ~kGreePower1Mask;
   remote_state[2] &= ~kGreePower2Mask;
 }
 
-void IRGreeAC::setPower(const bool state) {
-  if (state)
-    on();
+void IRGreeAC::setPower(const bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
-bool IRGreeAC::getPower() {
+bool IRGreeAC::getPower(void) {
   return (remote_state[0] & kGreePower1Mask) &&
          (remote_state[2] & kGreePower2Mask);
 }
@@ -198,7 +198,7 @@ void IRGreeAC::setTemp(const uint8_t temp) {
 }
 
 // Return the set temp. in deg C
-uint8_t IRGreeAC::getTemp() {
+uint8_t IRGreeAC::getTemp(void) {
   return ((remote_state[1] & 0xFU) + kGreeMinTemp);
 }
 
@@ -212,7 +212,7 @@ void IRGreeAC::setFan(const uint8_t speed) {
   remote_state[0] |= (fan << 4);
 }
 
-uint8_t IRGreeAC::getFan() { return ((remote_state[0] & kGreeFanMask) >> 4); }
+uint8_t IRGreeAC::getFan(void) { return (remote_state[0] & kGreeFanMask) >> 4; }
 
 void IRGreeAC::setMode(const uint8_t new_mode) {
   uint8_t mode = new_mode;
@@ -237,35 +237,35 @@ void IRGreeAC::setMode(const uint8_t new_mode) {
   remote_state[0] |= mode;
 }
 
-uint8_t IRGreeAC::getMode() { return (remote_state[0] & kGreeModeMask); }
+uint8_t IRGreeAC::getMode(void) { return (remote_state[0] & kGreeModeMask); }
 
-void IRGreeAC::setLight(const bool state) {
+void IRGreeAC::setLight(const bool on) {
   remote_state[2] &= ~kGreeLightMask;
-  remote_state[2] |= (state << 5);
+  remote_state[2] |= (on << 5);
 }
 
-bool IRGreeAC::getLight() { return remote_state[2] & kGreeLightMask; }
+bool IRGreeAC::getLight(void) { return remote_state[2] & kGreeLightMask; }
 
-void IRGreeAC::setXFan(const bool state) {
+void IRGreeAC::setXFan(const bool on) {
   remote_state[2] &= ~kGreeXfanMask;
-  remote_state[2] |= (state << 7);
+  remote_state[2] |= (on << 7);
 }
 
-bool IRGreeAC::getXFan() { return remote_state[2] & kGreeXfanMask; }
+bool IRGreeAC::getXFan(void) { return remote_state[2] & kGreeXfanMask; }
 
-void IRGreeAC::setSleep(const bool state) {
+void IRGreeAC::setSleep(const bool on) {
   remote_state[0] &= ~kGreeSleepMask;
-  remote_state[0] |= (state << 7);
+  remote_state[0] |= (on << 7);
 }
 
-bool IRGreeAC::getSleep() { return remote_state[0] & kGreeSleepMask; }
+bool IRGreeAC::getSleep(void) { return remote_state[0] & kGreeSleepMask; }
 
-void IRGreeAC::setTurbo(const bool state) {
+void IRGreeAC::setTurbo(const bool on) {
   remote_state[2] &= ~kGreeTurboMask;
-  remote_state[2] |= (state << 4);
+  remote_state[2] |= (on << 4);
 }
 
-bool IRGreeAC::getTurbo() { return remote_state[2] & kGreeTurboMask; }
+bool IRGreeAC::getTurbo(void) { return remote_state[2] & kGreeTurboMask; }
 
 void IRGreeAC::setSwingVertical(const bool automatic, const uint8_t position) {
   remote_state[0] &= ~kGreeSwingAutoMask;
@@ -297,11 +297,11 @@ void IRGreeAC::setSwingVertical(const bool automatic, const uint8_t position) {
   remote_state[4] |= new_position;
 }
 
-bool IRGreeAC::getSwingVerticalAuto() {
+bool IRGreeAC::getSwingVerticalAuto(void) {
   return remote_state[0] & kGreeSwingAutoMask;
 }
 
-uint8_t IRGreeAC::getSwingVerticalPosition() {
+uint8_t IRGreeAC::getSwingVerticalPosition(void) {
   return remote_state[4] & kGreeSwingPosMask;
 }
 
@@ -356,12 +356,73 @@ uint8_t IRGreeAC::convertSwingV(const stdAc::swingv_t swingv) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRGreeAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kGreeCool: return stdAc::opmode_t::kCool;
+    case kGreeHeat: return stdAc::opmode_t::kHeat;
+    case kGreeDry: return stdAc::opmode_t::kDry;
+    case kGreeFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRGreeAC::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kGreeFanMax: return stdAc::fanspeed_t::kMax;
+    case kGreeFanMax - 1: return stdAc::fanspeed_t::kMedium;
+    case kGreeFanMin: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRGreeAC::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case kGreeSwingUp: return stdAc::swingv_t::kHighest;
+    case kGreeSwingMiddleUp: return stdAc::swingv_t::kHigh;
+    case kGreeSwingMiddle: return stdAc::swingv_t::kMiddle;
+    case kGreeSwingMiddleDown: return stdAc::swingv_t::kLow;
+    case kGreeSwingDown: return stdAc::swingv_t::kLowest;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRGreeAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::GREE;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  if (this->getSwingVerticalAuto())
+    result.swingv = stdAc::swingv_t::kAuto;
+  else
+    result.swingv = this->toCommonSwingV(this->getSwingVerticalPosition());
+  result.turbo = this->getTurbo();
+  result.light = this->getLight();
+  result.clean = this->getXFan();
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.econo = false;
+  result.filter = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRGreeAC::toString() {
+String IRGreeAC::toString(void) {
   String result = "";
 #else
-std::string IRGreeAC::toString() {
+std::string IRGreeAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(150);  // Reserve some heap for the string to reduce fragging.

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -87,43 +87,47 @@ class IRGreeAC {
  public:
   explicit IRGreeAC(uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_GREE
   void send(const uint16_t repeat = kGreeDefaultRepeat);
 #endif  // SEND_GREE
-  void begin();
-  void on();
-  void off();
-  void setPower(const bool state);
-  bool getPower();
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setFan(const uint8_t speed);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t new_mode);
-  uint8_t getMode();
-  void setLight(const bool state);
-  bool getLight();
-  void setXFan(const bool state);
-  bool getXFan();
-  void setSleep(const bool state);
-  bool getSleep();
-  void setTurbo(const bool state);
-  bool getTurbo();
+  uint8_t getMode(void);
+  void setLight(const bool on);
+  bool getLight(void);
+  void setXFan(const bool on);
+  bool getXFan(void);
+  void setSleep(const bool on);
+  bool getSleep(void);
+  void setTurbo(const bool on);
+  bool getTurbo(void);
   void setSwingVertical(const bool automatic, const uint8_t position);
-  bool getSwingVerticalAuto();
-  uint8_t getSwingVerticalPosition();
+  bool getSwingVerticalAuto(void);
+  uint8_t getSwingVerticalPosition(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t swingv);
-  uint8_t* getRaw();
-  void setRaw(uint8_t new_code[]);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  stdAc::state_t toCommon(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[]);
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kGreeStateLength);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -135,7 +139,7 @@ class IRGreeAC {
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kGreeStateLength];
   void checksum(const uint16_t length = kGreeStateLength);
-  void fixup();
+  void fixup(void);
 };
 
 #endif  // IR_GREE_H_

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -47,8 +47,8 @@ const uint32_t kHaierAcMinGap = 150000;  // Completely made up value.
 //
 // Status: STABLE / Known to be working.
 //
-void IRsend::sendHaierAC(unsigned char data[], uint16_t nbytes,
-                         uint16_t repeat) {
+void IRsend::sendHaierAC(const unsigned char data[], const uint16_t nbytes,
+                         const uint16_t repeat) {
   if (nbytes < kHaierACStateLength) return;
 
   for (uint16_t r = 0; r <= repeat; r++) {
@@ -74,16 +74,16 @@ void IRsend::sendHaierAC(unsigned char data[], uint16_t nbytes,
 //
 // Status: Alpha / Untested on a real device.
 //
-void IRsend::sendHaierACYRW02(unsigned char data[], uint16_t nbytes,
-                              uint16_t repeat) {
+void IRsend::sendHaierACYRW02(const unsigned char data[], const uint16_t nbytes,
+                              const uint16_t repeat) {
   if (nbytes >= kHaierACYRW02StateLength) sendHaierAC(data, nbytes, repeat);
 }
 #endif  // SEND_HAIER_AC_YRW02
 
 // Class for emulating a Haier HSU07-HEA03 remote
-IRHaierAC::IRHaierAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRHaierAC::IRHaierAC(const uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRHaierAC::begin() { _irsend.begin(); }
+void IRHaierAC::begin(void) { _irsend.begin(); }
 
 #if SEND_HAIER_AC
 void IRHaierAC::send(const uint16_t repeat) {
@@ -92,7 +92,7 @@ void IRHaierAC::send(const uint16_t repeat) {
 }
 #endif  // SEND_HAIER_AC
 
-void IRHaierAC::checksum() {
+void IRHaierAC::checksum(void) {
   remote_state[8] = sumBytes(remote_state, kHaierACStateLength - 1);
 }
 
@@ -101,7 +101,7 @@ bool IRHaierAC::validChecksum(uint8_t state[], const uint16_t length) {
   return (state[length - 1] == sumBytes(state, length - 1));
 }
 
-void IRHaierAC::stateReset() {
+void IRHaierAC::stateReset(void) {
   for (uint8_t i = 1; i < kHaierACStateLength; i++) remote_state[i] = 0x0;
   remote_state[0] = kHaierAcPrefix;
   remote_state[2] = 0x20;
@@ -114,18 +114,18 @@ void IRHaierAC::stateReset() {
   setCommand(kHaierAcCmdOn);
 }
 
-uint8_t* IRHaierAC::getRaw() {
+uint8_t* IRHaierAC::getRaw(void) {
   checksum();
   return remote_state;
 }
 
-void IRHaierAC::setRaw(uint8_t new_code[]) {
+void IRHaierAC::setRaw(const uint8_t new_code[]) {
   for (uint8_t i = 0; i < kHaierACStateLength; i++) {
     remote_state[i] = new_code[i];
   }
 }
 
-void IRHaierAC::setCommand(uint8_t state) {
+void IRHaierAC::setCommand(const uint8_t state) {
   remote_state[1] &= 0b11110000;
   switch (state) {
     case kHaierAcCmdOff:
@@ -143,9 +143,9 @@ void IRHaierAC::setCommand(uint8_t state) {
   }
 }
 
-uint8_t IRHaierAC::getCommand() { return remote_state[1] & (0b00001111); }
+uint8_t IRHaierAC::getCommand(void) { return remote_state[1] & (0b00001111); }
 
-void IRHaierAC::setFan(uint8_t speed) {
+void IRHaierAC::setFan(const uint8_t speed) {
   uint8_t new_speed = kHaierAcFanAuto;
   switch (speed) {
     case kHaierAcFanLow:
@@ -166,7 +166,7 @@ void IRHaierAC::setFan(uint8_t speed) {
   remote_state[5] |= new_speed;
 }
 
-uint8_t IRHaierAC::getFan() {
+uint8_t IRHaierAC::getFan(void) {
   switch (remote_state[5] & 0b00000011) {
     case 1:
       return kHaierAcFanMed;
@@ -188,7 +188,7 @@ void IRHaierAC::setMode(uint8_t mode) {
   remote_state[6] |= (new_mode << 5);
 }
 
-uint8_t IRHaierAC::getMode() {
+uint8_t IRHaierAC::getMode(void) {
   return (remote_state[6] & kHaierAcModeMask) >> 5;
 }
 
@@ -210,19 +210,19 @@ void IRHaierAC::setTemp(const uint8_t celsius) {
   remote_state[1] |= ((temp - kHaierAcMinTemp) << 4);
 }
 
-uint8_t IRHaierAC::getTemp() {
+uint8_t IRHaierAC::getTemp(void) {
   return ((remote_state[1] & 0b11110000) >> 4) + kHaierAcMinTemp;
 }
 
-void IRHaierAC::setHealth(bool state) {
+void IRHaierAC::setHealth(const bool on) {
   setCommand(kHaierAcCmdHealth);
   remote_state[4] &= 0b11011111;
-  remote_state[4] |= (state << 5);
+  remote_state[4] |= (on << 5);
 }
 
 bool IRHaierAC::getHealth(void) { return remote_state[4] & (1 << 5); }
 
-void IRHaierAC::setSleep(bool on) {
+void IRHaierAC::setSleep(const bool on) {
   setCommand(kHaierAcCmdSleep);
   if (on)
     remote_state[7] |= kHaierAcSleepBit;
@@ -236,21 +236,21 @@ uint16_t IRHaierAC::getTime(const uint8_t ptr[]) {
   return (ptr[0] & 0b00011111) * 60 + (ptr[1] & 0b00111111);
 }
 
-int16_t IRHaierAC::getOnTimer() {
+int16_t IRHaierAC::getOnTimer(void) {
   if (remote_state[3] & 0b10000000)  // Check if the timer is turned on.
     return getTime(remote_state + 6);
   else
     return -1;
 }
 
-int16_t IRHaierAC::getOffTimer() {
+int16_t IRHaierAC::getOffTimer(void) {
   if (remote_state[3] & 0b01000000)  // Check if the timer is turned on.
     return getTime(remote_state + 4);
   else
     return -1;
 }
 
-uint16_t IRHaierAC::getCurrTime() { return getTime(remote_state + 2); }
+uint16_t IRHaierAC::getCurrTime(void) { return getTime(remote_state + 2); }
 
 void IRHaierAC::setTime(uint8_t ptr[], const uint16_t nr_mins) {
   uint16_t mins = nr_mins;
@@ -276,7 +276,7 @@ void IRHaierAC::setOffTimer(const uint16_t nr_mins) {
   setTime(remote_state + 4, nr_mins);
 }
 
-void IRHaierAC::cancelTimers() {
+void IRHaierAC::cancelTimers(void) {
   setCommand(kHaierAcCmdTimerCancel);
   remote_state[3] &= 0b00111111;
 }
@@ -285,7 +285,9 @@ void IRHaierAC::setCurrTime(const uint16_t nr_mins) {
   setTime(remote_state + 2, nr_mins);
 }
 
-uint8_t IRHaierAC::getSwing() { return (remote_state[2] & 0b11000000) >> 6; }
+uint8_t IRHaierAC::getSwing(void) {
+  return (remote_state[2] & 0b11000000) >> 6;
+}
 
 void IRHaierAC::setSwing(const uint8_t state) {
   if (state == getSwing()) return;  // Nothing to do.
@@ -426,10 +428,10 @@ stdAc::state_t IRHaierAC::toCommon(void) {
 
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRHaierAC::toString() {
+String IRHaierAC::toString(void) {
   String result = "";
 #else
-std::string IRHaierAC::toString() {
+std::string IRHaierAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(150);  // Reserve some heap for the string to reduce fragging.
@@ -558,7 +560,7 @@ std::string IRHaierAC::toString() {
 // Class for emulating a Haier YRW02 remote
 IRHaierACYRW02::IRHaierACYRW02(uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRHaierACYRW02::begin() { _irsend.begin(); }
+void IRHaierACYRW02::begin(void) { _irsend.begin(); }
 
 #if SEND_HAIER_AC_YRW02
 void IRHaierACYRW02::send(const uint16_t repeat) {
@@ -567,7 +569,7 @@ void IRHaierACYRW02::send(const uint16_t repeat) {
 }
 #endif  // SEND_HAIER_AC_YRW02
 
-void IRHaierACYRW02::checksum() {
+void IRHaierACYRW02::checksum(void) {
   remote_state[kHaierACYRW02StateLength - 1] =
       sumBytes(remote_state, kHaierACYRW02StateLength - 1);
 }
@@ -577,7 +579,7 @@ bool IRHaierACYRW02::validChecksum(uint8_t state[], const uint16_t length) {
   return (state[length - 1] == sumBytes(state, length - 1));
 }
 
-void IRHaierACYRW02::stateReset() {
+void IRHaierACYRW02::stateReset(void) {
   for (uint8_t i = 1; i < kHaierACYRW02StateLength; i++) remote_state[i] = 0x0;
   remote_state[0] = kHaierAcYrw02Prefix;
 
@@ -591,12 +593,12 @@ void IRHaierACYRW02::stateReset() {
   setPower(true);
 }
 
-uint8_t* IRHaierACYRW02::getRaw() {
+uint8_t* IRHaierACYRW02::getRaw(void) {
   checksum();
   return remote_state;
 }
 
-void IRHaierACYRW02::setRaw(uint8_t new_code[]) {
+void IRHaierACYRW02::setRaw(const uint8_t new_code[]) {
   for (uint8_t i = 0; i < kHaierACYRW02StateLength; i++) {
     remote_state[i] = new_code[i];
   }
@@ -618,7 +620,9 @@ void IRHaierACYRW02::setButton(uint8_t button) {
   }
 }
 
-uint8_t IRHaierACYRW02::getButton() { return remote_state[12] & (0b00001111); }
+uint8_t IRHaierACYRW02::getButton(void) {
+  return remote_state[12] & 0b00001111;
+}
 
 void IRHaierACYRW02::setMode(uint8_t mode) {
   uint8_t new_mode = mode;
@@ -637,7 +641,7 @@ void IRHaierACYRW02::setMode(uint8_t mode) {
   remote_state[7] |= (new_mode << 4);
 }
 
-uint8_t IRHaierACYRW02::getMode() { return remote_state[7] >> 4; }
+uint8_t IRHaierACYRW02::getMode(void) { return remote_state[7] >> 4; }
 
 void IRHaierACYRW02::setTemp(const uint8_t celcius) {
   uint8_t temp = celcius;
@@ -657,43 +661,47 @@ void IRHaierACYRW02::setTemp(const uint8_t celcius) {
   remote_state[1] |= ((temp - kHaierAcMinTemp) << 4);
 }
 
-uint8_t IRHaierACYRW02::getTemp() {
+uint8_t IRHaierACYRW02::getTemp(void) {
   return ((remote_state[1] & 0b11110000) >> 4) + kHaierAcMinTemp;
 }
 
-void IRHaierACYRW02::setHealth(bool state) {
+void IRHaierACYRW02::setHealth(const bool on) {
   setButton(kHaierAcYrw02ButtonHealth);
   remote_state[3] &= 0b11111101;
-  remote_state[3] |= (state << 1);
+  remote_state[3] |= (on << 1);
 }
 
 bool IRHaierACYRW02::getHealth(void) { return remote_state[3] & 0b00000010; }
 
-bool IRHaierACYRW02::getPower() { return remote_state[4] & kHaierAcYrw02Power; }
+bool IRHaierACYRW02::getPower(void) {
+  return remote_state[4] & kHaierAcYrw02Power;
+}
 
-void IRHaierACYRW02::setPower(bool state) {
+void IRHaierACYRW02::setPower(const bool on) {
   setButton(kHaierAcYrw02ButtonPower);
-  if (state)
+  if (on)
     remote_state[4] |= kHaierAcYrw02Power;
   else
     remote_state[4] &= ~kHaierAcYrw02Power;
 }
 
-void IRHaierACYRW02::on() { setPower(true); }
+void IRHaierACYRW02::on(void) { setPower(true); }
 
-void IRHaierACYRW02::off() { setPower(false); }
+void IRHaierACYRW02::off(void) { setPower(false); }
 
-bool IRHaierACYRW02::getSleep() { return remote_state[8] & kHaierAcYrw02Sleep; }
+bool IRHaierACYRW02::getSleep(void) {
+  return remote_state[8] & kHaierAcYrw02Sleep;
+}
 
-void IRHaierACYRW02::setSleep(bool state) {
+void IRHaierACYRW02::setSleep(const bool on) {
   setButton(kHaierAcYrw02ButtonSleep);
-  if (state)
+  if (on)
     remote_state[8] |= kHaierAcYrw02Sleep;
   else
     remote_state[8] &= ~kHaierAcYrw02Sleep;
 }
 
-uint8_t IRHaierACYRW02::getTurbo() { return remote_state[6] >> 6; }
+uint8_t IRHaierACYRW02::getTurbo(void) { return remote_state[6] >> 6; }
 
 void IRHaierACYRW02::setTurbo(uint8_t speed) {
   switch (speed) {
@@ -706,7 +714,7 @@ void IRHaierACYRW02::setTurbo(uint8_t speed) {
   }
 }
 
-uint8_t IRHaierACYRW02::getFan() { return remote_state[5] >> 4; }
+uint8_t IRHaierACYRW02::getFan(void) { return remote_state[5] >> 4; }
 
 void IRHaierACYRW02::setFan(uint8_t speed) {
   switch (speed) {
@@ -720,7 +728,7 @@ void IRHaierACYRW02::setFan(uint8_t speed) {
   }
 }
 
-uint8_t IRHaierACYRW02::getSwing() { return remote_state[1] & 0b00001111; }
+uint8_t IRHaierACYRW02::getSwing(void) { return remote_state[1] & 0b00001111; }
 
 void IRHaierACYRW02::setSwing(uint8_t state) {
   uint8_t newstate = state;
@@ -800,12 +808,70 @@ uint8_t IRHaierACYRW02::convertSwingV(const stdAc::swingv_t position) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRHaierACYRW02::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kHaierAcYrw02Cool: return stdAc::opmode_t::kCool;
+    case kHaierAcYrw02Heat: return stdAc::opmode_t::kHeat;
+    case kHaierAcYrw02Dry: return stdAc::opmode_t::kDry;
+    case kHaierAcYrw02Fan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRHaierACYRW02::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kHaierAcYrw02FanHigh: return stdAc::fanspeed_t::kMax;
+    case kHaierAcYrw02FanMed: return stdAc::fanspeed_t::kMedium;
+    case kHaierAcYrw02FanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRHaierACYRW02::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case kHaierAcYrw02SwingTop: return stdAc::swingv_t::kHighest;
+    case kHaierAcYrw02SwingMiddle: return stdAc::swingv_t::kMiddle;
+    case kHaierAcYrw02SwingDown: return stdAc::swingv_t::kLow;
+    case kHaierAcYrw02SwingBottom: return stdAc::swingv_t::kLowest;
+    case kHaierAcYrw02SwingOff: return stdAc::swingv_t::kOff;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRHaierACYRW02::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::HAIER_AC_YRW02;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getSwing());
+  result.filter = this->getHealth();
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.turbo = false;
+  result.econo = false;
+  result.light = false;
+  result.clean = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRHaierACYRW02::toString() {
+String IRHaierACYRW02::toString(void) {
   String result = "";
 #else
-std::string IRHaierACYRW02::toString() {
+std::string IRHaierACYRW02::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(130);  // Reserve some heap for the string to reduce fragging.

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -56,6 +56,7 @@ const uint8_t kHaierAcSwingDown = 0b00000010;
 const uint8_t kHaierAcSwingChg = 0b00000011;
 
 // Byte 6
+const uint8_t kHaierAcModeMask = 0b11100000;
 const uint8_t kHaierAcAuto = 0;
 const uint8_t kHaierAcCool = 1;
 const uint8_t kHaierAcDry = 2;
@@ -68,6 +69,9 @@ const uint8_t kHaierAcFanMed = 2;
 const uint8_t kHaierAcFanHigh = 3;
 
 const uint16_t kHaierAcMaxTime = (23 * 60) + 59;
+
+// Byte 7
+const uint8_t kHaierAcSleepBit = 0b01000000;
 
 // Legacy Haier AC defines.
 #define HAIER_AC_MIN_TEMP kHaierAcMinTemp
@@ -229,7 +233,10 @@ class IRHaierAC {
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
-
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString();
   static String timeToString(const uint16_t nr_mins);
@@ -295,6 +302,10 @@ class IRHaierACYRW02 {
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString();
 #else

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -190,44 +190,44 @@ const uint8_t kHaierAcYrw02ButtonSleep = 0xB;
 
 class IRHaierAC {
  public:
-  explicit IRHaierAC(uint16_t pin);
+  explicit IRHaierAC(const uint16_t pin);
 
 #if SEND_HAIER_AC
   void send(const uint16_t repeat = kHaierAcDefaultRepeat);
 #endif  // SEND_HAIER_AC
-  void begin();
+  void begin(void);
 
   void setCommand(const uint8_t command);
-  uint8_t getCommand();
+  uint8_t getCommand(void);
 
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
 
   void setFan(const uint8_t speed);
-  uint8_t getFan();
+  uint8_t getFan(void);
 
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setMode(const uint8_t mode);
 
-  bool getSleep();
-  void setSleep(const bool state);
-  bool getHealth();
-  void setHealth(const bool state);
+  bool getSleep(void);
+  void setSleep(const bool on);
+  bool getHealth(void);
+  void setHealth(const bool on);
 
-  int16_t getOnTimer();
+  int16_t getOnTimer(void);
   void setOnTimer(const uint16_t mins);
-  int16_t getOffTimer();
+  int16_t getOffTimer(void);
   void setOffTimer(const uint16_t mins);
-  void cancelTimers();
+  void cancelTimers(void);
 
-  uint16_t getCurrTime();
+  uint16_t getCurrTime(void);
   void setCurrTime(const uint16_t mins);
 
-  uint8_t getSwing();
+  uint8_t getSwing(void);
   void setSwing(const uint8_t state);
 
-  uint8_t* getRaw();
-  void setRaw(uint8_t new_code[]);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[]);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kHaierACStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
@@ -238,10 +238,10 @@ class IRHaierAC {
   static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
   stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
   static String timeToString(const uint16_t nr_mins);
 #else
-  std::string toString();
+  std::string toString(void);
   static std::string timeToString(const uint16_t nr_mins);
 #endif
 #ifndef UNIT_TEST
@@ -252,8 +252,8 @@ class IRHaierAC {
   IRsendTest _irsend;
 #endif
   uint8_t remote_state[kHaierACStateLength];
-  void stateReset();
-  void checksum();
+  void stateReset(void);
+  void checksum(void);
   static uint16_t getTime(const uint8_t ptr[]);
   static void setTime(uint8_t ptr[], const uint16_t nr_mins);
 };
@@ -265,38 +265,38 @@ class IRHaierACYRW02 {
 #if SEND_HAIER_AC_YRW02
   void send(const uint16_t repeat = kHaierAcYrw02DefaultRepeat);
 #endif  // SEND_HAIER_AC_YRW02
-  void begin();
+  void begin(void);
 
   void setButton(const uint8_t button);
-  uint8_t getButton();
+  uint8_t getButton(void);
 
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
 
   void setFan(const uint8_t speed);
-  uint8_t getFan();
+  uint8_t getFan(void);
 
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setMode(const uint8_t mode);
 
-  bool getPower();
-  void setPower(const bool state);
-  void on();
-  void off();
+  bool getPower(void);
+  void setPower(const bool on);
+  void on(void);
+  void off(void);
 
-  bool getSleep();
-  void setSleep(const bool state);
-  bool getHealth();
-  void setHealth(const bool state);
+  bool getSleep(void);
+  void setSleep(const bool on);
+  bool getHealth(void);
+  void setHealth(const bool on);
 
-  uint8_t getTurbo();
+  uint8_t getTurbo(void);
   void setTurbo(const uint8_t speed);
 
-  uint8_t getSwing();
+  uint8_t getSwing(void);
   void setSwing(const uint8_t state);
 
-  uint8_t* getRaw();
-  void setRaw(uint8_t new_code[]);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[]);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kHaierACYRW02StateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
@@ -307,9 +307,9 @@ class IRHaierACYRW02 {
   static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
   stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -319,8 +319,8 @@ class IRHaierACYRW02 {
   IRsendTest _irsend;
 #endif
   uint8_t remote_state[kHaierACYRW02StateLength];
-  void stateReset();
-  void checksum();
+  void stateReset(void);
+  void checksum(void);
 };
 
 #endif  // IR_HAIER_H_

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -44,8 +44,8 @@ const uint32_t kHitachiAcMinGap = kDefaultMessageGap;  // Just a guess.
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/417
-void IRsend::sendHitachiAC(unsigned char data[], uint16_t nbytes,
-                           uint16_t repeat) {
+void IRsend::sendHitachiAC(const unsigned char data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
   if (nbytes < kHitachiAcStateLength)
     return;  // Not enough bytes to send a proper message.
   sendGeneric(kHitachiAcHdrMark, kHitachiAcHdrSpace, kHitachiAcBitMark,
@@ -71,8 +71,8 @@ void IRsend::sendHitachiAC(unsigned char data[], uint16_t nbytes,
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/453
 //   Basically the same as sendHitatchiAC() except different size and header.
-void IRsend::sendHitachiAC1(unsigned char data[], uint16_t nbytes,
-                            uint16_t repeat) {
+void IRsend::sendHitachiAC1(const unsigned char data[], const uint16_t nbytes,
+                            const uint16_t repeat) {
   if (nbytes < kHitachiAc1StateLength)
     return;  // Not enough bytes to send a proper message.
   sendGeneric(kHitachiAc1HdrMark, kHitachiAc1HdrSpace, kHitachiAcBitMark,
@@ -98,8 +98,8 @@ void IRsend::sendHitachiAC1(unsigned char data[], uint16_t nbytes,
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/417
 //   Basically the same as sendHitatchiAC() except different size.
-void IRsend::sendHitachiAC2(unsigned char data[], uint16_t nbytes,
-                            uint16_t repeat) {
+void IRsend::sendHitachiAC2(const unsigned char data[], const uint16_t nbytes,
+                            const uint16_t repeat) {
   if (nbytes < kHitachiAc2StateLength)
     return;  // Not enough bytes to send a proper message.
   sendHitachiAC(data, nbytes, repeat);
@@ -110,9 +110,9 @@ void IRsend::sendHitachiAC2(unsigned char data[], uint16_t nbytes,
 // Inspired by:
 // https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
 
-IRHitachiAc::IRHitachiAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRHitachiAc::IRHitachiAc(const uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRHitachiAc::stateReset() {
+void IRHitachiAc::stateReset(void) {
   remote_state[0] = 0x80;
   remote_state[1] = 0x08;
   remote_state[2] = 0x0C;
@@ -130,7 +130,7 @@ void IRHitachiAc::stateReset() {
   setTemp(23);
 }
 
-void IRHitachiAc::begin() { _irsend.begin(); }
+void IRHitachiAc::begin(void) { _irsend.begin(); }
 
 uint8_t IRHitachiAc::calcChecksum(const uint8_t state[],
                                   const uint16_t length) {
@@ -148,7 +148,7 @@ bool IRHitachiAc::validChecksum(const uint8_t state[], const uint16_t length) {
   return (state[length - 1] == calcChecksum(state, length));
 }
 
-uint8_t *IRHitachiAc::getRaw() {
+uint8_t *IRHitachiAc::getRaw(void) {
   checksum();
   return remote_state;
 }
@@ -165,7 +165,7 @@ void IRHitachiAc::send(const uint16_t repeat) {
 }
 #endif  // SEND_HITACHI_AC
 
-bool IRHitachiAc::getPower() { return (remote_state[17] & 0x01); }
+bool IRHitachiAc::getPower(void) { return (remote_state[17] & 0x01); }
 
 void IRHitachiAc::setPower(const bool on) {
   if (on)
@@ -174,11 +174,11 @@ void IRHitachiAc::setPower(const bool on) {
     remote_state[17] &= 0xFE;
 }
 
-void IRHitachiAc::on() { setPower(true); }
+void IRHitachiAc::on(void) { setPower(true); }
 
-void IRHitachiAc::off() { setPower(false); }
+void IRHitachiAc::off(void) { setPower(false); }
 
-uint8_t IRHitachiAc::getMode() { return reverseBits(remote_state[10], 8); }
+uint8_t IRHitachiAc::getMode(void) { return reverseBits(remote_state[10], 8); }
 
 void IRHitachiAc::setMode(const uint8_t mode) {
   uint8_t newmode = mode;
@@ -200,7 +200,9 @@ void IRHitachiAc::setMode(const uint8_t mode) {
   setFan(getFan());  // Reset the fan speed after the mode change.
 }
 
-uint8_t IRHitachiAc::getTemp() { return reverseBits(remote_state[11], 8) >> 1; }
+uint8_t IRHitachiAc::getTemp(void) {
+  return reverseBits(remote_state[11], 8) >> 1;
+}
 
 void IRHitachiAc::setTemp(const uint8_t celsius) {
   uint8_t temp;
@@ -220,7 +222,7 @@ void IRHitachiAc::setTemp(const uint8_t celsius) {
     remote_state[9] = 0x10;
 }
 
-uint8_t IRHitachiAc::getFan() { return reverseBits(remote_state[13], 8); }
+uint8_t IRHitachiAc::getFan(void) { return reverseBits(remote_state[13], 8); }
 
 void IRHitachiAc::setFan(const uint8_t speed) {
   uint8_t fanmin = kHitachiAcFanAuto;
@@ -239,7 +241,7 @@ void IRHitachiAc::setFan(const uint8_t speed) {
   remote_state[13] = reverseBits(newspeed, 8);
 }
 
-bool IRHitachiAc::getSwingVertical() { return remote_state[14] & 0x80; }
+bool IRHitachiAc::getSwingVertical(void) { return remote_state[14] & 0x80; }
 
 void IRHitachiAc::setSwingVertical(const bool on) {
   if (on)
@@ -248,7 +250,7 @@ void IRHitachiAc::setSwingVertical(const bool on) {
     remote_state[14] &= 0x7F;
 }
 
-bool IRHitachiAc::getSwingHorizontal() { return remote_state[15] & 0x80; }
+bool IRHitachiAc::getSwingHorizontal(void) { return remote_state[15] & 0x80; }
 
 void IRHitachiAc::setSwingHorizontal(const bool on) {
   if (on)
@@ -291,12 +293,61 @@ uint8_t IRHitachiAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRHitachiAc::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kHitachiAcCool: return stdAc::opmode_t::kCool;
+    case kHitachiAcHeat: return stdAc::opmode_t::kHeat;
+    case kHitachiAcDry: return stdAc::opmode_t::kDry;
+    case kHitachiAcFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRHitachiAc::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kHitachiAcFanHigh: return stdAc::fanspeed_t::kMax;
+    case kHitachiAcFanHigh - 1: return stdAc::fanspeed_t::kHigh;
+    case kHitachiAcFanLow + 1: return stdAc::fanspeed_t::kMedium;
+    case kHitachiAcFanLow: return stdAc::fanspeed_t::kLow;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRHitachiAc::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::HITACHI_AC;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  result.swingh = this->getSwingHorizontal() ? stdAc::swingh_t::kAuto :
+                                               stdAc::swingh_t::kOff;
+  // Not supported.
+  result.quiet = false;
+  result.turbo = false;
+  result.clean = false;
+  result.econo = false;
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRHitachiAc::toString() {
+String IRHitachiAc::toString(void) {
   String result = "";
 #else
-std::string IRHitachiAc::toString() {
+std::string IRHitachiAc::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(110);  // Reserve some heap for the string to reduce fragging.
@@ -376,8 +427,8 @@ std::string IRHitachiAc::toString() {
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/417
 //   https://github.com/markszabo/IRremoteESP8266/issues/453
-bool IRrecv::decodeHitachiAC(decode_results *results, uint16_t nbits,
-                             bool strict) {
+bool IRrecv::decodeHitachiAC(decode_results *results, const uint16_t nbits,
+                             const bool strict) {
   const uint8_t kTolerance = 30;
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;  // Can't possibly be a valid HitachiAC message.

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -34,28 +34,28 @@ const uint8_t kHitachiAcAutoTemp = 23;  // 23C
 // Classes
 class IRHitachiAc {
  public:
-  explicit IRHitachiAc(uint16_t pin);
+  explicit IRHitachiAc(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_HITACHI_AC
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
 #endif  // SEND_HITACHI_AC
-  void begin();
-  void on();
-  void off();
+  void begin(void);
+  void on(void);
+  void off(void);
   void setPower(const bool on);
-  bool getPower();
+  bool getPower(void);
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setFan(const uint8_t speed);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t mode);
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setSwingVertical(const bool on);
-  bool getSwingVertical();
+  bool getSwingVertical(void);
   void setSwingHorizontal(const bool on);
-  bool getSwingHorizontal();
-  uint8_t* getRaw();
+  bool getSwingHorizontal(void);
+  uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kHitachiAcStateLength);
   static bool validChecksum(const uint8_t state[],
@@ -64,10 +64,13 @@ class IRHitachiAc {
                               const uint16_t length = kHitachiAcStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -124,36 +124,38 @@ void IRsend::sendKelvinator(unsigned char data[], uint16_t nbytes,
 }
 #endif  // SEND_KELVINATOR
 
-IRKelvinatorAC::IRKelvinatorAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRKelvinatorAC::IRKelvinatorAC(uint16_t pin) : _irsend(pin) {
+  this->stateReset();
+}
 
-void IRKelvinatorAC::stateReset() {
+void IRKelvinatorAC::stateReset(void) {
   for (uint8_t i = 0; i < kKelvinatorStateLength; i++) remote_state[i] = 0x0;
   remote_state[3] = 0x50;
   remote_state[11] = 0x70;
 }
 
-void IRKelvinatorAC::begin() { _irsend.begin(); }
+void IRKelvinatorAC::begin(void) { _irsend.begin(); }
 
-void IRKelvinatorAC::fixup() {
+void IRKelvinatorAC::fixup(void) {
   // X-Fan mode is only valid in COOL or DRY modes.
-  if (getMode() != kKelvinatorCool && getMode() != kKelvinatorDry)
-    setXFan(false);
-  checksum();  // Calculate the checksums
+  if (this->getMode() != kKelvinatorCool && this->getMode() != kKelvinatorDry)
+    this->setXFan(false);
+  this->checksum();  // Calculate the checksums
 }
 
 #if SEND_KELVINATOR
 void IRKelvinatorAC::send(const uint16_t repeat) {
-  fixup();  // Ensure correct settings before sending.
+  this->fixup();  // Ensure correct settings before sending.
   _irsend.sendKelvinator(remote_state, kKelvinatorStateLength, repeat);
 }
 #endif  // SEND_KELVINATOR
 
-uint8_t *IRKelvinatorAC::getRaw() {
-  fixup();  // Ensure correct settings before sending.
+uint8_t *IRKelvinatorAC::getRaw(void) {
+  this->fixup();  // Ensure correct settings before sending.
   return remote_state;
 }
 
-void IRKelvinatorAC::setRaw(uint8_t new_code[]) {
+void IRKelvinatorAC::setRaw(const uint8_t new_code[]) {
   for (uint8_t i = 0; i < kKelvinatorStateLength; i++) {
     remote_state[i] = new_code[i];
   }
@@ -196,46 +198,46 @@ bool IRKelvinatorAC::validChecksum(const uint8_t state[],
   return true;
 }
 
-void IRKelvinatorAC::on() {
+void IRKelvinatorAC::on(void) {
   remote_state[0] |= kKelvinatorPower;
   remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
-void IRKelvinatorAC::off() {
+void IRKelvinatorAC::off(void) {
   remote_state[0] &= ~kKelvinatorPower;
   remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
-void IRKelvinatorAC::setPower(bool state) {
-  if (state)
-    on();
+void IRKelvinatorAC::setPower(const bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
-bool IRKelvinatorAC::getPower() {
-  return ((remote_state[0] & kKelvinatorPower) != 0);
+bool IRKelvinatorAC::getPower(void) {
+  return remote_state[0] & kKelvinatorPower;
 }
 
 // Set the temp. in deg C
-void IRKelvinatorAC::setTemp(uint8_t temp) {
-  temp = std::max(kKelvinatorMinTemp, temp);
+void IRKelvinatorAC::setTemp(const uint8_t degrees) {
+  uint8_t temp = std::max(kKelvinatorMinTemp, degrees);
   temp = std::min(kKelvinatorMaxTemp, temp);
   remote_state[1] = (remote_state[1] & 0xF0U) | (temp - kKelvinatorMinTemp);
   remote_state[9] = remote_state[1];  // Duplicate to the 2nd command chunk.
 }
 
 // Return the set temp. in deg C
-uint8_t IRKelvinatorAC::getTemp() {
+uint8_t IRKelvinatorAC::getTemp(void) {
   return ((remote_state[1] & 0xFU) + kKelvinatorMinTemp);
 }
 
 // Set the speed of the fan, 0-5, 0 is auto, 1-5 is the speed
-void IRKelvinatorAC::setFan(uint8_t fan) {
-  fan = std::min(kKelvinatorFanMax, fan);  // Bounds check
+void IRKelvinatorAC::setFan(const uint8_t speed) {
+  uint8_t fan = std::min(kKelvinatorFanMax, speed);  // Bounds check
 
   // Only change things if we need to.
-  if (fan != getFan()) {
+  if (fan != this->getFan()) {
     // Set the basic fan values.
     uint8_t fan_basic = std::min(kKelvinatorBasicFanMax, fan);
     remote_state[0] = (remote_state[0] & kKelvinatorBasicFanMask) |
@@ -244,108 +246,117 @@ void IRKelvinatorAC::setFan(uint8_t fan) {
     // Set the advanced(?) fan value.
     remote_state[14] =
         (remote_state[14] & kKelvinatorFanMask) | (fan << kKelvinatorFanOffset);
-    setTurbo(false);  // Turbo mode is turned off if we change the fan settings.
+    // Turbo mode is turned off if we change the fan settings.
+    this->setTurbo(false);
   }
 }
 
-uint8_t IRKelvinatorAC::getFan() {
+uint8_t IRKelvinatorAC::getFan(void) {
   return ((remote_state[14] & ~kKelvinatorFanMask) >> kKelvinatorFanOffset);
 }
 
-uint8_t IRKelvinatorAC::getMode() {
+uint8_t IRKelvinatorAC::getMode(void) {
   return (remote_state[0] & ~kKelvinatorModeMask);
 }
 
-void IRKelvinatorAC::setMode(uint8_t mode) {
-  // If we get an unexpected mode, default to AUTO.
-  if (mode > kKelvinatorHeat) mode = kKelvinatorAuto;
-  remote_state[0] = (remote_state[0] & kKelvinatorModeMask) | mode;
-  remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
-  if (mode == kKelvinatorAuto || kKelvinatorDry)
-    // When the remote is set to Auto or Dry, it defaults to 25C and doesn't
-    // show it.
-    setTemp(kKelvinatorAutoTemp);
+void IRKelvinatorAC::setMode(const uint8_t mode) {
+  switch (mode) {
+    case kKelvinatorAuto:
+    case kKelvinatorDry:
+      // When the remote is set to Auto or Dry, it defaults to 25C and doesn't
+      // show it.
+      this->setTemp(kKelvinatorAutoTemp);
+      // FALL-THRU
+    case kKelvinatorHeat:
+    case kKelvinatorCool:
+    case kKelvinatorFan:
+      remote_state[0] = (remote_state[0] & kKelvinatorModeMask) | mode;
+      remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
+      break;
+    default:  // If we get an unexpected mode, default to AUTO.
+      this->setMode(kKelvinatorAuto);
+  }
 }
 
-void IRKelvinatorAC::setSwingVertical(bool state) {
-  if (state) {
+void IRKelvinatorAC::setSwingVertical(const bool on) {
+  if (on) {
     remote_state[0] |= kKelvinatorVentSwing;
     remote_state[4] |= kKelvinatorVentSwingV;
   } else {
     remote_state[4] &= ~kKelvinatorVentSwingV;
-    if (!getSwingHorizontal()) remote_state[0] &= ~kKelvinatorVentSwing;
+    if (!this->getSwingHorizontal()) remote_state[0] &= ~kKelvinatorVentSwing;
   }
   remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getSwingVertical() {
-  return ((remote_state[4] & kKelvinatorVentSwingV) != 0);
+bool IRKelvinatorAC::getSwingVertical(void) {
+  return remote_state[4] & kKelvinatorVentSwingV;
 }
 
-void IRKelvinatorAC::setSwingHorizontal(bool state) {
-  if (state) {
+void IRKelvinatorAC::setSwingHorizontal(const bool on) {
+  if (on) {
     remote_state[0] |= kKelvinatorVentSwing;
     remote_state[4] |= kKelvinatorVentSwingH;
   } else {
     remote_state[4] &= ~kKelvinatorVentSwingH;
-    if (!getSwingVertical()) remote_state[0] &= ~kKelvinatorVentSwing;
+    if (!this->getSwingVertical()) remote_state[0] &= ~kKelvinatorVentSwing;
   }
   remote_state[8] = remote_state[0];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getSwingHorizontal() {
-  return ((remote_state[4] & kKelvinatorVentSwingH) != 0);
+bool IRKelvinatorAC::getSwingHorizontal(void) {
+  return remote_state[4] & kKelvinatorVentSwingH;
 }
 
-void IRKelvinatorAC::setQuiet(bool state) {
+void IRKelvinatorAC::setQuiet(const bool on) {
   remote_state[12] &= ~kKelvinatorQuiet;
-  remote_state[12] |= (state << kKelvinatorQuietOffset);
+  remote_state[12] |= (on << kKelvinatorQuietOffset);
 }
 
-bool IRKelvinatorAC::getQuiet() {
-  return ((remote_state[12] & kKelvinatorQuiet) != 0);
+bool IRKelvinatorAC::getQuiet(void) {
+  return remote_state[12] & kKelvinatorQuiet;
 }
 
-void IRKelvinatorAC::setIonFilter(bool state) {
+void IRKelvinatorAC::setIonFilter(const bool on) {
   remote_state[2] &= ~kKelvinatorIonFilter;
-  remote_state[2] |= (state << kKelvinatorIonFilterOffset);
+  remote_state[2] |= (on << kKelvinatorIonFilterOffset);
   remote_state[10] = remote_state[2];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getIonFilter() {
-  return ((remote_state[2] & kKelvinatorIonFilter) != 0);
+bool IRKelvinatorAC::getIonFilter(void) {
+  return remote_state[2] & kKelvinatorIonFilter;
 }
 
-void IRKelvinatorAC::setLight(bool state) {
+void IRKelvinatorAC::setLight(const bool on) {
   remote_state[2] &= ~kKelvinatorLight;
-  remote_state[2] |= (state << kKelvinatorLightOffset);
+  remote_state[2] |= (on << kKelvinatorLightOffset);
   remote_state[10] = remote_state[2];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getLight() {
-  return ((remote_state[2] & kKelvinatorLight) != 0);
+bool IRKelvinatorAC::getLight(void) {
+  return remote_state[2] & kKelvinatorLight;
 }
 
 // Note: XFan mode is only valid in Cool or Dry mode.
-void IRKelvinatorAC::setXFan(bool state) {
+void IRKelvinatorAC::setXFan(const bool on) {
   remote_state[2] &= ~kKelvinatorXfan;
-  remote_state[2] |= (state << kKelvinatorXfanOffset);
+  remote_state[2] |= (on << kKelvinatorXfanOffset);
   remote_state[10] = remote_state[2];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getXFan() {
-  return ((remote_state[2] & kKelvinatorXfan) != 0);
+bool IRKelvinatorAC::getXFan(void) {
+  return remote_state[2] & kKelvinatorXfan;
 }
 
 // Note: Turbo mode is turned off if the fan speed is changed.
-void IRKelvinatorAC::setTurbo(bool state) {
+void IRKelvinatorAC::setTurbo(const bool on) {
   remote_state[2] &= ~kKelvinatorTurbo;
-  remote_state[2] |= (state << kKelvinatorTurboOffset);
+  remote_state[2] |= (on << kKelvinatorTurboOffset);
   remote_state[10] = remote_state[2];  // Duplicate to the 2nd command chunk.
 }
 
-bool IRKelvinatorAC::getTurbo() {
-  return ((remote_state[2] & kKelvinatorTurbo) != 0);
+bool IRKelvinatorAC::getTurbo(void) {
+  return remote_state[2] & kKelvinatorTurbo;
 }
 
 // Convert a standard A/C mode into its native mode.
@@ -364,20 +375,60 @@ uint8_t IRKelvinatorAC::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
+// Convert the a native mode to it's common equivalent.
+stdAc::opmode_t IRKelvinatorAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kKelvinatorCool: return stdAc::opmode_t::kCool;
+    case kKelvinatorHeat: return stdAc::opmode_t::kHeat;
+    case kKelvinatorDry: return stdAc::opmode_t::kDry;
+    case kKelvinatorFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert the a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRKelvinatorAC::toCommonFanSpeed(const uint8_t speed) {
+  return (stdAc::fanspeed_t)speed;
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRKelvinatorAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::KELVINATOR;
+  result.model = -1;  // Unused.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  result.swingh = this->getSwingHorizontal() ? stdAc::swingh_t::kAuto :
+                                               stdAc::swingh_t::kOff;
+  result.quiet = this->getQuiet();
+  result.turbo = this->getTurbo();
+  result.light = this->getLight();
+  result.filter = this->getIonFilter();
+  result.clean = this->getXFan();
+  // Not supported.
+  result.econo = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRKelvinatorAC::toString() {
+String IRKelvinatorAC::toString(void) {
   String result = "";
 #else
-std::string IRKelvinatorAC::toString() {
+std::string IRKelvinatorAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(160);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getPower() ? F("On") : F("Off");
   result += F(", Mode: ");
   result += uint64ToString(getMode());
   switch (getMode()) {
@@ -412,40 +463,19 @@ std::string IRKelvinatorAC::toString() {
       break;
   }
   result += F(", Turbo: ");
-  if (getTurbo())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getTurbo() ? F("On") : F("Off");
   result += F(", Quiet: ");
-  if (getQuiet())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getQuiet() ? F("On") : F("Off");
   result += F(", XFan: ");
-  if (getXFan())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getXFan() ? F("On") : F("Off");
   result += F(", IonFilter: ");
-  if (getIonFilter())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getIonFilter() ? F("On") : F("Off");
   result += F(", Light: ");
-  if (getLight())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getLight() ? F("On") : F("Off");
   result += F(", Swing (Horizontal): ");
-  if (getSwingHorizontal())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getSwingHorizontal() ? F("On") : F("Off");
   result += F(", Swing (Vertical): ");
-  if (getSwingVertical())
-    result += F("On");
-  else
-    result += F("Off");
+  result += getSwingVertical() ? F("On") : F("Off");
   return result;
 }
 
@@ -459,7 +489,7 @@ std::string IRKelvinatorAC::toString() {
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: ALPHA / Untested.
+// Status: STABLE / Known working.
 bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                               bool strict) {
   if (results->rawlen <
@@ -561,7 +591,7 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
   }
 
   // Success
-  results->decode_type = KELVINATOR;
+  results->decode_type = decode_type_t::KELVINATOR;
   results->bits = state_pos * 8;
   // No need to record the state as we stored it as we decoded it.
   // As we use result->state, we don't record value, address, or command as it

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -375,7 +375,7 @@ uint8_t IRKelvinatorAC::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert the a native mode to it's common equivalent.
+// Convert a native mode to it's common equivalent.
 stdAc::opmode_t IRKelvinatorAC::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kKelvinatorCool: return stdAc::opmode_t::kCool;
@@ -386,7 +386,7 @@ stdAc::opmode_t IRKelvinatorAC::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert the a native fan speed to it's common equivalent.
+// Convert a native fan speed to it's common equivalent.
 stdAc::fanspeed_t IRKelvinatorAC::toCommonFanSpeed(const uint8_t speed) {
   return (stdAc::fanspeed_t)speed;
 }

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -131,46 +131,49 @@ class IRKelvinatorAC {
  public:
   explicit IRKelvinatorAC(uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_KELVINATOR
   void send(const uint16_t repeat = kKelvinatorDefaultRepeat);
 #endif  // SEND_KELVINATOR
-  void begin();
-  void on();
-  void off();
-  void setPower(bool state);
-  bool getPower();
-  void setTemp(uint8_t temp);
-  uint8_t getTemp();
-  void setFan(uint8_t fan);
-  uint8_t getFan();
-  void setMode(uint8_t mode);
-  uint8_t getMode();
-  void setSwingVertical(bool state);
-  bool getSwingVertical();
-  void setSwingHorizontal(bool state);
-  bool getSwingHorizontal();
-  void setQuiet(bool state);
-  bool getQuiet();
-  void setIonFilter(bool state);
-  bool getIonFilter();
-  void setLight(bool state);
-  bool getLight();
-  void setXFan(bool state);
-  bool getXFan();
-  void setTurbo(bool state);
-  bool getTurbo();
-  uint8_t* getRaw();
-  void setRaw(uint8_t new_code[]);
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t degrees);
+  uint8_t getTemp(void);
+  void setFan(const uint8_t speed);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  void setSwingVertical(const bool on);
+  bool getSwingVertical(void);
+  void setSwingHorizontal(const bool on);
+  bool getSwingHorizontal(void);
+  void setQuiet(const bool on);
+  bool getQuiet(void);
+  void setIonFilter(const bool on);
+  bool getIonFilter(void);
+  void setLight(const bool on);
+  bool getLight(void);
+  void setXFan(const bool on);
+  bool getXFan(void);
+  void setTurbo(const bool on);
+  bool getTurbo(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[]);
   static uint8_t calcBlockChecksum(
       const uint8_t* block, const uint16_t length = kKelvinatorStateLength / 2);
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kKelvinatorStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -182,7 +185,7 @@ class IRKelvinatorAC {
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kKelvinatorStateLength];
   void checksum(const uint16_t length = kKelvinatorStateLength);
-  void fixup();
+  void fixup(void);
 };
 
 #endif  // IR_KELVINATOR_H_

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -91,52 +91,54 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Warning: Consider this very alpha code.
 
 // Initialise the object.
-IRMideaAC::IRMideaAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRMideaAC::IRMideaAC(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
 
 // Reset the state of the remote to a known good state/sequence.
-void IRMideaAC::stateReset() {
+void IRMideaAC::stateReset(void) {
   // Power On, Mode Auto, Fan Auto, Temp = 25C/77F
   remote_state = 0xA1826FFFFF62;
 }
 
 // Configure the pin for output.
-void IRMideaAC::begin() { _irsend.begin(); }
+void IRMideaAC::begin(void) { _irsend.begin(); }
 
 #if SEND_MIDEA
 // Send the current desired state to the IR LED.
 void IRMideaAC::send(const uint16_t repeat) {
-  checksum();  // Ensure correct checksum before sending.
+  this->checksum();  // Ensure correct checksum before sending.
   _irsend.sendMidea(remote_state, kMideaBits, repeat);
 }
 #endif  // SEND_MIDEA
 
 // Return a pointer to the internal state date of the remote.
-uint64_t IRMideaAC::getRaw() {
-  checksum();
+uint64_t IRMideaAC::getRaw(void) {
+  this->checksum();
   return remote_state & kMideaACStateMask;
 }
 
 // Override the internal state with the new state.
-void IRMideaAC::setRaw(uint64_t newState) {
+void IRMideaAC::setRaw(const uint64_t newState) {
   remote_state = newState & kMideaACStateMask;
 }
 
 // Set the requested power state of the A/C to off.
-void IRMideaAC::on() { remote_state |= kMideaACPower; }
+void IRMideaAC::on(void) { remote_state |= kMideaACPower; }
 
 // Set the requested power state of the A/C to off.
-void IRMideaAC::off() { remote_state &= (kMideaACStateMask ^ kMideaACPower); }
+void IRMideaAC::off(void) {
+  remote_state &= (kMideaACStateMask ^ kMideaACPower);
+}
 
 // Set the requested power state of the A/C.
-void IRMideaAC::setPower(const bool state) {
-  if (state)
-    on();
+void IRMideaAC::setPower(const bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
 // Return the requested power state of the A/C.
-bool IRMideaAC::getPower() { return (remote_state & kMideaACPower); }
+bool IRMideaAC::getPower(void) { return (remote_state & kMideaACPower); }
 
 // Set the temperature.
 // Args:
@@ -187,42 +189,39 @@ void IRMideaAC::setFan(const uint8_t fan) {
 }
 
 // Return the requested state of the unit's fan.
-uint8_t IRMideaAC::getFan() { return (remote_state >> 35) & 0b111; }
+uint8_t IRMideaAC::getFan(void) { return (remote_state >> 35) & 0b111; }
 
 // Get the requested climate operation mode of the a/c unit.
 // Returns:
 //   A uint8_t containing the A/C mode.
-uint8_t IRMideaAC::getMode() { return ((remote_state >> 32) & 0b111); }
+uint8_t IRMideaAC::getMode(void) { return ((remote_state >> 32) & 0b111); }
 
 // Set the requested climate operation mode of the a/c unit.
 void IRMideaAC::setMode(const uint8_t mode) {
-  // If we get an unexpected mode, default to AUTO.
-  uint64_t new_mode;
   switch (mode) {
     case kMideaACAuto:
     case kMideaACCool:
     case kMideaACHeat:
     case kMideaACDry:
     case kMideaACFan:
-      new_mode = mode;
-      break;
+      remote_state &= kMideaACModeMask;
+      remote_state |= ((uint64_t)mode << 32);
+      return;
     default:
-      new_mode = kMideaACAuto;
+      this->setMode(kMideaACAuto);
   }
-  remote_state &= kMideaACModeMask;
-  remote_state |= (new_mode << 32);
 }
 
 // Set the Sleep state of the A/C.
-void IRMideaAC::setSleep(const bool state) {
-  if (state)
+void IRMideaAC::setSleep(const bool on) {
+  if (on)
     remote_state |= kMideaACSleep;
   else
     remote_state &= (kMideaACStateMask ^ kMideaACSleep);
 }
 
 // Return the Sleep state of the A/C.
-bool IRMideaAC::getSleep() { return (remote_state & kMideaACSleep); }
+bool IRMideaAC::getSleep(void) { return (remote_state & kMideaACSleep); }
 
 // Calculate the checksum for a given array.
 // Args:
@@ -251,7 +250,7 @@ bool IRMideaAC::validChecksum(const uint64_t state) {
 }
 
 // Calculate & set the checksum for the current internal state of the remote.
-void IRMideaAC::checksum() {
+void IRMideaAC::checksum(void) {
   // Stored the checksum value in the last byte.
   remote_state &= kMideaACChecksumMask;
   remote_state |= calcChecksum(remote_state);
@@ -290,12 +289,58 @@ uint8_t IRMideaAC::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRMideaAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kMideaACCool: return stdAc::opmode_t::kCool;
+    case kMideaACHeat: return stdAc::opmode_t::kHeat;
+    case kMideaACDry: return stdAc::opmode_t::kDry;
+    case kMideaACFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRMideaAC::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kMideaACFanHigh: return stdAc::fanspeed_t::kMax;
+    case kMideaACFanMed: return stdAc::fanspeed_t::kMedium;
+    case kMideaACFanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRMideaAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::MIDEA;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp(result.celsius);
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingv = stdAc::swingv_t::kOff;
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.turbo = false;
+  result.clean = false;
+  result.econo = false;
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRMideaAC::toString() {
+String IRMideaAC::toString(void) {
   String result = "";
 #else
-std::string IRMideaAC::toString() {
+std::string IRMideaAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(70);  // Reserve some heap for the string to reduce fragging.

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -66,34 +66,37 @@ const uint64_t kMideaACChecksumMask = 0x0000FFFFFFFFFF00;
 
 class IRMideaAC {
  public:
-  explicit IRMideaAC(uint16_t pin);
+  explicit IRMideaAC(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_MIDEA
   void send(const uint16_t repeat = kMideaMinRepeat);
 #endif  // SEND_MIDEA
-  void begin();
-  void on();
-  void off();
-  void setPower(const bool state);
-  bool getPower();
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
   void setTemp(const uint8_t temp, const bool useCelsius = false);
   uint8_t getTemp(const bool useCelsius = false);
   void setFan(const uint8_t fan);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t mode);
-  uint8_t getMode();
-  void setRaw(uint64_t newState);
-  uint64_t getRaw();
+  uint8_t getMode(void);
+  void setRaw(const uint64_t newState);
+  uint64_t getRaw(void);
   static bool validChecksum(const uint64_t state);
-  void setSleep(const bool state);
-  bool getSleep();
+  void setSleep(const bool on);
+  bool getSleep(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -103,7 +106,7 @@ class IRMideaAC {
   IRsendTest _irsend;
 #endif
   uint64_t remote_state;
-  void checksum();
+  void checksum(void);
   static uint8_t calcChecksum(const uint64_t state);
 };
 

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -420,10 +420,12 @@ bool IRrecv::decodeMitsubishiAC(decode_results *results, uint16_t nbits,
 // Equipment it seems compatible with:
 //  * <Add models (A/C & remotes) you've gotten it working with here>
 // Initialise the object.
-IRMitsubishiAC::IRMitsubishiAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRMitsubishiAC::IRMitsubishiAC(const uint16_t pin) : _irsend(pin) {
+  this->stateReset();
+}
 
 // Reset the state of the remote to a known good state/sequence.
-void IRMitsubishiAC::stateReset() {
+void IRMitsubishiAC::stateReset(void) {
   // The state of the IR remote in IR code form.
   // Known good state obtained from:
   //   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266.ino#L108
@@ -445,39 +447,39 @@ void IRMitsubishiAC::stateReset() {
   for (uint8_t i = 11; i < kMitsubishiACStateLength - 1; i++)
     remote_state[i] = 0;
   remote_state[kMitsubishiACStateLength - 1] = 0x1F;
-  checksum();  // Calculate the checksum
+  this->checksum();  // Calculate the checksum
 }
 
 // Configure the pin for output.
-void IRMitsubishiAC::begin() { _irsend.begin(); }
+void IRMitsubishiAC::begin(void) { _irsend.begin(); }
 
 #if SEND_MITSUBISHI_AC
 // Send the current desired state to the IR LED.
 void IRMitsubishiAC::send(const uint16_t repeat) {
-  checksum();  // Ensure correct checksum before sending.
+  this->checksum();  // Ensure correct checksum before sending.
   _irsend.sendMitsubishiAC(remote_state, kMitsubishiACStateLength, repeat);
 }
 #endif  // SEND_MITSUBISHI_AC
 
 // Return a pointer to the internal state date of the remote.
-uint8_t *IRMitsubishiAC::getRaw() {
-  checksum();
+uint8_t *IRMitsubishiAC::getRaw(void) {
+  this->checksum();
   return remote_state;
 }
 
-void IRMitsubishiAC::setRaw(uint8_t *data) {
+void IRMitsubishiAC::setRaw(const uint8_t *data) {
   for (uint8_t i = 0; i < (kMitsubishiACStateLength - 1); i++) {
     remote_state[i] = data[i];
   }
-  checksum();
+  this->checksum();
 }
 
 // Calculate the checksum for the current internal state of the remote.
-void IRMitsubishiAC::checksum() {
-  remote_state[17] = calculateChecksum(remote_state);
+void IRMitsubishiAC::checksum(void) {
+  remote_state[17] = this->calculateChecksum(remote_state);
 }
 
-uint8_t IRMitsubishiAC::calculateChecksum(uint8_t *data) {
+uint8_t IRMitsubishiAC::calculateChecksum(const uint8_t *data) {
   uint8_t sum = 0;
   // Checksum is simple addition of all previous bytes stored
   // as an 8 bit value.
@@ -486,45 +488,46 @@ uint8_t IRMitsubishiAC::calculateChecksum(uint8_t *data) {
 }
 
 // Set the requested power state of the A/C to off.
-void IRMitsubishiAC::on() {
+void IRMitsubishiAC::on(void) {
   // state = ON;
   remote_state[5] |= kMitsubishiAcPower;
 }
 
 // Set the requested power state of the A/C to off.
-void IRMitsubishiAC::off() {
+void IRMitsubishiAC::off(void) {
   // state = OFF;
   remote_state[5] &= ~kMitsubishiAcPower;
 }
 
 // Set the requested power state of the A/C.
-void IRMitsubishiAC::setPower(bool state) {
-  if (state)
-    on();
+void IRMitsubishiAC::setPower(bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
 // Return the requested power state of the A/C.
-bool IRMitsubishiAC::getPower() {
+bool IRMitsubishiAC::getPower(void) {
   return ((remote_state[5] & kMitsubishiAcPower) != 0);
 }
 
 // Set the temp. in deg C
-void IRMitsubishiAC::setTemp(uint8_t temp) {
-  temp = std::max((uint8_t)kMitsubishiAcMinTemp, temp);
+void IRMitsubishiAC::setTemp(const uint8_t degrees) {
+  uint8_t temp = std::max((uint8_t)kMitsubishiAcMinTemp, degrees);
   temp = std::min((uint8_t)kMitsubishiAcMaxTemp, temp);
   remote_state[7] = temp - kMitsubishiAcMinTemp;
 }
 
 // Return the set temp. in deg C
-uint8_t IRMitsubishiAC::getTemp() {
+uint8_t IRMitsubishiAC::getTemp(void) {
   return (remote_state[7] + kMitsubishiAcMinTemp);
 }
 
 // Set the speed of the fan, 0-6.
 // 0 is auto, 1-5 is the speed, 6 is silent.
-void IRMitsubishiAC::setFan(uint8_t fan) {
+void IRMitsubishiAC::setFan(const uint8_t speed) {
+  uint8_t fan = speed;
   // Bounds check
   if (fan > kMitsubishiAcFanSilent)
     fan = kMitsubishiAcFanMax;        // Set the fan to maximum if out of range.
@@ -539,17 +542,17 @@ void IRMitsubishiAC::setFan(uint8_t fan) {
 }
 
 // Return the requested state of the unit's fan.
-uint8_t IRMitsubishiAC::getFan() {
+uint8_t IRMitsubishiAC::getFan(void) {
   uint8_t fan = remote_state[9] & 0b111;
   if (fan == kMitsubishiAcFanMax) return kMitsubishiAcFanSilent;
   return fan;
 }
 
 // Return the requested climate operation mode of the a/c unit.
-uint8_t IRMitsubishiAC::getMode() { return (remote_state[6]); }
+uint8_t IRMitsubishiAC::getMode(void) { return (remote_state[6]); }
 
 // Set the requested climate operation mode of the a/c unit.
-void IRMitsubishiAC::setMode(uint8_t mode) {
+void IRMitsubishiAC::setMode(const uint8_t mode) {
   // If we get an unexpected mode, default to AUTO.
   switch (mode) {
     case kMitsubishiAcAuto:
@@ -565,48 +568,54 @@ void IRMitsubishiAC::setMode(uint8_t mode) {
       remote_state[8] = 0b00110000;
       break;
     default:
-      mode = kMitsubishiAcAuto;
-      remote_state[8] = 0b00110000;
+      this->setMode(kMitsubishiAcAuto);
+      return;
   }
   remote_state[6] = mode;
 }
 
 // Set the requested vane operation mode of the a/c unit.
-void IRMitsubishiAC::setVane(uint8_t mode) {
-  mode = std::min(mode, (uint8_t)0b111);  // bounds check
-  mode |= 0b1000;
-  mode <<= 3;
+void IRMitsubishiAC::setVane(const uint8_t position) {
+  uint8_t pos = std::min(position, (uint8_t)0b111);  // bounds check
+  pos |= 0b1000;
+  pos <<= 3;
   remote_state[9] &= 0b11000111;  // Clear the previous setting.
-  remote_state[9] |= mode;
+  remote_state[9] |= pos;
 }
 
 // Return the requested vane operation mode of the a/c unit.
-uint8_t IRMitsubishiAC::getVane() {
+uint8_t IRMitsubishiAC::getVane(void) {
   return ((remote_state[9] & 0b00111000) >> 3);
 }
 
 // Return the clock setting of the message. 1=1/6 hour. e.g. 4pm = 48
-uint8_t IRMitsubishiAC::getClock() { return remote_state[10]; }
+uint8_t IRMitsubishiAC::getClock(void) { return remote_state[10]; }
 
 // Set the current time. 1 = 1/6 hour. e.g. 6am = 36.
-void IRMitsubishiAC::setClock(uint8_t clock) { remote_state[10] = clock; }
+void IRMitsubishiAC::setClock(const uint8_t clock) {
+  remote_state[10] = clock;
+}
 
 // Return the desired start time. 1 = 1/6 hour. e.g. 1am = 6
-uint8_t IRMitsubishiAC::getStartClock() { return remote_state[12]; }
+uint8_t IRMitsubishiAC::getStartClock(void) { return remote_state[12]; }
 
-// Set the desired start tiem of the AC.  1 = 1/6 hour. e.g. 8pm = 120
-void IRMitsubishiAC::setStartClock(uint8_t clock) { remote_state[12] = clock; }
+// Set the desired start time of the AC.  1 = 1/6 hour. e.g. 8pm = 120
+void IRMitsubishiAC::setStartClock(const uint8_t clock) {
+  remote_state[12] = clock;
+}
 
 // Return the desired stop time of the AC. 1 = 1/6 hour. e.g 10pm = 132
-uint8_t IRMitsubishiAC::getStopClock() { return remote_state[11]; }
+uint8_t IRMitsubishiAC::getStopClock(void) { return remote_state[11]; }
 
 // Set the desired stop time of the AC. 1 = 1/6 hour. e.g 10pm = 132
-void IRMitsubishiAC::setStopClock(uint8_t clock) { remote_state[11] = clock; }
+void IRMitsubishiAC::setStopClock(const uint8_t clock) {
+  remote_state[11] = clock;
+}
 
 // Return the timer setting. Possible values: kMitsubishiAcNoTimer,
 //  kMitsubishiAcStartTimer, kMitsubishiAcStopTimer,
 //  kMitsubishiAcStartStopTimer
-uint8_t IRMitsubishiAC::getTimer() { return remote_state[13] & 0b111; }
+uint8_t IRMitsubishiAC::getTimer(void) { return remote_state[13] & 0b111; }
 
 // Set the timer setting. Possible values: kMitsubishiAcNoTimer,
 //  kMitsubishiAcStartTimer, kMitsubishiAcStopTimer,
@@ -661,11 +670,70 @@ uint8_t IRMitsubishiAC::convertSwingV(const stdAc::swingv_t position) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRMitsubishiAC::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kMitsubishiAcCool: return stdAc::opmode_t::kCool;
+    case kMitsubishiAcHeat: return stdAc::opmode_t::kHeat;
+    case kMitsubishiAcDry: return stdAc::opmode_t::kDry;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRMitsubishiAC::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kMitsubishiAcFanRealMax: return stdAc::fanspeed_t::kMax;
+    case kMitsubishiAcFanRealMax - 1: return stdAc::fanspeed_t::kHigh;
+    case kMitsubishiAcFanRealMax - 2: return stdAc::fanspeed_t::kMedium;
+    case kMitsubishiAcFanRealMax - 3: return stdAc::fanspeed_t::kLow;
+    case kMitsubishiAcFanSilent: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRMitsubishiAC::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case 1: return stdAc::swingv_t::kHighest;
+    case 2: return stdAc::swingv_t::kHigh;
+    case 3: return stdAc::swingv_t::kMiddle;
+    case 4: return stdAc::swingv_t::kLow;
+    case 5: return stdAc::swingv_t::kLowest;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRMitsubishiAC::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::MITSUBISHI_AC;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getVane());
+  result.quiet = this->getFan() == kMitsubishiAcFanSilent;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.turbo = false;
+  result.clean = false;
+  result.econo = false;
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 #ifdef ARDUINO
-String IRMitsubishiAC::timeToString(uint64_t time) {
+String IRMitsubishiAC::timeToString(const uint64_t time) {
   String result = "";
 #else
-std::string IRMitsubishiAC::timeToString(uint64_t time) {
+std::string IRMitsubishiAC::timeToString(const uint64_t time) {
   std::string result = "";
 #endif  // ARDUINO
   if (time / 6 < 10) result += '0';
@@ -678,19 +746,19 @@ std::string IRMitsubishiAC::timeToString(uint64_t time) {
 
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRMitsubishiAC::toString() {
+String IRMitsubishiAC::toString(void) {
   String result = "";
 #else
-std::string IRMitsubishiAC::toString() {
+std::string IRMitsubishiAC::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(110);  // Reserve some heap for the string to reduce fragging.
   result += F("Power: ");
-  if (getPower())
+  if (this->getPower())
     result += F("On");
   else
     result += F("Off");
-  switch (getMode()) {
+  switch (this->getMode()) {
     case MITSUBISHI_AC_AUTO:
       result += F(" (AUTO)");
       break;
@@ -707,9 +775,9 @@ std::string IRMitsubishiAC::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Temp: ");
-  result += uint64ToString(getTemp());
+  result += uint64ToString(this->getTemp());
   result += F("C, FAN: ");
-  switch (getFan()) {
+  switch (this->getFan()) {
     case MITSUBISHI_AC_FAN_AUTO:
       result += F("AUTO");
       break;
@@ -720,10 +788,10 @@ std::string IRMitsubishiAC::toString() {
       result += F("SILENT");
       break;
     default:
-      result += uint64ToString(getFan());
+      result += uint64ToString(this->getFan());
   }
   result += F(", VANE: ");
-  switch (getVane()) {
+  switch (this->getVane()) {
     case MITSUBISHI_AC_VANE_AUTO:
       result += F("AUTO");
       break;
@@ -731,16 +799,16 @@ std::string IRMitsubishiAC::toString() {
       result += F("AUTO MOVE");
       break;
     default:
-      result += uint64ToString(getVane());
+      result += uint64ToString(this->getVane());
   }
   result += F(", Time: ");
-  result += timeToString(getClock());
+  result += this->timeToString(this->getClock());
   result += F(", On timer: ");
-  result += timeToString(getStartClock());
+  result += this->timeToString(this->getStartClock());
   result += F(", Off timer: ");
-  result += timeToString(getStopClock());
+  result += this->timeToString(this->getStopClock());
   result += F(", Timer: ");
-  switch (getTimer()) {
+  switch (this->getTimer()) {
     case kMitsubishiAcNoTimer:
       result += '-';
       break;
@@ -755,7 +823,7 @@ std::string IRMitsubishiAC::toString() {
       break;
     default:
       result += F("? (");
-      result += getTimer();
+      result += this->getTimer();
       result += F(")\n");
   }
   return result;

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -61,44 +61,48 @@ const uint8_t kMitsubishiAcStartStopTimer = 7;
 
 class IRMitsubishiAC {
  public:
-  explicit IRMitsubishiAC(uint16_t pin);
+  explicit IRMitsubishiAC(const uint16_t pin);
 
-  static uint8_t calculateChecksum(uint8_t* data);
+  static uint8_t calculateChecksum(const uint8_t* data);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_MITSUBISHI_AC
   void send(const uint16_t repeat = kMitsubishiACMinRepeat);
 #endif  // SEND_MITSUBISHI_AC
-  void begin();
-  void on();
-  void off();
-  void setPower(bool state);
-  bool getPower();
-  void setTemp(uint8_t temp);
-  uint8_t getTemp();
-  void setFan(uint8_t fan);
-  uint8_t getFan();
-  void setMode(uint8_t mode);
-  uint8_t getMode();
-  void setVane(uint8_t mode);
-  uint8_t getVane();
-  uint8_t* getRaw();
-  void setRaw(uint8_t* data);
-  uint8_t getClock();
-  void setClock(uint8_t clock);
-  uint8_t getStartClock();
-  void setStartClock(uint8_t clock);
-  uint8_t getStopClock();
-  void setStopClock(uint8_t clock);
-  uint8_t getTimer();
-  void setTimer(uint8_t timer);
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t degrees);
+  uint8_t getTemp(void);
+  void setFan(const uint8_t speed);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  void setVane(const uint8_t position);
+  uint8_t getVane(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t* data);
+  uint8_t getClock(void);
+  void setClock(const uint8_t clock);
+  uint8_t getStartClock(void);
+  void setStartClock(const uint8_t clock);
+  uint8_t getStopClock(void);
+  void setStopClock(const uint8_t clock);
+  uint8_t getTimer(void);
+  void setTimer(const uint8_t timer);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -108,12 +112,12 @@ class IRMitsubishiAC {
   IRsendTest _irsend;
 #endif
 #ifdef ARDUINO
-  String timeToString(uint64_t time);
+  String timeToString(const uint64_t time);
 #else
-  std::string timeToString(uint64_t time);
+  std::string timeToString(const uint64_t time);
 #endif
   uint8_t remote_state[kMitsubishiACStateLength];
-  void checksum();
+  void checksum(void);
 };
 
 #endif  // IR_MITSUBISHI_H_

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -76,7 +76,7 @@ void IRsend::sendMitsubishiHeavy152(const unsigned char data[],
 IRMitsubishiHeavy152Ac::IRMitsubishiHeavy152Ac(
     const uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRMitsubishiHeavy152Ac::begin() { _irsend.begin(); }
+void IRMitsubishiHeavy152Ac::begin(void) { _irsend.begin(); }
 
 #if SEND_MITSUBISHIHEAVY
 void IRMitsubishiHeavy152Ac::send(const uint16_t repeat) {
@@ -303,7 +303,6 @@ bool IRMitsubishiHeavy152Ac::validChecksum(const uint8_t *state,
   return true;
 }
 
-
 // Convert a standard A/C mode into its native mode.
 uint8_t IRMitsubishiHeavy152Ac::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
@@ -376,6 +375,80 @@ uint8_t IRMitsubishiHeavy152Ac::convertSwingH(const stdAc::swingh_t position) {
     default:
       return kMitsubishiHeavy152SwingHOff;
   }
+}
+
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRMitsubishiHeavy152Ac::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kMitsubishiHeavyCool: return stdAc::opmode_t::kCool;
+    case kMitsubishiHeavyHeat: return stdAc::opmode_t::kHeat;
+    case kMitsubishiHeavyDry: return stdAc::opmode_t::kDry;
+    case kMitsubishiHeavyFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRMitsubishiHeavy152Ac::toCommonFanSpeed(const uint8_t spd) {
+  switch (spd) {
+    case kMitsubishiHeavy152FanMax: return stdAc::fanspeed_t::kMax;
+    case kMitsubishiHeavy152FanHigh: return stdAc::fanspeed_t::kHigh;
+    case kMitsubishiHeavy152FanMed: return stdAc::fanspeed_t::kMedium;
+    case kMitsubishiHeavy152FanLow: return stdAc::fanspeed_t::kLow;
+    case kMitsubishiHeavy152FanEcono: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingh_t IRMitsubishiHeavy152Ac::toCommonSwingH(const uint8_t pos) {
+  switch (pos) {
+    case kMitsubishiHeavy152SwingHLeftMax: return stdAc::swingh_t::kLeftMax;
+    case kMitsubishiHeavy152SwingHLeft: return stdAc::swingh_t::kLeft;
+    case kMitsubishiHeavy152SwingHMiddle: return stdAc::swingh_t::kMiddle;
+    case kMitsubishiHeavy152SwingHRight: return stdAc::swingh_t::kRight;
+    case kMitsubishiHeavy152SwingHRightMax: return stdAc::swingh_t::kRightMax;
+    case kMitsubishiHeavy152SwingHOff: return stdAc::swingh_t::kOff;
+    default: return stdAc::swingh_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRMitsubishiHeavy152Ac::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case kMitsubishiHeavy152SwingVHighest: return stdAc::swingv_t::kHighest;
+    case kMitsubishiHeavy152SwingVHigh: return stdAc::swingv_t::kHigh;
+    case kMitsubishiHeavy152SwingVMiddle: return stdAc::swingv_t::kMiddle;
+    case kMitsubishiHeavy152SwingVLow: return stdAc::swingv_t::kLow;
+    case kMitsubishiHeavy152SwingVLowest: return stdAc::swingv_t::kLowest;
+    case kMitsubishiHeavy152SwingVOff: return stdAc::swingv_t::kOff;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRMitsubishiHeavy152Ac::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::MITSUBISHI_HEAVY_152;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getSwingVertical());
+  result.swingh = this->toCommonSwingH(this->getSwingHorizontal());
+  result.turbo = this->getTurbo();
+  result.econo = this->getEcono();
+  result.clean = this->getClean();
+  result.quiet = this->getSilent();
+  result.filter = this->getFilter();
+  result.sleep = this->getNight() ? 0 : -1;
+  // Not supported.
+  result.light = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
 }
 
 // Convert the internal state into a human readable string.
@@ -521,7 +594,7 @@ std::string IRMitsubishiHeavy152Ac::toString(void) {
 IRMitsubishiHeavy88Ac::IRMitsubishiHeavy88Ac(
     const uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRMitsubishiHeavy88Ac::begin() { _irsend.begin(); }
+void IRMitsubishiHeavy88Ac::begin(void) { _irsend.begin(); }
 
 #if SEND_MITSUBISHIHEAVY
 void IRMitsubishiHeavy88Ac::send(const uint16_t repeat) {
@@ -738,7 +811,6 @@ uint8_t IRMitsubishiHeavy88Ac::convertMode(const stdAc::opmode_t mode) {
   return IRMitsubishiHeavy152Ac::convertMode(mode);
 }
 
-
 // Convert a standard A/C Fan speed into its native fan speed.
 uint8_t IRMitsubishiHeavy88Ac::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
@@ -795,6 +867,69 @@ uint8_t IRMitsubishiHeavy88Ac::convertSwingH(const stdAc::swingh_t position) {
     default:
       return kMitsubishiHeavy88SwingHOff;
   }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRMitsubishiHeavy88Ac::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kMitsubishiHeavy88FanTurbo: return stdAc::fanspeed_t::kMax;
+    case kMitsubishiHeavy88FanHigh: return stdAc::fanspeed_t::kHigh;
+    case kMitsubishiHeavy88FanMed: return stdAc::fanspeed_t::kMedium;
+    case kMitsubishiHeavy88FanLow: return stdAc::fanspeed_t::kLow;
+    case kMitsubishiHeavy88FanEcono: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingh_t IRMitsubishiHeavy88Ac::toCommonSwingH(const uint8_t pos) {
+  switch (pos) {
+    case kMitsubishiHeavy88SwingHLeftMax: return stdAc::swingh_t::kLeftMax;
+    case kMitsubishiHeavy88SwingHLeft: return stdAc::swingh_t::kLeft;
+    case kMitsubishiHeavy88SwingHMiddle: return stdAc::swingh_t::kMiddle;
+    case kMitsubishiHeavy88SwingHRight: return stdAc::swingh_t::kRight;
+    case kMitsubishiHeavy88SwingHRightMax: return stdAc::swingh_t::kRightMax;
+    case kMitsubishiHeavy88SwingHOff: return stdAc::swingh_t::kOff;
+    default: return stdAc::swingh_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRMitsubishiHeavy88Ac::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case kMitsubishiHeavy88SwingVHighest: return stdAc::swingv_t::kHighest;
+    case kMitsubishiHeavy88SwingVHigh: return stdAc::swingv_t::kHigh;
+    case kMitsubishiHeavy88SwingVMiddle: return stdAc::swingv_t::kMiddle;
+    case kMitsubishiHeavy88SwingVLow: return stdAc::swingv_t::kLow;
+    case kMitsubishiHeavy88SwingVLowest: return stdAc::swingv_t::kLowest;
+    case kMitsubishiHeavy88SwingVOff: return stdAc::swingv_t::kOff;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRMitsubishiHeavy88Ac::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::MITSUBISHI_HEAVY_88;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = IRMitsubishiHeavy152Ac::toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getSwingVertical());
+  result.swingh = this->toCommonSwingH(this->getSwingHorizontal());
+  result.turbo = this->getTurbo();
+  result.econo = this->getEcono();
+  result.clean = this->getClean();
+  // Not supported.
+  result.quiet = false;
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
 }
 
 // Convert the internal state into a human readable string.

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -176,6 +176,11 @@ class IRMitsubishiHeavy152Ac {
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static uint8_t convertSwingV(const stdAc::swingv_t position);
   static uint8_t convertSwingH(const stdAc::swingh_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  static stdAc::swingh_t toCommonSwingH(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
 #else  // ARDUINO
@@ -190,7 +195,7 @@ class IRMitsubishiHeavy152Ac {
 #endif  // UNIT_TEST
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kMitsubishiHeavy152StateLength];
-  void checksum();
+  void checksum(void);
 };
 
 class IRMitsubishiHeavy88Ac {
@@ -245,6 +250,10 @@ class IRMitsubishiHeavy88Ac {
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static uint8_t convertSwingV(const stdAc::swingv_t position);
   static uint8_t convertSwingH(const stdAc::swingh_t position);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  static stdAc::swingh_t toCommonSwingH(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
 #else  // ARDUINO
@@ -259,6 +268,6 @@ class IRMitsubishiHeavy88Ac {
 #endif  // UNIT_TEST
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kMitsubishiHeavy152StateLength];
-  void checksum();
+  void checksum(void);
 };
 #endif  // IR_MITSUBISHIHEAVY_H_

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -77,7 +77,8 @@ const uint32_t kPanasonicAcMessageGap = kDefaultMessageGap;  // Just a guess.
 //
 // Note:
 //   This protocol is a modified version of Kaseikyo.
-void IRsend::sendPanasonic64(uint64_t data, uint16_t nbits, uint16_t repeat) {
+void IRsend::sendPanasonic64(const uint64_t data, const uint16_t nbits,
+                             const uint16_t repeat) {
   sendGeneric(kPanasonicHdrMark, kPanasonicHdrSpace, kPanasonicBitMark,
               kPanasonicOneSpace, kPanasonicBitMark, kPanasonicZeroSpace,
               kPanasonicBitMark, kPanasonicMinGap, kPanasonicMinCommandLength,
@@ -96,8 +97,8 @@ void IRsend::sendPanasonic64(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Note:
 //   This protocol is a modified version of Kaseikyo.
-void IRsend::sendPanasonic(uint16_t address, uint32_t data, uint16_t nbits,
-                           uint16_t repeat) {
+void IRsend::sendPanasonic(const uint16_t address, const uint32_t data,
+                           const uint16_t nbits, const uint16_t repeat) {
   sendPanasonic64(((uint64_t)address << 32) | (uint64_t)data, nbits, repeat);
 }
 
@@ -117,8 +118,10 @@ void IRsend::sendPanasonic(uint16_t address, uint32_t data, uint16_t nbits,
 //   Panasonic 48-bit protocol is a modified version of Kaseikyo.
 // Ref:
 //   http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?2615
-uint64_t IRsend::encodePanasonic(uint16_t manufacturer, uint8_t device,
-                                 uint8_t subdevice, uint8_t function) {
+uint64_t IRsend::encodePanasonic(const uint16_t manufacturer,
+                                 const uint8_t device,
+                                 const uint8_t subdevice,
+                                 const uint8_t function) {
   uint8_t checksum = device ^ subdevice ^ function;
   return (((uint64_t)manufacturer << 32) | ((uint64_t)device << 24) |
           ((uint64_t)subdevice << 16) | ((uint64_t)function << 8) | checksum);
@@ -141,8 +144,8 @@ uint64_t IRsend::encodePanasonic(uint16_t manufacturer, uint8_t device,
 // Ref:
 //   http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
 //   http://www.hifi-remote.com/wiki/index.php?title=Panasonic
-bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
-                             bool strict, uint32_t manufacturer) {
+bool IRrecv::decodePanasonic(decode_results *results, const uint16_t nbits,
+                             const bool strict, const uint32_t manufacturer) {
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;  // Not enough entries to be a Panasonic message.
   if (strict && nbits != kPanasonicBits)
@@ -217,7 +220,8 @@ bool IRrecv::decodePanasonic(decode_results *results, uint16_t nbits,
 //     A75C3747
 //     A75C3704
 //
-void IRsend::sendPanasonicAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+void IRsend::sendPanasonicAC(const uint8_t data[], const uint16_t nbytes,
+                             const uint16_t repeat) {
   if (nbytes < kPanasonicAcSection1Length) return;
   for (uint16_t r = 0; r <= repeat; r++) {
     // First section. (8 bytes)
@@ -236,16 +240,18 @@ void IRsend::sendPanasonicAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
 }
 #endif  // SEND_PANASONIC_AC
 
-IRPanasonicAc::IRPanasonicAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRPanasonicAc::IRPanasonicAc(const uint16_t pin) : _irsend(pin) {
+  this->stateReset();
+}
 
-void IRPanasonicAc::stateReset() {
+void IRPanasonicAc::stateReset(void) {
   for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)
     remote_state[i] = kPanasonicKnownGoodState[i];
   _temp = 25;  // An initial saved desired temp. Completely made up.
   _swingh = kPanasonicAcSwingHMiddle;  // A similar made up value for H Swing.
 }
 
-void IRPanasonicAc::begin() { _irsend.begin(); }
+void IRPanasonicAc::begin(void) { _irsend.begin(); }
 
 // Verify the checksum is valid for a given state.
 // Args:
@@ -264,12 +270,12 @@ uint8_t IRPanasonicAc::calcChecksum(uint8_t state[], const uint16_t length) {
 }
 
 void IRPanasonicAc::fixChecksum(const uint16_t length) {
-  remote_state[length - 1] = calcChecksum(remote_state, length);
+  remote_state[length - 1] = this->calcChecksum(remote_state, length);
 }
 
 #if SEND_PANASONIC_AC
 void IRPanasonicAc::send(const uint16_t repeat) {
-  fixChecksum();
+  this->fixChecksum();
   _irsend.sendPanasonicAC(remote_state, kPanasonicAcStateLength, repeat);
 }
 #endif  // SEND_PANASONIC_AC
@@ -302,7 +308,7 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
       remote_state[23] = 0x01;
       remote_state[25] = 0x06;
       // Has to be done last as setSwingHorizontal has model check built-in
-      setSwingHorizontal(_swingh);
+      this->setSwingHorizontal(_swingh);
       break;
     case kPanasonicNke:
       remote_state[17] = 0x06;
@@ -321,7 +327,7 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
   }
 }
 
-panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
+panasonic_ac_remote_model_t IRPanasonicAc::getModel(void) {
   if (remote_state[23] == 0x89) return kPanasonicRkr;
   if (remote_state[17] == 0x00) {
     if ((remote_state[21] & 0x10) && (remote_state[23] & 0x01))
@@ -335,8 +341,8 @@ panasonic_ac_remote_model_t IRPanasonicAc::getModel() {
   return kPanasonicUnknown;
 }
 
-uint8_t *IRPanasonicAc::getRaw() {
-  fixChecksum();
+uint8_t *IRPanasonicAc::getRaw(void) {
+  this->fixChecksum();
   return remote_state;
 }
 
@@ -357,32 +363,32 @@ void IRPanasonicAc::setRaw(const uint8_t state[]) {
 //
 // For all other models, setPower(true) should set the internal state to
 // turn it on, and setPower(false) should turn it off.
-void IRPanasonicAc::setPower(const bool state) {
-  if (state)
-    on();
+void IRPanasonicAc::setPower(const bool on) {
+  if (on)
+    this->on();
   else
-    off();
+    this->off();
 }
 
 // Return the A/C power state of the remote.
 // Except for CKP models, where it returns if the power state will be toggled
 // on the A/C unit when the next message is sent.
-bool IRPanasonicAc::getPower() {
+bool IRPanasonicAc::getPower(void) {
   return (remote_state[13] & kPanasonicAcPower) == kPanasonicAcPower;
 }
 
-void IRPanasonicAc::on() { remote_state[13] |= kPanasonicAcPower; }
+void IRPanasonicAc::on(void) { remote_state[13] |= kPanasonicAcPower; }
 
-void IRPanasonicAc::off() { remote_state[13] &= ~kPanasonicAcPower; }
+void IRPanasonicAc::off(void) { remote_state[13] &= ~kPanasonicAcPower; }
 
-uint8_t IRPanasonicAc::getMode() { return remote_state[13] >> 4; }
+uint8_t IRPanasonicAc::getMode(void) { return remote_state[13] >> 4; }
 
 void IRPanasonicAc::setMode(const uint8_t desired) {
   uint8_t mode = kPanasonicAcAuto;  // Default to Auto mode.
   switch (desired) {
     case kPanasonicAcFan:
       // Allegedly Fan mode has a temperature of 27.
-      setTemp(kPanasonicAcFanModeTemp, false);
+      this->setTemp(kPanasonicAcFanModeTemp, false);
       mode = desired;
       break;
     case kPanasonicAcAuto:
@@ -391,14 +397,14 @@ void IRPanasonicAc::setMode(const uint8_t desired) {
     case kPanasonicAcDry:
       mode = desired;
       // Set the temp to the saved temp, just incase our previous mode was Fan.
-      setTemp(_temp);
+      this->setTemp(_temp);
       break;
   }
   remote_state[13] &= 0x0F;  // Clear the previous mode bits.
   remote_state[13] |= mode << 4;
 }
 
-uint8_t IRPanasonicAc::getTemp() { return remote_state[14] >> 1; }
+uint8_t IRPanasonicAc::getTemp(void) { return remote_state[14] >> 1; }
 
 // Set the desitred temperature in Celcius.
 // Args:
@@ -414,7 +420,9 @@ void IRPanasonicAc::setTemp(const uint8_t celsius, const bool remember) {
   if (remember) _temp = temperature;
 }
 
-uint8_t IRPanasonicAc::getSwingVertical() { return remote_state[16] & 0x0F; }
+uint8_t IRPanasonicAc::getSwingVertical(void) {
+  return remote_state[16] & 0x0F;
+}
 
 void IRPanasonicAc::setSwingVertical(const uint8_t desired_elevation) {
   uint8_t elevation = desired_elevation;
@@ -426,7 +434,7 @@ void IRPanasonicAc::setSwingVertical(const uint8_t desired_elevation) {
   remote_state[16] |= elevation;
 }
 
-uint8_t IRPanasonicAc::getSwingHorizontal() { return remote_state[17]; }
+uint8_t IRPanasonicAc::getSwingHorizontal(void) { return remote_state[17]; }
 
 void IRPanasonicAc::setSwingHorizontal(const uint8_t desired_direction) {
   switch (desired_direction) {
@@ -442,7 +450,7 @@ void IRPanasonicAc::setSwingHorizontal(const uint8_t desired_direction) {
   }
   _swingh = desired_direction;  // Store the direction for later.
   uint8_t direction = desired_direction;
-  switch (getModel()) {
+  switch (this->getModel()) {
     case kPanasonicDke:
     case kPanasonicRkr:
       break;
@@ -462,12 +470,12 @@ void IRPanasonicAc::setFan(const uint8_t speed) {
         (remote_state[16] & 0x0F) | ((speed + kPanasonicAcFanOffset) << 4);
 }
 
-uint8_t IRPanasonicAc::getFan() {
+uint8_t IRPanasonicAc::getFan(void) {
   return (remote_state[16] >> 4) - kPanasonicAcFanOffset;
 }
 
-bool IRPanasonicAc::getQuiet() {
-  switch (getModel()) {
+bool IRPanasonicAc::getQuiet(void) {
+  switch (this->getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return remote_state[21] & kPanasonicAcQuietCkp;
@@ -476,9 +484,9 @@ bool IRPanasonicAc::getQuiet() {
   }
 }
 
-void IRPanasonicAc::setQuiet(const bool state) {
+void IRPanasonicAc::setQuiet(const bool on) {
   uint8_t quiet;
-  switch (getModel()) {
+  switch (this->getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       quiet = kPanasonicAcQuietCkp;
@@ -487,16 +495,16 @@ void IRPanasonicAc::setQuiet(const bool state) {
       quiet = kPanasonicAcQuiet;
   }
 
-  if (state) {
-    setPowerful(false);  // Powerful is mutually exclusive.
+  if (on) {
+    this->setPowerful(false);  // Powerful is mutually exclusive.
     remote_state[21] |= quiet;
   } else {
     remote_state[21] &= ~quiet;
   }
 }
 
-bool IRPanasonicAc::getPowerful() {
-  switch (getModel()) {
+bool IRPanasonicAc::getPowerful(void) {
+  switch (this->getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return remote_state[21] & kPanasonicAcPowerfulCkp;
@@ -505,9 +513,9 @@ bool IRPanasonicAc::getPowerful() {
   }
 }
 
-void IRPanasonicAc::setPowerful(const bool state) {
+void IRPanasonicAc::setPowerful(const bool on) {
   uint8_t powerful;
-  switch (getModel()) {
+  switch (this->getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       powerful = kPanasonicAcPowerfulCkp;
@@ -516,8 +524,8 @@ void IRPanasonicAc::setPowerful(const bool state) {
       powerful = kPanasonicAcPowerful;
   }
 
-  if (state) {
-    setQuiet(false);  // Quiet is mutually exclusive.
+  if (on) {
+    this->setQuiet(false);  // Quiet is mutually exclusive.
     remote_state[21] |= powerful;
   } else {
     remote_state[21] &= ~powerful;
@@ -528,7 +536,7 @@ uint16_t IRPanasonicAc::encodeTime(const uint8_t hours, const uint8_t mins) {
   return std::min(hours, (uint8_t)23) * 60 + std::min(mins, (uint8_t)59);
 }
 
-uint16_t IRPanasonicAc::getClock() {
+uint16_t IRPanasonicAc::getClock(void) {
   uint16_t result = ((remote_state[25] & 0b00000111) << 8) + remote_state[24];
   if (result == kPanasonicAcTimeSpecial) return 0;
   return result;
@@ -543,7 +551,7 @@ void IRPanasonicAc::setClock(const uint16_t mins_since_midnight) {
   remote_state[25] |= (corrected >> 8);
 }
 
-uint16_t IRPanasonicAc::getOnTimer() {
+uint16_t IRPanasonicAc::getOnTimer(void) {
   uint16_t result = ((remote_state[19] & 0b00000111) << 8) + remote_state[18];
   if (result == kPanasonicAcTimeSpecial) return 0;
   return result;
@@ -567,13 +575,13 @@ void IRPanasonicAc::setOnTimer(const uint16_t mins_since_midnight,
   remote_state[19] |= (corrected >> 8);
 }
 
-void IRPanasonicAc::cancelOnTimer() { setOnTimer(0, false); }
+void IRPanasonicAc::cancelOnTimer(void) { this->setOnTimer(0, false); }
 
-bool IRPanasonicAc::isOnTimerEnabled() {
+bool IRPanasonicAc::isOnTimerEnabled(void) {
   return remote_state[13] & kPanasonicAcOnTimer;
 }
 
-uint16_t IRPanasonicAc::getOffTimer() {
+uint16_t IRPanasonicAc::getOffTimer(void) {
   uint16_t result =
       ((remote_state[20] & 0b01111111) << 4) + (remote_state[19] >> 4);
   if (result == kPanasonicAcTimeSpecial) return 0;
@@ -599,9 +607,9 @@ void IRPanasonicAc::setOffTimer(const uint16_t mins_since_midnight,
   remote_state[20] |= corrected >> 4;
 }
 
-void IRPanasonicAc::cancelOffTimer() { setOffTimer(0, false); }
+void IRPanasonicAc::cancelOffTimer(void) { this->setOffTimer(0, false); }
 
-bool IRPanasonicAc::isOffTimerEnabled() {
+bool IRPanasonicAc::isOffTimerEnabled(void) {
   return remote_state[13] & kPanasonicAcOffTimer;
 }
 
@@ -685,12 +693,81 @@ uint8_t IRPanasonicAc::convertSwingH(const stdAc::swingh_t position) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRPanasonicAc::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kPanasonicAcCool: return stdAc::opmode_t::kCool;
+    case kPanasonicAcHeat: return stdAc::opmode_t::kHeat;
+    case kPanasonicAcDry: return stdAc::opmode_t::kDry;
+    case kPanasonicAcFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRPanasonicAc::toCommonFanSpeed(const uint8_t spd) {
+  switch (spd) {
+    case kPanasonicAcFanMax: return stdAc::fanspeed_t::kMax;
+    case kPanasonicAcFanMin + 3: return stdAc::fanspeed_t::kHigh;
+    case kPanasonicAcFanMin + 2: return stdAc::fanspeed_t::kMedium;
+    case kPanasonicAcFanMin + 1: return stdAc::fanspeed_t::kLow;
+    case kPanasonicAcFanMin: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingh_t IRPanasonicAc::toCommonSwingH(const uint8_t pos) {
+  switch (pos) {
+    case kPanasonicAcSwingHFullLeft: return stdAc::swingh_t::kLeftMax;
+    case kPanasonicAcSwingHLeft: return stdAc::swingh_t::kLeft;
+    case kPanasonicAcSwingHMiddle: return stdAc::swingh_t::kMiddle;
+    case kPanasonicAcSwingHRight: return stdAc::swingh_t::kRight;
+    case kPanasonicAcSwingHFullRight: return stdAc::swingh_t::kRightMax;
+    default: return stdAc::swingh_t::kAuto;
+  }
+}
+
+// Convert a native vertical swing to it's common equivalent.
+stdAc::swingv_t IRPanasonicAc::toCommonSwingV(const uint8_t pos) {
+  switch (pos) {
+    case kPanasonicAcSwingVUp: return stdAc::swingv_t::kHighest;
+    case kPanasonicAcSwingVDown: return stdAc::swingv_t::kLowest;
+    default: return stdAc::swingv_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRPanasonicAc::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::PANASONIC_AC;
+  result.model = this->getModel();
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->toCommonSwingV(this->getSwingVertical());
+  result.swingh = this->toCommonSwingH(this->getSwingHorizontal());
+  result.quiet = this->getQuiet();
+  result.turbo = this->getPowerful();
+  // Not supported.
+  result.econo = false;
+  result.clean = false;
+  result.filter = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRPanasonicAc::toString() {
+String IRPanasonicAc::toString(void) {
   String result = "";
 #else
-std::string IRPanasonicAc::toString() {
+std::string IRPanasonicAc::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(180);  // Reserve some heap for the string to reduce fragging.
@@ -857,8 +934,8 @@ std::string IRPanasonicAc::toString() {
 //   A/C Remotes:
 //     A75C3747 (Confirmed)
 //     A75C3704
-bool IRrecv::decodePanasonicAC(decode_results *results, uint16_t nbits,
-                               bool strict) {
+bool IRrecv::decodePanasonicAC(decode_results *results, const uint16_t nbits,
+                               const bool strict) {
   if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
     return false;
 

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -81,60 +81,65 @@ enum panasonic_ac_remote_model_t {
 
 class IRPanasonicAc {
  public:
-  explicit IRPanasonicAc(uint16_t pin);
+  explicit IRPanasonicAc(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_PANASONIC
   void send(const uint16_t repeat = kPanasonicAcDefaultRepeat);
 #endif  // SEND_PANASONIC
-  void begin();
-  void on();
-  void off();
-  void setPower(const bool state);
-  bool getPower();
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
   void setTemp(const uint8_t temp, const bool remember = true);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setFan(const uint8_t fan);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t mode);
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setRaw(const uint8_t state[]);
-  uint8_t *getRaw();
+  uint8_t *getRaw(void);
   static bool validChecksum(uint8_t *state,
                             const uint16_t length = kPanasonicAcStateLength);
   static uint8_t calcChecksum(uint8_t *state,
                               const uint16_t length = kPanasonicAcStateLength);
-  void setQuiet(const bool state);
-  bool getQuiet();
-  void setPowerful(const bool state);
-  bool getPowerful();
+  void setQuiet(const bool on);
+  bool getQuiet(void);
+  void setPowerful(const bool on);
+  bool getPowerful(void);
   void setModel(const panasonic_ac_remote_model_t model);
-  panasonic_ac_remote_model_t getModel();
+  panasonic_ac_remote_model_t getModel(void);
   void setSwingVertical(const uint8_t elevation);
-  uint8_t getSwingVertical();
+  uint8_t getSwingVertical(void);
   void setSwingHorizontal(const uint8_t direction);
-  uint8_t getSwingHorizontal();
+  uint8_t getSwingHorizontal(void);
   static uint16_t encodeTime(const uint8_t hours, const uint8_t mins);
-  uint16_t getClock();
+  uint16_t getClock(void);
   void setClock(const uint16_t mins_since_midnight);
-  uint16_t getOnTimer();
+  uint16_t getOnTimer(void);
   void setOnTimer(const uint16_t mins_since_midnight, const bool enable = true);
-  void cancelOnTimer();
-  bool isOnTimerEnabled();
-  uint16_t getOffTimer();
+  void cancelOnTimer(void);
+  bool isOnTimerEnabled(void);
+  uint16_t getOffTimer(void);
   void setOffTimer(const uint16_t mins_since_midnight,
                    const bool enable = true);
-  void cancelOffTimer();
-  bool isOffTimerEnabled();
+  void cancelOffTimer(void);
+  bool isOffTimerEnabled(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   uint8_t convertSwingV(const stdAc::swingv_t position);
   uint8_t convertSwingH(const stdAc::swingh_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  static stdAc::swingh_t toCommonSwingH(const uint8_t pos);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
   static String timeToString(const uint16_t mins_since_midnight);
 #else
-  std::string toString();
+  std::string toString(void);
   static std::string timeToString(const uint16_t mins_since_midnight);
 #endif
 #ifndef UNIT_TEST

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -61,7 +61,7 @@ const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 // Classes
 class IRSamsungAc {
  public:
-  explicit IRSamsungAc(uint16_t pin);
+  explicit IRSamsungAc(const uint16_t pin);
 
   void stateReset(void);
 #if SEND_SAMSUNG_AC
@@ -100,6 +100,9 @@ class IRSamsungAc {
                               const uint16_t length = kSamsungAcStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
 #else

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -48,7 +48,7 @@ const uint8_t kSharpAcBitTempManual = 0b00000100;
 
 class IRSharpAc {
  public:
-  explicit IRSharpAc(uint16_t pin);
+  explicit IRSharpAc(const uint16_t pin);
 
 #if SEND_SHARP_AC
   void send(const uint16_t repeat = kSharpAcDefaultRepeat);
@@ -59,39 +59,11 @@ class IRSharpAc {
   void setPower(const bool on);
   bool getPower(void);
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setFan(const uint8_t fan);
   uint8_t getFan(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
-  void setSwingVertical(const bool on);
-  bool getSwingVertical(void);
-  void setSwingHorizontal(const bool on);
-  bool getSwingHorizontal(void);
-  bool getQuiet(void);
-  void setQuiet(const bool on);
-  bool getPowerful(void);
-  void setPowerful(const bool on);
-  void setSensor(const bool on);
-  bool getSensor(void);
-  void setEcono(const bool on);
-  bool getEcono(void);
-  void setEye(const bool on);
-  bool getEye(void);
-  void setMold(const bool on);
-  bool getMold(void);
-  void setComfort(const bool on);
-  bool getComfort(void);
-  void enableOnTimer(const uint16_t starttime);
-  void disableOnTimer(void);
-  uint16_t getOnTime(void);
-  bool getOnTimerEnabled();
-  void enableOffTimer(const uint16_t endtime);
-  void disableOffTimer(void);
-  uint16_t getOffTime(void);
-  bool getOffTimerEnabled(void);
-  void setCurrentTime(const uint16_t mins_since_midnight);
-  uint16_t getCurrentTime(void);
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kSharpAcStateLength);
@@ -99,6 +71,9 @@ class IRSharpAc {
                             const uint16_t length = kSharpAcStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
   static String renderTime(const uint16_t timemins);

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -22,9 +22,9 @@ void IRsend::sendTcl112Ac(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TCL112AC
 
-IRTcl112Ac::IRTcl112Ac(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRTcl112Ac::IRTcl112Ac(const uint16_t pin) : _irsend(pin) { stateReset(); }
 
-void IRTcl112Ac::begin() { this->_irsend.begin(); }
+void IRTcl112Ac::begin(void) { this->_irsend.begin(); }
 
 #if SEND_TCL112AC
 void IRTcl112Ac::send(const uint16_t repeat) {
@@ -64,7 +64,7 @@ bool IRTcl112Ac::validChecksum(uint8_t state[], const uint16_t length) {
   return (length > 1 && state[length - 1] == calcChecksum(state, length));
 }
 
-void IRTcl112Ac::stateReset() {
+void IRTcl112Ac::stateReset(void) {
   for (uint8_t i = 0; i < kTcl112AcStateLength; i++)
     remote_state[i] = 0x0;
   // A known good state. (On, Cool, 24C)
@@ -79,7 +79,7 @@ void IRTcl112Ac::stateReset() {
   remote_state[13] = 0x03;
 }
 
-uint8_t* IRTcl112Ac::getRaw() {
+uint8_t* IRTcl112Ac::getRaw(void) {
   this->checksum();
   return remote_state;
 }
@@ -112,7 +112,7 @@ bool IRTcl112Ac::getPower(void) {
 // Get the requested climate operation mode of the a/c unit.
 // Returns:
 //   A uint8_t containing the A/C mode.
-uint8_t IRTcl112Ac::getMode() {
+uint8_t IRTcl112Ac::getMode(void) {
   return remote_state[6] & 0xF;
 }
 
@@ -151,7 +151,7 @@ void IRTcl112Ac::setTemp(const float celsius) {
   remote_state[7] |= ((uint8_t)kTcl112AcTempMax - nrHalfDegrees / 2);
 }
 
-float IRTcl112Ac::getTemp() {
+float IRTcl112Ac::getTemp(void) {
   float result = kTcl112AcTempMax - (remote_state[7] & 0xF);
   if (remote_state[12] & kTcl112AcHalfDegree) result += 0.5;
   return result;
@@ -174,7 +174,7 @@ void IRTcl112Ac::setFan(const uint8_t speed) {
 }
 
 // Return the currect fan speed.
-uint8_t IRTcl112Ac::getFan() {
+uint8_t IRTcl112Ac::getFan(void) {
   return remote_state[8] & kTcl112AcFanMask;
 }
 
@@ -291,12 +291,60 @@ uint8_t IRTcl112Ac::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRTcl112Ac::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kTcl112AcCool: return stdAc::opmode_t::kCool;
+    case kTcl112AcHeat: return stdAc::opmode_t::kHeat;
+    case kTcl112AcDry: return stdAc::opmode_t::kDry;
+    case kTcl112AcFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRTcl112Ac::toCommonFanSpeed(const uint8_t spd) {
+  switch (spd) {
+    case kTcl112AcFanHigh: return stdAc::fanspeed_t::kMax;
+    case kTcl112AcFanMed: return stdAc::fanspeed_t::kMedium;
+    case kTcl112AcFanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRTcl112Ac::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::TCL112AC;
+  result.model = -1;  // Not supported.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  result.swingh = this->getSwingHorizontal() ? stdAc::swingh_t::kAuto :
+                                               stdAc::swingh_t::kOff;
+  result.turbo = this->getTurbo();
+  result.light = this->getLight();
+  result.filter = this->getHealth();
+  result.econo = this->getEcono();
+  // Not supported.
+  result.quiet = false;
+  result.clean = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRTcl112Ac::toString() {
+String IRTcl112Ac::toString(void) {
   String result = "";
 #else
-std::string IRTcl112Ac::toString() {
+std::string IRTcl112Ac::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(140);  // Reserve some heap for the string to reduce fragging.
@@ -372,8 +420,8 @@ std::string IRTcl112Ac::toString() {
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/619
-bool IRrecv::decodeTcl112Ac(decode_results *results, uint16_t nbits,
-                            bool strict) {
+bool IRrecv::decodeTcl112Ac(decode_results *results, const uint16_t nbits,
+                            const bool strict) {
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;  // Can't possibly be a valid Samsung A/C message.
   if (strict && nbits != kTcl112AcBits) return false;

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -48,7 +48,7 @@ const uint8_t kTcl112AcBitTurbo  = 0b01000000;
 
 class IRTcl112Ac {
  public:
-  explicit IRTcl112Ac(uint16_t pin);
+  explicit IRTcl112Ac(const uint16_t pin);
 
 #if SEND_TCL112AC
   void send(const uint16_t repeat = kTcl112AcDefaultRepeat);
@@ -85,10 +85,13 @@ class IRTcl112Ac {
   bool getTurbo(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -98,7 +101,7 @@ class IRTcl112Ac {
   IRsendTest _irsend;
 #endif
   uint8_t remote_state[kTcl112AcStateLength];
-  void stateReset();
+  void stateReset(void);
   void checksum(const uint16_t length = kTcl112AcStateLength);
 };
 

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -27,7 +27,8 @@ const uint32_t kTecoGap = kDefaultMessageGap;  // Made-up value. Just a guess.
 //   data:   Contents of the message to be sent.
 //   nbits:  Nr. of bits of data to be sent. Typically kTecoBits.
 //   repeat: Nr. of additional times the message is to be sent.
-void IRsend::sendTeco(uint64_t data, uint16_t nbits, uint16_t repeat) {
+void IRsend::sendTeco(const uint64_t data, const uint16_t nbits,
+                      const uint16_t repeat) {
   sendGeneric(kTecoHdrMark, kTecoHdrSpace, kTecoBitMark, kTecoOneSpace,
               kTecoBitMark, kTecoZeroSpace, kTecoBitMark, kTecoGap,
               data, nbits, 38000, false, repeat, kDutyDefault);
@@ -35,9 +36,9 @@ void IRsend::sendTeco(uint64_t data, uint16_t nbits, uint16_t repeat) {
 #endif  // SEND_TECO
 
 // Class for decoding and constructing Teco AC messages.
-IRTecoAc::IRTecoAc(const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRTecoAc::IRTecoAc(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
 
-void IRTecoAc::begin() { _irsend.begin(); }
+void IRTecoAc::begin(void) { _irsend.begin(); }
 
 #if SEND_TECO
 void IRTecoAc::send(const uint16_t repeat) {
@@ -168,6 +169,53 @@ uint8_t IRTecoAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRTecoAc::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kTecoCool: return stdAc::opmode_t::kCool;
+    case kTecoHeat: return stdAc::opmode_t::kHeat;
+    case kTecoDry: return stdAc::opmode_t::kDry;
+    case kTecoFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRTecoAc::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kTecoFanHigh: return stdAc::fanspeed_t::kMax;
+    case kTecoFanMed: return stdAc::fanspeed_t::kMedium;
+    case kTecoFanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRTecoAc::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::TECO;
+  result.model = -1;  // Not supported.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwing() ? stdAc::swingv_t::kAuto :
+                                     stdAc::swingv_t::kOff;
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.turbo = false;
+  result.light = false;
+  result.filter = false;
+  result.econo = false;
+  result.quiet = false;
+  result.clean = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
 String IRTecoAc::toString(void) {
@@ -238,7 +286,8 @@ std::string IRTecoAc::toString(void) {
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: STABLE / Tested.
-bool IRrecv::decodeTeco(decode_results* results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeTeco(decode_results* results,
+                        const uint16_t nbits, const bool strict) {
   // Check if can possibly be a valid Teco message.
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1) return false;
   if (strict && nbits != kTecoBits) return false;  // Not what is expected

--- a/src/ir_Teco.h
+++ b/src/ir_Teco.h
@@ -125,6 +125,9 @@ class IRTecoAc {
 
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
   String toString(void);
 #else

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -47,33 +47,36 @@ const uint8_t kToshibaAcMaxTemp = 30;  // 30C
 
 class IRToshibaAC {
  public:
-  explicit IRToshibaAC(uint16_t pin);
+  explicit IRToshibaAC(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_TOSHIBA_AC
   void send(const uint16_t repeat = kToshibaACMinRepeat);
 #endif  // SEND_TOSHIBA_AC
-  void begin();
-  void on();
-  void off();
-  void setPower(bool state);
-  bool getPower();
-  void setTemp(uint8_t temp);
-  uint8_t getTemp();
-  void setFan(uint8_t fan);
-  uint8_t getFan();
-  void setMode(uint8_t mode);
-  uint8_t getMode(bool useRaw = false);
-  void setRaw(uint8_t newState[]);
-  uint8_t* getRaw();
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t degrees);
+  uint8_t getTemp(void);
+  void setFan(const uint8_t speed);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(const bool useRaw = false);
+  void setRaw(const uint8_t newState[]);
+  uint8_t* getRaw(void);
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kToshibaACStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -60,30 +60,33 @@ class IRTrotecESP {
 #if SEND_TROTEC
   void send(const uint16_t repeat = kTrotecDefaultRepeat);
 #endif  // SEND_TROTEC
-  void begin();
+  void begin(void);
 
   void setPower(const bool state);
-  bool getPower();
+  bool getPower(void);
 
   void setTemp(const uint8_t celsius);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
 
   void setSpeed(const uint8_t fan);
-  uint8_t getSpeed();
+  uint8_t getSpeed(void);
 
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setMode(const uint8_t mode);
 
-  bool getSleep();
-  void setSleep(bool sleep);
+  bool getSleep(void);
+  void setSleep(const bool on);
 
-  uint8_t getTimer();
+  uint8_t getTimer(void);
   void setTimer(const uint8_t timer);
 
-  uint8_t* getRaw();
+  uint8_t* getRaw(void);
 
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifndef UNIT_TEST
 
  private:
@@ -92,8 +95,8 @@ class IRTrotecESP {
   IRsendTest _irsend;
 #endif
   uint8_t remote_state[kTrotecStateLength];
-  void stateReset();
-  void checksum();
+  void stateReset(void);
+  void checksum(void);
 };
 
 #endif  // IR_TROTEC_H_

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -53,10 +53,12 @@ void IRsend::sendVestelAc(const uint64_t data, const uint16_t nbits,
 // Code to emulate Vestel A/C IR remote control unit.
 
 // Initialise the object.
-IRVestelAc::IRVestelAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRVestelAc::IRVestelAc(const uint16_t pin) : _irsend(pin) {
+  this->stateReset();
+}
 
 // Reset the state of the remote to a known good state/sequence.
-void IRVestelAc::stateReset() {
+void IRVestelAc::stateReset(void) {
   // Power On, Mode Auto, Fan Auto, Temp = 25C/77F
   remote_state = kVestelAcStateDefault;
   remote_time_state = kVestelAcTimeStateDefault;
@@ -64,14 +66,14 @@ void IRVestelAc::stateReset() {
 }
 
 // Configure the pin for output.
-void IRVestelAc::begin() {
+void IRVestelAc::begin(void) {
   _irsend.begin();
 }
 
 #if SEND_VESTEL_AC
 // Send the current desired state to the IR LED.
-void IRVestelAc::send() {
-  checksum();  // Ensure correct checksum before sending.
+void IRVestelAc::send(void) {
+  this->checksum();  // Ensure correct checksum before sending.
   uint64_t code_to_send;
   if (use_time_state)
     code_to_send = remote_time_state;
@@ -82,14 +84,14 @@ void IRVestelAc::send() {
 #endif  // SEND_VESTEL_AC
 
 // Return the internal state date of the remote.
-uint64_t IRVestelAc::getRaw() {
-  checksum();
+uint64_t IRVestelAc::getRaw(void) {
+  this->checksum();
   if (use_time_state) return remote_time_state;
   return remote_state;
 }
 
 // Override the internal state with the new state.
-void IRVestelAc::setRaw(uint8_t* newState) {
+void IRVestelAc::setRaw(const uint8_t* newState) {
   uint64_t upState = 0;
   for (int i = 0; i < 7; i++)
     upState |= static_cast<uint64_t>(newState[i]) << (i * 8);
@@ -109,15 +111,15 @@ void IRVestelAc::setRaw(const uint64_t newState) {
 }
 
 // Set the requested power state of the A/C to on.
-void IRVestelAc::on() { setPower(true); }
+void IRVestelAc::on(void) { setPower(true); }
 
 // Set the requested power state of the A/C to off.
-void IRVestelAc::off() { setPower(false); }
+void IRVestelAc::off(void) { setPower(false); }
 
 // Set the requested power state of the A/C.
-void IRVestelAc::setPower(const bool state) {
+void IRVestelAc::setPower(const bool on) {
   remote_state &= ~((uint64_t)0xF << kVestelAcPowerOffset);
-  if (state)
+  if (on)
     remote_state |= ((uint64_t)0xF << kVestelAcPowerOffset);
   else
     remote_state |= ((uint64_t)0xC << kVestelAcPowerOffset);
@@ -125,7 +127,7 @@ void IRVestelAc::setPower(const bool state) {
 }
 
 // Return the requested power state of the A/C.
-bool IRVestelAc::getPower() {
+bool IRVestelAc::getPower(void) {
   return (remote_state >> kVestelAcPowerOffset == 0xF);
 }
 
@@ -165,14 +167,14 @@ void IRVestelAc::setFan(const uint8_t fan) {
 }
 
 // Return the requested state of the unit's fan.
-uint8_t IRVestelAc::getFan() {
+uint8_t IRVestelAc::getFan(void) {
   return (remote_state >> kVestelAcFanOffset) & 0xF;
 }
 
 // Get the requested climate operation mode of the a/c unit.
 // Returns:
 //   A uint8_t containing the A/C mode.
-uint8_t IRVestelAc::getMode() {
+uint8_t IRVestelAc::getMode(void) {
   return (remote_state >> kVestelAcModeOffset) & 0xF;
 }
 
@@ -313,53 +315,54 @@ uint16_t IRVestelAc::getOffTimer(void) {
 }
 
 // Set the Sleep state of the A/C.
-void IRVestelAc::setSleep(const bool state) {
+void IRVestelAc::setSleep(const bool on) {
   remote_state &= ~((uint64_t)0xF << kVestelAcTurboSleepOffset);
-  remote_state |= (uint64_t)(state ? kVestelAcSleep : kVestelAcNormal)
+  remote_state |= (uint64_t)(on ? kVestelAcSleep : kVestelAcNormal)
                   << kVestelAcTurboSleepOffset;
   use_time_state = false;
 }
 
 // Return the Sleep state of the A/C.
-bool IRVestelAc::getSleep() {
+bool IRVestelAc::getSleep(void) {
   return ((remote_state >> kVestelAcTurboSleepOffset) & 0xF) == kVestelAcSleep;
 }
 
 // Set the Turbo state of the A/C.
-void IRVestelAc::setTurbo(const bool state) {
+void IRVestelAc::setTurbo(const bool on) {
   remote_state &= ~((uint64_t)0xF << kVestelAcTurboSleepOffset);
-  remote_state |= (uint64_t)(state ? kVestelAcTurbo : kVestelAcNormal)
+  remote_state |= (uint64_t)(on ? kVestelAcTurbo : kVestelAcNormal)
                   << kVestelAcTurboSleepOffset;
   use_time_state = false;
 }
 
 // Return the Turbo state of the A/C.
-bool IRVestelAc::getTurbo() {
+bool IRVestelAc::getTurbo(void) {
   return ((remote_state >> kVestelAcTurboSleepOffset) & 0xF) == kVestelAcTurbo;
 }
 
 // Set the Ion state of the A/C.
-void IRVestelAc::setIon(const bool state) {
+void IRVestelAc::setIon(const bool on) {
   remote_state &= ~((uint64_t)0x1 << kVestelAcIonOffset);
 
-  remote_state |= (uint64_t)(state ? 1 : 0) << kVestelAcIonOffset;
+  remote_state |= (uint64_t)(on ? 1 : 0) << kVestelAcIonOffset;
   use_time_state = false;
 }
 
 // Return the Ion state of the A/C.
-bool IRVestelAc::getIon() { return (remote_state >> kVestelAcIonOffset) & 1; }
+bool IRVestelAc::getIon(void) {
+  return (remote_state >> kVestelAcIonOffset) & 1;
+}
 
 // Set the Swing Roaming state of the A/C.
-void IRVestelAc::setSwing(const bool state) {
+void IRVestelAc::setSwing(const bool on) {
   remote_state &= ~((uint64_t)0xF << kVestelAcSwingOffset);
 
-  remote_state |= (uint64_t)(state ? kVestelAcSwing : 0xF)
-                  << kVestelAcSwingOffset;
+  remote_state |= (uint64_t)(on ? kVestelAcSwing : 0xF) << kVestelAcSwingOffset;
   use_time_state = false;
 }
 
 // Return the Swing Roaming state of the A/C.
-bool IRVestelAc::getSwing() {
+bool IRVestelAc::getSwing(void) {
   return ((remote_state >> kVestelAcSwingOffset) & 0xF) == kVestelAcSwing;
 }
 
@@ -385,22 +388,23 @@ uint8_t IRVestelAc::calcChecksum(const uint64_t state) {
 // Returns:
 //   A boolean.
 bool IRVestelAc::validChecksum(const uint64_t state) {
-  return (((state >> kVestelAcChecksumOffset) & 0xFF) == calcChecksum(state));
+  return (((state >> kVestelAcChecksumOffset) & 0xFF) ==
+          IRVestelAc::calcChecksum(state));
 }
 
 // Calculate & set the checksum for the current internal state of the remote.
-void IRVestelAc::checksum() {
+void IRVestelAc::checksum(void) {
   // Stored the checksum value in the last byte.
   remote_state &= ~((uint64_t)0xFF << kVestelAcChecksumOffset);
-  remote_state |= (uint64_t)calcChecksum(remote_state)
+  remote_state |= (uint64_t)this->calcChecksum(remote_state)
                   << kVestelAcChecksumOffset;
 
   remote_time_state &= ~((uint64_t)0xFF << kVestelAcChecksumOffset);
-  remote_time_state |= (uint64_t)calcChecksum(remote_time_state)
+  remote_time_state |= (uint64_t)this->calcChecksum(remote_time_state)
                        << kVestelAcChecksumOffset;
 }
 
-bool IRVestelAc::isTimeCommand() {
+bool IRVestelAc::isTimeCommand(void) {
   return (remote_state >> kVestelAcPowerOffset == 0x00 || use_time_state);
 }
 
@@ -437,38 +441,86 @@ uint8_t IRVestelAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRVestelAc::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kVestelAcCool: return stdAc::opmode_t::kCool;
+    case kVestelAcHeat: return stdAc::opmode_t::kHeat;
+    case kVestelAcDry: return stdAc::opmode_t::kDry;
+    case kVestelAcFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRVestelAc::toCommonFanSpeed(const uint8_t spd) {
+  switch (spd) {
+    case kVestelAcFanHigh: return stdAc::fanspeed_t::kMax;
+    case kVestelAcFanMed: return stdAc::fanspeed_t::kMedium;
+    case kVestelAcFanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRVestelAc::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::VESTEL_AC;
+  result.model = -1;  // Not supported.
+  result.power = this->getPower();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwing() ? stdAc::swingv_t::kAuto :
+                                     stdAc::swingv_t::kOff;
+  result.turbo = this->getTurbo();
+  result.filter = this->getIon();
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.light = false;
+  result.econo = false;
+  result.quiet = false;
+  result.clean = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRVestelAc::toString() {
+String IRVestelAc::toString(void) {
   String result = "";
 #else
-std::string IRVestelAc::toString() {
+std::string IRVestelAc::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  if (isTimeCommand()) {
+  if (this->isTimeCommand()) {
     result += F("Time: ");
     result += IRHaierAC::timeToString(getTime());
 
     result += F(", Timer: ");
-    result += isTimerActive() ? IRHaierAC::timeToString(getTimer()) : F("Off");
-
+    result += this->isTimerActive() ? IRHaierAC::timeToString(this->getTimer())
+                                    : F("Off");
     result += F(", On Timer: ");
-    result += (isOnTimerActive() && !isTimerActive())
-                  ? IRHaierAC::timeToString(getOnTimer())
+    result += (this->isOnTimerActive() && !this->isTimerActive())
+                  ? IRHaierAC::timeToString(this->getOnTimer())
                   : F("Off");
 
     result += F(", Off Timer: ");
     result +=
-        isOffTimerActive() ? IRHaierAC::timeToString(getOffTimer()) : F("Off");
+        this->isOffTimerActive() ? IRHaierAC::timeToString(this->getOffTimer())
+                                 : F("Off");
     return result;
   }
   // Not a time command, it's a normal command.
   result += F("Power: ");
-  result += (getPower() ? F("On") : F("Off"));
+  result += (this->getPower() ? F("On") : F("Off"));
   result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
+  result += uint64ToString(this->getMode());
+  switch (this->getMode()) {
     case kVestelAcAuto:
       result += F(" (AUTO)");
       break;
@@ -488,10 +540,10 @@ std::string IRVestelAc::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Temp: ");
-  result += uint64ToString(getTemp());
+  result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
-  result += uint64ToString(getFan());
-  switch (getFan()) {
+  result += uint64ToString(this->getFan());
+  switch (this->getFan()) {
     case kVestelAcFanAuto:
       result += F(" (AUTO)");
       break;
@@ -514,13 +566,13 @@ std::string IRVestelAc::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Sleep: ");
-  result += (getSleep() ? F("On") : F("Off"));
+  result += this->getSleep() ? F("On") : F("Off");
   result += F(", Turbo: ");
-  result += (getTurbo() ? F("On") : F("Off"));
+  result += this->getTurbo() ? F("On") : F("Off");
   result += F(", Ion: ");
-  result += (getIon() ? F("On") : F("Off"));
+  result += this->getIon() ? F("On") : F("Off");
   result += F(", Swing: ");
-  result += (getSwing() ? F("On") : F("Off"));
+  result += this->getSwing() ? F("On") : F("Off");
   return result;
 }
 
@@ -536,8 +588,8 @@ std::string IRVestelAc::toString() {
 //
 // Status: Alpha / Needs testing against a real device.
 //
-bool IRrecv::decodeVestelAc(decode_results* results, uint16_t nbits,
-                            bool strict) {
+bool IRrecv::decodeVestelAc(decode_results* results, const uint16_t nbits,
+                            const bool strict) {
   if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
     return false;
 

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -108,17 +108,17 @@ const uint64_t kVestelAcTimeStateDefault = 0x201ULL;
 
 class IRVestelAc {
  public:
-  explicit IRVestelAc(uint16_t pin);
+  explicit IRVestelAc(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_VESTEL_AC
-  void send();
+  void send(void);
 #endif  // SEND_VESTEL_AC
   void begin(void);
   void on(void);
   void off(void);
-  void setPower(const bool state);
-  bool getPower();
+  void setPower(const bool on);
+  bool getPower(void);
   void setAuto(const int8_t autoLevel);
   void setTimer(const uint16_t minutes);
   uint16_t getTimer(void);
@@ -134,17 +134,17 @@ class IRVestelAc {
   uint8_t getFan(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
-  void setRaw(uint8_t* newState);
+  void setRaw(const uint8_t* newState);
   void setRaw(const uint64_t newState);
   uint64_t getRaw(void);
   static bool validChecksum(const uint64_t state);
-  void setSwing(const bool state);
+  void setSwing(const bool on);
   bool getSwing(void);
-  void setSleep(const bool state);
+  void setSleep(const bool on);
   bool getSleep(void);
-  void setTurbo(const bool state);
+  void setTurbo(const bool on);
   bool getTurbo(void);
-  void setIon(const bool state);
+  void setIon(const bool on);
   bool getIon(void);
   bool isTimeCommand(void);
   bool isOnTimerActive(void);
@@ -154,12 +154,15 @@ class IRVestelAc {
   bool isTimerActive(void);
   void setTimerActive(const bool on);
   static uint8_t calcChecksum(const uint64_t state);
-  uint8_t convertMode(const stdAc::opmode_t mode);
-  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -171,7 +174,7 @@ class IRVestelAc {
   uint64_t remote_state;
   uint64_t remote_time_state;
   bool use_time_state;
-  void checksum();
+  void checksum(void);
 };
 
 #endif  // IR_VESTEL_H_

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -53,8 +53,8 @@ const uint8_t kWhirlpoolAcSections = 3;
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/509
-void IRsend::sendWhirlpoolAC(unsigned char data[], uint16_t nbytes,
-                             uint16_t repeat) {
+void IRsend::sendWhirlpoolAC(const unsigned char data[], const uint16_t nbytes,
+                             const uint16_t repeat) {
   if (nbytes < kWhirlpoolAcStateLength)
     return;  // Not enough bytes to send a proper message.
   for (uint16_t r = 0; r <= repeat; r++) {
@@ -85,17 +85,19 @@ void IRsend::sendWhirlpoolAC(unsigned char data[], uint16_t nbytes,
 // Decoding help from:
 //   @redmusicxd, @josh929800, @raducostea
 
-IRWhirlpoolAc::IRWhirlpoolAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRWhirlpoolAc::IRWhirlpoolAc(const uint16_t pin) : _irsend(pin) {
+  this->stateReset();
+}
 
-void IRWhirlpoolAc::stateReset() {
+void IRWhirlpoolAc::stateReset(void) {
   for (uint8_t i = 2; i < kWhirlpoolAcStateLength; i++) remote_state[i] = 0x0;
   remote_state[0] = 0x83;
   remote_state[1] = 0x06;
   remote_state[6] = 0x80;
-  _setTemp(kWhirlpoolAcAutoTemp);  // Default to a sane value.
+  this->_setTemp(kWhirlpoolAcAutoTemp);  // Default to a sane value.
 }
 
-void IRWhirlpoolAc::begin() { _irsend.begin(); }
+void IRWhirlpoolAc::begin(void) { _irsend.begin(); }
 
 bool IRWhirlpoolAc::validChecksum(uint8_t state[], const uint16_t length) {
   if (length > kWhirlpoolAcChecksumByte1 &&
@@ -128,13 +130,13 @@ void IRWhirlpoolAc::checksum(uint16_t length) {
 
 #if SEND_WHIRLPOOL_AC
 void IRWhirlpoolAc::send(const uint16_t repeat, const bool calcchecksum) {
-  if (calcchecksum) checksum();
+  if (calcchecksum) this->checksum();
   _irsend.sendWhirlpoolAC(remote_state, kWhirlpoolAcStateLength, repeat);
 }
 #endif  // SEND_WHIRLPOOL_AC
 
 uint8_t *IRWhirlpoolAc::getRaw(const bool calcchecksum) {
-  if (calcchecksum) checksum();
+  if (calcchecksum) this->checksum();
   return remote_state;
 }
 
@@ -143,7 +145,7 @@ void IRWhirlpoolAc::setRaw(const uint8_t new_code[], const uint16_t length) {
     remote_state[i] = new_code[i];
 }
 
-whirlpool_ac_remote_model_t IRWhirlpoolAc::getModel() {
+whirlpool_ac_remote_model_t IRWhirlpoolAc::getModel(void) {
   if (remote_state[kWhirlpoolAcAltTempPos] & kWhirlpoolAcAltTempMask)
     return DG11J191;
   else
@@ -160,13 +162,13 @@ void IRWhirlpoolAc::setModel(const whirlpool_ac_remote_model_t model) {
     default:
       remote_state[kWhirlpoolAcAltTempPos] &= ~kWhirlpoolAcAltTempMask;
   }
-  _setTemp(_desiredtemp);  // Different models have different temp values.
+  this->_setTemp(_desiredtemp);  // Different models have different temp values.
 }
 
 // Return the temp. offset in deg C for the current model.
-int8_t IRWhirlpoolAc::getTempOffset() {
-  switch (getModel()) {
-    case DG11J191:
+int8_t IRWhirlpoolAc::getTempOffset(void) {
+  switch (this->getModel()) {
+    case whirlpool_ac_remote_model_t::DG11J191:
       return -2;
       break;
     default:
@@ -177,7 +179,7 @@ int8_t IRWhirlpoolAc::getTempOffset() {
 // Set the temp. in deg C
 void IRWhirlpoolAc::_setTemp(const uint8_t temp, const bool remember) {
   if (remember) _desiredtemp = temp;
-  int8_t offset = getTempOffset();  // Cache the min temp for the model.
+  int8_t offset = this->getTempOffset();  // Cache the min temp for the model.
   uint8_t newtemp = std::max((uint8_t)(kWhirlpoolAcMinTemp + offset), temp);
   newtemp = std::min((uint8_t)(kWhirlpoolAcMaxTemp + offset), newtemp);
   remote_state[kWhirlpoolAcTempPos] =
@@ -187,23 +189,23 @@ void IRWhirlpoolAc::_setTemp(const uint8_t temp, const bool remember) {
 
 // Set the temp. in deg C
 void IRWhirlpoolAc::setTemp(const uint8_t temp) {
-  _setTemp(temp);
-  setSuper(false);  // Changing temp cancels Super/Jet mode.
-  setCommand(kWhirlpoolAcCommandTemp);
+  this->_setTemp(temp);
+  this->setSuper(false);  // Changing temp cancels Super/Jet mode.
+  this->setCommand(kWhirlpoolAcCommandTemp);
 }
 
 // Return the set temp. in deg C
-uint8_t IRWhirlpoolAc::getTemp() {
+uint8_t IRWhirlpoolAc::getTemp(void) {
   return ((remote_state[kWhirlpoolAcTempPos] & kWhirlpoolAcTempMask) >> 4) +
-         + kWhirlpoolAcMinTemp + getTempOffset();
+         + kWhirlpoolAcMinTemp + this->getTempOffset();
 }
 
 void IRWhirlpoolAc::_setMode(const uint8_t mode) {
   switch (mode) {
     case kWhirlpoolAcAuto:
-      setFan(kWhirlpoolAcFanAuto);
-      _setTemp(kWhirlpoolAcAutoTemp, false);
-      setSleep(false);  // Cancel sleep mode when in auto/6thsense mode.
+      this->setFan(kWhirlpoolAcFanAuto);
+      this->_setTemp(kWhirlpoolAcAutoTemp, false);
+      this->setSleep(false);  // Cancel sleep mode when in auto/6thsense mode.
       // FALL THRU
     case kWhirlpoolAcHeat:
     case kWhirlpoolAcCool:
@@ -211,20 +213,20 @@ void IRWhirlpoolAc::_setMode(const uint8_t mode) {
     case kWhirlpoolAcFan:
       remote_state[kWhirlpoolAcModePos] &= ~kWhirlpoolAcModeMask;
       remote_state[kWhirlpoolAcModePos] |= mode;
-      setCommand(kWhirlpoolAcCommandMode);
+      this->setCommand(kWhirlpoolAcCommandMode);
       break;
     default:
       return;
   }
-  if (mode == kWhirlpoolAcAuto) setCommand(kWhirlpoolAcCommand6thSense);
+  if (mode == kWhirlpoolAcAuto) this->setCommand(kWhirlpoolAcCommand6thSense);
 }
 
 void IRWhirlpoolAc::setMode(const uint8_t mode) {
-    setSuper(false);  // Changing mode cancels Super/Jet mode.
-    _setMode(mode);
+    this->setSuper(false);  // Changing mode cancels Super/Jet mode.
+    this->_setMode(mode);
 }
 
-uint8_t IRWhirlpoolAc::getMode() {
+uint8_t IRWhirlpoolAc::getMode(void) {
   return remote_state[kWhirlpoolAcModePos] & kWhirlpoolAcModeMask;
 }
 
@@ -236,13 +238,13 @@ void IRWhirlpoolAc::setFan(const uint8_t speed) {
     case kWhirlpoolAcFanHigh:
       remote_state[kWhirlpoolAcFanPos] =
           (remote_state[kWhirlpoolAcFanPos] & ~kWhirlpoolAcFanMask) | speed;
-      setSuper(false);  // Changing fan speed cancels Super/Jet mode.
-      setCommand(kWhirlpoolAcCommandFanSpeed);
+      this->setSuper(false);  // Changing fan speed cancels Super/Jet mode.
+      this->setCommand(kWhirlpoolAcCommandFanSpeed);
       break;
   }
 }
 
-uint8_t IRWhirlpoolAc::getFan() {
+uint8_t IRWhirlpoolAc::getFan(void) {
   return remote_state[kWhirlpoolAcFanPos] & kWhirlpoolAcFanMask;
 }
 
@@ -257,7 +259,7 @@ void IRWhirlpoolAc::setSwing(const bool on) {
   setCommand(kWhirlpoolAcCommandSwing);
 }
 
-bool IRWhirlpoolAc::getSwing() {
+bool IRWhirlpoolAc::getSwing(void) {
   return (remote_state[kWhirlpoolAcFanPos] & kWhirlpoolAcSwing1Mask) &&
          (remote_state[kWhirlpoolAcOffTimerPos] & kWhirlpoolAcSwing2Mask);
 }
@@ -269,7 +271,7 @@ void IRWhirlpoolAc::setLight(const bool on) {
     remote_state[kWhirlpoolAcClockPos] |= kWhirlpoolAcLightMask;
 }
 
-bool IRWhirlpoolAc::getLight() {
+bool IRWhirlpoolAc::getLight(void) {
   return !(remote_state[kWhirlpoolAcClockPos] & kWhirlpoolAcLightMask);
 }
 
@@ -292,49 +294,53 @@ bool IRWhirlpoolAc::isTimerEnabled(const uint16_t pos) {
   return remote_state[pos - 1] & kWhirlpoolAcTimerEnableMask;
 }
 
-void IRWhirlpoolAc::enableTimer(const uint16_t pos, const bool state) {
-  if (state)
+void IRWhirlpoolAc::enableTimer(const uint16_t pos, const bool on) {
+  if (on)
     remote_state[pos - 1] |= kWhirlpoolAcTimerEnableMask;
   else
     remote_state[pos - 1] &= ~kWhirlpoolAcTimerEnableMask;
 }
 
 void IRWhirlpoolAc::setClock(const uint16_t minspastmidnight) {
-  setTime(kWhirlpoolAcClockPos, minspastmidnight);
+  this->setTime(kWhirlpoolAcClockPos, minspastmidnight);
 }
 
-uint16_t IRWhirlpoolAc::getClock() { return getTime(kWhirlpoolAcClockPos); }
+uint16_t IRWhirlpoolAc::getClock(void) {
+  return this->getTime(kWhirlpoolAcClockPos);
+}
 
 void IRWhirlpoolAc::setOffTimer(const uint16_t minspastmidnight) {
-  setTime(kWhirlpoolAcOffTimerPos, minspastmidnight);
+  this->setTime(kWhirlpoolAcOffTimerPos, minspastmidnight);
 }
 
-uint16_t IRWhirlpoolAc::getOffTimer() {
-  return getTime(kWhirlpoolAcOffTimerPos);
+uint16_t IRWhirlpoolAc::getOffTimer(void) {
+  return this->getTime(kWhirlpoolAcOffTimerPos);
 }
 
-bool IRWhirlpoolAc::isOffTimerEnabled() {
-  return isTimerEnabled(kWhirlpoolAcOffTimerPos);
+bool IRWhirlpoolAc::isOffTimerEnabled(void) {
+  return this->isTimerEnabled(kWhirlpoolAcOffTimerPos);
 }
 
-void IRWhirlpoolAc::enableOffTimer(const bool state) {
-  enableTimer(kWhirlpoolAcOffTimerPos, state);
-  setCommand(kWhirlpoolAcCommandOffTimer);
+void IRWhirlpoolAc::enableOffTimer(const bool on) {
+  this->enableTimer(kWhirlpoolAcOffTimerPos, on);
+  this->setCommand(kWhirlpoolAcCommandOffTimer);
 }
 
 void IRWhirlpoolAc::setOnTimer(const uint16_t minspastmidnight) {
-  setTime(kWhirlpoolAcOnTimerPos, minspastmidnight);
+  this->setTime(kWhirlpoolAcOnTimerPos, minspastmidnight);
 }
 
-uint16_t IRWhirlpoolAc::getOnTimer() { return getTime(kWhirlpoolAcOnTimerPos); }
-
-bool IRWhirlpoolAc::isOnTimerEnabled() {
-  return isTimerEnabled(kWhirlpoolAcOnTimerPos);
+uint16_t IRWhirlpoolAc::getOnTimer(void) {
+  return this->getTime(kWhirlpoolAcOnTimerPos);
 }
 
-void IRWhirlpoolAc::enableOnTimer(const bool state) {
-  enableTimer(kWhirlpoolAcOnTimerPos, state);
-  setCommand(kWhirlpoolAcCommandOnTimer);
+bool IRWhirlpoolAc::isOnTimerEnabled(void) {
+  return this->isTimerEnabled(kWhirlpoolAcOnTimerPos);
+}
+
+void IRWhirlpoolAc::enableOnTimer(const bool on) {
+  this->enableTimer(kWhirlpoolAcOnTimerPos, on);
+  this->setCommand(kWhirlpoolAcCommandOnTimer);
 }
 
 void IRWhirlpoolAc::setPowerToggle(const bool on) {
@@ -342,54 +348,54 @@ void IRWhirlpoolAc::setPowerToggle(const bool on) {
     remote_state[kWhirlpoolAcPowerTogglePos] |= kWhirlpoolAcPowerToggleMask;
   else
     remote_state[kWhirlpoolAcPowerTogglePos] &= ~kWhirlpoolAcPowerToggleMask;
-  setSuper(false);  // Changing power cancels Super/Jet mode.
-  setCommand(kWhirlpoolAcCommandPower);
+  this->setSuper(false);  // Changing power cancels Super/Jet mode.
+  this->setCommand(kWhirlpoolAcCommandPower);
 }
 
-bool IRWhirlpoolAc::getPowerToggle() {
+bool IRWhirlpoolAc::getPowerToggle(void) {
   return remote_state[kWhirlpoolAcPowerTogglePos] & kWhirlpoolAcPowerToggleMask;
 }
 
-uint8_t IRWhirlpoolAc::getCommand() {
+uint8_t IRWhirlpoolAc::getCommand(void) {
   return remote_state[kWhirlpoolAcCommandPos];
 }
 
 void IRWhirlpoolAc::setSleep(const bool on) {
   if (on) {
     remote_state[kWhirlpoolAcSleepPos] |= kWhirlpoolAcSleepMask;
-    setFan(kWhirlpoolAcFanLow);
+    this->setFan(kWhirlpoolAcFanLow);
   } else {
     remote_state[kWhirlpoolAcSleepPos] &= ~kWhirlpoolAcSleepMask;
   }
-  setCommand(kWhirlpoolAcCommandSleep);
+  this->setCommand(kWhirlpoolAcCommandSleep);
 }
 
-bool IRWhirlpoolAc::getSleep() {
+bool IRWhirlpoolAc::getSleep(void) {
   return remote_state[kWhirlpoolAcSleepPos] & kWhirlpoolAcSleepMask;
 }
 
 // AKA Jet/Turbo mode.
 void IRWhirlpoolAc::setSuper(const bool on) {
   if (on) {
-    setFan(kWhirlpoolAcFanHigh);
-    switch (getMode()) {
+    this->setFan(kWhirlpoolAcFanHigh);
+    switch (this->getMode()) {
       case kWhirlpoolAcHeat:
-        setTemp(kWhirlpoolAcMaxTemp + getTempOffset());
+        this->setTemp(kWhirlpoolAcMaxTemp + this->getTempOffset());
         break;
       case kWhirlpoolAcCool:
       default:
-        setTemp(kWhirlpoolAcMinTemp + getTempOffset());
-        setMode(kWhirlpoolAcCool);
+        this->setTemp(kWhirlpoolAcMinTemp + this->getTempOffset());
+        this->setMode(kWhirlpoolAcCool);
         break;
     }
     remote_state[kWhirlpoolAcSuperPos] |= kWhirlpoolAcSuperMask;
   } else {
     remote_state[kWhirlpoolAcSuperPos] &= ~kWhirlpoolAcSuperMask;
   }
-  setCommand(kWhirlpoolAcCommandSuper);
+  this->setCommand(kWhirlpoolAcCommandSuper);
 }
 
-bool IRWhirlpoolAc::getSuper() {
+bool IRWhirlpoolAc::getSuper(void) {
   return remote_state[kWhirlpoolAcSuperPos] & kWhirlpoolAcSuperMask;
 }
 
@@ -429,6 +435,53 @@ uint8_t IRWhirlpoolAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
+// Convert a native mode to it's common equivalent.
+stdAc::opmode_t IRWhirlpoolAc::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kWhirlpoolAcCool: return stdAc::opmode_t::kCool;
+    case kWhirlpoolAcHeat: return stdAc::opmode_t::kHeat;
+    case kWhirlpoolAcDry: return stdAc::opmode_t::kDry;
+    case kWhirlpoolAcFan: return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRWhirlpoolAc::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kWhirlpoolAcFanHigh: return stdAc::fanspeed_t::kMax;
+    case kWhirlpoolAcFanMedium: return stdAc::fanspeed_t::kMedium;
+    case kWhirlpoolAcFanLow: return stdAc::fanspeed_t::kMin;
+    default: return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRWhirlpoolAc::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::WHIRLPOOL_AC;
+  result.model = this->getModel();
+  result.power = this->getPowerToggle();
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwing() ? stdAc::swingv_t::kAuto :
+                                     stdAc::swingv_t::kOff;
+  result.turbo = this->getSuper();
+  result.light = this->getLight();
+  result.sleep = this->getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.filter = false;
+  result.econo = false;
+  result.clean = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
 #ifdef ARDUINO
 String IRWhirlpoolAc::timeToString(const uint16_t minspastmidnight) {
   String result = "";
@@ -448,16 +501,16 @@ std::string IRWhirlpoolAc::timeToString(const uint16_t minspastmidnight) {
 
 // Convert the internal state into a human readable string.
 #ifdef ARDUINO
-String IRWhirlpoolAc::toString() {
+String IRWhirlpoolAc::toString(void) {
   String result = "";
 #else
-std::string IRWhirlpoolAc::toString() {
+std::string IRWhirlpoolAc::toString(void) {
   std::string result = "";
 #endif  // ARDUINO
   result.reserve(200);  // Reserve some heap for the string to reduce fragging.
   result += F("Model: ");
-  result += uint64ToString(getModel());
-  switch (getModel()) {
+  result += uint64ToString(this->getModel());
+  switch (this->getModel()) {
     case DG11J191:
       result += F(" (DG11J191)");
       break;
@@ -468,13 +521,10 @@ std::string IRWhirlpoolAc::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Power toggle: ");
-  if (getPowerToggle())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getPowerToggle() ? F("On") : F("Off");
   result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
+  result += uint64ToString(this->getMode());
+  switch (this->getMode()) {
     case kWhirlpoolAcHeat:
       result += F(" (HEAT)");
       break;
@@ -494,9 +544,9 @@ std::string IRWhirlpoolAc::toString() {
       result += F(" (UNKNOWN)");
   }
   result += F(", Temp: ");
-  result += uint64ToString(getTemp());
+  result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
-  result += uint64ToString(getFan());
+  result += uint64ToString(this->getFan());
   switch (getFan()) {
     case kWhirlpoolAcFanAuto:
       result += F(" (AUTO)");
@@ -515,40 +565,28 @@ std::string IRWhirlpoolAc::toString() {
       break;
   }
   result += F(", Swing: ");
-  if (getSwing())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getSwing() ? F("On") : F("Off");
   result += F(", Light: ");
-  if (getLight())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getLight() ? F("On") : F("Off");
   result += F(", Clock: ");
-  result += timeToString(getClock());
+  result += this->timeToString(this->getClock());
   result += F(", On Timer: ");
-  if (isOnTimerEnabled())
-    result += timeToString(getOnTimer());
+  if (this->isOnTimerEnabled())
+    result += this->timeToString(this->getOnTimer());
   else
     result += F("Off");
   result += F(", Off Timer: ");
-  if (isOffTimerEnabled())
-    result += timeToString(getOffTimer());
+  if (this->isOffTimerEnabled())
+    result += this->timeToString(this->getOffTimer());
   else
     result += F("Off");
   result += F(", Sleep: ");
-  if (getSleep())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getSleep() ? F("On") : F("Off");
   result += F(", Super: ");
-  if (getSuper())
-    result += F("On");
-  else
-    result += F("Off");
+  result += this->getSuper() ? F("On") : F("Off");
   result += F(", Command: ");
-  result += uint64ToString(getCommand());
-  switch (getCommand()) {
+  result += uint64ToString(this->getCommand());
+  switch (this->getCommand()) {
     case kWhirlpoolAcCommandLight:
       result += F(" (LIGHT)");
       break;
@@ -607,8 +645,8 @@ std::string IRWhirlpoolAc::toString() {
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/509
-bool IRrecv::decodeWhirlpoolAC(decode_results *results, uint16_t nbits,
-                               bool strict) {
+bool IRrecv::decodeWhirlpoolAC(decode_results *results, const uint16_t nbits,
+                               const bool strict) {
   if (results->rawlen < 2 * nbits + 4 + kHeader + kFooter - 1)
     return false;  // Can't possibly be a valid Whirlpool A/C message.
   if (strict) {

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -87,45 +87,45 @@ enum whirlpool_ac_remote_model_t {
 // Classes
 class IRWhirlpoolAc {
  public:
-  explicit IRWhirlpoolAc(uint16_t pin);
+  explicit IRWhirlpoolAc(const uint16_t pin);
 
-  void stateReset();
+  void stateReset(void);
 #if SEND_WHIRLPOOL_AC
   void send(const uint16_t repeat = kWhirlpoolAcDefaultRepeat,
             const bool calcchecksum = true);
 #endif  // SEND_WHIRLPOOL_AC
-  void begin();
-  void on();
-  void off();
+  void begin(void);
+  void on(void);
+  void off(void);
   void setPowerToggle(const bool on);
-  bool getPowerToggle();
+  bool getPowerToggle(void);
   void setSleep(const bool on);
-  bool getSleep();
+  bool getSleep(void);
   void setSuper(const bool on);
-  bool getSuper();
+  bool getSuper(void);
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setFan(const uint8_t speed);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t mode);
-  uint8_t getMode();
+  uint8_t getMode(void);
   void setSwing(const bool on);
-  bool getSwing();
+  bool getSwing(void);
   void setLight(const bool on);
-  bool getLight();
-  uint16_t getClock();
+  bool getLight(void);
+  uint16_t getClock(void);
   void setClock(const uint16_t minspastmidnight);
-  uint16_t getOnTimer();
+  uint16_t getOnTimer(void);
   void setOnTimer(const uint16_t minspastmidnight);
-  void enableOnTimer(const bool state);
-  bool isOnTimerEnabled();
-  uint16_t getOffTimer();
+  void enableOnTimer(const bool on);
+  bool isOnTimerEnabled(void);
+  uint16_t getOffTimer(void);
   void setOffTimer(const uint16_t minspastmidnight);
-  void enableOffTimer(const bool state);
-  bool isOffTimerEnabled();
+  void enableOffTimer(const bool on);
+  bool isOffTimerEnabled(void);
   void setCommand(const uint8_t code);
-  uint8_t getCommand();
-  whirlpool_ac_remote_model_t getModel();
+  uint8_t getCommand(void);
+  whirlpool_ac_remote_model_t getModel(void);
   void setModel(const whirlpool_ac_remote_model_t model);
   uint8_t* getRaw(const bool calcchecksum = true);
   void setRaw(const uint8_t new_code[],
@@ -134,10 +134,13 @@ class IRWhirlpoolAc {
                             const uint16_t length = kWhirlpoolAcStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
 #ifdef ARDUINO
-  String toString();
+  String toString(void);
 #else
-  std::string toString();
+  std::string toString(void);
 #endif
 #ifndef UNIT_TEST
 
@@ -156,7 +159,7 @@ class IRWhirlpoolAc {
   void enableTimer(const uint16_t pos, const bool state);
   void _setTemp(const uint8_t temp, const bool remember = true);
   void _setMode(const uint8_t mode);
-  int8_t getTempOffset();
+  int8_t getTempOffset(void);
 #ifdef ARDUINO
   String timeToString(uint16_t minspastmidnight);
 #else

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -245,7 +245,7 @@ TEST(TestIRac, Haier) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Command: 1 (On), Mode: 3 (HEAT), Temp: 24C, Fan: 2, Swing: 1 (Up), "
+      "Command: 1 (On), Mode: 1 (COOL), Temp: 24C, Fan: 2, Swing: 1 (Up), "
       "Sleep: On, Health: On, Current Time: 13:45, On Timer: Off, "
       "Off Timer: Off";
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -43,7 +43,7 @@ TEST(TestIRac, Argo) {
             false,                       // Turbo
             -1);                         // Sleep
   EXPECT_TRUE(ac.getPower());
-  EXPECT_EQ(1, ac.getMode());
+  EXPECT_EQ(kArgoHeat, ac.getMode());
   EXPECT_EQ(21, ac.getTemp());
   EXPECT_EQ(kArgoFlapAuto, ac.getFlap());
   EXPECT_FALSE(ac.getMax());  // Turbo

--- a/test/IRrecv_test.cpp
+++ b/test/IRrecv_test.cpp
@@ -399,7 +399,7 @@ TEST(TestDecode, DecodeDenon) {
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x2278, irsend.capture.value);
   // Legacy Denon 14-bit message.
   irsend.reset();
@@ -407,15 +407,15 @@ TEST(TestDecode, DecodeDenon) {
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x1278, irsend.capture.value);
   // Normal Denon 48-bit message. (Panasonic/Kaseikyo)
   irsend.reset();
-  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS);
+  irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_48_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenon48Bits, irsend.capture.bits);
   EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,7 +38,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
   ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test \
-	ir_MitsubishiHeavy_test
+	ir_MitsubishiHeavy_test ir_Trotec_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -107,7 +107,8 @@ PROTOCOLS_H = $(USER_DIR)/ir_Argo.h \
 		$(USER_DIR)/ir_Whirlpool.h \
 		$(USER_DIR)/ir_Vestel.h \
 		$(USER_DIR)/ir_Tcl.h \
-		$(USER_DIR)/ir_Teco.h
+		$(USER_DIR)/ir_Teco.h \
+		$(USER_DIR)/ir_Trotec.h
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o IRac.o ir_GlobalCache.o \
              $(PROTOCOLS) gtest_main.a
@@ -563,3 +564,9 @@ ir_Argo.o : $(USER_DIR)/ir_Argo.cpp $(COMMON_DEPS)
 
 ir_Trotec.o : $(USER_DIR)/ir_Trotec.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Trotec.cpp
+
+ir_Trotec_test.o : ir_Trotec_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Trotec_test.cpp
+
+ir_Trotec_test : $(COMMON_OBJ) ir_Trotec_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -38,7 +38,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
 	ir_Carrier_test ir_Haier_test ir_Hitachi_test ir_GICable_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
   ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test \
-	ir_MitsubishiHeavy_test ir_Trotec_test
+	ir_MitsubishiHeavy_test ir_Trotec_test ir_Argo_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -561,6 +561,12 @@ ir_Lego_test : $(COMMON_OBJ) ir_Lego_test.o
 
 ir_Argo.o : $(USER_DIR)/ir_Argo.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Argo.cpp
+
+ir_Argo_test.o : ir_Argo_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Argo_test.cpp
+
+ir_Argo_test : $(COMMON_OBJ) ir_Argo_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
 
 ir_Trotec.o : $(USER_DIR)/ir_Trotec.cpp $(COMMON_DEPS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Trotec.cpp

--- a/test/ir_Argo_test.cpp
+++ b/test/ir_Argo_test.cpp
@@ -1,0 +1,38 @@
+// Copyright 2019 David Conran
+#include "ir_Argo.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+
+TEST(TestArgoACClass, toCommon) {
+  IRArgoAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kArgoCool);
+  ac.setTemp(20);
+  ac.setFan(kArgoFan3);
+  ac.setMax(true);
+  ac.setNight(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::ARGO, ac.toCommon().protocol);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  // Unsupported.
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -597,3 +597,32 @@ TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
       ac.toString());
   EXPECT_EQ(0xB2BF40, ac.getRaw());
 }
+
+TEST(TestCoolixACClass, toCommon) {
+  IRCoolixAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kCoolixCool);
+  ac.setTemp(20);
+  ac.setFan(kCoolixFanMax);
+
+  // Now test it.
+  ASSERT_EQ(decode_type_t::COOLIX, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1904,3 +1904,107 @@ TEST(TestDecodeDaikin216, SyntheticExample) {
   ASSERT_EQ(kDaikin216Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
 }
+
+TEST(TestDaikinClass, toCommon) {
+  IRDaikinESP ac(0);
+  ac.setPower(true);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(20);
+  ac.setFan(kDaikinFanMax);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  ac.setQuiet(false);
+  ac.setPowerful(true);
+  ac.setEcono(false);
+  ac.setMold(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::DAIKIN, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+TEST(TestDaikin2Class, toCommon) {
+  IRDaikin2 ac(0);
+  ac.setPower(true);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(20);
+  ac.setFan(kDaikinFanMax);
+  ac.setSwingVertical(kDaikin2SwingVHigh + 3);
+  ac.setSwingHorizontal(kDaikin2SwingHAuto);
+  ac.setQuiet(false);
+  ac.setPowerful(true);
+  ac.setEcono(false);
+  ac.setMold(true);
+  ac.setLight(true);
+  ac.setPurify(true);
+  ac.setBeep(true);
+  ac.enableSleepTimer(6 * 60);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::DAIKIN2, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_TRUE(ac.toCommon().filter);
+  ASSERT_TRUE(ac.toCommon().beep);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kMiddle, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
+  ASSERT_EQ(6 * 60, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+TEST(TestDaikin216Class, toCommon) {
+  IRDaikin216 ac(0);
+  ac.setPower(true);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(20);
+  ac.setFan(kDaikinFanMax);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  ac.setQuiet(false);
+  ac.setPowerful(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::DAIKIN216, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Denon_test.cpp
+++ b/test/ir_Denon_test.cpp
@@ -25,7 +25,7 @@ TEST(TestSendDenon, SendDataOnly) {
 
   irsend.reset();
   // Denon Eco Mode On. (Panasonic/Kaseikyo)
-  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS);
+  irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits);
   EXPECT_EQ(
       "f36700d50"
       "m3456s1728"
@@ -45,7 +45,7 @@ TEST(TestSendDenon, SendNormalWithRepeats) {
   irsend.begin();
 
   irsend.reset();
-  irsend.sendDenon(0x2278, DENON_BITS, 1);  // 1 repeat.
+  irsend.sendDenon(0x2278, kDenonBits, 1);  // 1 repeat.
   EXPECT_EQ(
       "f38000d33"
       "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
@@ -61,7 +61,7 @@ TEST(TestSendDenon, SendNormalWithRepeats) {
       "m260s780m260s780m260s780m260s780m260s1820m260s1820m260s1820"
       "m260s43602",
       irsend.outputStr());
-  irsend.sendDenon(0x2278, DENON_BITS, 2);  // 2 repeats.
+  irsend.sendDenon(0x2278, kDenonBits, 2);  // 2 repeats.
   EXPECT_EQ(
       "f38000d33"
       "m260s780m260s1820m260s780m260s780m260s780m260s1820m260s780m260s780"
@@ -90,7 +90,7 @@ TEST(TestSendDenon, Send48BitWithRepeats) {
   irsend.begin();
 
   irsend.reset();
-  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS, 1);  // 1 repeat.
+  irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits, 1);  // 1 repeat.
   EXPECT_EQ(
       "f36700d50"
       "m3456s1728"
@@ -110,7 +110,7 @@ TEST(TestSendDenon, Send48BitWithRepeats) {
       "m432s1296m432s1296m432s1296m432s432m432s432m432s432m432s1296m432s1296"
       "m432s98928",
       irsend.outputStr());
-  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS, 2);  // 2 repeats.
+  irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits, 2);  // 2 repeats.
   EXPECT_EQ(
       "f36700d50"
       "m3456s1728"
@@ -185,9 +185,9 @@ TEST(TestDecodeDenon, NormalDecodeWithStrict) {
   irsend.sendDenon(0x2278);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenonBits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x2278, irsend.capture.value);
   EXPECT_EQ(0x2, irsend.capture.address);
   EXPECT_EQ(0x79, irsend.capture.command);
@@ -208,11 +208,11 @@ TEST(TestDecodeDenon, NormalDecodeWithStrict) {
 
   // Normal Denon 48-bit message. (Panasonic/Kaseikyo)
   irsend.reset();
-  irsend.sendDenon(0x2A4C028D6CE3, DENON_48_BITS);
+  irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_48_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenon48Bits, irsend.capture.bits);
   EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
   EXPECT_EQ(0x2A4C, irsend.capture.address);
   EXPECT_EQ(0x028D6CE3, irsend.capture.command);
@@ -235,9 +235,9 @@ TEST(TestDecodeDenon, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test_power, 67);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenonBits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x2278, irsend.capture.value);
   EXPECT_EQ(0x2, irsend.capture.address);
   EXPECT_EQ(0x79, irsend.capture.command);
@@ -256,9 +256,9 @@ TEST(TestDecodeDenon, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test_eco, 103);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
-  EXPECT_EQ(DENON_48_BITS, irsend.capture.bits);
+  EXPECT_EQ(kDenon48Bits, irsend.capture.bits);
   EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
   EXPECT_EQ(0x2A4C, irsend.capture.address);
   EXPECT_EQ(0x028D6CE3, irsend.capture.command);
@@ -281,6 +281,6 @@ TEST(TestDecodeDenon, FailToDecodeNonDenonExample) {
 
   ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture));
   ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenonLegacyBits, false));
-  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, DENON_BITS, false));
-  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, DENON_48_BITS, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenonBits, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, false));
 }

--- a/test/ir_Gree_test.cpp
+++ b/test/ir_Gree_test.cpp
@@ -530,3 +530,36 @@ TEST(TestDecodeGree, NormalRealExample) {
       "Swing Vertical Pos: 2",
       irgree.toString());
 }
+
+TEST(TestGreeClass, toCommon) {
+  IRGreeAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kGreeCool);
+  ac.setTemp(20);
+  ac.setFan(kGreeFanMax);
+  ac.setSwingVertical(false, kGreeSwingUp);
+  ac.setTurbo(true);
+  ac.setXFan(true);
+  ac.setLight(true);
+  ac.setSleep(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::GREE, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kHighest, ac.toCommon().swingv);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -377,7 +377,7 @@ TEST(TestHaierACClass, MessageConstuction) {
   haier.setSleep(true);
   haier.setCurrTime(615);  // 10:15am
   EXPECT_EQ(
-      "Command: 8 (Sleep), Mode: 3 (HEAT), Temp: 21C, Fan: 3 (MAX), "
+      "Command: 8 (Sleep), Mode: 1 (COOL), Temp: 21C, Fan: 3 (MAX), "
       "Swing: 3 (Chg), Sleep: On, Health: On, "
       "Current Time: 10:15, On Timer: Off, Off Timer: Off",
       haier.toString());
@@ -386,7 +386,7 @@ TEST(TestHaierACClass, MessageConstuction) {
   haier.setCommand(kHaierAcCmdOn);
 
   EXPECT_EQ(
-      "Command: 1 (On), Mode: 2 (DRY), Temp: 21C, Fan: 2, "
+      "Command: 1 (On), Mode: 1 (COOL), Temp: 21C, Fan: 2, "
       "Swing: 3 (Chg), Sleep: On, Health: On, "
       "Current Time: 10:15, On Timer: 13:20, Off Timer: 18:45",
       haier.toString());
@@ -396,18 +396,18 @@ TEST(TestHaierACClass, MessageConstuction) {
   EXPECT_EQ(
       "Command: 2 (Mode), Mode: 3 (HEAT), Temp: 21C, Fan: 2, "
       "Swing: 3 (Chg), Sleep: On, Health: On, "
-      "Current Time: 10:15, On Timer: 13:52, Off Timer: 18:45",
+      "Current Time: 10:15, On Timer: 13:20, Off Timer: 18:45",
       haier.toString());
 
   haier.setTemp(25);
   EXPECT_EQ(
       "Command: 6 (Temp Up), Mode: 3 (HEAT), Temp: 25C, Fan: 2, "
       "Swing: 3 (Chg), Sleep: On, Health: On, "
-      "Current Time: 10:15, On Timer: 13:52, Off Timer: 18:45",
+      "Current Time: 10:15, On Timer: 13:20, Off Timer: 18:45",
       haier.toString());
 
   uint8_t expectedState[kHaierACStateLength] = {0xA5, 0x96, 0xEA, 0xCF, 0x32,
-                                                0xED, 0x2D, 0x74, 0xB4};
+                                                0xED, 0x6D, 0x54, 0xD4};
   EXPECT_STATE_EQ(expectedState, haier.getRaw(), kHaierACBits);
 
   // Check that the checksum is valid.
@@ -831,7 +831,7 @@ TEST(TestDecodeHaierAC, RealExample1) {
   IRHaierAC haier(0);
   haier.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Command: 1 (On), Mode: 0 (AUTO), Temp: 16C, Fan: 0 (AUTO), "
+      "Command: 1 (On), Mode: 1 (COOL), Temp: 16C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, "
       "Current Time: 00:01, On Timer: Off, Off Timer: Off",
       haier.toString());
@@ -873,7 +873,7 @@ TEST(TestDecodeHaierAC, RealExample2) {
   IRHaierAC haier(0);
   haier.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Command: 6 (Temp Up), Mode: 0 (AUTO), Temp: 22C, Fan: 0 (AUTO), "
+      "Command: 6 (Temp Up), Mode: 1 (COOL), Temp: 22C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, "
       "Current Time: 00:01, On Timer: Off, Off Timer: Off",
       haier.toString());
@@ -915,7 +915,7 @@ TEST(TestDecodeHaierAC, RealExample3) {
   IRHaierAC haier(0);
   haier.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Command: 12 (Health), Mode: 0 (AUTO), Temp: 30C, Fan: 0 (AUTO), "
+      "Command: 12 (Health), Mode: 1 (COOL), Temp: 30C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: On, "
       "Current Time: 00:09, On Timer: Off, Off Timer: Off",
       haier.toString());
@@ -1002,13 +1002,14 @@ TEST(TestHaierAcIssues, Issue668) {
   // Turn on the AC.
   ac._irsend.reset();
   char expected_on[] =
-      "Command: 1 (On), Mode: 0 (AUTO), Temp: 25C, Fan: 0 (AUTO), "
+      "Command: 1 (On), Mode: 1 (COOL), Temp: 25C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, Current Time: 00:00, "
       "On Timer: Off, Off Timer: Off";
   // State taken from real capture:
   //   https://github.com/markszabo/IRremoteESP8266/issues/668#issuecomment-483531895
   uint8_t expected_on_state[9] = {
       0xA5, 0x91, 0x20, 0x00, 0x0C, 0xC0, 0x20, 0x00, 0x42};
+  ac.setMode(kHaierAcCool);
   ac.setCommand(kHaierAcCmdOn);
   EXPECT_EQ(expected_on, ac.toString());
   ac.send();
@@ -1039,7 +1040,7 @@ TEST(TestHaierAcIssues, Issue668) {
   // Increase the temp by 1.
   ac._irsend.reset();
   char expected_temp_plus_one[] =
-      "Command: 6 (Temp Up), Mode: 0 (AUTO), Temp: 26C, Fan: 0 (AUTO), "
+      "Command: 6 (Temp Up), Mode: 1 (COOL), Temp: 26C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, Current Time: 00:00, "
       "On Timer: Off, Off Timer: Off";
   // State taken from real capture:
@@ -1063,7 +1064,7 @@ TEST(TestHaierAcIssues, Issue668) {
   // Decrease the temp by 1.
   ac._irsend.reset();
   char expected_temp_minus_one[] =
-      "Command: 7 (Temp Down), Mode: 0 (AUTO), Temp: 25C, Fan: 0 (AUTO), "
+      "Command: 7 (Temp Down), Mode: 1 (COOL), Temp: 25C, Fan: 0 (AUTO), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, Current Time: 00:00, "
       "On Timer: Off, Off Timer: Off";
   ASSERT_EQ(26, ac.getTemp());
@@ -1077,4 +1078,35 @@ TEST(TestHaierAcIssues, Issue668) {
   EXPECT_EQ(kHaierACBits, ac._irsend.capture.bits);
   acText.setRaw(ac._irsend.capture.state);
   EXPECT_EQ(expected_temp_minus_one, acText.toString());
+}
+
+TEST(TestHaierACClass, toCommon) {
+  IRHaierAC ac(0);
+  ac.setCommand(kHaierAcCmdOn);
+  ac.setMode(kHaierAcCool);
+  ac.setTemp(20);
+  ac.setFan(kHaierAcFanHigh);
+  ac.setSwing(kHaierAcSwingChg);
+  ac.setHealth(true);
+  ac.setSleep(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::HAIER_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().filter);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
 }

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -1110,3 +1110,34 @@ TEST(TestHaierACClass, toCommon) {
   ASSERT_FALSE(ac.toCommon().beep);
   ASSERT_EQ(-1, ac.toCommon().clock);
 }
+
+TEST(TestHaierACYRW02Class, toCommon) {
+  IRHaierACYRW02 ac(0);
+  ac.setPower(true);
+  ac.setMode(kHaierAcYrw02Cool);
+  ac.setTemp(20);
+  ac.setFan(kHaierAcYrw02FanHigh);
+  ac.setSwing(kHaierAcYrw02SwingTop);
+  ac.setHealth(true);
+  ac.setSleep(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::HAIER_AC_YRW02, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().filter);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kHighest, ac.toCommon().swingv);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -769,7 +769,6 @@ TEST(TestDecodeHitachiAC2, NormalRealExample) {
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAc2Bits);
 }
 
-
 TEST(TestIRHitachiAcClass, toCommon) {
   IRHitachiAc ac(0);
   ac.setPower(true);

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -768,3 +768,34 @@ TEST(TestDecodeHitachiAC2, NormalRealExample) {
   ASSERT_EQ(kHitachiAc2Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(hitachi_code, irsend.capture.state, kHitachiAc2Bits);
 }
+
+
+TEST(TestIRHitachiAcClass, toCommon) {
+  IRHitachiAc ac(0);
+  ac.setPower(true);
+  ac.setMode(kHitachiAcCool);
+  ac.setTemp(20);
+  ac.setFan(kHitachiAcFanHigh);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::HITACHI_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Kelvinator_test.cpp
+++ b/test/ir_Kelvinator_test.cpp
@@ -520,3 +520,39 @@ TEST(TestDecodeKelvinator, NormalSynthetic) {
   ASSERT_EQ(kKelvinatorBits, irsend.capture.bits);
   EXPECT_STATE_EQ(kelv_code, irsend.capture.state, kKelvinatorBits);
 }
+
+TEST(TestKelvinatorClass, toCommon) {
+  IRKelvinatorAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kKelvinatorCool);
+  ac.setTemp(20);
+  ac.setFan(kKelvinatorFanMax);
+  ac.setIonFilter(true);
+  ac.setXFan(true);
+  ac.setQuiet(false);
+  ac.setTurbo(true);
+  ac.setLight(true);
+  ac.setSwingHorizontal(false);
+  ac.setSwingVertical(true);
+
+  // Now test it.
+  ASSERT_EQ(decode_type_t::KELVINATOR, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_TRUE(ac.toCommon().filter);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -656,3 +656,31 @@ TEST(TestDecodeMidea, DecodeRealExample) {
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
 }
+
+TEST(TestMideaACClass, toCommon) {
+  IRMideaAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kMideaACCool);
+  ac.setTemp(20, true);
+  ac.setFan(kMideaACFanHigh);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::MIDEA, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_MitsubishiHeavy_test.cpp
+++ b/test/ir_MitsubishiHeavy_test.cpp
@@ -849,3 +849,72 @@ TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
       "3D: Off, Clean: Off",
       ac.toString());
 }
+
+TEST(TestMitsubishiHeavy152AcClass, toCommon) {
+  IRMitsubishiHeavy152Ac ac(0);
+  ac.setPower(true);
+  ac.setMode(kMitsubishiHeavyCool);
+  ac.setTemp(20);
+  ac.setFan(kMitsubishiHeavy152FanLow);
+  ac.setSwingVertical(kMitsubishiHeavy152SwingVHighest);
+  ac.setSwingHorizontal(kMitsubishiHeavy152SwingHRightMax);
+  ac.setTurbo(false);
+  ac.setEcono(true);
+  ac.setClean(true);
+  ac.setFilter(true);
+  ac.setSilent(true);
+  ac.setNight(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::MITSUBISHI_HEAVY_152, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMin, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kHighest, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kRightMax, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().econo);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_TRUE(ac.toCommon().quiet);
+  ASSERT_TRUE(ac.toCommon().filter);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+TEST(TestMitsubishiHeavy88AcClass, toCommon) {
+  IRMitsubishiHeavy88Ac ac(0);
+  ac.setPower(true);
+  ac.setMode(kMitsubishiHeavyCool);
+  ac.setTemp(20);
+  ac.setFan(kMitsubishiHeavy88FanLow);
+  ac.setSwingVertical(kMitsubishiHeavy88SwingVHighest);
+  ac.setSwingHorizontal(kMitsubishiHeavy88SwingHRightMax);
+  ac.setTurbo(false);
+  ac.setEcono(true);
+  ac.setClean(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::MITSUBISHI_HEAVY_88, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMin, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kHighest, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kRightMax, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().econo);
+  ASSERT_TRUE(ac.toCommon().clean);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -1133,3 +1133,32 @@ TEST(TestDecodeMitsubishi2, DecodeRealExample) {
   EXPECT_EQ(0xF, irsend.capture.address);
   EXPECT_EQ(0x82, irsend.capture.command);
 }
+
+TEST(TestMitsubishiACClass, toCommon) {
+  IRMitsubishiAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kMitsubishiAcCool);
+  ac.setTemp(20);
+  ac.setFan(kMitsubishiAcFanMax);
+  ac.setVane(kMitsubishiAcVaneAuto);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::MITSUBISHI_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -1139,7 +1139,7 @@ TEST(TestMitsubishiACClass, toCommon) {
   ac.setPower(true);
   ac.setMode(kMitsubishiAcCool);
   ac.setTemp(20);
-  ac.setFan(kMitsubishiAcFanMax);
+  ac.setFan(kMitsubishiAcFanSilent);
   ac.setVane(kMitsubishiAcVaneAuto);
   // Now test it.
   ASSERT_EQ(decode_type_t::MITSUBISHI_AC, ac.toCommon().protocol);
@@ -1148,14 +1148,14 @@ TEST(TestMitsubishiACClass, toCommon) {
   ASSERT_TRUE(ac.toCommon().celsius);
   ASSERT_EQ(20, ac.toCommon().degrees);
   ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
-  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::fanspeed_t::kMin, ac.toCommon().fanspeed);
   ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_TRUE(ac.toCommon().quiet);
   // Unsupported.
   ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
   ASSERT_FALSE(ac.toCommon().turbo);
   ASSERT_FALSE(ac.toCommon().clean);
   ASSERT_FALSE(ac.toCommon().light);
-  ASSERT_FALSE(ac.toCommon().quiet);
   ASSERT_FALSE(ac.toCommon().econo);
   ASSERT_FALSE(ac.toCommon().filter);
   ASSERT_FALSE(ac.toCommon().beep);

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -1142,3 +1142,36 @@ TEST(TestDecodePanasonicAC, CkpModelSpecifics) {
   EXPECT_EQ(kPanasonicCkp, pana.getModel());
   EXPECT_STATE_EQ(ckpPowerfulOn, pana.getRaw(), kPanasonicAcBits);
 }
+
+TEST(TestIRPanasonicAcClass, toCommon) {
+  IRPanasonicAc ac(0);
+  ac.setModel(panasonic_ac_remote_model_t::kPanasonicDke);
+  ac.setPower(true);
+  ac.setMode(kPanasonicAcCool);
+  ac.setTemp(20);
+  ac.setFan(kPanasonicAcFanMax);
+  ac.setSwingVertical(kPanasonicAcSwingVAuto);
+  ac.setSwingHorizontal(kPanasonicAcSwingHMiddle);
+  ac.setPowerful(true);
+  ac.setQuiet(false);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::PANASONIC_AC, ac.toCommon().protocol);
+  ASSERT_EQ(panasonic_ac_remote_model_t::kPanasonicDke, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kMiddle, ac.toCommon().swingh);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -1214,3 +1214,35 @@ TEST(TestIRSamsungAcClass, Issue604SendPowerHack) {
   EXPECT_EQ(text, ac.toString());
   EXPECT_EQ(freqduty + poweron + settings, ac._irsend.outputStr());
 }
+
+TEST(TestIRSamsungAcClass, toCommon) {
+  IRSamsungAc ac(0);
+  ac.setPower(true);
+  ac.setMode(kSamsungAcCool);
+  ac.setTemp(20);
+  ac.setFan(kSamsungAcFanAuto);
+  ac.setSwing(true);
+  ac.setBeep(true);
+  ac.setClean(true);
+  ac.setQuiet(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::SAMSUNG_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kAuto, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().quiet);
+  ASSERT_TRUE(ac.toCommon().clean);
+  ASSERT_TRUE(ac.toCommon().beep);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -677,3 +677,31 @@ TEST(TestSharpAcClass, KnownStates) {
   EXPECT_EQ("Power: On, Mode: 3 (DRY), Temp: 15C, Fan: 2 (AUTO)",
             ac.toString());
 }
+
+TEST(TestSharpAcClass, toCommon) {
+  IRSharpAc ac(0);
+  ac.setPower(true);
+  ac.setMode(kSharpAcCool);
+  ac.setTemp(20);
+  ac.setFan(kSharpAcFanMax);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::SHARP_AC, ac.toCommon().protocol);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  // Unsupported.
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -382,3 +382,38 @@ TEST(TestTcl112AcClass, FanSpeed) {
   ac.setFan(kTcl112AcFanHigh + 1);
   EXPECT_EQ(kTcl112AcFanAuto, ac.getFan());
 }
+
+
+TEST(TestTcl112AcClass, toCommon) {
+  IRTcl112Ac ac(0);
+  ac.setPower(true);
+  ac.setMode(kTcl112AcCool);
+  ac.setTemp(20);
+  ac.setFan(kTcl112AcFanHigh);
+  ac.setSwingVertical(true);
+  ac.setSwingHorizontal(true);
+  ac.setTurbo(true);
+  ac.setHealth(true);
+  ac.setEcono(true);
+  ac.setLight(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::TCL112AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().econo);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_TRUE(ac.toCommon().filter);
+  // Unsupported.
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Teco_test.cpp
+++ b/test/ir_Teco_test.cpp
@@ -356,3 +356,34 @@ TEST(TestDecodeTeco, RealNormalExample) {
       "Swing: On",
       ac.toString());
 }
+
+
+TEST(TestTecoACClass, toCommon) {
+  IRTecoAc ac(0);
+  ac.setPower(true);
+  ac.setMode(kTecoCool);
+  ac.setTemp(20);
+  ac.setFan(kTecoFanHigh);
+  ac.setSwing(true);
+  ac.setSleep(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::TECO, ac.toCommon().protocol);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Toshiba_test.cpp
+++ b/test/ir_Toshiba_test.cpp
@@ -669,3 +669,31 @@ TEST(TestDecodeToshibaAC, RealExamples) {
   // sending the power off message.
   EXPECT_EQ(kToshibaAcHeat, toshiba.getMode());
 }
+
+TEST(TestToshibaACClass, toCommon) {
+  IRToshibaAC ac(0);
+  ac.setPower(true);
+  ac.setMode(kToshibaAcCool);
+  ac.setTemp(20);
+  ac.setFan(kToshibaAcFanMax);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::TOSHIBA_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Trotec_test.cpp
+++ b/test/ir_Trotec_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2019 David Conran
+#include "ir_Trotec.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+
+TEST(TestTrotecESPClass, toCommon) {
+  IRTrotecESP ac(0);
+  ac.setPower(true);
+  ac.setMode(kTrotecCool);
+  ac.setTemp(20);
+  ac.setSpeed(kTrotecFanHigh);
+  ac.setSleep(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::TROTEC, ac.toCommon().protocol);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(0, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Vestel_test.cpp
+++ b/test/ir_Vestel_test.cpp
@@ -511,3 +511,34 @@ TEST(TestDecodeVestelAc, Housekeeping) {
   ASSERT_EQ("VESTEL_AC", typeToString(VESTEL_AC));
   ASSERT_FALSE(hasACState(VESTEL_AC));  // Uses uint64_t, not uint8_t*.
 }
+
+TEST(TestVestelAcClass, toCommon) {
+  IRVestelAc ac(0);
+  ac.setPower(true);
+  ac.setMode(kVestelAcCool);
+  ac.setTemp(20);
+  ac.setFan(kVestelAcFanHigh);
+  ac.setSwing(true);
+  ac.setTurbo(true);
+  ac.setIon(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::VESTEL_AC, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().filter);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}

--- a/test/ir_Whirlpool_test.cpp
+++ b/test/ir_Whirlpool_test.cpp
@@ -583,3 +583,36 @@ TEST(TestIRWhirlpoolAcClass, MessageConstruction) {
       ac.toString());
   EXPECT_STATE_EQ(expectedState, ac.getRaw(), kWhirlpoolAcBits);
 }
+
+TEST(TestIRWhirlpoolAcClass, toCommon) {
+  IRWhirlpoolAc ac(0);
+  ac.setModel(whirlpool_ac_remote_model_t::DG11J13A);
+  ac.setPowerToggle(true);
+  ac.setMode(kWhirlpoolAcCool);
+  ac.setTemp(18);
+  ac.setFan(kWhirlpoolAcFanHigh);
+  ac.setSwing(true);
+  ac.setSuper(true);
+  ac.setLight(true);
+  ac.setSleep(false);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::WHIRLPOOL_AC, ac.toCommon().protocol);
+  ASSERT_EQ(whirlpool_ac_remote_model_t::DG11J13A, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(18, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  ASSERT_TRUE(ac.toCommon().turbo);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}


### PR DESCRIPTION
- Convert captured IR A/C messages and update the internal/MQTT climate state.
- Supports all "common" supported A/C messages.
  * Note: Argo and Trotec don't currently have decoders so will not work in practice.
- Relevant unit tests.
- Update numerous A/C classes/protocols to current code standards.
- Major rework/breaking change to Argo A/C support.
- **[BUG]** Fixed a bug with setMode()/getMode() for HAIER_AC.
- Update Denon to use the proper constant name style.
- Add #define switches _IRMQTTServer_ to control new functionality:
  * USE_DECODED_AC_SETTINGS: Whether we use the new functionality or not
  * IGNORE_DECODED_AC_PROTOCOL: Allow other A/C remotes to control non-same A/Cs
  * REPLAY_DECODED_AC_MESSAGE: Do we replay the decoded A/C message or not

Tested on a Nodemcu board with a Kelvinator A/C remote. Appears to work as
expected.

For #702
FYI #668