### PR TITLE
Add sanity tests for unexpected conditions in IRrecv.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -15,6 +15,9 @@ extern "C" {
 #include <Arduino.h>
 #endif
 #include <algorithm>
+#ifdef UNIT_TEST
+#include <cassert>
+#endif  // UNIT_TEST
 #include "IRremoteESP8266.h"
 #include "IRutils.h"
 
@@ -683,6 +686,17 @@ bool IRrecv::match(uint32_t measured, uint32_t desired, uint8_t tolerance,
   DPRINT(measured);
   DPRINT(" <= ");
   DPRINTLN(ticksHigh(desired, tolerance, delta));
+#ifdef UNIT_TEST
+  // Sanity checks that we don't have values that cause integer over/underflow.
+  // Only performed during testing so there is no performance hit in normal
+  // operation.
+  assert(ticksLow(desired, tolerance, delta) <= desired);
+  // Check if we overflowed.  (UINT32_MAX >> 3 is approx 9 minutes!)
+  assert(ticksHigh(desired, tolerance, delta) < UINT32_MAX >> 3);
+  // Check if our high mark is below where we started. This could happen.
+  // If there is a legit case, then this should be removed.
+  assert(ticksHigh(desired, tolerance, delta) >= desired);
+#endif  // UNIT_TEST
   return (measured >= ticksLow(desired, tolerance, delta) &&
           measured <= ticksHigh(desired, tolerance, delta));
 }
@@ -716,6 +730,17 @@ bool IRrecv::matchAtLeast(uint32_t measured, uint32_t desired,
   DPRINT(", ");
   DPRINT(ticksLow(MS_TO_USEC(irparams.timeout), tolerance, delta));
   DPRINTLN(")]");
+#ifdef UNIT_TEST
+  // Sanity checks that we don't have values that cause integer over/underflow.
+  // Only performed during testing so there is no performance hit in normal
+  // operation.
+  assert(ticksLow(desired, tolerance, delta) <= desired);
+  // Check if we overflowed.  (UINT32_MAX >> 3 is approx 9 minutes!)
+  assert(ticksHigh(desired, tolerance, delta) < UINT32_MAX >> 3);
+  // Check if our high mark is below where we started. This could happen.
+  // If there is a legit case, then this should be removed.
+  assert(ticksHigh(desired, tolerance, delta) >= desired);
+#endif  // UNIT_TEST
   // We really should never get a value of 0, except as the last value
   // in the buffer. If that is the case, then assume infinity and return true.
   if (measured == 0) return true;

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -119,25 +119,20 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
   uint64_t data = 0;
   uint16_t offset = kStartOffset;
   uint16_t actualBits;
-  uint32_t timeSoFar = 0;  // Time in uSecs of the message length.
 
   // Header
-  timeSoFar += results->rawbuf[offset] * kRawTick;
   if (!matchMark(results->rawbuf[offset], kSonyHdrMark)) return false;
   // Calculate how long the common tick time is based on the header mark.
   uint32_t tick = results->rawbuf[offset++] * kRawTick / kSonyHdrMarkTicks;
 
   // Data
   for (actualBits = 0; offset < results->rawlen - 1; actualBits++, offset++) {
-    // The gap after a Sony packet for a repeat should be kSonyMinGap or
-    //   (kSonyRptLength - timeSoFar) according to the spec.
-    if (matchSpace(results->rawbuf[offset], kSonyMinGapTicks * tick) ||
-        matchAtLeast(results->rawbuf[offset], kSonyRptLength - timeSoFar))
+    // The gap after a Sony packet for a repeat should be kSonyMinGap according
+    // to the spec.
+    if (matchAtLeast(results->rawbuf[offset], kSonyMinGapTicks * tick))
       break;  // Found a repeat space.
-    timeSoFar += results->rawbuf[offset] * kRawTick;
     if (!matchSpace(results->rawbuf[offset++], kSonySpaceTicks * tick))
       return false;
-    timeSoFar += results->rawbuf[offset] * kRawTick;
     if (matchMark(results->rawbuf[offset], kSonyOneMarkTicks * tick))
       data = (data << 1) | 1;
     else if (matchMark(results->rawbuf[offset], kSonyZeroMarkTicks * tick))

--- a/test/ir_Sony_test.cpp
+++ b/test/ir_Sony_test.cpp
@@ -153,7 +153,7 @@ TEST(TestDecodeSony, NormalSonyDecodeWithStrict) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony20Bits, 0x1, 0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(kSony20Bits, irsend.capture.bits);
   EXPECT_EQ(0x81080, irsend.capture.value);
@@ -164,7 +164,7 @@ TEST(TestDecodeSony, NormalSonyDecodeWithStrict) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony15Bits, 21, 1), kSony15Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(kSony15Bits, irsend.capture.bits);
   EXPECT_EQ(0x5480, irsend.capture.value);
@@ -175,7 +175,7 @@ TEST(TestDecodeSony, NormalSonyDecodeWithStrict) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony12Bits, 21, 1), kSony12Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(kSony12Bits, irsend.capture.bits);
   EXPECT_EQ(0xA90, irsend.capture.value);
@@ -248,7 +248,7 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0xFF, irsend.capture.value);
@@ -264,7 +264,7 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(13, irsend.capture.bits);
   EXPECT_EQ(0x1FFF, irsend.capture.value);
@@ -280,7 +280,7 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(17, irsend.capture.bits);
   EXPECT_EQ(0x1FFFF, irsend.capture.value);
@@ -296,19 +296,18 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
   EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(21, irsend.capture.bits);
   EXPECT_EQ(0x1FFFFF, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-
   irsend.reset();
   // Illegal 64-bit (max) Sony-like message.
   irsend.sendSony(0xFFFFFFFFFFFFFFFF, 64, 0);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -316,7 +315,6 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   EXPECT_EQ(0x0, irsend.capture.command);
 }
 
-// Decode unsupported Sony messages. i.e non-standard sizes.
 TEST(TestDecodeSony, DecodeGlobalCacheExample) {
   IRsendTest irsend(4);
   IRrecv irrecv(4);
@@ -331,7 +329,7 @@ TEST(TestDecodeSony, DecodeGlobalCacheExample) {
   irsend.makeDecodeResult();
 
   // Without strict.
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(12, irsend.capture.bits);
   EXPECT_EQ(0x750, irsend.capture.value);


### PR DESCRIPTION
Add some match sanity checks (via `assert()`) for conditions where we may have typo-ed
a value. They only run during Unit Testing, so no performance hit.

This uncovered a situation in `decodeSony` where we could underflow an
integer (and thus make a poor match determination. i.e. No security risk)
for a hypothetically long version of an out-of-spec Sony IR message.
e.g. Far too many bits to be a Sony message.

Improved some of the Sony Unit Tests while here.