### PR TITLE
Add example code for a Smart(er) IR Repeater.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ script:
   - arduino --verify --board $BD $PWD/examples/ControlSamsungAC/ControlSamsungAC.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnPanasonicAC/TurnOnPanasonicAC.ino
   - arduino --verify --board $BD $PWD/examples/TurnOnMitsubishiHeavyAc/TurnOnMitsubishiHeavyAc.ino
+  - arduino --verify --board $BD $PWD/examples/DumbIRRepeater/DumbIRRepeater.ino
+  - arduino --verify --board $BD $PWD/examples/SmartIRRepeater/SmartIRRepeater.ino
 
   # Also check the tools programs compile.
   - (cd tools; make all)

--- a/examples/SmartIRRepeater/SmartIRRepeater.ino
+++ b/examples/SmartIRRepeater/SmartIRRepeater.ino
@@ -1,0 +1,143 @@
+/*
+ * IRremoteESP8266: SmartIRRepeater.ino - Record and playback IR codes.
+ * Copyright 2019 David Conran (crankyoldgit)
+ *
+ * This program will try to capture incoming IR messages and tries to
+ * intelligently replay them back.
+ * It uses the advanced detection features of the library, and the custom
+ * sending routines. Thus it will try to use the correct frequencies,
+ * duty cycles, and repeats as it thinks is required.
+ * Anything it doesn't understand, it will try to replay back as best it can,
+ * but at 38kHz.
+ * Note:
+ *   That might NOT be the frequency of the incoming message, so some not
+ *   recogised messages that are replayed may not work. The frequency & duty
+ *   cycle of unknown incoming messages is lost at the point of the Hardware IR
+ *   demodulator. The ESP can't see it.
+ *
+ *                               W A R N I N G
+ *   This code is just for educational/example use only. No help will be given
+ *   to you to make it do something else, or to make it work with some
+ *   weird device or circuit, or to make it more usable or practical.
+ *   If it works for you. Great. If not, Congratulations on changing/fixing it.
+ *
+ * An IR detector/demodulator must be connected to the input, kRecvPin.
+ * An IR LED circuit must be connected to the output, kIrLedPin.
+ *
+ * Example circuit diagrams (both are needed):
+ *  https://github.com/markszabo/IRremoteESP8266/wiki#ir-receiving
+ *  https://github.com/markszabo/IRremoteESP8266/wiki#ir-sending
+ *
+ * Common mistakes & tips:
+ *   * Don't just connect the IR LED directly to the pin, it won't
+ *     have enough current to drive the IR LED effectively.
+ *   * Make sure you have the IR LED polarity correct.
+ *     See: https://learn.sparkfun.com/tutorials/polarity/diode-and-led-polarity
+ *   * Some digital camera/phones can be used to see if the IR LED is flashed.
+ *     Replace the IR LED with a normal LED if you don't have a digital camera
+ *     when debugging.
+ *   * Avoid using the following pins unless you really know what you are doing:
+ *     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
+ *     * Pin 1/TX/TXD0: Any serial transmissions from the ESP will interfere.
+ *     * Pin 3/RX/RXD0: Any serial transmissions to the ESP will interfere.
+ *   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
+ *     for your first time. e.g. ESP-12 etc.
+ *
+ * Changes:
+ *   Version 1.0: June, 2019
+ *     - Initial version.
+ */
+
+#include <Arduino.h>
+#include <IRsend.h>
+#include <IRrecv.h>
+#include <IRremoteESP8266.h>
+#include <IRutils.h>
+
+// ==================== start of TUNEABLE PARAMETERS ====================
+
+// The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
+const uint16_t kRecvPin = 14;
+
+// GPIO to use to control the IR LED circuit. Recommended: 4 (D2).
+const uint16_t kIrLedPin = 4;
+
+// The Serial connection baud rate.
+// NOTE: Make sure you set your Serial Monitor to the same speed.
+const uint32_t kBaudRate = 115200;
+
+// As this program is a special purpose capture/resender, let's use a larger
+// than expected buffer so we can handle very large IR messages.
+const uint16_t kCaptureBufferSize = 1024;  // 1024 == ~511 bits
+
+// kTimeout is the Nr. of milli-Seconds of no-more-data before we consider a
+// message ended.
+const uint8_t kTimeout = 50;  // Milli-Seconds
+
+// kFrequency is the modulation frequency all UNKNOWN messages will be sent at.
+const uint16_t kFrequency = 38000;  // in Hz. e.g. 38kHz.
+
+// ==================== end of TUNEABLE PARAMETERS ====================
+
+// The IR transmitter.
+IRsend irsend(kIrLedPin);
+// The IR receiver.
+IRrecv irrecv(kRecvPin, kCaptureBufferSize, kTimeout, false);
+// Somewhere to store the captured message.
+decode_results results;
+
+// This section of code runs only once at start-up.
+void setup() {
+  irrecv.enableIRIn();  // Start up the IR receiver.
+  irsend.begin();       // Start up the IR sender.
+
+  Serial.begin(kBaudRate, SERIAL_8N1);
+  while (!Serial)  // Wait for the serial connection to be establised.
+    delay(50);
+  Serial.println();
+
+  Serial.print("SmartIRRepeater is now running and waiting for IR input "
+               "on Pin ");
+  Serial.println(kRecvPin);
+  Serial.print("and will retransmit it on Pin ");
+  Serial.println(kIrLedPin);
+}
+
+// The repeating section of the code
+void loop() {
+  // Check if an IR message has been received.
+  if (irrecv.decode(&results)) {  // We have captured something.
+    // The capture has stopped at this point.
+    decode_type_t protocol = results.decode_type;
+    uint16_t size = results.bits;
+    bool success = true;
+    // Is it a protocol we don't understand?
+    if (protocol == decode_type_t::UNKNOWN) {  // Yes.
+      // Convert the results into an array suitable for sendRaw().
+      // resultToRawArray() allocates the memory we need for the array.
+      uint16_t *raw_array = resultToRawArray(&results);
+      // Find out how many elements are in the array.
+      size = getCorrectedRawLength(&results);
+      // Send it out via the IR LED circuit.
+      irsend.sendRaw(raw_array, size, kFrequency);
+      // Deallocate the memory allocated by resultToRawArray().
+      delete [] raw_array;
+    } else if (hasACState(protocol)) {  // Does the message require a state[]?
+      // It does, so send with bytes instead.
+      success = irsend.send(protocol, results.state, size / 8);
+    } else {  // Anything else must be a simple message protocol. ie. <= 64 bits
+      success = irsend.send(protocol, results.value, size);
+    }
+    // Resume capturing IR messages. It was not restarted until after we sent
+    // the message so we didn't capture our own message.
+    irrecv.resume();
+
+    // Display a crude timestamp & notification.
+    uint32_t now = millis();
+    Serial.printf(
+        "%06u.%03u: A %d-bit %s message was %ssuccessfully retransmitted.\n",
+        now / 1000, now % 1000, size, typeToString(protocol).c_str(),
+        success ? "" : "un");
+  }
+  yield();  // Or delay(milliseconds); This ensures the ESP doesn't WDT reset.
+}

--- a/examples/SmartIRRepeater/platformio.ini
+++ b/examples/SmartIRRepeater/platformio.ini
@@ -1,0 +1,19 @@
+[platformio]
+lib_extra_dirs = ../../
+src_dir=.
+
+[common]
+build_flags =
+lib_deps_builtin =
+lib_deps_external =
+lib_ldf_mode = chain+
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -499,7 +499,8 @@ void IRsend::sendRaw(uint16_t buf[], uint16_t len, uint16_t hz) {
 //   nbits: How many bits long the message is to be.
 // Returns:
 //   bool: True if it is a type we can attempt to send, false if not.
-bool IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
+bool IRsend::send(const decode_type_t type, const uint64_t data,
+                  const uint16_t nbits) {
   switch (type) {
 #if SEND_AIWA_RC_T501
     case AIWA_RC_T501:
@@ -670,6 +671,141 @@ bool IRsend::send(decode_type_t type, uint64_t data, uint16_t nbits) {
       sendWhynter(data, nbits);
       break;
 #endif
+    default:
+      return false;
+  }
+  return true;
+}
+
+// Send a complex (>= 64 bits) IR message of a given type.
+// An unknown/unsupported type will do nothing.
+// Args:
+//   type:   Protocol number/type of the message you want to send.
+//   state:  A pointer to the array of bytes that make up the state[].
+//   nbytes: How many bytes are in the state.
+// Returns:
+//   bool: True if it is a type we can attempt to send, false if not.
+bool IRsend::send(const decode_type_t type, const unsigned char *state,
+                  const uint16_t nbytes) {
+  switch (type) {
+#if SEND_ARGO
+    case ARGO:
+      sendArgo(state, nbytes);
+      break;
+#endif  // SEND_ARGO
+#if SEND_DAIKIN
+    case DAIKIN:
+      sendDaikin(state, nbytes);
+      break;
+#endif  // SEND_DAIKIN
+#if SEND_DAIKIN2
+    case DAIKIN2:
+      sendDaikin2(state, nbytes);
+      break;
+#endif  // SEND_DAIKIN2
+#if SEND_DAIKIN216
+    case DAIKIN216:
+      sendDaikin216(state, nbytes);
+      break;
+#endif  // SEND_DAIKIN216
+#if SEND_ELECTRA_AC
+    case ELECTRA_AC:
+      sendElectraAC(state, nbytes);
+      break;
+#endif  // SEND_ELECTRA_AC
+#if SEND_FUJITSU_AC
+    case FUJITSU_AC:
+      sendFujitsuAC(state, nbytes);
+      break;
+#endif  // SEND_FUJITSU_AC
+#if SEND_GREE
+    case GREE:
+      sendGree(state, nbytes);
+      break;
+#endif  // SEND_GREE
+#if SEND_HAIER_AC
+    case HAIER_AC:
+      sendHaierAC(state, nbytes);
+      break;
+#endif  // SEND_HAIER_AC
+#if SEND_HAIER_AC_YRW02
+    case HAIER_AC_YRW02:
+      sendHaierACYRW02(state, nbytes);
+      break;
+#endif  // SEND_HAIER_AC_YRW02
+#if SEND_HITACHI_AC
+    case HITACHI_AC:
+      sendHitachiAC(state, nbytes);
+      break;
+#endif  // SEND_HITACHI_AC
+#if SEND_HITACHI_AC1
+    case HITACHI_AC1:
+      sendHitachiAC1(state, nbytes);
+      break;
+#endif  // SEND_HITACHI_AC1
+#if SEND_HITACHI_AC2
+    case HITACHI_AC2:
+      sendHitachiAC2(state, nbytes);
+      break;
+#endif  // SEND_HITACHI_AC2
+#if SEND_KELVINATOR
+    case KELVINATOR:
+      sendKelvinator(state, nbytes);
+      break;
+#endif  // SEND_KELVINATOR
+#if SEND_MITSUBISHI_AC
+    case MITSUBISHI_AC:
+      sendMitsubishiAC(state, nbytes);
+      break;
+#endif  // SEND_MITSUBISHI_AC
+#if SEND_MITSUBISHIHEAVY
+    case MITSUBISHI_HEAVY_88:
+      sendMitsubishiHeavy88(state, nbytes);
+      break;
+    case MITSUBISHI_HEAVY_152:
+      sendMitsubishiHeavy152(state, nbytes);
+      break;
+#endif  // SEND_MITSUBISHIHEAVY
+#if SEND_MWM
+    case MWM:
+      sendMWM(state, nbytes);
+      break;
+#endif  // SEND_MWM
+#if SEND_PANASONIC_AC
+    case PANASONIC_AC:
+      sendPanasonicAC(state, nbytes);
+      break;
+#endif  // SEND_PANASONIC_AC
+#if SEND_SAMSUNG_AC
+    case SAMSUNG_AC:
+      sendSamsungAC(state, nbytes);
+      break;
+#endif  // SEND_SAMSUNG_AC
+#if SEND_SHARP_AC
+    case SHARP_AC:
+      sendSharpAc(state, nbytes);
+      break;
+#endif  // SEND_SHARP_AC
+#if SEND_TCL112AC
+    case TCL112AC:
+      sendTcl112Ac(state, nbytes);
+      break;
+#endif  // SEND_TCL112AC
+#if SEND_TOSHIBA_AC
+    case TOSHIBA_AC:
+      sendToshibaAC(state, nbytes);
+      break;
+#endif  // SEND_TOSHIBA_AC
+#if SEND_TROTEC
+    case TROTEC:
+      sendTrotec(state, nbytes);
+      break;
+#endif  // SEND_TROTEC
+#if SEND_WHIRLPOOL_AC
+    case WHIRLPOOL_AC:
+      sendWhirlpoolAC(state, nbytes);
+      break;
+#endif  // SEND_WHIRLPOOL_AC
     default:
       return false;
   }

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -137,7 +137,10 @@ class IRsend {
                    const uint8_t *dataptr, const uint16_t nbytes,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
-  bool send(decode_type_t type, uint64_t data, uint16_t nbits);
+  bool send(const decode_type_t type, const uint64_t data,
+            const uint16_t nbits);
+  bool send(const decode_type_t type, const uint8_t state[],
+            const uint16_t nbytes);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,
                uint16_t repeat = kNoRepeat);
@@ -263,9 +266,9 @@ class IRsend {
                        uint16_t repeat = kMitsubishiMinRepeat);
 #endif
 #if SEND_MITSUBISHI_AC
-  void sendMitsubishiAC(unsigned char data[],
-                        uint16_t nbytes = kMitsubishiACStateLength,
-                        uint16_t repeat = kMitsubishiACMinRepeat);
+  void sendMitsubishiAC(const unsigned char data[],
+                        const uint16_t nbytes = kMitsubishiACStateLength,
+                        const uint16_t repeat = kMitsubishiACMinRepeat);
 #endif
 #if SEND_MITSUBISHIHEAVY
   void sendMitsubishiHeavy88(
@@ -278,8 +281,8 @@ class IRsend {
       const uint16_t repeat = kMitsubishiHeavy152MinRepeat);
 #endif
 #if SEND_FUJITSU_AC
-  void sendFujitsuAC(unsigned char data[], uint16_t nbytes,
-                     uint16_t repeat = kFujitsuAcMinRepeat);
+  void sendFujitsuAC(const unsigned char data[], const uint16_t nbytes,
+                     const uint16_t repeat = kFujitsuAcMinRepeat);
 #endif
 #if SEND_INAX
   void sendInax(const uint64_t data, const uint16_t nbits = kInaxBits,
@@ -289,9 +292,9 @@ class IRsend {
   void sendGC(uint16_t buf[], uint16_t len);
 #endif
 #if SEND_KELVINATOR
-  void sendKelvinator(unsigned char data[],
-                      uint16_t nbytes = kKelvinatorStateLength,
-                      uint16_t repeat = kKelvinatorDefaultRepeat);
+  void sendKelvinator(const unsigned char data[],
+                      const uint16_t nbytes = kKelvinatorStateLength,
+                      const uint16_t repeat = kKelvinatorDefaultRepeat);
 #endif
 #if SEND_DAIKIN
   void sendDaikin(const unsigned char data[],
@@ -299,8 +302,9 @@ class IRsend {
                   const uint16_t repeat = kDaikinDefaultRepeat);
 #endif
 #if SEND_DAIKIN2
-  void sendDaikin2(unsigned char data[], uint16_t nbytes = kDaikin2StateLength,
-                   uint16_t repeat = kDaikin2DefaultRepeat);
+  void sendDaikin2(const unsigned char data[],
+                   const uint16_t nbytes = kDaikin2StateLength,
+                   const uint16_t repeat = kDaikin2DefaultRepeat);
 #endif
 #if SEND_DAIKIN216
   void sendDaikin216(const unsigned char data[],
@@ -312,10 +316,10 @@ class IRsend {
                       uint16_t repeat = kAiwaRcT501MinRepeats);
 #endif
 #if SEND_GREE
-  void sendGree(uint64_t data, uint16_t nbits = kGreeBits,
-                uint16_t repeat = kGreeDefaultRepeat);
-  void sendGree(uint8_t data[], uint16_t nbytes = kGreeStateLength,
-                uint16_t repeat = kGreeDefaultRepeat);
+  void sendGree(const uint64_t data, const uint16_t nbits = kGreeBits,
+                const uint16_t repeat = kGreeDefaultRepeat);
+  void sendGree(const uint8_t data[], const uint16_t nbytes = kGreeStateLength,
+                const uint16_t repeat = kGreeDefaultRepeat);
 #endif
 #if SEND_GOODWEATHER
   void sendGoodweather(const uint64_t data,
@@ -400,9 +404,9 @@ class IRsend {
                   uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_ELECTRA_AC
-  void sendElectraAC(unsigned char data[],
-                     uint16_t nbytes = kElectraAcStateLength,
-                     uint16_t repeat = kNoRepeat);
+  void sendElectraAC(const unsigned char data[],
+                     const uint16_t nbytes = kElectraAcStateLength,
+                     const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_PANASONIC_AC
   void sendPanasonicAC(const unsigned char data[],
@@ -415,8 +419,8 @@ class IRsend {
   uint64_t encodePioneer(uint16_t address, uint16_t command);
 #endif
 #if SEND_MWM
-  void sendMWM(unsigned char data[], uint16_t nbytes,
-               uint16_t repeat = kNoRepeat);
+  void sendMWM(const unsigned char data[], const uint16_t nbytes,
+               const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_VESTEL_AC
   void sendVestelAc(const uint64_t data, const uint16_t nbits = kVestelAcBits,

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -718,8 +718,8 @@ bool IRrecv::decodeDaikin(decode_results *results, const uint16_t nbits,
 //
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/582
-void IRsend::sendDaikin2(unsigned char data[], uint16_t nbytes,
-                        uint16_t repeat) {
+void IRsend::sendDaikin2(const unsigned char data[], const uint16_t nbytes,
+                         const uint16_t repeat) {
   if (nbytes < kDaikin2Section1Length)
     return;  // Not enough bytes to send a partial message.
 

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -37,7 +37,8 @@ const uint32_t kElectraAcMessageGap = kDefaultMessageGap;  // Just a guess.
 //
 // Status: Alpha / Needs testing against a real device.
 //
-void IRsend::sendElectraAC(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+void IRsend::sendElectraAC(const uint8_t data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
   for (uint16_t r = 0; r <= repeat; r++)
     sendGeneric(kElectraAcHdrMark, kElectraAcHdrSpace, kElectraAcBitMark,
                 kElectraAcOneSpace, kElectraAcBitMark, kElectraAcZeroSpace,

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -42,8 +42,8 @@ const uint16_t kFujitsuAcMinGap = 8100;
 //
 // Status: STABLE / Known Good.
 //
-void IRsend::sendFujitsuAC(unsigned char data[], uint16_t nbytes,
-                           uint16_t repeat) {
+void IRsend::sendFujitsuAC(const unsigned char data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
   sendGeneric(kFujitsuAcHdrMark, kFujitsuAcHdrSpace, kFujitsuAcBitMark,
               kFujitsuAcOneSpace, kFujitsuAcBitMark, kFujitsuAcZeroSpace,
               kFujitsuAcBitMark, kFujitsuAcMinGap, data, nbytes, 38, false,

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -47,7 +47,8 @@ const uint8_t kGreeBlockFooterBits = 3;
 //
 // Ref:
 //   https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp
-void IRsend::sendGree(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
+void IRsend::sendGree(const unsigned char data[], const uint16_t nbytes,
+                      const uint16_t repeat) {
   if (nbytes < kGreeStateLength)
     return;  // Not enough bytes to send a proper message.
 
@@ -80,7 +81,8 @@ void IRsend::sendGree(unsigned char data[], uint16_t nbytes, uint16_t repeat) {
 //
 // Ref:
 //   https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp
-void IRsend::sendGree(uint64_t data, uint16_t nbits, uint16_t repeat) {
+void IRsend::sendGree(const uint64_t data, const uint16_t nbits,
+                      const uint16_t repeat) {
   if (nbits != kGreeBits)
     return;  // Wrong nr. of bits to send a proper message.
   // Set IR carrier frequency

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -82,8 +82,8 @@ const uint8_t kKelvinatorTurbo = 1 << kKelvinatorTurboOffset;
 //
 // Status: STABLE / Known working.
 //
-void IRsend::sendKelvinator(unsigned char data[], uint16_t nbytes,
-                            uint16_t repeat) {
+void IRsend::sendKelvinator(const unsigned char data[], const uint16_t nbytes,
+                            const uint16_t repeat) {
   if (nbytes < kKelvinatorStateLength)
     return;  // Not enough bytes to send a proper message.
 

--- a/src/ir_MWM.cpp
+++ b/src/ir_MWM.cpp
@@ -37,7 +37,8 @@ const int16_t kMark = 0;
 //
 // Status: Implemented.
 //
-void IRsend::sendMWM(uint8_t data[], uint16_t nbytes, uint16_t repeat) {
+void IRsend::sendMWM(const uint8_t data[], const uint16_t nbytes,
+                     const uint16_t repeat) {
   if (nbytes < 3) return;  // Shortest possible message is 3 bytes
 
   // Set 38kHz IR carrier frequency & a 1/4 (25%) duty cycle.

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -268,8 +268,8 @@ bool IRrecv::decodeMitsubishi2(decode_results *results, uint16_t nbits,
 //
 // Status: BETA / Appears to be working.
 //
-void IRsend::sendMitsubishiAC(unsigned char data[], uint16_t nbytes,
-                              uint16_t repeat) {
+void IRsend::sendMitsubishiAC(const unsigned char data[], const uint16_t nbytes,
+                              const uint16_t repeat) {
   if (nbytes < kMitsubishiACStateLength)
     return;  // Not enough bytes to send a proper message.
 


### PR DESCRIPTION
Example code how to use better capture and repeating than the
DumbIRRepeater example code. i.e. Use correct frequencies etc when we can.

* Add a generic `send(protocol, state[], bytes)` function that sends
  complex (> 64 bit) IR protocols. Add some unit test coverage.
* Update most of the complex send protocols to use `const` for parameters.

This code is for example / educational purposes only. Its
functionality is NOT supported.