### PR TITLE
[BUG] Add missing on/off() to IRCoolixAC class.

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -1,5 +1,5 @@
 // Copyright bakrus
-// Copyright 2017 David Conran
+// Copyright 2017,2019 David Conran
 
 #include "ir_Coolix.h"
 #include <algorithm>
@@ -20,6 +20,7 @@
 //
 // Supports:
 //   RG57K7(B)/BGEF remote control for Beko BINR 070/071 split-type aircon.
+//   MSABAU-07HRFN1-QRD0GW Midea aircon unit (circa 2016)
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/484
 

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -200,6 +200,14 @@ void IRCoolixAC::setPower(const bool power) {
   }
 }
 
+void IRCoolixAC::on(void) {
+  this->setPower(true);
+}
+
+void IRCoolixAC::off(void) {
+  this->setPower(false);
+}
+
 bool IRCoolixAC::getSwing() { return remote_state == kCoolixSwing; }
 
 void IRCoolixAC::setSwing() {
@@ -260,18 +268,30 @@ void IRCoolixAC::clearSensorTemp() {
 
 void IRCoolixAC::setMode(const uint8_t mode) {
   uint32_t actualmode = mode;
+  switch (actualmode) {
+    case kCoolixAuto:
+    case kCoolixDry:
+      if (this->getFan() == kCoolixFanAuto)
+        //  No kCoolixFanAuto in Dry/Auto mode.
+        this->setFan(kCoolixFanAuto0, false);
+      break;
+    case kCoolixCool:
+    case kCoolixHeat:
+    case kCoolixFan:
+      if (this->getFan() == kCoolixFanAuto0)
+        // kCoolixFanAuto0 only in Dry/Auto mode.
+        this->setFan(kCoolixFanAuto, false);
+      break;
+    default:  // Anything else, go with Auto mode.
+      this->setMode(kCoolixAuto);
+      return;
+  }
   // Fan mode is a special case of Dry.
   if (mode == kCoolixFan) actualmode = kCoolixDry;
-  switch (actualmode) {
-    case kCoolixCool:
-    case kCoolixAuto:
-    case kCoolixHeat:
-    case kCoolixDry:
-      recoverSavedState();
-      remote_state = (remote_state & ~kCoolixModeMask) | (actualmode << 2);
-      // Force the temp into a known-good state.
-      setTemp(getTemp());
-  }
+  recoverSavedState();
+  remote_state = (remote_state & ~kCoolixModeMask) | (actualmode << 2);
+  // Force the temp into a known-good state.
+  setTemp(getTemp());
   if (mode == kCoolixFan) setTempRaw(kCoolixFanTempCode);
 }
 
@@ -286,15 +306,33 @@ uint8_t IRCoolixAC::getFan() {
   return (getNormalState() & kCoolixFanMask) >> 13;
 }
 
-void IRCoolixAC::setFan(const uint8_t speed) {
+void IRCoolixAC::setFan(const uint8_t speed, const bool modecheck) {
   recoverSavedState();
   uint8_t newspeed = speed;
   switch (speed) {
+    case kCoolixFanAuto:  // Dry & Auto mode can't have this speed.
+      if (modecheck) {
+        switch (this->getMode()) {
+          case kCoolixAuto:
+          case kCoolixDry:
+            newspeed = kCoolixFanAuto0;
+        }
+      }
+      break;
+    case kCoolixFanAuto0:  // Only Dry & Auto mode can have this speed.
+      if (modecheck) {
+        switch (this->getMode()) {
+          case kCoolixAuto:
+          case kCoolixDry:
+            break;
+          default:
+            newspeed = kCoolixFanAuto;
+        }
+      }
+      break;
     case kCoolixFanMin:
     case kCoolixFanMed:
     case kCoolixFanMax:
-    case kCoolixFanAuto:
-    case kCoolixFanAuto0:
     case kCoolixFanZoneFollow:
     case kCoolixFanFixed:
       break;

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -106,7 +106,7 @@ class IRCoolixAC {
   void setSensorTemp(const uint8_t desired);
   uint8_t getSensorTemp();
   void clearSensorTemp();
-  void setFan(const uint8_t fan);
+  void setFan(const uint8_t speed, const bool modecheck = true);
   uint8_t getFan();
   void setMode(const uint8_t mode);
   uint8_t getMode();

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -395,6 +395,8 @@ TEST(TestCoolixACClass, SetAndGetMode) {
 TEST(TestCoolixACClass, SetAndGetFan) {
   IRCoolixAC ircoolix(0);
 
+  // This mode allows pretty much everything except Auto0 speed.
+  ircoolix.setMode(kCoolixCool);
   ircoolix.setFan(kCoolixFanMax);
   EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
   ircoolix.setFan(kCoolixFanMin);
@@ -403,12 +405,29 @@ TEST(TestCoolixACClass, SetAndGetFan) {
   EXPECT_EQ(kCoolixFanZoneFollow, ircoolix.getFan());
   ircoolix.setFan(kCoolixFanAuto);
   EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
+  ircoolix.setFan(kCoolixFanAuto0);
+  EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
   ircoolix.setFan(kCoolixFanMax);
   EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
   ASSERT_NE(3, kCoolixFanAuto);
   // Now try some unexpected value.
   ircoolix.setFan(3);
   EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
+
+  // These modes allows pretty much everything except Auto speed.
+  ircoolix.setMode(kCoolixDry);
+  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
+  ircoolix.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
+  ircoolix.setFan(kCoolixFanAuto);
+  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
+
+  ircoolix.setMode(kCoolixAuto);
+  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
+  ircoolix.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
+  ircoolix.setFan(kCoolixFanAuto0);
+  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
 }
 
 TEST(TestCoolixACClass, SetGetClearSensorTempAndZoneFollow) {
@@ -625,4 +644,104 @@ TEST(TestCoolixACClass, toCommon) {
   ASSERT_FALSE(ac.toCommon().filter);
   ASSERT_FALSE(ac.toCommon().beep);
   ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+TEST(TestCoolixACClass, Issue722) {
+  IRrecv irrecv(0);
+  IRCoolixAC ac(0);
+
+  // Auto 17C ON pressed
+  uint32_t on_auto_17c_fan_auto0 = 0xB21F08;
+  ac.begin();
+  ac.setPower(true);
+  ac.setMode(kCoolixAuto);
+  ac.setFan(kCoolixFanAuto);
+  ac.setTemp(17);
+  EXPECT_EQ(on_auto_17c_fan_auto0, ac.getRaw());
+
+  // Off
+  uint32_t off = 0xB27BE0;
+  ac.off();
+  EXPECT_EQ(off, ac.getRaw());
+
+  // ON Auto Temp 18C
+  uint32_t on_auto_18c_fan_auto0 = 0xB21F18;
+  ac.setTemp(18);
+  EXPECT_EQ(on_auto_18c_fan_auto0, ac.getRaw());
+
+  // Set Mode Cool 18C
+  uint32_t on_cool_18c_fan_auto = 0xB2BF10;
+  ac.setMode(kCoolixCool);
+  EXPECT_EQ(on_cool_18c_fan_auto, ac.getRaw());
+
+  // Set Mode DRY 18C
+  uint32_t on_dry_18c_fan_auto0 = 0xB21F14;
+  ac.setMode(kCoolixDry);
+  EXPECT_EQ(on_dry_18c_fan_auto0, ac.getRaw());
+
+  // Set Mode HEAT 18C
+  uint32_t on_heat_18c_fan_auto = 0xB2BF1C;
+  ac.setMode(kCoolixHeat);
+  EXPECT_EQ(on_heat_18c_fan_auto, ac.getRaw());
+
+  // Set mode FAN
+  uint32_t on_fan_18c_fan_auto = 0xB2BFE4;
+  ac.setMode(kCoolixFan);
+  EXPECT_EQ(on_fan_18c_fan_auto, ac.getRaw());
+
+  // Fan level 2 (initial was auto)
+  uint32_t on_fan_18c_fan_min = 0xB29FE4;
+  ac.setFan(kCoolixFanMin);
+  EXPECT_EQ(on_fan_18c_fan_min, ac.getRaw());
+
+  // Fan level 3
+  uint32_t on_fan_18c_fan_med = 0xB25FE4;
+  ac.setFan(kCoolixFanMed);
+  EXPECT_EQ(on_fan_18c_fan_med, ac.getRaw());
+
+  // Fan level 4
+  uint32_t on_fan_18c_fan_max = 0xB23FE4;
+  ac.setFan(kCoolixFanMax);
+  EXPECT_EQ(on_fan_18c_fan_max, ac.getRaw());
+
+  // Test sending the last message to verify the class send() method works.
+  ac.send();
+  ac._irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&ac._irsend.capture));
+  EXPECT_EQ(COOLIX, ac._irsend.capture.decode_type);
+  EXPECT_EQ(kCoolixBits, ac._irsend.capture.bits);
+  EXPECT_EQ(on_fan_18c_fan_max, ac._irsend.capture.value);
+  EXPECT_EQ(0x0, ac._irsend.capture.address);
+  EXPECT_EQ(0x0, ac._irsend.capture.command);
+  EXPECT_EQ(
+      // Raw data supplied by @mariusmotea
+      "f38000d50"
+      // 4434,4376,
+      "m4480s4480"
+      // 566,1614,592,504,566,1618,566,1616,568,528,564,532,564,1616,568,532,
+      "m560s1680m560s560m560s1680m560s1680m560s560m560s560m560s1680m560s560"
+      // 566,530,566,1620,568,528,566,530,566,1618,564,1618,566,530,564,1624,
+      "m560s560m560s1680m560s560m560s560m560s1680m560s1680m560s560m560s1680"
+      // 538,560,566,530,564,1620,566,1618,566,1618,566,1616,566,1616,566,1620,
+      "m560s560m560s560m560s1680m560s1680m560s1680m560s1680m560s1680m560s1680"
+      // 568,1620,566,1616,566,530,566,530,564,530,562,532,564,530,566,530,
+      "m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560m560s560"
+      // 566,1622,566,1616,540,1642,566,528,566,530,566,1616,566,530,566,532,
+      "m560s1680m560s1680m560s1680m560s560m560s560m560s1680m560s560m560s560"
+      // 564,532,564,530,566,530,566,1614,566,1616,562,532,564,1620,566,1618,
+      "m560s560m560s560m560s560m560s1680m560s1680m560s560m560s1680m560s1680"
+      // 538,5254,4432,4364,566,1616,568,530,564,1620,568,1616,564,532,564,530,
+      "m560s5040m4480s4480m560s1680m560s560m560s1680m560s1680m560s560m560s560"
+      // 566,1616,566,532,564,532,566,1620,568,528,566,530,566,1616,564,1618,
+      "m560s1680m560s560m560s560m560s1680m560s560m560s560m560s1680m560s1680"
+      // 566,530,566,1622,566,532,566,528,566,1620,568,1614,566,1618,566,1618,
+      "m560s560m560s1680m560s560m560s560m560s1680m560s1680m560s1680m560s1680"
+      // 566,1614,568,1618,566,1622,568,1616,566,530,564,530,566,530,566,528,
+      "m560s1680m560s1680m560s1680m560s1680m560s560m560s560m560s560m560s560"
+      // 564,530,566,532,566,1622,564,1616,566,1616,564,532,564,530,564,1616,
+      "m560s560m560s560m560s1680m560s1680m560s1680m560s560m560s560m560s1680"
+      // 564,530,564,532,566,530,564,530,566,528,564,1618,564,1618,564,532,
+      "m560s560m560s560m560s560m560s560m560s560m560s1680m560s1680m560s560"
+      // 564,1620,566,1618,562  // Raw data matches what is expected.
+      "m560s1680m560s1680m560s5040", ac._irsend.outputStr());
 }


### PR DESCRIPTION
Seems we were missing the fairly standard `on()`/`off()` class methods.

Enforce the correct "auto" fan speed when in the corresponding op mode.
Previously this _might_ have created invalid Coolix Codes.

Unit tests to confirm everything constructs correctly compared to supplied
real-world data and message construction matches real-world data.

Fixes #722