### PR TITLE
Add experimental decodeArgo() support.

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -26,6 +26,7 @@
 #include <IRremoteESP8266.h>
 #include <IRutils.h>
 // The following are only needed for extended decoding of A/C Messages
+#include <ir_Argo.h>
 #include <ir_Coolix.h>
 #include <ir_Daikin.h>
 #include <ir_Fujitsu.h>
@@ -119,8 +120,15 @@ IRrecv irrecv(kRecvPin, kCaptureBufferSize, kTimeout, true);
 decode_results results;  // Somewhere to store the results
 
 // Display the human readable state of an A/C message if we can.
-void dumpACInfo(decode_results *results) {
+void dumpACInfo(const decode_results * const results) {
   String description = "";
+#if DECODE_ARGO
+  if (results->decode_type == ARGO) {
+    IRArgoAC ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_ARGO
 #if DECODE_DAIKIN
   if (results->decode_type == DAIKIN) {
     IRDaikinESP ac(0);

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -523,6 +523,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting MITSUBISHIHEAVY (88 bit) decode");
   if (decodeMitsubishiHeavy(results, kMitsubishiHeavy88Bits)) return true;
 #endif
+#if DECODE_ARGO
+  DPRINTLN("Attempting Argo decode");
+  if (decodeArgo(results)) return true;
+#endif  // DECODE_ARGO
 #if DECODE_SHARP_AC
   DPRINTLN("Attempting SHARP_AC decode");
   if (decodeSharpAc(results)) return true;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -156,6 +156,10 @@ class IRrecv {
   bool decodeNEC(decode_results *results, uint16_t nbits = kNECBits,
                  bool strict = true);
 #endif
+#if DECODE_ARGO
+  bool decodeArgo(decode_results *results, const uint16_t nbits = kArgoBits,
+                  const bool strict = true);
+#endif  // DECODE_ARGO
 #if DECODE_SONY
   bool decodeSony(decode_results *results, uint16_t nbits = kSonyMinBits,
                   bool strict = false);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -147,7 +147,7 @@
 #define DECODE_PRONTO          false  // Not written.
 #define SEND_PRONTO            true
 
-#define DECODE_ARGO            false  // Not written.
+#define DECODE_ARGO            true  // Experimental
 #define SEND_ARGO              true
 
 #define DECODE_TROTEC          false  // Not implemented.
@@ -328,6 +328,7 @@ const uint16_t kSingleRepeat = 1;
 const uint16_t kAiwaRcT501Bits = 15;
 const uint16_t kAiwaRcT501MinRepeats = kSingleRepeat;
 const uint16_t kArgoStateLength = 12;
+const uint16_t kArgoBits = kArgoStateLength * 8;
 const uint16_t kArgoDefaultRepeat = kNoRepeat;
 const uint16_t kCoolixBits = 24;
 const uint16_t kCoolixDefaultRepeat = 1;

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -503,6 +503,7 @@ std::string typeToString(const decode_type_t protocol, const bool isRepeat) {
 // Does the given protocol use a complex state as part of the decode?
 bool hasACState(const decode_type_t protocol) {
   switch (protocol) {
+    case ARGO:
     case DAIKIN:
     case DAIKIN2:
     case DAIKIN216:

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -4,6 +4,11 @@
 #ifndef IR_ARGO_H_
 #define IR_ARGO_H_
 
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#else
+#include <string>
+#endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
 #ifdef UNIT_TEST
@@ -57,6 +62,8 @@ const uint8_t kArgoFan1 = 1;  // 0b10
 
 // byte[4]
 const uint8_t kArgoRoomTempHighMask = 0b00000011;
+const uint8_t kArgoTempOffset = 4;
+const uint8_t kArgoMaxRoomTemp = ((1 << 5) - 1) + kArgoTempOffset;  // 35C
 
 // byte[9]
 const uint8_t kArgoPowerBit = 0b00100000;
@@ -64,7 +71,6 @@ const uint8_t kArgoMaxBit =   0b00001000;
 const uint8_t kArgoNightBit = 0b00000100;
 const uint8_t kArgoIFeelBit = 0b10000000;
 
-const uint8_t kArgoTempOffset = 4;
 const uint8_t kArgoMinTemp = 10;  // Celsius offset +4
 const uint8_t kArgoMaxTemp = 32;  // Celsius
 
@@ -141,13 +147,22 @@ class IRArgoAC {
   uint8_t getRoomTemp(void);
 
   uint8_t* getRaw(void);
-  void setRaw(const char state[]);
+  void setRaw(const uint8_t state[]);
+  static uint8_t calcChecksum(const uint8_t state[],
+                              const uint16_t length = kArgoStateLength);
+  static bool validChecksum(const uint8_t state[],
+                            const uint16_t length = kArgoStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static uint8_t convertSwingV(const stdAc::swingv_t position);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   stdAc::state_t toCommon(void);
+#ifdef ARDUINO
+  String toString();
+#else
+  std::string toString();
+#endif
 #ifndef UNIT_TEST
 
  private:

--- a/test/ir_Argo_test.cpp
+++ b/test/ir_Argo_test.cpp
@@ -36,3 +36,186 @@ TEST(TestArgoACClass, toCommon) {
   ASSERT_FALSE(ac.toCommon().quiet);
   ASSERT_EQ(-1, ac.toCommon().clock);
 }
+
+TEST(TestArgoACClass, MessageConstructon) {
+  IRArgoAC ac(0);
+  ac.setPower(true);
+  ac.setTemp(20);
+  ac.setMode(kArgoCool);
+  ac.setFan(kArgoFanAuto);
+  ac.setRoomTemp(21);
+  ac.setiFeel(true);
+  ac.setMax(true);
+  ac.setNight(true);
+
+  // Don't implicitly trust this. It's just a guess.
+  uint8_t expected[kArgoStateLength] = {
+      0xAC, 0xF5, 0x00, 0x24, 0x02, 0x00, 0x00, 0x00, 0x00, 0xAC, 0xD6, 0x01};
+  EXPECT_STATE_EQ(expected, ac.getRaw(), kArgoBits);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Fan: 0 (AUTO), Temp: 20C, Room Temp: 21C, "
+      "Max: On, iFeel: On, Night: On",
+      ac.toString());
+}
+
+// Tests for sendArgo().
+
+// Test sending typical data only.
+TEST(TestSendArgo, SendDataOnly) {
+  IRsendTest irsend(0);
+  irsend.begin();
+  uint8_t data[kArgoStateLength] = {
+      0xAC, 0xF5, 0x00, 0x24, 0x02, 0x00, 0x00, 0x00, 0x00, 0xAC, 0xD6, 0x01};
+
+  irsend.sendArgo(data);
+  EXPECT_EQ(
+      "f38000d50"
+      "m6400s3300"
+      "m400s900m400s900m400s2200m400s2200m400s900m400s2200m400s900m400s2200"
+      "m400s2200m400s900m400s2200m400s900m400s2200m400s2200m400s2200m400s2200"
+      "m400s900m400s900m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s2200m400s900m400s900m400s2200m400s900m400s900"
+      "m400s900m400s2200m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900m400s900m400s2200m400s2200m400s900m400s2200m400s900m400s2200"
+      "m400s900m400s2200m400s2200m400s900m400s2200m400s900m400s2200m400s2200"
+      "m400s2200m400s900m400s900m400s900m400s900m400s900m400s900"
+      "m400s900",
+      irsend.outputStr());
+}
+
+// Tests for decodeArgo().
+// Decode normal Argo messages.
+
+TEST(TestDecodeArgo, SyntheticDecode) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  // Synthesised Normal Argo message.
+  irsend.reset();
+  uint8_t expectedState[kArgoStateLength] = {
+      0xAC, 0xF5, 0x00, 0x24, 0x02, 0x00, 0x00, 0x00, 0x00, 0xAC, 0xD6, 0x01};
+  irsend.sendArgo(expectedState);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(decode_type_t::ARGO, irsend.capture.decode_type);
+  EXPECT_EQ(kArgoBits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+
+TEST(TestArgoACClass, SetAndGetTemp) {
+  IRArgoAC ac(0);
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  ac.setTemp(kArgoMinTemp);
+  EXPECT_EQ(kArgoMinTemp, ac.getTemp());
+  ac.setTemp(kArgoMaxTemp);
+  EXPECT_EQ(kArgoMaxTemp, ac.getTemp());
+  ac.setTemp(kArgoMinTemp - 1);
+  EXPECT_EQ(kArgoMinTemp, ac.getTemp());
+  ac.setTemp(kArgoMaxTemp + 1);
+  EXPECT_EQ(kArgoMaxTemp, ac.getTemp());
+}
+
+TEST(TestArgoACClass, SetAndGetRoomTemp) {
+  IRArgoAC ac(0);
+
+  ac.setRoomTemp(25);
+  EXPECT_EQ(25, ac.getRoomTemp());
+  ac.setRoomTemp(kArgoTempOffset);
+  EXPECT_EQ(kArgoTempOffset, ac.getRoomTemp());
+  ac.setRoomTemp(kArgoMaxRoomTemp);
+  EXPECT_EQ(kArgoMaxRoomTemp, ac.getRoomTemp());
+  ac.setRoomTemp(kArgoTempOffset - 1);
+  EXPECT_EQ(kArgoTempOffset, ac.getRoomTemp());
+  ac.setRoomTemp(kArgoMaxRoomTemp + 1);
+  EXPECT_EQ(kArgoMaxRoomTemp, ac.getRoomTemp());
+}
+
+TEST(TestArgoACClass, SetAndGetMode) {
+  IRArgoAC ac(0);
+
+  ac.setMode(kArgoHeat);
+  EXPECT_EQ(kArgoHeat, ac.getMode());
+  ac.setMode(kArgoCool);
+  EXPECT_EQ(kArgoCool, ac.getMode());
+  ac.setMode(kArgoDry);
+  EXPECT_EQ(kArgoDry, ac.getMode());
+  ac.setMode(kArgoAuto);
+  EXPECT_EQ(kArgoAuto, ac.getMode());
+  ac.setMode(kArgoHeatAuto);
+  EXPECT_EQ(kArgoHeatAuto, ac.getMode());
+  ac.setMode(kArgoOff);
+  EXPECT_EQ(kArgoOff, ac.getMode());
+  ac.setMode(255);
+  EXPECT_EQ(kArgoAuto, ac.getMode());
+}
+
+TEST(TestArgoACClass, SetAndGetFan) {
+  IRArgoAC ac(0);
+
+  ac.setFan(kArgoFan3);
+  EXPECT_EQ(kArgoFan3, ac.getFan());
+  ac.setFan(kArgoFan1);
+  EXPECT_EQ(kArgoFan1, ac.getFan());
+  ac.setFan(kArgoFanAuto);
+  EXPECT_EQ(kArgoFanAuto, ac.getFan());
+  ac.setFan(kArgoFan3);
+  EXPECT_EQ(kArgoFan3, ac.getFan());
+  ASSERT_NE(7, kArgoFan3);
+  // Now try some unexpected value.
+  ac.setFan(7);
+  EXPECT_EQ(kArgoFan3, ac.getFan());
+}
+
+TEST(TestArgoACClass, Night) {
+  IRArgoAC ac(0);
+  ac.setNight(false);
+  ASSERT_FALSE(ac.getNight());
+  ac.setNight(true);
+  ASSERT_TRUE(ac.getNight());
+  ac.setNight(false);
+  ASSERT_FALSE(ac.getNight());
+}
+
+TEST(TestArgoACClass, iFeel) {
+  IRArgoAC ac(0);
+  ac.setiFeel(false);
+  ASSERT_FALSE(ac.getiFeel());
+  ac.setiFeel(true);
+  ASSERT_TRUE(ac.getiFeel());
+  ac.setiFeel(false);
+  ASSERT_FALSE(ac.getiFeel());
+}
+
+TEST(TestArgoACClass, Power) {
+  IRArgoAC ac(0);
+  ac.setPower(false);
+  ASSERT_FALSE(ac.getPower());
+  ac.setPower(true);
+  ASSERT_TRUE(ac.getPower());
+  ac.setPower(false);
+  ASSERT_FALSE(ac.getPower());
+}
+
+TEST(TestArgoACClass, Max) {
+  IRArgoAC ac(0);
+  ac.setMax(false);
+  ASSERT_FALSE(ac.getMax());
+  ac.setMax(true);
+  ASSERT_TRUE(ac.getMax());
+  ac.setMax(false);
+  ASSERT_FALSE(ac.getMax());
+}
+
+TEST(TestUtils, Housekeeping) {
+  ASSERT_EQ("ARGO", typeToString(decode_type_t::ARGO));
+  ASSERT_EQ(decode_type_t::ARGO, strToDecodeType("ARGO"));
+  ASSERT_TRUE(hasACState(decode_type_t::ARGO));
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -50,7 +50,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_Magiquest.o ir_Lasertag.o ir_Carrier.o ir_Haier.o ir_Hitachi.o \
             ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o ir_Pioneer.o \
             ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o \
-						ir_MitsubishiHeavy.o
+						ir_MitsubishiHeavy.o ir_Argo.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o $(PROTOCOLS)
@@ -211,3 +211,6 @@ ir_Tcl.o : $(USER_DIR)/ir_Tcl.cpp $(USER_DIR)/ir_Tcl.h $(GTEST_HEADERS)
 
 ir_Lego.o : $(USER_DIR)/ir_Lego.cpp $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/ir_Lego.cpp
+
+ir_Argo.o : $(USER_DIR)/ir_Argo.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Argo.cpp


### PR DESCRIPTION
This probably doesn't work as we have no test data to speak of and is
based soley on `sendArgo()` which may or may not work, but it self decodes.

Unit tests for a lot of the class methods have been added.