### PR TITLE
[BUG] IRMQTTServer: Continue to use same Temperature units.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3269,6 +3269,14 @@ bool decodeCommonAc(const decode_results *decode) {
     state.model = climate.model;
   }
 #endif  // IGNORE_DECODED_AC_PROTOCOL
+// Continue to use the previously prefered temperature units.
+// i.e. Keep using Celsius or Fahrenheit.
+if (climate.celsius != state.celsius) {
+  // We've got a mismatch, so we need to convert.
+  state.degrees = climate.celsius ? fahrenheitToCelsius(state.degrees)
+                                  : celsiusToFahrenheit(state.degrees);
+  state.celsius = climate.celsius;
+}
 #if MQTT_ENABLE
   sendClimate(climate, state, MqttClimateStat, true, false, false,
               REPLAY_DECODED_AC_MESSAGE);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -15,6 +15,7 @@
 #endif
 #include "IRsend.h"
 #include "IRremoteESP8266.h"
+#include "IRutils.h"
 #include "ir_Argo.h"
 #include "ir_Coolix.h"
 #include "ir_Daikin.h"
@@ -743,7 +744,7 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
 //   on:      Should the unit be powered on? (or in some cases, toggled)
 //   mode:    What operating mode should the unit perform? e.g. Cool, Heat etc.
 //   degrees: What temperature should the unit be set to?
-//   celsius: Use degreees Celsius, otherwise Fahrenheit.
+//   celsius: Use degrees Celsius, otherwise Fahrenheit.
 //   fan:     Fan speed.
 // The following args are all "if supported" by the underlying A/C classes.
 //   swingv:  Control the vertical swing of the vanes.
@@ -769,11 +770,11 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
                   const bool beep, const int16_t sleep, const int16_t clock) {
   // Convert the temperature to Celsius.
   float degC;
-  bool on = power;
   if (celsius)
     degC = degrees;
   else
-    degC = (degrees - 32.0) * (5.0 / 9.0);
+    degC = fahrenheitToCelsius(degrees);
+  bool on = power;
   // A hack for Home Assistant, it appears to need/want an Off opmode.
   if (mode == stdAc::opmode_t::kOff) on = false;
   // Per vendor settings & setup.

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -772,3 +772,7 @@ uint64_t invertBits(const uint64_t data, const uint16_t nbits) {
   // Mask off any unwanted bits and return the result.
   return (result & ((1ULL << nbits) - 1));
 }
+
+float celsiusToFahrenheit(const float deg) { return (deg * 9.0) / 5.0 + 32.0; }
+
+float fahrenheitToCelsius(const float deg) { return (deg - 32.0) * 5.0 / 9.0; }

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -45,4 +45,6 @@ uint16_t countBits(const uint64_t data, const uint8_t length,
                    const bool ones = true, const uint16_t init = 0);
 uint64_t invertBits(const uint64_t data, const uint16_t nbits);
 decode_type_t strToDecodeType(const char *str);
+float celsiusToFahrenheit(const float deg);
+float fahrenheitToCelsius(const float deg);
 #endif  // IRUTILS_H_

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -643,8 +643,8 @@ void IRHaierACYRW02::setMode(uint8_t mode) {
 
 uint8_t IRHaierACYRW02::getMode(void) { return remote_state[7] >> 4; }
 
-void IRHaierACYRW02::setTemp(const uint8_t celcius) {
-  uint8_t temp = celcius;
+void IRHaierACYRW02::setTemp(const uint8_t celsius) {
+  uint8_t temp = celsius;
   if (temp < kHaierAcMinTemp)
     temp = kHaierAcMinTemp;
   else if (temp > kHaierAcMaxTemp)

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -149,7 +149,8 @@ void IRMideaAC::setTemp(const uint8_t temp, const bool useCelsius) {
   if (useCelsius) {
     new_temp = std::max(kMideaACMinTempC, new_temp);
     new_temp = std::min(kMideaACMaxTempC, new_temp);
-    new_temp = (uint8_t)((new_temp * 1.8) + 32.5);  // 0.5 so we rounding.
+    // Convert and add 0.5 for rounding.
+    new_temp = celsiusToFahrenheit(new_temp) + 0.5;
   }
   new_temp = std::max(kMideaACMinTempF, new_temp);
   new_temp = std::min(kMideaACMaxTempF, new_temp);
@@ -166,7 +167,7 @@ void IRMideaAC::setTemp(const uint8_t temp, const bool useCelsius) {
 uint8_t IRMideaAC::getTemp(const bool useCelsius) {
   uint8_t temp = ((remote_state >> 24) & 0x1F) + kMideaACMinTempF;
   if (useCelsius) {
-    temp = (uint8_t)((temp - 32) / 1.8);
+    temp = fahrenheitToCelsius(temp);
   }
   return temp;
 }

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -406,7 +406,7 @@ void IRPanasonicAc::setMode(const uint8_t desired) {
 
 uint8_t IRPanasonicAc::getTemp(void) { return remote_state[14] >> 1; }
 
-// Set the desitred temperature in Celcius.
+// Set the desitred temperature in Celsius.
 // Args:
 //   celsius: The temperature to set the A/C unit to.
 //   remember: A boolean flag for the class to remember the temperature.

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -31,7 +31,7 @@
 //   Swing: 4 bits. (auto 0xA, stop 0xF)
 //   turbo_sleep_normal: 4bits. (normal 0x1, sleep 0x3, turbo 0x7)
 //   Unused: 8 bits. (0x00)
-//   Temperature: 4 bits. (Celcius, but offset by -16 degrees. e.g. 0x0 = 16C)
+//   Temperature: 4 bits. (Celsius, but offset by -16 degrees. e.g. 0x0 = 16C)
 //   Fan Speed: 4 bits (auto 0x1, low 0x5, mid 0x9, high 0xB, 0xD auto hot,
 //                    0xC auto cool)
 //   Mode: 3 bits. (auto 0x0, cold 0x1, dry 0x2, fan 0x3, hot 0x4)

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -415,3 +415,17 @@ TEST(TestUtils, htmlEscape) {
       "&amp;quot&semi;&amp;lt&semi;&amp;apos&semi;&amp;gt&semi;&amp;amp&semi;",
       htmlEscape("&quot;&lt;&apos;&gt;&amp;"));
 }
+
+TEST(TestUtils, TemperatureConversion) {
+  // Freezing point of water.
+  ASSERT_EQ(32.0, celsiusToFahrenheit(0.0));
+  ASSERT_EQ(0.0, fahrenheitToCelsius(32.0));
+  // Boiling point of water.
+  ASSERT_EQ(212.0, celsiusToFahrenheit(100.0));
+  ASSERT_EQ(100.0, fahrenheitToCelsius(212.0));
+  // Room Temp. (RTP)
+  ASSERT_EQ(77.0, celsiusToFahrenheit(25.0));
+  ASSERT_EQ(25.0, fahrenheitToCelsius(77.0));
+  // Misc
+  ASSERT_EQ(-40.0, fahrenheitToCelsius(-40.0));
+}


### PR DESCRIPTION
- Create standard temp conversion routines.
- Update previous temp conversion to use new routines.
- Unit tests for the conversion routines.
- Fix some of my atrocious spelling mistakes.

Ref https://github.com/markszabo/IRremoteESP8266/issues/702#issuecomment-493727948