### PR TITLE
[BUG] Ensure `IRrecv`'s GPIO is set to input mode.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -183,7 +183,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.2.1-beta"
+#define _MY_VERSION_ "v1.2.2-testing"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds
@@ -195,12 +195,13 @@ const int8_t kTxGpios[] = {-1, 0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16};
 const int8_t kRxGpios[] = {-1, 0, 1, 2, 3, 4, 5, 12, 13, 14, 15};
 #endif  // ESP8266
 #if defined(ESP32)
+// Ref: https://randomnerdtutorials.com/esp32-pinout-reference-gpios/
 const int8_t kTxGpios[] = {
-    -1, 0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-    25, 26, 27, 28, 29, 30, 31, 32, 33};
+    -1, 0, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23,
+    25, 26, 27, 32, 33};
 const int8_t kRxGpios[] = {
-    -1, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-    25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39};
+    -1, 1, 2, 3, 4, 5, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23,
+    25, 26, 27, 32, 33, 34, 35, 36, 39};
 #endif  // ESP32
 
 // JSON stuff

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2170,14 +2170,11 @@ void setup(void) {
   if (rx_gpio != kGpioUnused)
     irrecv = new IRrecv(rx_gpio, kCaptureBufferSize, kCaptureTimeout, true);
   if (irrecv != NULL) {
-#if IR_RX_PULLUP
-    pinMode(rx_gpio, INPUT_PULLUP);
-#endif  // IR_RX_PULLUP
 #if DECODE_HASH
     // Ignore messages with less than minimum on or off pulses.
     irrecv->setUnknownThreshold(kMinUnknownSize);
 #endif  // DECODE_HASH
-    irrecv->enableIRIn();  // Start the receiver
+    irrecv->enableIRIn(IR_RX_PULLUP);  // Start the receiver
   }
 #endif  // IR_RX
   commonAc = new IRac(txGpioTable[0]);

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -194,8 +194,21 @@ IRrecv::~IRrecv(void) {
 #endif  // ESP32
 }
 
-// initialization
-void IRrecv::enableIRIn(void) {
+// Set up and (re)start the IR capture mechanism.
+//
+// Args:
+//   pullup: A flag indicating should the GPIO use the internal pullup resistor.
+//           (Default: `false`. i.e. No.)
+void IRrecv::enableIRIn(const bool pullup) {
+  // ESP32's seem to require explicitly setting the GPIO to INPUT etc.
+  // This wasn't required on the ESP8266s, but it shouldn't hurt to make sure.
+  if (pullup) {
+#ifndef UNIT_TEST
+    pinMode(irparams.recvpin, INPUT_PULLUP);
+  } else {
+    pinMode(irparams.recvpin, INPUT);
+#endif  // UNIT_TEST
+  }
 #if defined(ESP32)
   // Initialize the ESP32 timer.
   timer = timerBegin(_timer_num, 80, true);  // 80MHz / 80 = 1 uSec granularity.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -123,7 +123,7 @@ class IRrecv {
 #endif  // ESP32
   ~IRrecv(void);                                                  // Destructor
   bool decode(decode_results *results, irparams_t *save = NULL);
-  void enableIRIn(void);
+  void enableIRIn(const bool pullup = false);
   void disableIRIn(void);
   void resume(void);
   uint16_t getBufSize(void);


### PR DESCRIPTION
* Testing on different ESP32 boards highlighted that unlike ESP8266's
  the GPIO needs to be explicitly set to INPUT (or INPUT_PULLUP) mode for
  interrupts to work correctly.

* Adjust list of available GPIO/GPI's on ESP32 in IRMQTTServer.
* Add option to use `INPUT_PULLUP` via `IRrecv.enableIRIn(true)`.
  - Default is false. i.e. `INPUT`

Fixes #768