### PR TITLE
Update swing handling for Fujitsu A/Cs.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -266,34 +266,45 @@ void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
                    const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                    const bool quiet, const bool turbo, const bool econo) {
   ac->setModel(model);
-  ac->setMode(ac->convertMode(mode));
-  ac->setTemp(degrees);
-  ac->setFanSpeed(ac->convertFan(fan));
-  uint8_t swing = kFujitsuAcSwingOff;
-  if (swingv > stdAc::swingv_t::kOff) swing |= kFujitsuAcSwingVert;
-  if (swingh > stdAc::swingh_t::kOff) swing |= kFujitsuAcSwingHoriz;
-  ac->setSwing(swing);
-  if (quiet) ac->setFanSpeed(kFujitsuAcFanQuiet);
-  if (ac->getModel() == fujitsu_ac_remote_model_t::ARREB1E) {
-    // Some functions are only available on some models.
-    if (turbo) {
-      ac->setCmd(kFujitsuAcCmdPowerful);
-      // Powerful is a separate command.
-      ac->send();
+  if (on) {
+    // Do all special messages (except "Off") first,
+    // These need to be sent separately.
+    switch (ac->getModel()) {
+      // Some functions are only available on some models.
+      case fujitsu_ac_remote_model_t::ARREB1E:
+        if (turbo) {
+          ac->setCmd(kFujitsuAcCmdPowerful);
+          // Powerful is a separate command.
+          ac->send();
+        }
+        if (econo) {
+          ac->setCmd(kFujitsuAcCmdEcono);
+          // Econo is a separate command.
+          ac->send();
+        }
+        break;
+      default:
+        {};
     }
-    if (econo) {
-      ac->setCmd(kFujitsuAcCmdEcono);
-      // Econo is a separate command.
-      ac->send();
-    }
+    // Normal operation.
+    ac->setMode(ac->convertMode(mode));
+    ac->setTemp(degrees);
+    ac->setFanSpeed(ac->convertFan(fan));
+    uint8_t swing = kFujitsuAcSwingOff;
+    if (swingv > stdAc::swingv_t::kOff) swing |= kFujitsuAcSwingVert;
+    if (swingh > stdAc::swingh_t::kOff) swing |= kFujitsuAcSwingHoriz;
+    ac->setSwing(swing);
+    if (quiet) ac->setFanSpeed(kFujitsuAcFanQuiet);
+    // No Light setting available.
+    // No Filter setting available.
+    // No Clean setting available.
+    // No Beep setting available.
+    // No Sleep setting available.
+    // No Clock setting available.
+  } else {
+    // Off is special case/message. We don't need to send other messages.
+    ac->off();
   }
-  // No Light setting available.
-  // No Filter setting available.
-  // No Clean setting available.
-  // No Beep setting available.
-  // No Sleep setting available.
-  // No Clock setting available.
-  if (!on) ac->off();
   ac->send();
 }
 #endif  // SEND_FUJITSU_AC

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -173,8 +173,11 @@ TEST(TestIRac, Fujitsu) {
   IRFujitsuAC ac(0);
   IRac irac(0);
   IRrecv capture(0);
-  std::string expected =
-      "Power: On, Mode: 1 (COOL), Temp: 19C, Fan: 2 (MED), "
+  std::string ardb1_expected =
+      "Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 19C, Fan: 2 (MED), "
+      "Command: N/A";
+  std::string arrah2e_expected =
+      "Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 19C, Fan: 2 (MED), "
       "Swing: Off, Command: N/A";
 
   ac.begin();
@@ -189,13 +192,13 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Quiet
                false,                       // Turbo (Powerful)
                false);                      // Econo
-  ASSERT_EQ("Model: 2 (ARDB1), " + expected, ac.toString());
+  ASSERT_EQ(ardb1_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits - 8, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state, ac._irsend.capture.bits / 8);
-  ASSERT_EQ("Model: 2 (ARDB1), " + expected, ac.toString());
+  ASSERT_EQ(ardb1_expected, ac.toString());
 
   ac._irsend.reset();
   irac.fujitsu(&ac,
@@ -209,13 +212,13 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Quiet
                false,                       // Turbo (Powerful)
                false);                      // Econo
-  ASSERT_EQ("Model: 1 (ARRAH2E), " + expected, ac.toString());
+  ASSERT_EQ(arrah2e_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
   ac.setRaw(ac._irsend.capture.state, ac._irsend.capture.bits / 8);
-  ASSERT_EQ("Model: 1 (ARRAH2E), " + expected, ac.toString());
+  ASSERT_EQ(arrah2e_expected, ac.toString());
 }
 
 TEST(TestIRac, Goodweather) {

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -6,188 +6,175 @@
 #include "ir_Fujitsu.h"
 #include "gtest/gtest.h"
 
-template<typename T, size_t size>
-::testing::AssertionResult ArraysMatch(const T (&expected)[size],
-                                       const T* actual) {
-  for (size_t i(0); i < size; ++i) {
-    if (expected[i] != actual[i]) {
-      int e = expected[i];
-      int a = actual[i];
-      return ::testing::AssertionFailure() << "array[" << i
-        << "] (" << std::hex << a << std::dec << ") != expected[" << i
-        << "] (" << std::hex << e << std::dec << ")";
-    }
-  }
-  return ::testing::AssertionSuccess();
-}
 // Tests for Fujitsu A/C methods.
 
 // Test sending typical data only.
 TEST(TestIRFujitsuACClass, GetRawDefault) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);  // AR-RAH2E
-  fujitsu.setSwing(kFujitsuAcSwingBoth);
-  fujitsu.setMode(kFujitsuAcModeCool);
-  fujitsu.setFanSpeed(kFujitsuAcFanHigh);
-  fujitsu.setTemp(24);
-  fujitsu.setCmd(kFujitsuAcCmdTurnOn);
+  IRFujitsuAC ac(0);  // AR-RAH2E
+  ac.setSwing(kFujitsuAcSwingBoth);
+  ac.setMode(kFujitsuAcModeCool);
+  ac.setFanSpeed(kFujitsuAcFanHigh);
+  ac.setTemp(24);
+  ac.setCmd(kFujitsuAcCmdTurnOn);
   uint8_t expected_arrah2e[16] = {
       0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
       0x81, 0x01, 0x31, 0x00, 0x00, 0x00, 0x20, 0xFD};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 16 * 8);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
             "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: N/A",
-            fujitsu.toString());
+            ac.toString());
 
   uint8_t expected_ardb1[15] = {
       0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
-      0x81, 0x01, 0x31, 0x00, 0x00, 0x00, 0x1D};
-  fujitsu.setModel(ARDB1);
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
+      0x81, 0x01, 0x01, 0x00, 0x00, 0x00, 0x4D};
+  ac.setModel(ARDB1);
+  EXPECT_STATE_EQ(expected_ardb1, ac.getRaw(), 15 * 8);
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: N/A",
-            fujitsu.toString());
+            "Fan: 1 (HIGH), Command: N/A",
+            ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, GetRawTurnOff) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  fujitsu.setModel(ARRAH2E);
-  fujitsu.off();
+  IRFujitsuAC ac(0);
+  ac.setModel(ARRAH2E);
+  ac.off();
   uint8_t expected_arrah2e[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02, 0xFD};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLengthShort, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 7 * 8);
+  EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: Off, Mode: 1 (COOL), Temp: 24C, "
             "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: N/A",
-            fujitsu.toString());
+            ac.toString());
 
-  fujitsu.setModel(ARDB1);
+  ac.setModel(ARDB1);
   uint8_t expected_ardb1[6] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02};
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLengthShort - 1, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected_ardb1, ac.getRaw(), 6 * 8);
+  EXPECT_EQ(kFujitsuAcStateLengthShort - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: Off, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: N/A",
-            fujitsu.toString());
+            "Fan: 1 (HIGH), Command: N/A",
+            ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, GetRawStepHoriz) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  fujitsu.stepHoriz();
+  IRFujitsuAC ac(0);
+  ac.stepHoriz();
   uint8_t expected[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x79, 0x86};
-  EXPECT_TRUE(ArraysMatch(expected, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLengthShort, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected, ac.getRaw(), 7 * 8);
+  EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
       "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: Step vane horizontally",
-      fujitsu.toString());
+      ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, GetRawStepVert) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  fujitsu.setModel(ARRAH2E);
-  fujitsu.stepVert();
+  IRFujitsuAC ac(0);
+  ac.setModel(ARRAH2E);
+  ac.stepVert();
   uint8_t expected_arrah2e[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x6C, 0x93};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLengthShort, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 7 * 8);
+  EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
             "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: Step vane vertically",
-            fujitsu.toString());
+            ac.toString());
 
-  fujitsu.setModel(ARDB1);
-  fujitsu.stepVert();
+  ac.setModel(ARDB1);
+  ac.stepVert();
   uint8_t expected_ardb1[6] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x6C};
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, fujitsu.getRaw()));
+  EXPECT_STATE_EQ(expected_ardb1, ac.getRaw(), 6 * 8);
   EXPECT_EQ(kFujitsuAcStateLengthShort - 1,
-            fujitsu.getStateLength());
+            ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: Step vane vertically",
-            fujitsu.toString());
+            "Fan: 1 (HIGH), Command: Step vane vertically",
+            ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, GetRawWithSwingHoriz) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  fujitsu.setCmd(kFujitsuAcCmdStayOn);
-  fujitsu.setSwing(kFujitsuAcSwingHoriz);
-  fujitsu.setMode(kFujitsuAcModeCool);
-  fujitsu.setFanSpeed(kFujitsuAcFanQuiet);
-  fujitsu.setTemp(25);
+  IRFujitsuAC ac(0);
+  ac.setCmd(kFujitsuAcCmdStayOn);
+  ac.setSwing(kFujitsuAcSwingHoriz);
+  ac.setMode(kFujitsuAcModeCool);
+  ac.setFanSpeed(kFujitsuAcFanQuiet);
+  ac.setTemp(25);
   uint8_t expected[16] = {0x14, 0x63, 0x0, 0x10, 0x10, 0xFE, 0x9, 0x30,
                           0x90, 0x1, 0x24, 0x0, 0x0, 0x0, 0x20, 0xFB};
-  EXPECT_TRUE(ArraysMatch(expected, fujitsu.getRaw()));
+  EXPECT_STATE_EQ(expected, ac.getRaw(), 16 * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 25C, "
             "Fan: 4 (QUIET), Swing: Horiz, Command: N/A",
-            fujitsu.toString());
+            ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, GetRawWithFan) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  fujitsu.setCmd(kFujitsuAcCmdStayOn);
-  fujitsu.setSwing(kFujitsuAcSwingHoriz);
-  fujitsu.setMode(kFujitsuAcModeFan);
-  fujitsu.setFanSpeed(kFujitsuAcFanMed);
-  fujitsu.setTemp(20);  // temp doesn't matter for fan
+  IRFujitsuAC ac(0);
+  ac.setCmd(kFujitsuAcCmdStayOn);
+  ac.setSwing(kFujitsuAcSwingHoriz);
+  ac.setMode(kFujitsuAcModeFan);
+  ac.setFanSpeed(kFujitsuAcFanMed);
+  ac.setTemp(20);  // temp doesn't matter for fan
                         // but it is sent by the RC anyway
-  fujitsu.setModel(ARRAH2E);
+  ac.setModel(ARRAH2E);
   uint8_t expected_arrah2e[16] = {
-      0x14, 0x63, 0x0, 0x10, 0x10, 0xFE, 0x9, 0x30,
-      0x40, 0x3, 0x22, 0x0, 0x0, 0x0, 0x20, 0x4B};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0x40, 0x03, 0x22, 0x00, 0x00, 0x00, 0x20, 0x4B};
+  EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 16 * 8);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 3 (FAN), Temp: 20C, "
-            "Fan: 2 (MED), Swing: Horiz, Command: N/A", fujitsu.toString());
+            "Fan: 2 (MED), Swing: Horiz, Command: N/A", ac.toString());
 
-  fujitsu.setModel(ARDB1);
+  ac.setModel(ARDB1);
   uint8_t expected_ardb1[15] = {
-      0x14, 0x63, 0x0, 0x10, 0x10, 0xFC, 0x8, 0x30,
-      0x40, 0x3, 0x22, 0x0, 0x0, 0x0, 0x6B};
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, fujitsu.getRaw()));
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
+      0x40, 0x03, 0x02, 0x00, 0x00, 0x00, 0x8B};
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
+  EXPECT_STATE_EQ(expected_ardb1, ac.getRaw(), ac.getStateLength() * 8);
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 3 (FAN), Temp: 20C, "
-            "Fan: 2 (MED), Swing: Horiz, Command: N/A", fujitsu.toString());
+            "Fan: 2 (MED), Command: N/A", ac.toString());
 }
 
 TEST(TestIRFujitsuACClass, SetRaw) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
-  EXPECT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+  IRFujitsuAC ac(0);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   uint8_t expected_default_arrah2e[kFujitsuAcStateLength] = {
       0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
       0x81, 0x01, 0x31, 0x00, 0x00, 0x00, 0x20, 0xFD};
-  EXPECT_TRUE(ArraysMatch(expected_default_arrah2e, fujitsu.getRaw()));
+  EXPECT_STATE_EQ(expected_default_arrah2e, ac.getRaw(),
+                  ac.getStateLength() * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
             "Fan: 1 (HIGH), Swing: Vert + Horiz, Command: N/A",
-            fujitsu.toString());
+            ac.toString());
   // Now set a new state via setRaw();
   // This state is a real state from an AR-DB1 remote.
   uint8_t new_state1[kFujitsuAcStateLength - 1] = {
     0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
     0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x9F};
-  fujitsu.setRaw(new_state1, kFujitsuAcStateLength - 1);
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
-  EXPECT_TRUE(ArraysMatch(new_state1, fujitsu.getRaw()));
+  ac.setRaw(new_state1, kFujitsuAcStateLength - 1);
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
+  EXPECT_STATE_EQ(new_state1, ac.getRaw(), ac.getStateLength() * 8);
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 19C, "
-            "Fan: 0 (AUTO), Swing: Off, Command: N/A", fujitsu.toString());
+            "Fan: 0 (AUTO), Command: N/A", ac.toString());
 }
 
 TEST(TestSendFujitsuAC, GenerateMessage) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  IRsendTest irsend(4);
-  fujitsu.begin();
+  IRFujitsuAC ac(0);
+  IRsendTest irsend(0);
+  ac.begin();
   irsend.begin();
 
-  fujitsu.setCmd(kFujitsuAcCmdStayOn);
-  fujitsu.setSwing(kFujitsuAcSwingBoth);
-  fujitsu.setMode(kFujitsuAcModeCool);
-  fujitsu.setFanSpeed(kFujitsuAcFanHigh);
-  fujitsu.setTemp(24);
+  ac.setCmd(kFujitsuAcCmdStayOn);
+  ac.setSwing(kFujitsuAcSwingBoth);
+  ac.setMode(kFujitsuAcModeCool);
+  ac.setFanSpeed(kFujitsuAcFanHigh);
+  ac.setTemp(24);
 
-  EXPECT_EQ(kFujitsuAcFanHigh, fujitsu.getFanSpeed());
-  EXPECT_EQ(kFujitsuAcModeCool, fujitsu.getMode());
-  EXPECT_EQ(24, fujitsu.getTemp());
-  EXPECT_EQ(kFujitsuAcSwingBoth, fujitsu.getSwing());
-  EXPECT_EQ(kFujitsuAcCmdStayOn, fujitsu.getCmd());
+  EXPECT_EQ(kFujitsuAcFanHigh, ac.getFanSpeed());
+  EXPECT_EQ(kFujitsuAcModeCool, ac.getMode());
+  EXPECT_EQ(24, ac.getTemp());
+  EXPECT_EQ(kFujitsuAcSwingBoth, ac.getSwing());
+  EXPECT_EQ(kFujitsuAcCmdStayOn, ac.getCmd());
 
   irsend.reset();
-  irsend.sendFujitsuAC(fujitsu.getRaw(), kFujitsuAcStateLength);
+  irsend.sendFujitsuAC(ac.getRaw(), kFujitsuAcStateLength);
   EXPECT_EQ(
   "f38000d50"
   "m3324s1574"
@@ -212,17 +199,17 @@ TEST(TestSendFujitsuAC, GenerateMessage) {
 }
 
 TEST(TestSendFujitsuAC, GenerateShortMessage) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  IRsendTest irsend(4);
-  fujitsu.begin();
+  IRFujitsuAC ac(0);
+  IRsendTest irsend(0);
+  ac.begin();
   irsend.begin();
 
-  fujitsu.off();
+  ac.off();
 
-  EXPECT_EQ(kFujitsuAcCmdTurnOff, fujitsu.getCmd());
+  EXPECT_EQ(kFujitsuAcCmdTurnOff, ac.getCmd());
 
   irsend.reset();
-  irsend.sendFujitsuAC(fujitsu.getRaw(), kFujitsuAcStateLengthShort);
+  irsend.sendFujitsuAC(ac.getRaw(), kFujitsuAcStateLengthShort);
   EXPECT_EQ(
   "f38000d50"
   "m3324s1574m448s390m448s390m448s1182m448s390m448s1182m448s390m448s390m448"
@@ -237,14 +224,14 @@ TEST(TestSendFujitsuAC, GenerateShortMessage) {
 
 // Issue #275
 TEST(TestSendFujitsuAC, Issue275) {
-  IRFujitsuAC fujitsu = IRFujitsuAC(4);
-  IRsendTest irsend(4);
-  fujitsu.begin();
+  IRFujitsuAC ac(0);
+  IRsendTest irsend(0);
+  ac.begin();
   irsend.begin();
   irsend.reset();
 
-  fujitsu.setCmd(kFujitsuAcCmdTurnOff);
-  irsend.sendFujitsuAC(fujitsu.getRaw(), kFujitsuAcStateLengthShort);
+  ac.setCmd(kFujitsuAcCmdTurnOff);
+  irsend.sendFujitsuAC(ac.getRaw(), kFujitsuAcStateLengthShort);
   EXPECT_EQ(
       "f38000d50"
       // Header
@@ -305,51 +292,51 @@ TEST(TestSendFujitsuAC, Issue275) {
 
 TEST(TestDecodeFujitsuAC, SyntheticShortMessages) {
   IRsendTest irsend(0);
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
+  IRFujitsuAC ac(0);
   IRrecv irrecv(0);
 
   irsend.begin();
   irsend.reset();
 
-  fujitsu.setModel(ARRAH2E);
-  fujitsu.setCmd(kFujitsuAcCmdTurnOff);
-  irsend.sendFujitsuAC(fujitsu.getRaw(), fujitsu.getStateLength());
+  ac.setModel(ARRAH2E);
+  ac.setCmd(kFujitsuAcCmdTurnOff);
+  irsend.sendFujitsuAC(ac.getRaw(), ac.getStateLength());
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcMinBits + 8, irsend.capture.bits);
   uint8_t expected_arrah2e[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02, 0xFD};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, irsend.capture.state));
+  EXPECT_STATE_EQ(expected_arrah2e, irsend.capture.state, irsend.capture.bits);
 
   irsend.reset();
 
-  fujitsu.setModel(ARDB1);
-  fujitsu.setCmd(kFujitsuAcCmdTurnOff);
-  irsend.sendFujitsuAC(fujitsu.getRaw(), fujitsu.getStateLength());
+  ac.setModel(ARDB1);
+  ac.setCmd(kFujitsuAcCmdTurnOff);
+  irsend.sendFujitsuAC(ac.getRaw(), ac.getStateLength());
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcMinBits, irsend.capture.bits);
   uint8_t expected_ardb1[6] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02};
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, irsend.capture.state));
+  EXPECT_STATE_EQ(expected_ardb1, irsend.capture.state, irsend.capture.bits);
 }
 
 TEST(TestDecodeFujitsuAC, SyntheticLongMessages) {
   IRsendTest irsend(0);
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
+  IRFujitsuAC ac(0);
   IRrecv irrecv(0);
   irsend.begin();
 
   irsend.reset();
 
-  fujitsu.setModel(ARRAH2E);
-  fujitsu.setCmd(kFujitsuAcCmdStayOn);
-  fujitsu.setSwing(kFujitsuAcSwingVert);
-  fujitsu.setMode(kFujitsuAcModeCool);
-  fujitsu.setFanSpeed(kFujitsuAcFanQuiet);
-  fujitsu.setTemp(18);
-  irsend.sendFujitsuAC(fujitsu.getRaw(), fujitsu.getStateLength());
-  ASSERT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+  ac.setModel(ARRAH2E);
+  ac.setCmd(kFujitsuAcCmdStayOn);
+  ac.setSwing(kFujitsuAcSwingVert);
+  ac.setMode(kFujitsuAcModeCool);
+  ac.setFanSpeed(kFujitsuAcFanQuiet);
+  ac.setTemp(18);
+  irsend.sendFujitsuAC(ac.getRaw(), ac.getStateLength());
+  ASSERT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decodeFujitsuAC(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
@@ -357,34 +344,34 @@ TEST(TestDecodeFujitsuAC, SyntheticLongMessages) {
   uint8_t expected_arrah2e[kFujitsuAcStateLength] = {
     0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
     0x20, 0x01, 0x14, 0x00, 0x00, 0x00, 0x20, 0x7B};
-  EXPECT_TRUE(ArraysMatch(expected_arrah2e, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected_arrah2e, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 18C, "
-            "Fan: 4 (QUIET), Swing: Vert, Command: N/A", fujitsu.toString());
+            "Fan: 4 (QUIET), Swing: Vert, Command: N/A", ac.toString());
 
   irsend.reset();
 
-  fujitsu.setModel(ARDB1);
-  irsend.sendFujitsuAC(fujitsu.getRaw(), fujitsu.getStateLength());
+  ac.setModel(ARDB1);
+  irsend.sendFujitsuAC(ac.getRaw(), ac.getStateLength());
   irsend.makeDecodeResult();
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits - 8, irsend.capture.bits);
   uint8_t expected_ardb1[kFujitsuAcStateLength - 1] = {
     0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
-    0x20, 0x01, 0x14, 0x00, 0x00, 0x00, 0x9B};
-  EXPECT_TRUE(ArraysMatch(expected_ardb1, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
+    0x20, 0x01, 0x04, 0x00, 0x00, 0x00, 0xAB};
+  EXPECT_STATE_EQ(expected_ardb1, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 18C, "
-            "Fan: 4 (QUIET), Swing: Vert, Command: N/A", fujitsu.toString());
+            "Fan: 4 (QUIET), Command: N/A", ac.toString());
 }
 
 TEST(TestDecodeFujitsuAC, RealShortARDB1OffExample) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
+  IRFujitsuAC ac(0);
 
   irsend.begin();
 
@@ -406,17 +393,17 @@ TEST(TestDecodeFujitsuAC, RealShortARDB1OffExample) {
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcMinBits, irsend.capture.bits);
   uint8_t expected[6] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02};
-  EXPECT_TRUE(ArraysMatch(expected, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLengthShort - 1, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLengthShort - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: Off, Mode: 0 (AUTO), Temp: 16C, "
-            "Fan: 0 (AUTO), Swing: Off, Command: N/A", fujitsu.toString());
+            "Fan: 0 (AUTO), Command: N/A", ac.toString());
 }
 
 TEST(TestDecodeFujitsuAC, RealLongARDB1Example) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
+  IRFujitsuAC ac(0);
 
   irsend.begin();
   irsend.reset();
@@ -450,11 +437,11 @@ TEST(TestDecodeFujitsuAC, RealLongARDB1Example) {
   uint8_t expected1[kFujitsuAcStateLength - 1] = {
       0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
       0x21, 0x01, 0x04, 0x00, 0x00, 0x00, 0xAA};
-  EXPECT_TRUE(ArraysMatch(expected1, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected1, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 18C, "
-            "Fan: 4 (QUIET), Swing: Off, Command: N/A", fujitsu.toString());
+            "Fan: 4 (QUIET), Command: N/A", ac.toString());
 
   irsend.reset();
   uint16_t rawData2[243] = {
@@ -487,17 +474,17 @@ TEST(TestDecodeFujitsuAC, RealLongARDB1Example) {
   uint8_t expected2[kFujitsuAcStateLength - 1] = {
       0x14, 0x63, 0x00, 0x10, 0x10, 0xFC, 0x08, 0x30,
       0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x9F};
-  EXPECT_TRUE(ArraysMatch(expected2, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLength - 1, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(expected2, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLength - 1, ac.getStateLength());
   EXPECT_EQ("Model: 2 (ARDB1), Power: On, Mode: 1 (COOL), Temp: 19C, "
-            "Fan: 0 (AUTO), Swing: Off, Command: N/A", fujitsu.toString());
+            "Fan: 0 (AUTO), Command: N/A", ac.toString());
 }
 
 TEST(TestDecodeFujitsuAC, Issue414) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
-  IRFujitsuAC fujitsu = IRFujitsuAC(0);
+  IRFujitsuAC ac(0);
 
   // Capture as supplied by arpmota
   uint16_t rawData[259] = {3352, 1574, 480, 350, 480, 346, 480, 1190, 458, 346,
@@ -529,11 +516,11 @@ TEST(TestDecodeFujitsuAC, Issue414) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, irsend.capture.bits);
-  EXPECT_TRUE(ArraysMatch(state, irsend.capture.state));
-  fujitsu.setRaw(irsend.capture.state, irsend.capture.bits / 8);
-  EXPECT_EQ(kFujitsuAcStateLength, fujitsu.getStateLength());
+  EXPECT_STATE_EQ(state, irsend.capture.state, irsend.capture.bits);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 4 (HEAT), Temp: 24C, "
-            "Fan: 0 (AUTO), Swing: Off, Command: N/A", fujitsu.toString());
+            "Fan: 0 (AUTO), Swing: Off, Command: N/A", ac.toString());
 
   // Resend it using the state this time.
   irsend.reset();
@@ -542,7 +529,7 @@ TEST(TestDecodeFujitsuAC, Issue414) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(FUJITSU_AC, irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, irsend.capture.bits);
-  EXPECT_TRUE(ArraysMatch(state, irsend.capture.state));
+  EXPECT_STATE_EQ(state, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "f38000d50"
       "m3324s1574"
@@ -770,7 +757,7 @@ TEST(TestIRFujitsuACClass, toggleSwing) {
 
   EXPECT_EQ(
       "Model: 4 (ARJW2), Power: On, Mode: 1 (COOL), Temp: 24C, Fan: 1 (HIGH), "
-      "Swing: Vert + Horiz, Command: Toggle horizontal swing",
+      "Command: Toggle horizontal swing",
       ac.toString());
 
   // Test without the update set.


### PR DESCRIPTION
- Ditch using the internal swing state for some Fujitsu A/C models.
- Rework unit tests based on above.
- Refactor unit tests to use `EXPECT_STATE_EQ()`
- Update common A/C support to reflect model specific swing changes.

Fixes #688