### PR TITLE
IRMQTTServer: Add sequencing for sending MQTT IR commands.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -181,7 +181,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.1.0-beta"
+#define _MY_VERSION_ "v1.1.1-beta"
 
 const uint8_t kSendTableSize = sizeof(gpioTable);
 // JSON stuff
@@ -199,6 +199,10 @@ const char* kHttpPassKey = "http_pass";
 #if MQTT_ENABLE
 const uint32_t kBroadcastPeriodMs = MQTTbroadcastInterval * 1000;  // mSeconds.
 const uint32_t kStatListenPeriodMs = 5 * 1000;  // mSeconds
+const int32_t kMaxPauseMs = 10000;  // 10 Seconds.
+const char * kSequenceDelimiter = ";";
+const char * kCommandDelimiter = ",";
+const char kPauseChar = 'P';
 
 void mqttCallback(char* topic, byte* payload, unsigned int length);
 String listOfCommandTopics(void);

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -9,7 +9,7 @@ lib_deps_builtin =
 lib_deps_external =
   PubSubClient
   WifiManager@0.14
-  ArduinoJson
+  ArduinoJson@<6.0
 
 [env:nodemcuv2]
 platform = espressif8266


### PR DESCRIPTION
- Tested on a d1_mini. Appears to work fine and as expected.
- Solves a problem where subsequent MQTT commands could be missed.
- Allows for better timing control between sending multiple IR messages.