### PR TITLE
Add kPeriodOffset for CPU Freq of 160MHz.

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -21,7 +21,6 @@
 // Constants
 // Offset (in microseconds) to use in Period time calculations to account for
 // code excution time in producing the software PWM signal.
-#if defined (ESP8266)
 #if (F_CPU == 160000000L)
 // Calculated on an ESP8266 NodeMCU v2 board using:
 // v2.6.0 with v2.5.2 ESP core @ 160MHz
@@ -30,7 +29,6 @@ const int8_t kPeriodOffset = -2;
 // Calculated on ESP8266 Wemos D1 mini using v2.4.1 with v2.4.0 ESP core @ 40MHz
 const int8_t kPeriodOffset = -5;
 #endif  // (F_CPU == 160000000L)
-#endif  // ESP8266
 const uint8_t kDutyDefault = 50;  // Percentage
 const uint8_t kDutyMax = 100;     // Percentage
 // delayMicroseconds() is only accurate to 16383us.

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -21,8 +21,16 @@
 // Constants
 // Offset (in microseconds) to use in Period time calculations to account for
 // code excution time in producing the software PWM signal.
-// Value was calculated on Wemos D1 mini using v2.4.1 with v2.4.0 ESP core
+#if defined (ESP8266)
+#if (F_CPU == 160000000L)
+// Calculated on an ESP8266 NodeMCU v2 board using:
+// v2.6.0 with v2.5.2 ESP core @ 160MHz
+const int8_t kPeriodOffset = -2;
+#else  // (F_CPU == 160000000L)
+// Calculated on ESP8266 Wemos D1 mini using v2.4.1 with v2.4.0 ESP core @ 40MHz
 const int8_t kPeriodOffset = -5;
+#endif  // (F_CPU == 160000000L)
+#endif  // ESP8266
 const uint8_t kDutyDefault = 50;  // Percentage
 const uint8_t kDutyMax = 100;     // Percentage
 // delayMicroseconds() is only accurate to 16383us.


### PR DESCRIPTION
Add a default value that should be correct @ 160MHz cpu freq.

Fixes #728