### PR TITLE
Daikin160: Add detailed & common a/c support.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3410,6 +3410,14 @@ bool decodeCommonAc(const decode_results *decode) {
       break;
     }
 #endif  // DECODE_DAIKIN
+#if DECODE_DAIKIN160
+    case decode_type_t::DAIKIN160: {
+      IRDaikin160 ac(txgpio);
+      ac.setRaw(decode->state);
+      state = ac.toCommon();
+      break;
+    }
+#endif  // DECODE_DAIKIN160
 #if DECODE_DAIKIN2
     case decode_type_t::DAIKIN2: {
       IRDaikin2 ac(txgpio);

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -136,6 +136,13 @@ void dumpACInfo(const decode_results * const results) {
     description = ac.toString();
   }
 #endif  // DECODE_DAIKIN
+#if DECODE_DAIKIN160
+  if (results->decode_type == DAIKIN160) {
+    IRDaikin160 ac(0);
+    ac.setRaw(results->state);
+    description = ac.toString();
+  }
+#endif  // DECODE_DAIKIN160
 #if DECODE_DAIKIN2
   if (results->decode_type == DAIKIN2) {
     IRDaikin2 ac(0);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -225,7 +225,7 @@ void IRac::daikin160(IRDaikin160 *ac,
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
-  ac->setSwingVertical((int8_t)swingv >= 0);
+  ac->setSwingVertical(ac->convertSwingV(swingv));
   ac->send();
 }
 #endif  // SEND_DAIKIN160

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -49,6 +49,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_DAIKIN
     case decode_type_t::DAIKIN:
 #endif
+#if SEND_DAIKIN160
+    case decode_type_t::DAIKIN160:
+#endif
 #if SEND_DAIKIN2
     case decode_type_t::DAIKIN2:
 #endif
@@ -212,6 +215,20 @@ void IRac::daikin(IRDaikinESP *ac,
   ac->send();
 }
 #endif  // SEND_DAIKIN
+
+#if SEND_DAIKIN160
+void IRac::daikin160(IRDaikin160 *ac,
+                     const bool on, const stdAc::opmode_t mode,
+                     const float degrees, const stdAc::fanspeed_t fan,
+                     const stdAc::swingv_t swingv) {
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical((int8_t)swingv >= 0);
+  ac->send();
+}
+#endif  // SEND_DAIKIN160
 
 #if SEND_DAIKIN2
 void IRac::daikin2(IRDaikin2 *ac,
@@ -899,6 +916,14 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
       break;
     }
 #endif  // SEND_DAIKIN
+#if SEND_DAIKIN160
+    case DAIKIN160:
+    {
+      IRDaikin160 ac(_pin);
+      daikin160(&ac, on, mode, degC, fan, swingv);
+      break;
+    }
+#endif  // SEND_DAIKIN160
 #if SEND_DAIKIN2
     case DAIKIN2:
     {

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -86,6 +86,12 @@ class IRac {
               const bool quiet, const bool turbo, const bool econo,
               const bool clean);
 #endif  // SEND_DAIKIN
+#if SEND_DAIKIN160
+void daikin160(IRDaikin160 *ac,
+               const bool on, const stdAc::opmode_t mode,
+               const float degrees, const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv);
+#endif  // SEND_DAIKIN160
 #if SEND_DAIKIN2
   void daikin2(IRDaikin2 *ac,
                const bool on, const stdAc::opmode_t mode,

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -6,6 +6,7 @@ http://harizanov.com/2012/02/control-daikin-air-conditioner-over-the-internet/
 Copyright 2016 sillyfrog
 Copyright 2017 sillyfrog, crankyoldgit
 Copyright 2018-2019 crankyoldgit
+Copyright 2019 pasna (IRDaikin160 class)
 */
 
 #include "ir_Daikin.h"
@@ -1851,13 +1852,6 @@ IRDaikin160::IRDaikin160(uint16_t pin) : _irsend(pin) { stateReset(); }
 
 void IRDaikin160::begin() { _irsend.begin(); }
 
-#if SEND_DAIKIN160
-void IRDaikin160::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin160(remote_state, kDaikin160StateLength, repeat);
-}
-#endif  // SEND_DAIKIN160
-
 // Verify the checksum is valid for a given state.
 // Args:
 //   state:  The array to verify the checksum of.
@@ -1896,6 +1890,10 @@ void IRDaikin160::stateReset() {
   remote_state[7] =  0x11;
   remote_state[8] =  0xDA;
   remote_state[9] =  0x27;
+  remote_state[12] = 0x30;
+  remote_state[13] = 0x11;
+  remote_state[16] = 0x1E;
+  remote_state[17] = 0x0A;
   // remote_state[19] is a checksum byte, it will be set by checksum().
 }
 
@@ -1907,6 +1905,183 @@ uint8_t *IRDaikin160::getRaw() {
 void IRDaikin160::setRaw(const uint8_t new_code[]) {
   for (uint8_t i = 0; i < kDaikin160StateLength; i++)
     remote_state[i] = new_code[i];
+}
+
+#if SEND_DAIKIN160
+void IRDaikin160::send(const uint16_t repeat) {
+  checksum();
+  _irsend.sendDaikin160(remote_state, kDaikin160StateLength, repeat);
+}
+#endif  // SEND_DAIKIN160
+
+void IRDaikin160::on() {
+  remote_state[kDaikin160BytePower] |= kDaikinBitPower;
+}
+
+void IRDaikin160::off() {
+  remote_state[kDaikin160BytePower] &= ~kDaikinBitPower;
+}
+
+void IRDaikin160::setPower(const bool state) {
+  if (state)
+    on();
+  else
+    off();
+}
+
+bool IRDaikin160::getPower() {
+  return remote_state[kDaikin160BytePower] & kDaikinBitPower;
+}
+
+uint8_t IRDaikin160::getMode() {
+  return (remote_state[kDaikin160ByteMode] & kDaikin160MaskMode) >> 4;
+}
+
+void IRDaikin160::setMode(const uint8_t mode) {
+  switch (mode) {
+    case kDaikinAuto:
+    case kDaikinCool:
+    case kDaikinHeat:
+    case kDaikinFan:
+    case kDaikinDry:
+      remote_state[kDaikin160ByteMode] &= ~kDaikin160MaskMode;
+      remote_state[kDaikin160ByteMode] |= (mode << 4);
+      break;
+    default:
+      this->setMode(kDaikinAuto);
+  }
+}
+
+// Convert a standard A/C mode into its native mode.
+uint8_t IRDaikin160::convertMode(const stdAc::opmode_t mode) {
+  return IRDaikinESP::convertMode(mode);
+}
+
+// Set the temp in deg C
+void IRDaikin160::setTemp(const uint8_t temp) {
+  uint8_t degrees = std::max(temp, kDaikinMinTemp);
+  degrees = std::min(degrees, kDaikinMaxTemp) * 2 - 20;
+  remote_state[kDaikin160ByteTemp] &= ~kDaikin160MaskTemp;
+  remote_state[kDaikin160ByteTemp] |= degrees;
+}
+
+uint8_t IRDaikin160::getTemp(void) {
+  return (((remote_state[kDaikin160ByteTemp] & kDaikin160MaskTemp) / 2 ) + 10);
+}
+
+// Set the speed of the fan, 1-5 or kDaikinFanAuto or kDaikinFanQuiet
+void IRDaikin160::setFan(const uint8_t fan) {
+  uint8_t fanset;
+  if (fan == kDaikinFanQuiet || fan == kDaikinFanAuto)
+    fanset = fan;
+  else if (fan < kDaikinFanMin || fan > kDaikinFanMax)
+    fanset = kDaikinFanAuto;
+  else
+    fanset = 2 + fan;
+  // Set the fan speed bits, leave *upper* 4 bits alone
+  remote_state[kDaikin160ByteFan] &= ~kDaikin160MaskFan;
+  remote_state[kDaikin160ByteFan] |= fanset;
+}
+
+uint8_t IRDaikin160::getFan() {
+  uint8_t fan = remote_state[kDaikin160ByteFan] & kDaikin160MaskFan;
+  if (fan != kDaikinFanQuiet && fan != kDaikinFanAuto) fan -= 2;
+  return fan;
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRDaikin160::convertFan(const stdAc::fanspeed_t speed) {
+  return IRDaikinESP::convertFan(speed);
+}
+
+void IRDaikin160::setSwingVertical(const bool on) {
+  if (on)
+    remote_state[kDaikin160ByteSwingV] |= kDaikin160MaskSwingV;
+  else
+    remote_state[kDaikin160ByteSwingV] &= ~kDaikin160MaskSwingV;
+}
+
+bool IRDaikin160::getSwingVertical(void) {
+  return remote_state[kDaikin160ByteSwingV] & kDaikin160MaskSwingV;
+}
+
+// Convert the A/C state to it's common equivalent.
+stdAc::state_t IRDaikin160::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::DAIKIN160;
+  result.model = -1;  // No models used.
+  result.power = this->getPower();
+  result.mode = IRDaikinESP::toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = IRDaikinESP::toCommonFanSpeed(this->getFan());
+  result.swingv = this->getSwingVertical() ? stdAc::swingv_t::kAuto :
+                                             stdAc::swingv_t::kOff;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.turbo = false;
+  result.light = false;
+  result.clean = false;
+  result.econo = false;
+  result.filter = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}
+
+// Convert the internal state into a human readable string.
+String IRDaikin160::toString() {
+  String result = "";
+  result.reserve(80);  // Reserve some heap for the string to reduce fragging.
+  result += F("Power: ");
+  if (this->getPower())
+    result += F("On");
+  else
+    result += F("Off");
+  result += F(", Mode: ");
+  result += uint64ToString(this->getMode());
+  switch (getMode()) {
+    case kDaikinAuto:
+      result += F(" (AUTO)");
+      break;
+    case kDaikinCool:
+      result += F(" (COOL)");
+      break;
+    case kDaikinHeat:
+      result += F(" (HEAT)");
+      break;
+    case kDaikinDry:
+      result += F(" (DRY)");
+      break;
+    case kDaikinFan:
+      result += F(" (FAN)");
+      break;
+    default:
+      result += F(" (UNKNOWN)");
+  }
+  result += F(", Temp: ");
+  result += uint64ToString(this->getTemp());
+  result += F("C, Fan: ");
+  result += uint64ToString(this->getFan());
+  switch (this->getFan()) {
+    case kDaikinFanAuto:
+      result += F(" (AUTO)");
+      break;
+    case kDaikinFanQuiet:
+      result += F(" (QUIET)");
+      break;
+    case kDaikinFanMin:
+      result += F(" (MIN)");
+      break;
+    case kDaikinFanMax:
+      result += F(" (MAX)");
+      break;
+  }
+  result += F(", Swing (Vertical): ");
+  result += this->getSwingVertical() ? F("On") : F("Off");
+  return result;
 }
 
 #if DECODE_DAIKIN160

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -2033,7 +2033,7 @@ uint8_t IRDaikin160::convertSwingV(const stdAc::swingv_t position) {
     case stdAc::swingv_t::kMiddle:
     case stdAc::swingv_t::kLow:
     case stdAc::swingv_t::kLowest:
-      return (uint8_t)position;
+      return kDaikin160SwingVHighest + 1 - (uint8_t)position;
     default:
       return kDaikin160SwingVAuto;
   }

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -237,11 +237,11 @@ const uint8_t kDaikin160ByteFan = 17;
 const uint8_t kDaikin160MaskFan = 0b00001111;
 const uint8_t kDaikin160ByteSwingV = 13;
 const uint8_t kDaikin160MaskSwingV = 0b11110000;
-const uint8_t kDaikin160SwingVHighest = 0x1;
-const uint8_t kDaikin160SwingVHigh =    0x2;
+const uint8_t kDaikin160SwingVLowest =  0x1;
+const uint8_t kDaikin160SwingVLow =     0x2;
 const uint8_t kDaikin160SwingVMiddle =  0x3;
-const uint8_t kDaikin160SwingVLow =     0x4;
-const uint8_t kDaikin160SwingVLowest =  0x5;
+const uint8_t kDaikin160SwingVHigh =    0x4;
+const uint8_t kDaikin160SwingVHighest = 0x5;
 const uint8_t kDaikin160SwingVAuto =    0xF;
 
 // Legacy defines.
@@ -502,7 +502,7 @@ class IRDaikin160 {
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   void setSwingVertical(const uint8_t position);
   uint8_t getSwingVertical(void);
-  uint8_t convertSwingV(const stdAc::swingv_t position);
+  static uint8_t convertSwingV(const stdAc::swingv_t position);
   static stdAc::swingv_t toCommonSwingV(const uint8_t setting);
   stdAc::state_t toCommon(void);
   String toString(void);

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -10,6 +10,7 @@
 //   Brand: Daikin,  Model: FTXZ50NV1B A/C
 //   Brand: Daikin,  Model: ARC433B69 remote
 //   Brand: Daikin,  Model: ARC423A5 remote
+//   Brand: Daikin,  Model: FTE12HV2S A/C
 
 #ifndef IR_DAIKIN_H_
 #define IR_DAIKIN_H_

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -236,10 +236,13 @@ const uint8_t kDaikin160MaskTemp = 0b01111110;
 const uint8_t kDaikin160ByteFan = 17;
 const uint8_t kDaikin160MaskFan = 0b00001111;
 const uint8_t kDaikin160ByteSwingV = 13;
-const uint8_t kDaikin160MaskSwingV = 0b11110001;
-const uint8_t kDaikin160SwingVHigh = 0x5;
-const uint8_t kDaikin160SwingVLow = 0x1;
-const uint8_t kDaikin160SwingVAuto = 0xF;
+const uint8_t kDaikin160MaskSwingV = 0b11110000;
+const uint8_t kDaikin160SwingVHighest = 0x1;
+const uint8_t kDaikin160SwingVHigh =    0x2;
+const uint8_t kDaikin160SwingVMiddle =  0x3;
+const uint8_t kDaikin160SwingVLow =     0x4;
+const uint8_t kDaikin160SwingVLowest =  0x5;
+const uint8_t kDaikin160SwingVAuto =    0xF;
 
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
@@ -497,8 +500,10 @@ class IRDaikin160 {
   void setFan(const uint8_t fan);
   uint8_t getFan(void);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
-  void setSwingVertical(const bool on);
-  bool getSwingVertical(void);
+  void setSwingVertical(const uint8_t position);
+  uint8_t getSwingVertical(void);
+  uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t setting);
   stdAc::state_t toCommon(void);
   String toString(void);
 #ifndef UNIT_TEST

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -227,6 +227,19 @@ const uint16_t kDaikin160Sections = 2;
 const uint16_t kDaikin160Section1Length = 7;
 const uint16_t kDaikin160Section2Length = kDaikin160StateLength -
                                           kDaikin160Section1Length;
+const uint8_t kDaikin160BytePower = 12;
+const uint8_t kDaikin160ByteMode = kDaikin160BytePower;
+const uint8_t kDaikin160MaskMode = 0b01110000;
+const uint8_t kDaikin160ByteTemp = 16;
+const uint8_t kDaikin160MaskTemp = 0b01111110;
+const uint8_t kDaikin160ByteFan = 17;
+const uint8_t kDaikin160MaskFan = 0b00001111;
+const uint8_t kDaikin160ByteSwingV = 13;
+const uint8_t kDaikin160MaskSwingV = 0b11110001;
+const uint8_t kDaikin160SwingVHigh = 0x5;
+const uint8_t kDaikin160SwingVLow = 0x1;
+const uint8_t kDaikin160SwingVAuto = 0xF;
+
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
 #define DAIKIN_HEAT kDaikinHeat
@@ -471,6 +484,22 @@ class IRDaikin160 {
   void setRaw(const uint8_t new_code[]);
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kDaikin160StateLength);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  void setSwingVertical(const bool on);
+  bool getSwingVertical(void);
+  stdAc::state_t toCommon(void);
+  String toString(void);
 #ifndef UNIT_TEST
 
  private:

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -137,6 +137,29 @@ TEST(TestIRac, Daikin) {
   ASSERT_EQ(expected, ac.toString());
 }
 
+TEST(TestIRac, Daikin160) {
+  IRDaikin160 ac(0);
+  IRac irac(0);
+  IRrecv capture(0);
+  char expected[] =
+      "Power: On, Mode: 2 (DRY), Temp: 23C, Fan: 1 (MIN), Swing (Vertical): On";
+
+  ac.begin();
+  irac.daikin160(&ac,
+                 true,                        // Power
+                 stdAc::opmode_t::kDry,       // Mode
+                 23,                          // Celsius
+                 stdAc::fanspeed_t::kLow,     // Fan speed
+                 stdAc::swingv_t::kAuto);     // Veritcal swing
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(DAIKIN160, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin160Bits, ac._irsend.capture.bits);
+  ac.setRaw(ac._irsend.capture.state);
+  ASSERT_EQ(expected, ac.toString());
+}
+
 TEST(TestIRac, Daikin2) {
   IRDaikin2 ac(0);
   IRac irac(0);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -142,15 +142,16 @@ TEST(TestIRac, Daikin160) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Mode: 2 (DRY), Temp: 23C, Fan: 1 (MIN), Swing (Vertical): On";
+      "Power: On, Mode: 2 (DRY), Temp: 23C, Fan: 1 (MIN), "
+      "Vent Position (V): 3 (Middle)";
 
   ac.begin();
   irac.daikin160(&ac,
                  true,                        // Power
                  stdAc::opmode_t::kDry,       // Mode
                  23,                          // Celsius
-                 stdAc::fanspeed_t::kLow,     // Fan speed
-                 stdAc::swingv_t::kAuto);     // Veritcal swing
+                 stdAc::fanspeed_t::kMin,     // Fan speed
+                 stdAc::swingv_t::kMiddle);   // Veritcal swing
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -2081,7 +2081,7 @@ TEST(TestDecodeDaikin160, RealExample) {
   IRDaikin160 ac(0);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ("Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
-            "Vent Position (V): 1 (Highest)", ac.toString());
+            "Vent Position (V): 1 (Lowest)", ac.toString());
 }
 
 TEST(TestDecodeDaikin160, SyntheticExample) {
@@ -2188,6 +2188,13 @@ TEST(TestDaikin160Class, VaneSwing) {
 
   ac.setSwingVertical(255);
   EXPECT_EQ(kDaikin160SwingVAuto, ac.getSwingVertical());
+
+  EXPECT_EQ(kDaikin160SwingVHighest,
+            IRDaikin160::convertSwingV(stdAc::swingv_t::kHighest));
+  EXPECT_EQ(kDaikin160SwingVLowest,
+            IRDaikin160::convertSwingV(stdAc::swingv_t::kLowest));
+  EXPECT_EQ(kDaikin160SwingVMiddle,
+            IRDaikin160::convertSwingV(stdAc::swingv_t::kMiddle));
 }
 
 TEST(TestDaikin160Class, Power) {
@@ -2276,7 +2283,7 @@ TEST(TestDaikin160Class, HumanReadable) {
 
   EXPECT_EQ(
       "Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
-      "Vent Position (V): 1 (Highest)",
+      "Vent Position (V): 1 (Lowest)",
       ac.toString());
   ac.setMode(kDaikinAuto);
   ac.setTemp(19);

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1,5 +1,6 @@
-// Copyright 2017 David Conran
+// Copyright 2017-2019 David Conran
 #include "ir_Daikin.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -1518,18 +1519,22 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("DAIKIN", typeToString(decode_type_t::DAIKIN));
   ASSERT_EQ(decode_type_t::DAIKIN, strToDecodeType("DAIKIN"));
   ASSERT_TRUE(hasACState(decode_type_t::DAIKIN));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::DAIKIN));
 
   ASSERT_EQ("DAIKIN160", typeToString(decode_type_t::DAIKIN160));
   ASSERT_EQ(decode_type_t::DAIKIN160, strToDecodeType("DAIKIN160"));
   ASSERT_TRUE(hasACState(decode_type_t::DAIKIN160));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::DAIKIN160));
 
   ASSERT_EQ("DAIKIN2", typeToString(decode_type_t::DAIKIN2));
   ASSERT_EQ(decode_type_t::DAIKIN2, strToDecodeType("DAIKIN2"));
   ASSERT_TRUE(hasACState(decode_type_t::DAIKIN2));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::DAIKIN2));
 
   ASSERT_EQ("DAIKIN216", typeToString(decode_type_t::DAIKIN216));
   ASSERT_EQ(decode_type_t::DAIKIN216, strToDecodeType("DAIKIN216"));
   ASSERT_TRUE(hasACState(decode_type_t::DAIKIN216));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::DAIKIN216));
 }
 
 // https://github.com/markszabo/IRremoteESP8266/issues/582#issuecomment-453863879
@@ -1700,7 +1705,6 @@ TEST(TestDaikin216Class, OperatingMode) {
   ac.setMode(255);
   EXPECT_EQ(kDaikinAuto, ac.getMode());
 }
-
 
 TEST(TestDaikin216Class, VaneSwing) {
   IRDaikin216 ac(0);
@@ -2074,6 +2078,10 @@ TEST(TestDecodeDaikin160, RealExample) {
   ASSERT_EQ(DAIKIN160, irsend.capture.decode_type);
   ASSERT_EQ(kDaikin160Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+  IRDaikin160 ac(0);
+  ac.setRaw(irsend.capture.state);
+  EXPECT_EQ("Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
+            "Swing (Vertical): On", ac.toString());
 }
 
 TEST(TestDecodeDaikin160, SyntheticExample) {
@@ -2095,4 +2103,188 @@ TEST(TestDecodeDaikin160, SyntheticExample) {
   ASSERT_EQ(DAIKIN160, irsend.capture.decode_type);
   ASSERT_EQ(kDaikin160Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+}
+
+TEST(TestDaikin160Class, toCommon) {
+  IRDaikin160 ac(0);
+  ac.setPower(true);
+  ac.setMode(kDaikinCool);
+  ac.setTemp(20);
+  ac.setFan(kDaikinFanMax);
+  ac.setSwingVertical(true);
+  // Now test it.
+  ASSERT_EQ(decode_type_t::DAIKIN160, ac.toCommon().protocol);
+  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_TRUE(ac.toCommon().power);
+  ASSERT_TRUE(ac.toCommon().celsius);
+  ASSERT_EQ(20, ac.toCommon().degrees);
+  ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
+  ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
+  // Unsupported.
+  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_FALSE(ac.toCommon().turbo);
+  ASSERT_FALSE(ac.toCommon().quiet);
+  ASSERT_FALSE(ac.toCommon().clean);
+  ASSERT_FALSE(ac.toCommon().econo);
+  ASSERT_FALSE(ac.toCommon().light);
+  ASSERT_FALSE(ac.toCommon().filter);
+  ASSERT_FALSE(ac.toCommon().beep);
+  ASSERT_EQ(-1, ac.toCommon().sleep);
+  ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+TEST(TestDaikin160Class, FanSpeed) {
+  IRDaikin160 ac(0);
+  ac.begin();
+
+  // Unexpected value should default to Auto.
+  ac.setFan(0);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  // Unexpected value should default to Auto.
+  ac.setFan(255);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanMax);
+  EXPECT_EQ(kDaikinFanMax, ac.getFan());
+
+  // Beyond Max should default to Auto.
+  ac.setFan(kDaikinFanMax + 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanMax - 1);
+  EXPECT_EQ(kDaikinFanMax - 1, ac.getFan());
+
+  ac.setFan(kDaikinFanMin);
+  EXPECT_EQ(kDaikinFanMin, ac.getFan());
+
+  ac.setFan(kDaikinFanMin + 1);
+  EXPECT_EQ(kDaikinFanMin + 1, ac.getFan());
+
+  // Beyond Min should default to Auto.
+  ac.setFan(kDaikinFanMin - 1);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(3);
+  EXPECT_EQ(3, ac.getFan());
+
+  ac.setFan(kDaikinFanAuto);
+  EXPECT_EQ(kDaikinFanAuto, ac.getFan());
+
+  ac.setFan(kDaikinFanQuiet);
+  EXPECT_EQ(kDaikinFanQuiet, ac.getFan());
+}
+
+TEST(TestDaikin160Class, VaneSwing) {
+  IRDaikin160 ac(0);
+  ac.begin();
+
+  ac.setSwingVertical(false);
+  EXPECT_FALSE(ac.getSwingVertical());
+
+  ac.setSwingVertical(true);
+  EXPECT_TRUE(ac.getSwingVertical());
+
+  ac.setSwingVertical(false);
+  EXPECT_FALSE(ac.getSwingVertical());
+}
+
+TEST(TestDaikin160Class, Power) {
+  IRDaikin160 ac(0);
+  ac.begin();
+
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestDaikin160Class, Temperature) {
+  IRDaikin160 ac(0);
+  ac.begin();
+
+  ac.setTemp(0);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp - 1);
+  EXPECT_EQ(kDaikinMinTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMaxTemp + 1);
+  EXPECT_EQ(kDaikinMaxTemp, ac.getTemp());
+
+  ac.setTemp(kDaikinMinTemp + 1);
+  EXPECT_EQ(kDaikinMinTemp + 1, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
+TEST(TestDaikin160Class, OperatingMode) {
+  IRDaikin160 ac(0);
+  ac.begin();
+
+  ac.setMode(kDaikinAuto);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(kDaikinCool);
+  EXPECT_EQ(kDaikinCool, ac.getMode());
+
+  ac.setMode(kDaikinHeat);
+  EXPECT_EQ(kDaikinHeat, ac.getMode());
+
+  ac.setMode(kDaikinDry);
+  EXPECT_EQ(kDaikinDry, ac.getMode());
+
+  ac.setMode(kDaikinFan);
+  EXPECT_EQ(kDaikinFan, ac.getMode());
+
+  ac.setMode(kDaikinFan + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(kDaikinAuto + 1);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kDaikinAuto, ac.getMode());
+}
+
+TEST(TestDaikin160Class, HumanReadable) {
+  IRDaikin160 ac(0);
+
+  EXPECT_EQ(
+      "Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
+      "Swing (Vertical): On",
+      ac.toString());
+  ac.setMode(kDaikinAuto);
+  ac.setTemp(19);
+  ac.setFan(kDaikinFanMin);
+  ac.setSwingVertical(false);
+  ac.setPower(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (AUTO), Temp: 19C, Fan: 1 (MIN), "
+      "Swing (Vertical): Off",
+      ac.toString());
 }

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -2081,7 +2081,7 @@ TEST(TestDecodeDaikin160, RealExample) {
   IRDaikin160 ac(0);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ("Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
-            "Swing (Vertical): On", ac.toString());
+            "Vent Position (V): 1 (Highest)", ac.toString());
 }
 
 TEST(TestDecodeDaikin160, SyntheticExample) {
@@ -2111,7 +2111,7 @@ TEST(TestDaikin160Class, toCommon) {
   ac.setMode(kDaikinCool);
   ac.setTemp(20);
   ac.setFan(kDaikinFanMax);
-  ac.setSwingVertical(true);
+  ac.setSwingVertical(kDaikin160SwingVAuto);
   // Now test it.
   ASSERT_EQ(decode_type_t::DAIKIN160, ac.toCommon().protocol);
   ASSERT_EQ(-1, ac.toCommon().model);
@@ -2180,14 +2180,14 @@ TEST(TestDaikin160Class, VaneSwing) {
   IRDaikin160 ac(0);
   ac.begin();
 
-  ac.setSwingVertical(false);
-  EXPECT_FALSE(ac.getSwingVertical());
+  ac.setSwingVertical(kDaikin160SwingVAuto);
+  EXPECT_EQ(kDaikin160SwingVAuto, ac.getSwingVertical());
 
-  ac.setSwingVertical(true);
-  EXPECT_TRUE(ac.getSwingVertical());
+  ac.setSwingVertical(kDaikin160SwingVHigh);
+  EXPECT_EQ(kDaikin160SwingVHigh, ac.getSwingVertical());
 
-  ac.setSwingVertical(false);
-  EXPECT_FALSE(ac.getSwingVertical());
+  ac.setSwingVertical(255);
+  EXPECT_EQ(kDaikin160SwingVAuto, ac.getSwingVertical());
 }
 
 TEST(TestDaikin160Class, Power) {
@@ -2276,15 +2276,15 @@ TEST(TestDaikin160Class, HumanReadable) {
 
   EXPECT_EQ(
       "Power: Off, Mode: 3 (COOL), Temp: 25C, Fan: 10 (AUTO), "
-      "Swing (Vertical): On",
+      "Vent Position (V): 1 (Highest)",
       ac.toString());
   ac.setMode(kDaikinAuto);
   ac.setTemp(19);
   ac.setFan(kDaikinFanMin);
-  ac.setSwingVertical(false);
+  ac.setSwingVertical(kDaikin160SwingVAuto);
   ac.setPower(true);
   EXPECT_EQ(
       "Power: On, Mode: 0 (AUTO), Temp: 19C, Fan: 1 (MIN), "
-      "Swing (Vertical): Off",
+      "Vent Position (V): 15 (Auto)",
       ac.toString());
 }


### PR DESCRIPTION
* Now supports:
  - Power
  - Mode
  - Temperature
  - Fan Speed
  - Vertical Swing
  - toString
  - common a/c api.

* Unit test coverage for new features.
* Update example code to reflect changes.

This commit is based on @pasna's work. I'm only taking credit for bug fixes &
unit tests.

Obsoletes PR #771 & #772 (too difficult to merge cleanly)
Fixes #731