### PR TITLE
Initial support for the ESP32 architecture & boards.

### DIFF
--- a/.github/Contributors.md
+++ b/.github/Contributors.md
@@ -2,7 +2,7 @@
 ### Main contributors & maintainers
 - [Mark Szabo](https://github.com/markszabo/) : Initial IR sending on ESP8266
 - [Sébastien Warin](https://github.com/sebastienwarin/) (http://sebastien.warin.fr) : Initial IR receiving on ESP8266
-- [David Conran](https://github.com/crankyoldgit/)
+- [David Conran](https://github.com/crankyoldgit/) : ESP32 support and pretty much everything else.
 - [Roi Dayan](https://github.com/roidayan/)
 - [Marcos de Alcântara Marinho](https://github.com/marcosamarinho/)
 - [Massimiliano Pinto](https://github.com/pintomax/)

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
 _(Please use this template for reporting issues. You can delete what ever is not relevant. Giving us this information will help us help you faster. Please also read the [FAQ](https://github.com/markszabo/IRremoteESP8266/wiki/Frequently-Asked-Questions) & [Troubleshooting Guide](https://github.com/markszabo/IRremoteESP8266/wiki/Troubleshooting-Guide). Your problem may already have an answer there.)_
 
-### Version/revison of the library used
+### Version/revision of the library used
 _Typically located in the `library.json` & `src/IRremoteESP8266.h` files in the root directory of the library.
 e.g. v2.0.0, or 'master' as at 1st of June, 2017. etc._
 
@@ -30,7 +30,7 @@ _What can we do to (pref. reliably) repeat what is happening?_
 _Include all relevant code snippets or links to the actual code files. Tip: [How to quote your code so it is still readable](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#code)._
 
 #### Circuit diagram and hardware used (if applicable)
-_Link to an image of the circuit diagram used. Part number of the IR receiver module etc._
+_Link to an image of the circuit diagram used. Part number of the IR receiver module etc. ESP8266 or ESP32 board type._
 
 ### I have followed the steps in the [Troubleshooting Guide](https://github.com/markszabo/IRremoteESP8266/wiki/Troubleshooting-Guide) & read the [FAQ](https://github.com/markszabo/IRremoteESP8266/wiki/Frequently-Asked-Questions)
 _Yes/No._

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/markszabo/IRremoteESP8266.svg)](http://isitmaintained.com/project/markszabo/IRremoteESP8266 "Percentage of issues still open")
 [![GitLicense](https://gitlicense.com/badge/markszabo/IRremoteESP8266)](https://gitlicense.com/license/markszabo/IRremoteESP8266)
 
-This library enables you to **send _and_ receive** infra-red signals on an [ESP8266 using the Arduino framework](https://github.com/esp8266/Arduino) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* etc.
+This library enables you to **send _and_ receive** infra-red signals on an [ESP8266](https://github.com/esp8266/Arduino) or an
+[ESP32](https://github.com/espressif/arduino-esp32) using the [Arduino framework](https://www.arduino.cc/) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* demodulators etc.
 
 ## v2.6.1 Now Available
 Version 2.6.1 of the library is now [available](https://github.com/markszabo/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.

--- a/examples/ControlSamsungAC/platformio.ini
+++ b/examples/ControlSamsungAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/DumbIRRepeater/platformio.ini
+++ b/examples/DumbIRRepeater/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRGCSendDemo/platformio.ini
+++ b/examples/IRGCSendDemo/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRGCTCPServer/IRGCTCPServer.ino
+++ b/examples/IRGCTCPServer/IRGCTCPServer.ino
@@ -40,6 +40,9 @@
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
+#ifdef ESP32
+#error "This example code does NOT work with the ESP32 yet!"
+#endif
 #include <ESP8266WiFi.h>
 #include <IRremoteESP8266.h>
 #include <IRsend.h>

--- a/examples/IRGCTCPServer/IRGCTCPServer.ino
+++ b/examples/IRGCTCPServer/IRGCTCPServer.ino
@@ -40,10 +40,12 @@
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
-#ifdef ESP32
-#error "This example code does NOT work with the ESP32 yet!"
-#endif
+#if defined(ESP8266)
 #include <ESP8266WiFi.h>
+#endif  // ESP8266
+#if defined(ESP32)
+#include <WiFi.h>
+#endif  // ESP32
 #include <IRremoteESP8266.h>
 #include <IRsend.h>
 #include <WiFiClient.h>

--- a/examples/IRGCTCPServer/platformio.ini
+++ b/examples/IRGCTCPServer/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -5,10 +5,6 @@
 #ifndef EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 #define EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 
-#ifdef ESP32
-#error "This example code does NOT work with the ESP32 yet!"
-#endif
-
 #include <IRremoteESP8266.h>
 #include <IRrecv.h>
 #include <IRsend.h>
@@ -235,6 +231,12 @@ const int32_t kMaxPauseMs = 10000;  // 10 Seconds.
 const char * kSequenceDelimiter = ";";
 const char * kCommandDelimiter = ",";
 const char kPauseChar = 'P';
+#if defined(ESP8266)
+const uint32_t kChipId = ESP.getChipId();
+#endif  // ESP8266
+#if defined(ESP32)
+const uint32_t kChipId = ESP.getEfuseMac();  // Discard the top 16 bits.
+#endif  // ESP32
 
 const char* kClimateTopics =
     "(" KEY_PROTOCOL "|" KEY_MODEL "|" KEY_POWER "|" KEY_MODE "|" KEY_TEMP "|"

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -250,6 +250,7 @@ void handleSendMqttDiscovery(void);
 void subscribing(const String topic_name);
 void unsubscribing(const String topic_name);
 void mqttLog(const String mesg);
+bool mountSpiffs(void);
 bool reconnect(void);
 void receivingMQTT(String const topic_name, String const callback_str);
 void callback(char* topic, byte* payload, unsigned int length);

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -5,6 +5,10 @@
 #ifndef EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 #define EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 
+#ifdef ESP32
+#error "This example code does NOT work with the ESP32 yet!"
+#endif
+
 #include <IRremoteESP8266.h>
 #include <IRrecv.h>
 #include <IRsend.h>

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -211,6 +211,7 @@ const char* kMqttPrefixKey = "mqtt_prefix";
 const char* kHostnameKey = "hostname";
 const char* kHttpUserKey = "http_user";
 const char* kHttpPassKey = "http_pass";
+const char* kCommandDelimiter = ",";
 
 // URLs
 const char* kUrlRoot = "/";
@@ -228,8 +229,7 @@ const char* kUrlWipe = "/reset";
 const uint32_t kBroadcastPeriodMs = MQTTbroadcastInterval * 1000;  // mSeconds.
 const uint32_t kStatListenPeriodMs = 5 * 1000;  // mSeconds
 const int32_t kMaxPauseMs = 10000;  // 10 Seconds.
-const char * kSequenceDelimiter = ";";
-const char * kCommandDelimiter = ",";
+const char* kSequenceDelimiter = ";";
 const char kPauseChar = 'P';
 #if defined(ESP8266)
 const uint32_t kChipId = ESP.getChipId();

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -31,9 +31,10 @@
  *
  * - Arduino IDE:
  *   o Install the following libraries via Library Manager
- *     - ArduinoJson (https://arduinojson.org/) (Version >= 5.x and < 6)
+ *     - ArduinoJson (https://arduinojson.org/) (Version >= 5.0 and < 6.0)
  *     - PubSubClient (https://pubsubclient.knolleary.net/)
- *     - WiFiManager (https://github.com/tzapu/WiFiManager) (Version >= 0.14)
+ *     - WiFiManager (https://github.com/tzapu/WiFiManager)
+ *                   (ESP8266: Version >= 0.14, ESP32: 'development' branch.)
  *   o You MUST change <PubSubClient.h> to have the following (or larger) value:
  *     (with REPORT_RAW_UNKNOWNS 1024 or more is recommended)
  *     #define MQTT_MAX_PACKET_SIZE 768
@@ -42,10 +43,10 @@
  *     the accompanying platformio.ini file.
  *
  * ## First Boot (Initial setup)
- * The ESP8266 board will boot into the WiFiManager's AP mode.
+ * The ESP board will boot into the WiFiManager's AP mode.
  * i.e. It will create a WiFi Access Point with a SSID like: "ESP123456" etc.
  * Connect to that SSID. Then point your browser to http://192.168.4.1/ and
- * configure the ESP8266 to connect to your desired WiFi network and associated
+ * configure the ESP to connect to your desired WiFi network and associated
  * required settings. It will remember these details on next boot if the device
  * connects successfully.
  * More information can be found here:
@@ -1719,7 +1720,7 @@ uint16_t countValuesInStr(const String str, char sep) {
 // Args:
 //   size:  Nr. of uint16_t's need to be in the new array.
 // Returns:
-//   A Ptr to the new array. Restarts the ESP8266 if it fails.
+//   A Ptr to the new array. Restarts the ESP if it fails.
 uint16_t * newCodeArray(const uint16_t size) {
   uint16_t *result;
 

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -334,6 +334,10 @@
 // Globals
 #if defined(ESP8266)
 ESP8266WebServer server(kHttpPort);
+#endif  // ESP8266
+#if defined(ESP32)
+WebServer server(kHttpPort);
+#endif  // ESP32
 #if MDNS_ENABLE
 MDNSResponder mdns;
 #endif  // MDNS_ENABLE
@@ -414,13 +418,13 @@ TimerMs statListenTime = TimerMs();  // How long we've been listening for.
 #endif  // MQTT_ENABLE
 
 bool isSerialGpioUsedByIr(void) {
-  const uint8_t kSerialTxGpio = 1;  // The GPIO serial output is sent to.
-                                    // Note: *DOES NOT* control Serial output.
+  const int8_t kSerialTxGpio = 1;  // The GPIO serial output is sent to.
+                                   // Note: *DOES NOT* control Serial output.
 #if defined(ESP32)
-  const uint8_t kSerialRxGpio = 3;  // The GPIO serial input is received on.
+  const int8_t kSerialRxGpio = 3;  // The GPIO serial input is received on.
 #endif  // ESP32
   // Ensure we are not trodding on anything IR related.
-#ifdef IR_RX
+#if IR_RX
   switch (rx_gpio) {
 #if defined(ESP32)
     case kSerialRxGpio:
@@ -2049,9 +2053,9 @@ void handleGpioSetting(void) {
   html += htmlEnd();
   server.send(200, "text/html", html);
   if (changed) {
-#if defined(MQTT_ENABLE)
+#if MQTT_ENABLE
     mqttLog("GPIOs were changed. Rebooting!");
-#endif  // MQTT
+#endif  // MQTT_ENABLE
     delay(1000);
     ESP.restart();
     delay(2000);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -414,16 +414,29 @@ TimerMs statListenTime = TimerMs();  // How long we've been listening for.
 #endif  // MQTT_ENABLE
 
 bool isSerialGpioUsedByIr(void) {
-  const int8_t kSerialTxGpio = 1;  // The GPIO serial output is sent too.
-                                   // Note: *DOES NOT* control Serial output.
+  const uint8_t kSerialTxGpio = 1;  // The GPIO serial output is sent to.
+                                    // Note: *DOES NOT* control Serial output.
+#if defined(ESP32)
+  const uint8_t kSerialRxGpio = 3;  // The GPIO serial input is received on.
+#endif  // ESP32
   // Ensure we are not trodding on anything IR related.
-#if IR_RX
-  if (rx_gpio == kSerialTxGpio)
-    return true;  // Serial port is in use by IR capture. Abort.
+#ifdef IR_RX
+  switch (rx_gpio) {
+#if defined(ESP32)
+    case kSerialRxGpio:
+#endif  // ESP32
+    case kSerialTxGpio:
+      return true;  // Serial port is in use by IR capture. Abort.
+  }
 #endif  // IR_RX
   for (uint8_t i = 0; i < kNrOfIrTxGpios; i++)
-    if (txGpioTable[i] == kSerialTxGpio)
-      return true;  // Serial port is in use for IR sending. Abort.
+    switch (txGpioTable[i]) {
+#if defined(ESP32)
+      case kSerialRxGpio:
+#endif  // ESP32
+      case kSerialTxGpio:
+        return true;  // Serial port is in use for IR sending. Abort.
+    }
   return false;  // Not in use as far as we can tell.
 }
 

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1273,6 +1273,7 @@ void handleInfo(void) {
 #if defined(ESP32)
     "ESP32 SDK Version: " + ESP.getSdkVersion() + "<br>"
 #endif  // ESP32
+    "Cpu Freq: " + String(ESP.getCpuFreqMHz()) + "MHz<br>"
     "IR Send GPIO(s): " + listOfTxGpios() + "<br>"
     "Total send requests: " + String(sendReqCounter) + "<br>"
     "Last message sent: " + String(lastSendSucceeded ? "Ok" : "FAILED") +

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -8,8 +8,19 @@ lib_ldf_mode = chain+
 lib_deps_builtin =
 lib_deps_external =
   PubSubClient
-  WifiManager@0.14
   ArduinoJson@<6.0
+
+[common_esp8266]
+lib_deps_external =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}
+  WifiManager@>=0.14
+
+[common_esp32]
+lib_deps_external =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}
+  https://github.com/tzapu/WiFiManager.git#development
 
 [env:nodemcuv2]
 platform = espressif8266
@@ -18,8 +29,7 @@ board = nodemcuv2
 lib_ldf_mode = ${common.lib_ldf_mode}
 build_flags = ${common.build_flags}
 lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
+  ${common_esp8266.lib_deps_external}
 
 [env:d1_mini]
 platform=espressif8266
@@ -28,8 +38,7 @@ board=d1_mini
 lib_ldf_mode = ${common.lib_ldf_mode}
 build_flags = ${common.build_flags}
 lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
+  ${common_esp8266.lib_deps_external}
 
 [env:d1_mini_no_mqtt]
 platform=espressif8266
@@ -38,5 +47,13 @@ board=d1_mini
 lib_ldf_mode = ${common.lib_ldf_mode}
 build_flags = ${common.build_flags} -DMQTT_ENABLE=false
 lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
+  ${common_esp8266.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common_esp32.lib_deps_external}

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -1,9 +1,11 @@
 /*
  * IRremoteESP8266: IRServer - demonstrates sending IR codes controlled from a webserver
+ * Version 0.3 May, 2019
  * Version 0.2 June, 2017
  * Copyright 2015 Mark Szabo
+ * Copyright 2019 David Conran
  *
- * An IR LED circuit *MUST* be connected to the ESP8266 on a pin
+ * An IR LED circuit *MUST* be connected to the ESP on a pin
  * as specified by kIrLed below.
  *
  * TL;DR: The IR LED needs to be driven by a transistor for a good result.
@@ -29,12 +31,16 @@
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
-#ifdef ESP32
-#error "This example code does NOT work with the ESP32 yet!"
-#endif
+#if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
+#endif  // ESP8266
+#if defined(ESP32)
+#include <WiFi.h>
+#include <WebServer.h>
+#include <ESPmDNS.h>
+#endif  // ESP32
 #include <IRremoteESP8266.h>
 #include <IRsend.h>
 #include <WiFiClient.h>
@@ -43,18 +49,27 @@ const char* kSsid = ".....";
 const char* kPassword = ".....";
 MDNSResponder mdns;
 
+#if defined(ESP8266)
 ESP8266WebServer server(80);
+#undef HOSTNAME
+#define HOSTNAME "esp8266"
+#endif  // ESP8266
+#if defined(ESP32)
+WebServer server(80);
+#undef HOSTNAME
+#define HOSTNAME "esp32"
+#endif  // ESP32
 
-const uint16_t kIrLed = 4;  // ESP8266 GPIO pin to use. Recommended: 4 (D2).
+const uint16_t kIrLed = 4;  // ESP GPIO pin to use. Recommended: 4 (D2).
 
 IRsend irsend(kIrLed);  // Set the GPIO to be used to sending the message.
 
 void handleRoot() {
   server.send(200, "text/html",
               "<html>" \
-                "<head><title>ESP8266 Demo</title></head>" \
+                "<head><title>" HOSTNAME " Demo</title></head>" \
                 "<body>" \
-                  "<h1>Hello from ESP8266, you can send NEC encoded IR" \
+                  "<h1>Hello from " HOSTNAME ", you can send NEC encoded IR" \
                       "signals from here!</h1>" \
                   "<p><a href=\"ir?code=16769055\">Send 0xFFE01F</a></p>" \
                   "<p><a href=\"ir?code=16429347\">Send 0xFAB123</a></p>" \
@@ -107,7 +122,11 @@ void setup(void) {
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP().toString());
 
-  if (mdns.begin("esp8266", WiFi.localIP())) {
+#if defined(ESP8266)
+  if (mdns.begin(HOSTNAME, WiFi.localIP())) {
+#else  // ESP8266
+  if (mdns.begin(HOSTNAME)) {
+#endif  // ESP8266
     Serial.println("MDNS responder started");
   }
 

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -29,6 +29,9 @@
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
+#ifdef ESP32
+#error "This example code does NOT work with the ESP32 yet!"
+#endif
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>

--- a/examples/IRServer/platformio.ini
+++ b/examples/IRServer/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRrecvDemo/platformio.ini
+++ b/examples/IRrecvDemo/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRrecvDump/platformio.ini
+++ b/examples/IRrecvDump/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -302,9 +302,9 @@ void dumpACInfo(const decode_results * const results) {
   if (description != "") Serial.println("Mesg Desc.: " + description);
 }
 
-// The section of code run only once at start-up.
+// This section of code runs only once at start-up.
 void setup() {
-#ifdef ESP8266
+#if defined(ESP8266)
   Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
 #else  // ESP8266
   Serial.begin(kBaudRate, SERIAL_8N1);

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -304,7 +304,11 @@ void dumpACInfo(const decode_results * const results) {
 
 // The section of code run only once at start-up.
 void setup() {
+#ifdef ESP8266
   Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
+#else  // ESP8266
+  Serial.begin(kBaudRate, SERIAL_8N1);
+#endif  // ESP8266
   while (!Serial)  // Wait for the serial connection to be establised.
     delay(50);
   Serial.println();

--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRsendDemo/IRsendDemo.ino
+++ b/examples/IRsendDemo/IRsendDemo.ino
@@ -53,7 +53,11 @@ uint8_t samsungState[kSamsungAcStateLength] = {
 
 void setup() {
   irsend.begin();
+#if ESP8266
   Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);
+#else  // ESP8266
+  Serial.begin(115200, SERIAL_8N1);
+#endif  // ESP8266
 }
 
 void loop() {

--- a/examples/IRsendDemo/platformio.ini
+++ b/examples/IRsendDemo/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/IRsendProntoDemo/platformio.ini
+++ b/examples/IRsendProntoDemo/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/JVCPanasonicSendDemo/platformio.ini
+++ b/examples/JVCPanasonicSendDemo/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/LGACSend/platformio.ini
+++ b/examples/LGACSend/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnArgoAC/platformio.ini
+++ b/examples/TurnOnArgoAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnDaikinAC/platformio.ini
+++ b/examples/TurnOnDaikinAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnFujitsuAC/platformio.ini
+++ b/examples/TurnOnFujitsuAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnKelvinatorAC/platformio.ini
+++ b/examples/TurnOnKelvinatorAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnMitsubishiAC/platformio.ini
+++ b/examples/TurnOnMitsubishiAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnMitsubishiHeavyAc/platformio.ini
+++ b/examples/TurnOnMitsubishiHeavyAc/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnPanasonicAC/platformio.ini
+++ b/examples/TurnOnPanasonicAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnToshibaAC/platformio.ini
+++ b/examples/TurnOnToshibaAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/examples/TurnOnTrotecAC/platformio.ini
+++ b/examples/TurnOnTrotecAC/platformio.ini
@@ -17,3 +17,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/library.json
+++ b/library.json
@@ -40,5 +40,5 @@
     }
   ],
   "frameworks": "arduino",
-  "platforms": "espressif8266"
+  "platforms": ["espressif8266", "espressif32"]
 }

--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Send and receive infrared signals with multiple protocols (ESP8266)
 paragraph=This library enables you to send and receive infra-red signals on an ESP8266.
 category=Device Control
 url=https://github.com/markszabo/IRremoteESP8266
-architectures=esp8266
+architectures=esp8266,esp32

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,3 +27,13 @@ build_flags = ${common.build_flags}
 lib_deps =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags = ${common.build_flags}
+lib_deps =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -136,18 +136,21 @@ static void USE_IRAM_ATTR gpio_intr() {
 //              (Range: 0-3. Default: kDefaultESP32Timer)
 // Returns:
 //   An IRrecv class object.
+#if defined(ESP32)
 IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
                const uint8_t timeout, const bool save_buffer,
                const uint8_t timer_num) {
+  // There are only 4 timers. 0 to 3.
+  _timer_num = std::min(timer_num, (uint8_t)3);
+#else  // ESP32
+IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
+               const uint8_t timeout, const bool save_buffer) {
+#endif  // ESP32
   irparams.recvpin = recvpin;
   irparams.bufsize = bufsize;
   // Ensure we are going to be able to store all possible values in the
   // capture buffer.
   irparams.timeout = std::min(timeout, (uint8_t)kMaxTimeoutMs);
-#if defined(ESP32)
-  // There are only 4 timers. 0 to 3.
-  _timer_num = std::min(timer_num, (uint8_t)3);
-#endif  // ESP32
   irparams.rawbuf = new uint16_t[bufsize];
   if (irparams.rawbuf == NULL) {
     DPRINTLN(

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -111,11 +111,17 @@ class decode_results {
 // main class for receiving IR
 class IRrecv {
  public:
+#if defined(ESP32)
   explicit IRrecv(const uint16_t recvpin, const uint16_t bufsize = kRawBuf,
                   const uint8_t timeout = kTimeoutMs,
                   const bool save_buffer = false,
                   const uint8_t timer_num = kDefaultESP32Timer);  // Constructor
-  ~IRrecv(void);                                                      // Destructor
+#else  // ESP32
+  explicit IRrecv(const uint16_t recvpin, const uint16_t bufsize = kRawBuf,
+                  const uint8_t timeout = kTimeoutMs,
+                  const bool save_buffer = false);                // Constructor
+#endif  // ESP32
+  ~IRrecv(void);                                                  // Destructor
   bool decode(decode_results *results, irparams_t *save = NULL);
   void enableIRIn(void);
   void disableIRIn(void);

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -51,6 +51,9 @@ const uint16_t kMaxTimeoutMs = kRawTick * (UINT16_MAX / MS_TO_USEC(1));
 const uint32_t kFnvPrime32 = 16777619UL;
 const uint32_t kFnvBasis32 = 2166136261UL;
 
+// Which of the ESP32 timers to use by default. (0-3)
+const uint8_t kDefaultESP32Timer = 3;
+
 #if DECODE_AC
 // Hitachi AC is the current largest state size.
 const uint16_t kStateSizeMax = kHitachiAc2StateLength;
@@ -108,17 +111,18 @@ class decode_results {
 // main class for receiving IR
 class IRrecv {
  public:
-  explicit IRrecv(uint16_t recvpin, uint16_t bufsize = kRawBuf,
-                  uint8_t timeout = kTimeoutMs,
-                  bool save_buffer = false);  // Constructor
-  ~IRrecv();                                  // Destructor
+  explicit IRrecv(const uint16_t recvpin, const uint16_t bufsize = kRawBuf,
+                  const uint8_t timeout = kTimeoutMs,
+                  const bool save_buffer = false,
+                  const uint8_t timer_num = kDefaultESP32Timer);  // Constructor
+  ~IRrecv(void);                                                      // Destructor
   bool decode(decode_results *results, irparams_t *save = NULL);
-  void enableIRIn();
-  void disableIRIn();
-  void resume();
-  uint16_t getBufSize();
+  void enableIRIn(void);
+  void disableIRIn(void);
+  void resume(void);
+  uint16_t getBufSize(void);
 #if DECODE_HASH
-  void setUnknownThreshold(uint16_t length);
+  void setUnknownThreshold(const uint16_t length);
 #endif
   static bool match(uint32_t measured, uint32_t desired,
                     uint8_t tolerance = kTolerance, uint16_t delta = 0);
@@ -133,8 +137,9 @@ class IRrecv {
  private:
 #endif
   irparams_t *irparams_save;
+  uint8_t _timer_num;
 #if DECODE_HASH
-  uint16_t unknown_threshold;
+  uint16_t _unknown_threshold;
 #endif
   // These are called by decode
   void copyIrParams(volatile irparams_t *src, irparams_t *dst);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -21,14 +21,17 @@
 // Constants
 // Offset (in microseconds) to use in Period time calculations to account for
 // code excution time in producing the software PWM signal.
-#if (F_CPU == 160000000L)
+#if defined (ESP32)
+// Calculated on a generic ESP-WROOM-32 board with v3.2-18 SDK @ 240MHz
+const int8_t kPeriodOffset = -2;
+#elif (defined(ESP8266) && F_CPU == 160000000L)
 // Calculated on an ESP8266 NodeMCU v2 board using:
 // v2.6.0 with v2.5.2 ESP core @ 160MHz
 const int8_t kPeriodOffset = -2;
-#else  // (F_CPU == 160000000L)
+#else  // (defined(ESP8266) && F_CPU == 160000000L)
 // Calculated on ESP8266 Wemos D1 mini using v2.4.1 with v2.4.0 ESP core @ 40MHz
 const int8_t kPeriodOffset = -5;
-#endif  // (F_CPU == 160000000L)
+#endif  // (defined(ESP8266) && F_CPU == 160000000L)
 const uint8_t kDutyDefault = 50;  // Percentage
 const uint8_t kDutyMax = 100;     // Percentage
 // delayMicroseconds() is only accurate to 16383us.

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -21,7 +21,7 @@
 // Constants
 // Offset (in microseconds) to use in Period time calculations to account for
 // code excution time in producing the software PWM signal.
-#if defined (ESP32)
+#if defined(ESP32)
 // Calculated on a generic ESP-WROOM-32 board with v3.2-18 SDK @ 240MHz
 const int8_t kPeriodOffset = -2;
 #elif (defined(ESP8266) && F_CPU == 160000000L)

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -24,7 +24,7 @@
 #if defined(ESP32)
 // Calculated on a generic ESP-WROOM-32 board with v3.2-18 SDK @ 240MHz
 const int8_t kPeriodOffset = -2;
-#elif (defined(ESP8266) && F_CPU == 160000000L)
+#elif (defined(ESP8266) && F_CPU == 160000000L)  // NOLINT(whitespace/parens)
 // Calculated on an ESP8266 NodeMCU v2 board using:
 // v2.6.0 with v2.5.2 ESP core @ 160MHz
 const int8_t kPeriodOffset = -2;


### PR DESCRIPTION
Similar send & receive functionality as the ESP8266 platform.
   i.e. It bit-bangs a software PWM signal when sending IR messages.

* Tested on a _GOOUUU-ESP32_ development board, and on ESP8266 boards (d1_mini, nodemcuv2)
* `IRrecvDumpV2` and `IRMQTTServer` examples appear to work as expected.
* `IRMQTTServer` example code requires the _development_ version of the `WifiManager` library.
* All examples build successfully on ESP32. Not all of them have been tested.
* Full platformio support and `platformio.ini`s for each example added. Everything automatically builds out of the box under PlatformIO.
* Reduce some of the ESP8266-isms and references in the library as it now also supports ESP32.
* Improvements to how `IRMQTTServer` handles first boot and/or corrupted SPIFFS situations.

**If you have an ESP32 board, please test this an let us know if there are any issues.** 