### PR TITLE
Add `calibrate()` to all the A/C classes.

### DIFF
--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -113,6 +113,7 @@ class IRArgoAC {
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_ARGO
   void begin(void);
   void on(void);

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -95,6 +95,7 @@ class IRCoolixAC {
   void stateReset();
 #if SEND_COOLIX
   void send(const uint16_t repeat = kCoolixDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_COOLIX
   void begin();
   void on();

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -233,6 +233,7 @@ class IRDaikinESP {
 
 #if SEND_DAIKIN
   void send(const uint16_t repeat = kDaikinDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin(void);
   void on(void);
@@ -312,6 +313,7 @@ class IRDaikin2 {
 
 #if SEND_DAIKIN2
   void send(const uint16_t repeat = kDaikin2DefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   void on();
@@ -409,6 +411,7 @@ class IRDaikin216 {
 
 #if SEND_DAIKIN216
   void send(const uint16_t repeat = kDaikin216DefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   uint8_t* getRaw();

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -90,6 +90,7 @@ class IRFujitsuAC {
   void stateReset(void);
 #if SEND_FUJITSU_AC
   void send(const uint16_t repeat = kFujitsuAcMinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_FUJITSU_AC
   void begin(void);
   void off(void);

--- a/src/ir_Goodweather.h
+++ b/src/ir_Goodweather.h
@@ -93,6 +93,7 @@ class IRGoodweatherAc {
   void stateReset(void);
 #if SEND_GOODWEATHER
   void send(const uint16_t repeat = kGoodweatherMinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_GOODWEATHER
   void begin(void);
   void on(void);

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -90,6 +90,7 @@ class IRGreeAC {
   void stateReset(void);
 #if SEND_GREE
   void send(const uint16_t repeat = kGreeDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_GREE
   void begin(void);
   void on(void);

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -194,6 +194,7 @@ class IRHaierAC {
 
 #if SEND_HAIER_AC
   void send(const uint16_t repeat = kHaierAcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HAIER_AC
   void begin(void);
 

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -39,6 +39,7 @@ class IRHitachiAc {
   void stateReset(void);
 #if SEND_HITACHI_AC
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HITACHI_AC
   void begin(void);
   void on(void);

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -134,6 +134,7 @@ class IRKelvinatorAC {
   void stateReset(void);
 #if SEND_KELVINATOR
   void send(const uint16_t repeat = kKelvinatorDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_KELVINATOR
   void begin(void);
   void on(void);

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -71,6 +71,7 @@ class IRMideaAC {
   void stateReset(void);
 #if SEND_MIDEA
   void send(const uint16_t repeat = kMideaMinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MIDEA
   void begin(void);
   void on(void);

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -68,6 +68,7 @@ class IRMitsubishiAC {
   void stateReset(void);
 #if SEND_MITSUBISHI_AC
   void send(const uint16_t repeat = kMitsubishiACMinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHI_AC
   void begin(void);
   void on(void);

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -122,6 +122,7 @@ class IRMitsubishiHeavy152Ac {
   void stateReset(void);
 #if SEND_MITSUBISHIHEAVY
   void send(const uint16_t repeat = kMitsubishiHeavy152MinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHIHEAVY
   void begin(void);
   void on(void);

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -86,6 +86,7 @@ class IRPanasonicAc {
   void stateReset(void);
 #if SEND_PANASONIC
   void send(const uint16_t repeat = kPanasonicAcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_PANASONIC
   void begin(void);
   void on(void);

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -71,6 +71,7 @@ class IRSamsungAc {
                     const bool calcchecksum = true);
   void sendOn(const uint16_t repeat = kSamsungAcDefaultRepeat);
   void sendOff(const uint16_t repeat = kSamsungAcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SAMSUNG_AC
   void begin(void);
   void on(void);

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -52,6 +52,7 @@ class IRSharpAc {
 
 #if SEND_SHARP_AC
   void send(const uint16_t repeat = kSharpAcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SHARP_AC
   void begin(void);
   void on(void);

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -52,6 +52,7 @@ class IRTcl112Ac {
 
 #if SEND_TCL112AC
   void send(const uint16_t repeat = kTcl112AcDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TCL
   void begin(void);
   uint8_t* getRaw(void);

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -52,6 +52,7 @@ class IRToshibaAC {
   void stateReset(void);
 #if SEND_TOSHIBA_AC
   void send(const uint16_t repeat = kToshibaACMinRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TOSHIBA_AC
   void begin(void);
   void on(void);

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -65,6 +65,7 @@ class IRTrotecESP {
 
 #if SEND_TROTEC
   void send(const uint16_t repeat = kTrotecDefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TROTEC
   void begin(void);
 

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -113,6 +113,7 @@ class IRVestelAc {
   void stateReset(void);
 #if SEND_VESTEL_AC
   void send(void);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_VESTEL_AC
   void begin(void);
   void on(void);

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -93,6 +93,7 @@ class IRWhirlpoolAc {
 #if SEND_WHIRLPOOL_AC
   void send(const uint16_t repeat = kWhirlpoolAcDefaultRepeat,
             const bool calcchecksum = true);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_WHIRLPOOL_AC
   void begin(void);
   void on(void);


### PR DESCRIPTION
You could run `calibrate()` on the IRsend class, but not the IRsend class
used inside each A/C class. Added the ability to use that if desired.

Ref #728