### PR TITLE
[BUG] set/getEye() uses wrong bit. Add set/getWeeklyTimerEnable()

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -312,25 +312,6 @@ bool IRDaikinESP::getEcono(void) {
   return remote[kDaikinByteEcono] & kDaikinBitEcono;
 }
 
-// Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
-// TODO(crankyoldgit): Restore this when we have the correct bit for it.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-void IRDaikinESP::setEye(const bool on) {
-#pragma GCC diagnostic pop
-  // if (on)
-  //   remote[kDaikinByteEye] |= kDaikinBitEye;
-  // else
-  //   remote[kDaikinByteEye] &= ~kDaikinBitEye;
-}
-
-bool IRDaikinESP::getEye(void) {
-  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
-  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
-  // return remote[kDaikinByteEye] & kDaikinBitEye;
-  return false;
-}
-
 void IRDaikinESP::setMold(const bool on) {
   if (on)
     remote[kDaikinByteMold] |= kDaikinBitMold;
@@ -590,10 +571,6 @@ std::string IRDaikinESP::toString(void) {
   result += this->getQuiet() ? F("On") : F("Off");
   result += F(", Sensor: ");
   result += this->getSensor() ? F("On") : F("Off");
-  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
-  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
-  // result += F(", Eye: ");
-  // result += this->getEye() ? F("On") : F("Off");
   result += F(", Mold: ");
   result += this->getMold() ? F("On") : F("Off");
   result += F(", Comfort: ");

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -312,15 +312,23 @@ bool IRDaikinESP::getEcono(void) {
   return remote[kDaikinByteEcono] & kDaikinBitEcono;
 }
 
+// Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
+// TODO(crankyoldgit): Restore this when we have the correct bit for it.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 void IRDaikinESP::setEye(const bool on) {
-  if (on)
-    remote[kDaikinByteEye] |= kDaikinBitEye;
-  else
-    remote[kDaikinByteEye] &= ~kDaikinBitEye;
+#pragma GCC diagnostic pop
+  // if (on)
+  //   remote[kDaikinByteEye] |= kDaikinBitEye;
+  // else
+  //   remote[kDaikinByteEye] &= ~kDaikinBitEye;
 }
 
 bool IRDaikinESP::getEye(void) {
-  return remote[kDaikinByteEye] & kDaikinBitEye;
+  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
+  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
+  // return remote[kDaikinByteEye] & kDaikinBitEye;
+  return false;
 }
 
 void IRDaikinESP::setMold(const bool on) {
@@ -417,6 +425,16 @@ uint8_t IRDaikinESP::getCurrentDay(void) {
   return ((remote[kDaikinByteClockMinsHigh] & 0x38) >> 3);
 }
 
+void IRDaikinESP::setWeeklyTimerEnable(const bool on) {
+  if (on)
+    remote[kDaikinByteWeeklyTimer] &= ~kDaikinBitWeeklyTimer;  // Clear the bit.
+  else
+    remote[kDaikinByteWeeklyTimer] |= kDaikinBitWeeklyTimer;  // Set the bit.
+}
+
+bool IRDaikinESP::getWeeklyTimerEnable(void) {
+  return !(remote[kDaikinByteWeeklyTimer] & kDaikinBitWeeklyTimer);
+}
 
 // Convert a standard A/C mode into its native mode.
 uint8_t IRDaikinESP::convertMode(const stdAc::opmode_t mode) {
@@ -572,8 +590,10 @@ std::string IRDaikinESP::toString(void) {
   result += this->getQuiet() ? F("On") : F("Off");
   result += F(", Sensor: ");
   result += this->getSensor() ? F("On") : F("Off");
-  result += F(", Eye: ");
-  result += this->getEye() ? F("On") : F("Off");
+  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
+  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
+  // result += F(", Eye: ");
+  // result += this->getEye() ? F("On") : F("Off");
   result += F(", Mold: ");
   result += this->getMold() ? F("On") : F("Off");
   result += F(", Comfort: ");
@@ -613,6 +633,8 @@ std::string IRDaikinESP::toString(void) {
     result += this->renderTime(this->getOffTime());
   else
     result += F("Off");
+  result += F(", Weekly Timer: ");
+  result += this->getWeeklyTimerEnable() ? F("On") : F("Off");
   return result;
 }
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -257,8 +257,6 @@ class IRDaikinESP {
   bool getSensor(void);
   void setEcono(const bool on);
   bool getEcono(void);
-  void setEye(const bool on);
-  bool getEye(void);
   void setMold(const bool on);
   bool getMold(void);
   void setComfort(const bool on);

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -123,6 +123,8 @@ const uint8_t kDaikinByteEcono = kDaikinByteSensor;
 const uint8_t kDaikinBitEcono = 0b00000100;
 const uint8_t kDaikinByteEye = kDaikinByteSensor;
 const uint8_t kDaikinBitEye = 0b10000000;
+const uint8_t kDaikinByteWeeklyTimer = kDaikinByteSensor;
+const uint8_t kDaikinBitWeeklyTimer = 0b10000000;
 const uint8_t kDaikinByteMold = 33;
 const uint8_t kDaikinBitMold = 0b00000010;
 const uint8_t kDaikinByteOffTimer = kDaikinBytePower;
@@ -273,6 +275,8 @@ class IRDaikinESP {
   uint16_t getCurrentTime(void);
   void setCurrentDay(const uint8_t day_of_week);
   uint8_t getCurrentDay(void);
+  void setWeeklyTimerEnable(const bool on);
+  bool getWeeklyTimerEnable(void);
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kDaikinStateLength);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -84,9 +84,10 @@ TEST(TestIRac, Daikin) {
   IRac irac(0);
   char expected[] =
       "Power: On, Mode: 3 (COOL), Temp: 19C, Fan: 2, Powerful: Off, "
-      "Quiet: Off, Sensor: Off, Eye: Off, Mold: On, Comfort: Off, "
+      "Quiet: Off, Sensor: Off, Mold: On, Comfort: Off, "
       "Swing (Horizontal): Off, Swing (Vertical): Off, "
-      "Current Time: 0:00, Current Day: (UNKNOWN), On Time: Off, Off Time: Off";
+      "Current Time: 0:00, Current Day: (UNKNOWN), On Time: Off, "
+      "Off Time: Off, Weekly Timer: On";
 
   ac.begin();
   irac.daikin(&ac,

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -542,6 +542,9 @@ TEST(TestDaikinClass, OnOffTimers) {
 
 // Test Eye mode.
 TEST(TestDaikinClass, EyeSetting) {
+  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
+  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
+  /*
   IRDaikinESP ac(0);
   ac.begin();
 
@@ -567,6 +570,50 @@ TEST(TestDaikinClass, EyeSetting) {
   ac.setEye(false);
   ASSERT_FALSE(ac.getEye());
   EXPECT_TRUE(ac.getEcono());
+  */
+}
+
+TEST(TestDaikinClass, WeeklyTimerEnable) {
+  IRDaikinESP ac(0);
+  ac.begin();
+
+  // The Weekly Timer Enabled flag is stored in the same byte as Econo mode.
+  // Econo mode tests are there to make sure it isn't harmed and vice-versa.
+  ac.setEcono(false);
+  ac.setWeeklyTimerEnable(false);
+  ASSERT_FALSE(ac.getWeeklyTimerEnable());
+  EXPECT_FALSE(ac.getEcono());
+
+  ac.setWeeklyTimerEnable(true);
+  ASSERT_TRUE(ac.getWeeklyTimerEnable());
+  EXPECT_FALSE(ac.getEcono());
+
+  ac.setEcono(false);
+  ASSERT_TRUE(ac.getWeeklyTimerEnable());
+  EXPECT_FALSE(ac.getEcono());
+
+  ac.setEcono(true);
+  ASSERT_TRUE(ac.getWeeklyTimerEnable());
+  EXPECT_TRUE(ac.getEcono());
+
+  ac.setWeeklyTimerEnable(false);
+  ASSERT_FALSE(ac.getWeeklyTimerEnable());
+  EXPECT_TRUE(ac.getEcono());
+
+  // Tests with real data from:
+  // https://github.com/markszabo/IRremoteESP8266/issues/704#issuecomment-493731421
+  uint8_t on[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7, 0x11, 0xDA, 0x27, 0x00,
+      0x42, 0xE3, 0x0B, 0x42, 0x11, 0xDA, 0x27, 0x00, 0x00, 0x68, 0x32, 0x00,
+      0x30, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC1, 0x00, 0x00, 0x03};
+  uint8_t off[kDaikinStateLength] = {
+      0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7, 0x11, 0xDA, 0x27, 0x00,
+      0x42, 0xE3, 0x0B, 0x42, 0x11, 0xDA, 0x27, 0x00, 0x00, 0x68, 0x32, 0x00,
+      0x30, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC1, 0x80, 0x00, 0x83};
+  ac.setRaw(on);
+  EXPECT_TRUE(ac.getWeeklyTimerEnable());
+  ac.setRaw(off);
+  EXPECT_FALSE(ac.getWeeklyTimerEnable());
 }
 
 // Test Mold mode.
@@ -684,16 +731,19 @@ TEST(TestDaikinClass, HumanReadable) {
 
   EXPECT_EQ(
       "Power: On, Mode: 4 (HEAT), Temp: 15C, Fan: 11 (QUIET), "
-      "Powerful: Off, Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, "
+      "Powerful: Off, Quiet: Off, Sensor: Off, Mold: Off, "
       "Comfort: Off, Swing (Horizontal): Off, Swing (Vertical): Off, "
-      "Current Time: 0:00, Current Day: (UNKNOWN), On Time: Off, Off Time: Off",
+      "Current Time: 0:00, Current Day: (UNKNOWN), On Time: Off, "
+      "Off Time: Off, Weekly Timer: On",
       ac.toString());
   ac.setMode(kDaikinAuto);
   ac.setTemp(25);
   ac.setFan(kDaikinFanAuto);
   ac.setQuiet(true);
   ac.setSensor(true);
-  ac.setEye(true);
+  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
+  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
+  // ac.setEye(true);
   ac.setMold(true);
   ac.setSwingVertical(true);
   ac.setSwingHorizontal(true);
@@ -702,12 +752,14 @@ TEST(TestDaikinClass, HumanReadable) {
   ac.enableOnTimer(8 * 60 + 0);
   ac.enableOffTimer(17 * 60 + 30);
   ac.setComfort(true);
+  ac.setWeeklyTimerEnable(false);
   ac.off();
   EXPECT_EQ(
       "Power: Off, Mode: 0 (AUTO), Temp: 25C, Fan: 10 (AUTO), "
-      "Powerful: Off, Quiet: On, Sensor: On, Eye: On, Mold: On, Comfort: On, "
+      "Powerful: Off, Quiet: On, Sensor: On, Mold: On, Comfort: On, "
       "Swing (Horizontal): On, Swing (Vertical): On, "
-      "Current Time: 9:15, Current Day: WED, On Time: 8:00, Off Time: 17:30",
+      "Current Time: 9:15, Current Day: WED, On Time: 8:00, Off Time: 17:30, "
+      "Weekly Timer: Off",
       ac.toString());
 }
 
@@ -857,10 +909,10 @@ TEST(TestDecodeDaikin, RealExample) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
-      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Quiet: Off, Sensor: Off, Mold: Off, Comfort: Off, "
       "Swing (Horizontal): Off, Swing (Vertical): Off, "
       "Current Time: 22:18, Current Day: (UNKNOWN), "
-      "On Time: 21:30, Off Time: 6:10", ac.toString());
+      "On Time: 21:30, Off Time: 6:10, Weekly Timer: On", ac.toString());
 }
 
 // Decoding a message we entirely constructed based solely on a given state.
@@ -890,10 +942,10 @@ TEST(TestDecodeDaikin, ShortSyntheticExample) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
-      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Quiet: Off, Sensor: Off, Mold: Off, Comfort: Off, "
       "Swing (Horizontal): Off, Swing (Vertical): Off, "
       "Current Time: 22:18, Current Day: (UNKNOWN), "
-      "On Time: 21:30, Off Time: 6:10", ac.toString());
+      "On Time: 21:30, Off Time: 6:10, Weekly Timer: On", ac.toString());
 }
 
 // Decoding a message we entirely constructed based solely on a given state.
@@ -919,10 +971,10 @@ TEST(TestDecodeDaikin, LongSyntheticExample) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 3 (COOL), Temp: 29C, Fan: 10 (AUTO), Powerful: On, "
-      "Quiet: Off, Sensor: Off, Eye: Off, Mold: Off, Comfort: Off, "
+      "Quiet: Off, Sensor: Off, Mold: Off, Comfort: Off, "
       "Swing (Horizontal): Off, Swing (Vertical): Off, "
       "Current Time: 22:18, Current Day: (UNKNOWN), "
-      "On Time: 21:30, Off Time: 6:10", ac.toString());
+      "On Time: 21:30, Off Time: 6:10, Weekly Timer: On", ac.toString());
 }
 
 // Test decoding a message captured from a real IR remote.

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -540,39 +540,6 @@ TEST(TestDaikinClass, OnOffTimers) {
   ASSERT_FALSE(ac.getPowerful());
 }
 
-// Test Eye mode.
-TEST(TestDaikinClass, EyeSetting) {
-  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
-  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
-  /*
-  IRDaikinESP ac(0);
-  ac.begin();
-
-  // The Eye setting is stored in the same byte as Econo mode.
-  // Econo mode tests are there to make sure it isn't harmed and vice-versa.
-  ac.setEcono(false);
-  ac.setEye(false);
-  ASSERT_FALSE(ac.getEye());
-  EXPECT_FALSE(ac.getEcono());
-
-  ac.setEye(true);
-  ASSERT_TRUE(ac.getEye());
-  EXPECT_FALSE(ac.getEcono());
-
-  ac.setEcono(false);
-  ASSERT_TRUE(ac.getEye());
-  EXPECT_FALSE(ac.getEcono());
-
-  ac.setEcono(true);
-  ASSERT_TRUE(ac.getEye());
-  EXPECT_TRUE(ac.getEcono());
-
-  ac.setEye(false);
-  ASSERT_FALSE(ac.getEye());
-  EXPECT_TRUE(ac.getEcono());
-  */
-}
-
 TEST(TestDaikinClass, WeeklyTimerEnable) {
   IRDaikinESP ac(0);
   ac.begin();
@@ -741,9 +708,6 @@ TEST(TestDaikinClass, HumanReadable) {
   ac.setFan(kDaikinFanAuto);
   ac.setQuiet(true);
   ac.setSensor(true);
-  // Disabled due to https://github.com/markszabo/IRremoteESP8266/issues/704
-  // TODO(crankyoldgit): Restore this when we have the correct bit for it.
-  // ac.setEye(true);
   ac.setMold(true);
   ac.setSwingVertical(true);
   ac.setSwingHorizontal(true);


### PR DESCRIPTION
According to @NetNerd in #704 we are using the wrong bit for the
Intellegent Eye function of the A/C. Disabled until we can establish the
correct bit for it.

It turns out that bit us used instead for the Weekly Timer enabled flag.
Add & update suitable routines and unit tests accordingly.

For #704