### PR TITLE
Fix travis enum34 issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - arduino --board $BD --save-prefs
   - arduino --pref "compiler.warning_level=all" --save-prefs
   - sudo apt-get install jq
+  - sudo apt-get purge python-enum34
   - sudo pip install pylint
 script:
   # Check that everything compiles.


### PR DESCRIPTION
Travis is failing with this error message:

_"Cannot uninstall 'enum34'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall."_

when `sudo pip install pylint` is run.