### PR TITLE
Increase tolerance value for TCL112AC protocol.

### DIFF
--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -440,7 +440,7 @@ bool IRrecv::decodeTcl112Ac(decode_results *results, const uint16_t nbits,
        i++, dataBitsSoFar += 8, offset += data_result.used) {
     data_result = matchData(&(results->rawbuf[offset]), 8, kTcl112AcBitMark,
                             kTcl112AcOneSpace, kTcl112AcBitMark,
-                            kTcl112AcZeroSpace, kTolerance, 0, false);
+                            kTcl112AcZeroSpace, kTcl112AcTolerance, 0, false);
     if (data_result.success == false) {
       DPRINT("DEBUG: offset = ");
       DPRINTLN(offset + data_result.used);

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -10,6 +10,7 @@
 #endif
 #include "IRremoteESP8266.h"
 #include "IRsend.h"
+#include "IRrecv.h"
 #ifdef UNIT_TEST
 #include "IRsend_test.h"
 #endif
@@ -21,6 +22,7 @@ const uint16_t kTcl112AcBitMark = 500;
 const uint16_t kTcl112AcOneSpace = 1050;
 const uint16_t kTcl112AcZeroSpace = 325;
 const uint32_t kTcl112AcGap = kDefaultMessageGap;  // Just a guess.
+const uint8_t kTcl112AcTolerance = kTolerance + 5;  // Percent
 
 const uint8_t kTcl112AcHeat = 1;
 const uint8_t kTcl112AcDry =  2;


### PR DESCRIPTION
Increase the tolerance by 5% to help match poor TCL112AC signals.

Fixes #744