### PR TITLE
Refactor A/C toString()'s to reduce code size. Saves 3.5K.

### DIFF
--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -798,3 +798,30 @@ uint64_t invertBits(const uint64_t data, const uint16_t nbits) {
 float celsiusToFahrenheit(const float deg) { return (deg * 9.0) / 5.0 + 32.0; }
 
 float fahrenheitToCelsius(const float deg) { return (deg - 32.0) * 5.0 / 9.0; }
+
+namespace IRutils {
+  String acBoolToString(const bool value, const String text,
+                        const bool precomma) {
+    String result = "";
+    if (precomma) result += F(", ");
+    result += text;
+    result += F(": ");
+    return result + (value ? F("On") : F("Off"));
+  }
+
+  String acModeToString(const uint8_t mode, const uint8_t automatic,
+                        const uint8_t cool, const uint8_t heat,
+                        const uint8_t dry, const uint8_t fan) {
+    String result = ", Mode: ";
+    result += uint64ToString(mode);
+    result += F(" (");
+    if (mode == automatic) result += F("AUTO");
+    else if (mode == cool) result += F("COOL");
+    else if (mode == heat) result += F("HEAT");
+    else if (mode == dry) result += F("DRY");
+    else if (mode == fan) result += F("FAN");
+    else
+      result += F("UNKNOWN");
+    return result + ')';
+  }
+}  // namespace IRutils

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -39,4 +39,11 @@ uint64_t invertBits(const uint64_t data, const uint16_t nbits);
 decode_type_t strToDecodeType(const char *str);
 float celsiusToFahrenheit(const float deg);
 float fahrenheitToCelsius(const float deg);
+namespace IRutils {
+  String acBoolToString(const bool value, const String text,
+                        const bool precomma = true);
+  String acModeToString(const uint8_t mode, const uint8_t automatic,
+                        const uint8_t cool, const uint8_t heat,
+                        const uint8_t dry, const uint8_t fan);
+}  // namespace IRutils
 #endif  // IRUTILS_H_

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -336,8 +336,7 @@ stdAc::state_t IRArgoAC::toCommon(void) {
 String IRArgoAC::toString() {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += getPower() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
   result += F(", Mode: ");
   result += uint64ToString(getMode());
   switch (getMode()) {
@@ -386,12 +385,9 @@ String IRArgoAC::toString() {
   result += F(", Room Temp: ");
   result += uint64ToString(getRoomTemp());
   result += 'C';
-  result += F(", Max: ");
-  result += getMax() ? F("On") : F("Off");
-  result += F(", iFeel: ");
-  result += getiFeel() ? F("On") : F("Off");
-  result += F(", Night: ");
-  result += getNight() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getMax(), F("Max"));
+  result += IRutils::acBoolToString(getiFeel(), F("iFeel"));
+  result += IRutils::acBoolToString(getNight(), F("Night"));
   return result;
 }
 

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -425,13 +425,8 @@ stdAc::state_t IRCoolixAC::toCommon(void) {
 String IRCoolixAC::toString() {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower()) {
-    result += F("On");
-  } else {
-    result += F("Off");
-    return result;  // If it's off, there is no other info.
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  if (!getPower()) return result;  // If it's off, there is no other info.
   // Special modes.
   if (getSwing()) {
     result += F(", Swing: Toggle");
@@ -453,27 +448,9 @@ String IRCoolixAC::toString() {
     result += F(", Clean: Toggle");
     return result;
   }
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kCoolixAuto:
-      result += F(" (AUTO)");
-      break;
-    case kCoolixCool:
-      result += F(" (COOL)");
-      break;
-    case kCoolixHeat:
-      result += F(" (HEAT)");
-      break;
-    case kCoolixDry:
-      result += F(" (DRY)");
-      break;
-    case kCoolixFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acModeToString(getMode(), kCoolixAuto,
+                                    kCoolixCool, kCoolixHeat,
+                                    kCoolixDry, kCoolixFan);
   result += F(", Fan: ");
   result += uint64ToString(getFan());
   switch (getFan()) {
@@ -506,11 +483,7 @@ String IRCoolixAC::toString() {
     result += uint64ToString(getTemp());
     result += 'C';
   }
-  result += F(", Zone Follow: ");
-  if (getZoneFollow())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getZoneFollow(), F("Zone Follow"));
   result += F(", Sensor Temp: ");
   if (getSensorTemp() > kCoolixSensorTempMax)
     result += F("Ignored");

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -508,29 +508,10 @@ String IRDaikinESP::renderTime(const uint16_t timemins) {
 String IRDaikinESP::toString(void) {
   String result = "";
   result.reserve(230);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += this->getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kDaikinAuto:
-      result += F(" (AUTO)");
-      break;
-    case kDaikinCool:
-      result += F(" (COOL)");
-      break;
-    case kDaikinHeat:
-      result += F(" (HEAT)");
-      break;
-    case kDaikinDry:
-      result += F(" (DRY)");
-      break;
-    case kDaikinFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kDaikinAuto,
+                                    kDaikinCool, kDaikinHeat,
+                                    kDaikinDry, kDaikinFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
@@ -549,20 +530,15 @@ String IRDaikinESP::toString(void) {
       result += F(" (MAX)");
       break;
   }
-  result += F(", Powerful: ");
-  result += this->getPowerful() ? F("On") : F("Off");
-  result += F(", Quiet: ");
-  result += this->getQuiet() ? F("On") : F("Off");
-  result += F(", Sensor: ");
-  result += this->getSensor() ? F("On") : F("Off");
-  result += F(", Mold: ");
-  result += this->getMold() ? F("On") : F("Off");
-  result += F(", Comfort: ");
-  result += this->getComfort() ? F("On") : F("Off");
-  result += F(", Swing (Horizontal): ");
-  result += this->getSwingHorizontal() ? F("On") : F("Off");
-  result += F(", Swing (Vertical): ");
-  result += this->getSwingVertical() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getPowerful(), F("Powerful"));
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getSensor(), F("Sensor"));
+  result += IRutils::acBoolToString(getMold(), F("Mold"));
+  result += IRutils::acBoolToString(getComfort(), F("Comfort"));
+  result += IRutils::acBoolToString(getSwingHorizontal(),
+                                    F("Swing (Horizontal)"));
+  result += IRutils::acBoolToString(getSwingVertical(),
+                                    F("Swing (Vertical)"));
   result += F(", Current Time: ");
   result += this->renderTime(this->getCurrentTime());
   result += F(", Current Day: ");
@@ -1192,32 +1168,10 @@ stdAc::state_t IRDaikin2::toCommon(void) {
 String IRDaikin2::toString() {
   String result = "";
   result.reserve(310);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kDaikinAuto:
-      result += F(" (AUTO)");
-      break;
-    case kDaikinCool:
-      result += F(" (COOL)");
-      break;
-    case kDaikinHeat:
-      result += F(" (HEAT)");
-      break;
-    case kDaikinDry:
-      result += F(" (DRY)");
-      break;
-    case kDaikinFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kDaikinAuto,
+                                    kDaikinCool, kDaikinHeat,
+                                    kDaikinDry, kDaikinFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -1319,27 +1273,19 @@ String IRDaikin2::toString() {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Mold: ");
-  result += (getMold() ? F("On") : F("Off"));
-  result += F(", Clean: ");
-  result += (getClean() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getMold(), F("Mold"));
+  result += IRutils::acBoolToString(getClean(), F("Clean"));
   result += F(", Fresh Air: ");
   if (getFreshAir())
     result += (getFreshAirHigh() ? "High" : "On");
   else
     result += F("Off");
-  result += F(", Eye: ");
-  result += (getEye() ? F("On") : F("Off"));
-  result += F(", Eye Auto: ");
-  result += (getEyeAuto() ? F("On") : F("Off"));
-  result += F(", Quiet: ");
-  result += (getQuiet() ? F("On") : F("Off"));
-  result += F(", Powerful: ");
-  result += (getPowerful() ? F("On") : F("Off"));
-  result += ", Purify: ";
-  result += (getPurify() ? F("On") : F("Off"));
-  result += F(", Econo: ");
-  result += (getEcono() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getEye(), F("Eye"));
+  result += IRutils::acBoolToString(getEyeAuto(), F("Eye Auto"));
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getPowerful(), F("Powerful"));
+  result += IRutils::acBoolToString(getPurify(), F("Purify"));
+  result += IRutils::acBoolToString(getEcono(), F("Econo"));
   return result;
 }
 
@@ -1686,32 +1632,10 @@ stdAc::state_t IRDaikin216::toCommon(void) {
 String IRDaikin216::toString() {
   String result = "";
   result.reserve(120);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (this->getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (getMode()) {
-    case kDaikinAuto:
-      result += F(" (AUTO)");
-      break;
-    case kDaikinCool:
-      result += F(" (COOL)");
-      break;
-    case kDaikinHeat:
-      result += F(" (HEAT)");
-      break;
-    case kDaikinDry:
-      result += F(" (DRY)");
-      break;
-    case kDaikinFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kDaikinAuto,
+                                    kDaikinCool, kDaikinHeat,
+                                    kDaikinDry, kDaikinFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
@@ -1730,14 +1654,11 @@ String IRDaikin216::toString() {
       result += F(" (MAX)");
       break;
   }
-  result += F(", Swing (Horizontal): ");
-  result += this->getSwingHorizontal() ? F("On") : F("Off");
-  result += F(", Swing (Vertical): ");
-  result += this->getSwingVertical() ? F("On") : F("Off");
-  result += F(", Quiet: ");
-  result += (this->getQuiet() ? F("On") : F("Off"));
-  result += F(", Powerful: ");
-  result += (this->getPowerful() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getSwingHorizontal(),
+                                    F("Swing (Horizontal)"));
+  result += IRutils::acBoolToString(getSwingVertical(), F("Swing (Vertical)"));
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getPowerful(), F("Powerful"));
   return result;
 }
 

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -538,29 +538,10 @@ String IRFujitsuAC::toString(void) {
     case fujitsu_ac_remote_model_t::ARJW2: result += F(" (ARJW2)"); break;
     default: result += F(" (UNKNOWN)");
   }
-  result += F(", Power: ");
-  result += this->getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kFujitsuAcModeAuto:
-      result += F(" (AUTO)");
-      break;
-    case kFujitsuAcModeCool:
-      result += F(" (COOL)");
-      break;
-    case kFujitsuAcModeHeat:
-      result += F(" (HEAT)");
-      break;
-    case kFujitsuAcModeDry:
-      result += F(" (DRY)");
-      break;
-    case kFujitsuAcModeFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"));
+  result += IRutils::acModeToString(getMode(), kFujitsuAcModeAuto,
+                                    kFujitsuAcModeCool, kFujitsuAcModeHeat,
+                                    kFujitsuAcModeDry, kFujitsuAcModeFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -303,29 +303,10 @@ stdAc::state_t IRGoodweatherAc::toCommon(void) {
 String IRGoodweatherAc::toString() {
   String result = "";
   result.reserve(150);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += this->getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kGoodweatherAuto:
-      result += F(" (AUTO)");
-      break;
-    case kGoodweatherCool:
-      result += F(" (COOL)");
-      break;
-    case kGoodweatherHeat:
-      result += F(" (HEAT)");
-      break;
-    case kGoodweatherDry:
-      result += F(" (DRY)");
-      break;
-    case kGoodweatherFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kGoodweatherAuto,
+                                    kGoodweatherCool, kGoodweatherHeat,
+                                    kGoodweatherDry, kGoodweatherFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -443,29 +443,10 @@ stdAc::state_t IRGreeAC::toCommon(void) {
 String IRGreeAC::toString(void) {
   String result = "";
   result.reserve(150);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += this->getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kGreeAuto:
-      result += F(" (AUTO)");
-      break;
-    case kGreeCool:
-      result += F(" (COOL)");
-      break;
-    case kGreeHeat:
-      result += F(" (HEAT)");
-      break;
-    case kGreeDry:
-      result += F(" (DRY)");
-      break;
-    case kGreeFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kGreeAuto,
+                                    kGreeCool, kGreeHeat,
+                                    kGreeDry, kGreeFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -478,18 +459,12 @@ String IRGreeAC::toString(void) {
       result += F(" (MAX)");
       break;
   }
-  result += F(", Turbo: ");
-  result += this->getTurbo() ? F("On") : F("Off");
-  result += F(", IFeel: ");
-  result += this->getIFeel() ? F("On") : F("Off");
-  result += F(", WiFi: ");
-  result += this->getWiFi() ? F("On") : F("Off");
-  result += F(", XFan: ");
-  result += this->getXFan() ? F("On") : F("Off");
-  result += F(", Light: ");
-  result += this->getLight() ? F("On") : F("Off");
-  result += F(", Sleep: ");
-  result += this->getSleep() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getIFeel(), F("IFeel"));
+  result += IRutils::acBoolToString(getWiFi(), F("WiFi"));
+  result += IRutils::acBoolToString(getXFan(), F("XFan"));
+  result += IRutils::acBoolToString(getLight(), F("Light"));
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
   result += F(", Swing Vertical Mode: ");
   result += this->getSwingVerticalAuto() ? F("Auto") : F("Manual");
   result += F(", Swing Vertical Pos: ");

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -459,27 +459,9 @@ String IRHaierAC::toString(void) {
       result += F("Unknown");
   }
   result += ')';
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kHaierAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kHaierAcCool:
-      result += F(" (COOL)");
-      break;
-    case kHaierAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kHaierAcDry:
-      result += F(" (DRY)");
-      break;
-    case kHaierAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acModeToString(getMode(), kHaierAcAuto,
+                                    kHaierAcCool, kHaierAcHeat,
+                                    kHaierAcDry, kHaierAcFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -512,16 +494,8 @@ String IRHaierAC::toString(void) {
       result += F("Unknown");
   }
   result += ')';
-  result += F(", Sleep: ");
-  if (getSleep())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Health: ");
-  if (getHealth())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
+  result += IRutils::acBoolToString(getHealth(), F("Health"));
   result += F(", Current Time: ");
   result += timeToString(getCurrTime());
   result += F(", On Timer: ");
@@ -534,7 +508,6 @@ String IRHaierAC::toString(void) {
     result += timeToString(getOffTimer());
   else
     result += F("Off");
-
   return result;
 }
 // End of IRHaierAC class.
@@ -852,11 +825,7 @@ stdAc::state_t IRHaierACYRW02::toCommon(void) {
 String IRHaierACYRW02::toString(void) {
   String result = "";
   result.reserve(130);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
   uint8_t cmd = getButton();
   result += F(", Button: ");
   result += uint64ToString(cmd);
@@ -893,27 +862,9 @@ String IRHaierACYRW02::toString(void) {
       result += F("Unknown");
   }
   result += ')';
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kHaierAcYrw02Auto:
-      result += F(" (Auto)");
-      break;
-    case kHaierAcYrw02Cool:
-      result += F(" (Cool)");
-      break;
-    case kHaierAcYrw02Heat:
-      result += F(" (Heat)");
-      break;
-    case kHaierAcYrw02Dry:
-      result += F(" (Dry)");
-      break;
-    case kHaierAcYrw02Fan:
-      result += F(" (Fan)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acModeToString(getMode(), kHaierAcYrw02Auto,
+                                    kHaierAcYrw02Cool, kHaierAcYrw02Heat,
+                                    kHaierAcYrw02Dry, kHaierAcYrw02Fan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -977,17 +928,8 @@ String IRHaierACYRW02::toString(void) {
       result += F("Unknown");
   }
   result += ')';
-  result += F(", Sleep: ");
-  if (getSleep())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Health: ");
-  if (getHealth())
-    result += F("On");
-  else
-    result += F("Off");
-
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
+  result += IRutils::acBoolToString(getHealth(), F("Health"));
   return result;
 }
 // End of IRHaierACYRW02 class.

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -340,32 +340,10 @@ stdAc::state_t IRHitachiAc::toCommon(void) {
 String IRHitachiAc::toString(void) {
   String result = "";
   result.reserve(110);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kHitachiAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kHitachiAcCool:
-      result += F(" (COOL)");
-      break;
-    case kHitachiAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kHitachiAcDry:
-      result += F(" (DRY)");
-      break;
-    case kHitachiAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kHitachiAcAuto,
+                                    kHitachiAcCool, kHitachiAcHeat,
+                                    kHitachiAcDry, kHitachiAcFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -384,16 +362,10 @@ String IRHitachiAc::toString(void) {
       result += F(" (UNKNOWN)");
       break;
   }
-  result += F(", Swing (Vertical): ");
-  if (getSwingVertical())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Swing (Horizontal): ");
-  if (getSwingHorizontal())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getSwingVertical(), F("Swing (Vertical)"));
+  result += IRutils::acBoolToString(getSwingHorizontal(),
+                                    F("Swing (Horizontal)"));
+
   return result;
 }
 

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -416,29 +416,10 @@ stdAc::state_t IRKelvinatorAC::toCommon(void) {
 String IRKelvinatorAC::toString(void) {
   String result = "";
   result.reserve(160);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kKelvinatorAuto:
-      result += F(" (AUTO)");
-      break;
-    case kKelvinatorCool:
-      result += F(" (COOL)");
-      break;
-    case kKelvinatorHeat:
-      result += F(" (HEAT)");
-      break;
-    case kKelvinatorDry:
-      result += F(" (DRY)");
-      break;
-    case kKelvinatorFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kKelvinatorAuto, kKelvinatorCool,
+                                    kKelvinatorHeat, kKelvinatorDry,
+                                    kKelvinatorFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -451,20 +432,14 @@ String IRKelvinatorAC::toString(void) {
       result += F(" (MAX)");
       break;
   }
-  result += F(", Turbo: ");
-  result += getTurbo() ? F("On") : F("Off");
-  result += F(", Quiet: ");
-  result += getQuiet() ? F("On") : F("Off");
-  result += F(", XFan: ");
-  result += getXFan() ? F("On") : F("Off");
-  result += F(", IonFilter: ");
-  result += getIonFilter() ? F("On") : F("Off");
-  result += F(", Light: ");
-  result += getLight() ? F("On") : F("Off");
-  result += F(", Swing (Horizontal): ");
-  result += getSwingHorizontal() ? F("On") : F("Off");
-  result += F(", Swing (Vertical): ");
-  result += getSwingVertical() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getXFan(), F("XFan"));
+  result += IRutils::acBoolToString(getIonFilter(), F("IonFilter"));
+  result += IRutils::acBoolToString(getLight(), F("Light"));
+  result += IRutils::acBoolToString(getSwingHorizontal(),
+                                    F("Swing (Horizontal)"));
+  result += IRutils::acBoolToString(getSwingVertical(), F("Swing (Vertical)"));
   return result;
 }
 

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -335,32 +335,10 @@ stdAc::state_t IRMideaAC::toCommon(void) {
 String IRMideaAC::toString(void) {
   String result = "";
   result.reserve(70);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kMideaACAuto:
-      result += F(" (AUTO)");
-      break;
-    case kMideaACCool:
-      result += F(" (COOL)");
-      break;
-    case kMideaACHeat:
-      result += F(" (HEAT)");
-      break;
-    case kMideaACDry:
-      result += F(" (DRY)");
-      break;
-    case kMideaACFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kMideaACAuto, kMideaACCool,
+                                    kMideaACHeat, kMideaACDry,
+                                    kMideaACFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp(true));
   result += F("C/");
@@ -381,11 +359,7 @@ String IRMideaAC::toString(void) {
       result += F(" (HI)");
       break;
   }
-  result += F(", Sleep: ");
-  if (getSleep())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
   return result;
 }
 

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -706,27 +706,10 @@ String IRMitsubishiAC::timeToString(const uint64_t time) {
 String IRMitsubishiAC::toString(void) {
   String result = "";
   result.reserve(110);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (this->getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  switch (this->getMode()) {
-    case MITSUBISHI_AC_AUTO:
-      result += F(" (AUTO)");
-      break;
-    case MITSUBISHI_AC_COOL:
-      result += F(" (COOL)");
-      break;
-    case MITSUBISHI_AC_DRY:
-      result += F(" (DRY)");
-      break;
-    case MITSUBISHI_AC_HEAT:
-      result += F(" (HEAT)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kMitsubishiAcAuto,
+                                    kMitsubishiAcCool, kMitsubishiAcHeat,
+                                    kMitsubishiAcDry, kMitsubishiAcAuto);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, FAN: ");

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -455,29 +455,10 @@ stdAc::state_t IRMitsubishiHeavy152Ac::toCommon(void) {
 String IRMitsubishiHeavy152Ac::toString(void) {
   String result = "";
   result.reserve(180);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kMitsubishiHeavyAuto:
-      result += F(" (Auto)");
-      break;
-    case kMitsubishiHeavyCool:
-      result += F(" (Cool)");
-      break;
-    case kMitsubishiHeavyHeat:
-      result += F(" (Heat)");
-      break;
-    case kMitsubishiHeavyDry:
-      result += F(" (Dry)");
-      break;
-    case kMitsubishiHeavyFan:
-      result += F(" (Fan)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kMitsubishiHeavyAuto,
+                                    kMitsubishiHeavyCool, kMitsubishiHeavyHeat,
+                                    kMitsubishiHeavyDry, kMitsubishiHeavyFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp()) + 'C';
   result += F(", Fan: ");
@@ -567,20 +548,13 @@ String IRMitsubishiHeavy152Ac::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Silent: ");
-  result += (this->getSilent() ? F("On") : F("Off"));
-  result += F(", Turbo: ");
-  result += (this->getTurbo() ? F("On") : F("Off"));
-  result += F(", Econo: ");
-  result += (this->getEcono() ? F("On") : F("Off"));
-  result += F(", Night: ");
-  result += (this->getNight() ? F("On") : F("Off"));
-  result += F(", Filter: ");
-  result += (this->getFilter() ? F("On") : F("Off"));
-  result += F(", 3D: ");
-  result += (this->get3D() ? F("On") : F("Off"));
-  result += F(", Clean: ");
-  result += (this->getClean() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getSilent(), F("Silent"));
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getEcono(), F("Econo"));
+  result += IRutils::acBoolToString(getNight(), F("Night"));
+  result += IRutils::acBoolToString(getFilter(), F("Filter"));
+  result += IRutils::acBoolToString(get3D(), F("3D"));
+  result += IRutils::acBoolToString(getClean(), F("Clean"));
   return result;
 }
 
@@ -931,29 +905,10 @@ stdAc::state_t IRMitsubishiHeavy88Ac::toCommon(void) {
 String IRMitsubishiHeavy88Ac::toString(void) {
   String result = "";
   result.reserve(140);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kMitsubishiHeavyAuto:
-      result += F(" (Auto)");
-      break;
-    case kMitsubishiHeavyCool:
-      result += F(" (Cool)");
-      break;
-    case kMitsubishiHeavyHeat:
-      result += F(" (Heat)");
-      break;
-    case kMitsubishiHeavyDry:
-      result += F(" (Dry)");
-      break;
-    case kMitsubishiHeavyFan:
-      result += F(" (Fan)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kMitsubishiHeavyAuto,
+                                    kMitsubishiHeavyCool, kMitsubishiHeavyHeat,
+                                    kMitsubishiHeavyDry, kMitsubishiHeavyFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp()) + 'C';
   result += F(", Fan: ");
@@ -1043,14 +998,10 @@ String IRMitsubishiHeavy88Ac::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Turbo: ");
-  result += (this->getTurbo() ? F("On") : F("Off"));
-  result += F(", Econo: ");
-  result += (this->getEcono() ? F("On") : F("Off"));
-  result += F(", 3D: ");
-  result += (this->get3D() ? F("On") : F("Off"));
-  result += F(", Clean: ");
-  result += (this->getClean() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getEcono(), F("Econo"));
+  result += IRutils::acBoolToString(get3D(), F("3D"));
+  result += IRutils::acBoolToString(getClean(), F("Clean"));
   return result;
 }
 

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -761,32 +761,10 @@ String IRPanasonicAc::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kPanasonicAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kPanasonicAcCool:
-      result += F(" (COOL)");
-      break;
-    case kPanasonicAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kPanasonicAcDry:
-      result += F(" (DRY)");
-      break;
-    case kPanasonicAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"));
+  result += IRutils::acModeToString(getMode(), kPanasonicAcAuto,
+                                    kPanasonicAcCool, kPanasonicAcHeat,
+                                    kPanasonicAcDry, kPanasonicAcFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -856,16 +834,8 @@ String IRPanasonicAc::toString(void) {
           break;
       }
   }
-  result += F(", Quiet: ");
-  if (getQuiet())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Powerful: ");
-  if (getPowerful())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getPowerful(), F("Powerful"));
   result += F(", Clock: ");
   result += timeToString(getClock());
   result += F(", On Timer: ");

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -659,32 +659,10 @@ stdAc::state_t IRSamsungAc::toCommon(void) {
 String IRSamsungAc::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  if (getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (getMode()) {
-    case kSamsungAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kSamsungAcCool:
-      result += F(" (COOL)");
-      break;
-    case kSamsungAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kSamsungAcDry:
-      result += F(" (DRY)");
-      break;
-    case kSamsungAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kSamsungAcAuto, kSamsungAcCool,
+                                    kSamsungAcHeat, kSamsungAcDry,
+                                    kSamsungAcFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -710,31 +688,11 @@ String IRSamsungAc::toString(void) {
       result += F(" (UNKNOWN)");
       break;
   }
-  result += F(", Swing: ");
-  if (getSwing())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Beep: ");
-  if (getBeep())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Clean: ");
-  if (getBeep())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Quiet: ");
-  if (getQuiet())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Powerful: ");
-  if (getPowerful())
-    result += F("On");
-  else
-    result += F("Off");
+  result += IRutils::acBoolToString(getSwing(), F("Swing"));
+  result += IRutils::acBoolToString(getBeep(), F("Beep"));
+  result += IRutils::acBoolToString(getClean(), F("Clean"));
+  result += IRutils::acBoolToString(getQuiet(), F("Quiet"));
+  result += IRutils::acBoolToString(getPowerful(), F("Powerful"));
   return result;
 }
 

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -488,26 +488,10 @@ stdAc::state_t IRSharpAc::toCommon(void) {
 String IRSharpAc::toString(void) {
   String result = "";
   result.reserve(60);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += this->getPower() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kSharpAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kSharpAcCool:
-      result += F(" (COOL)");
-      break;
-    case kSharpAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kSharpAcDry:
-      result += F(" (DRY)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kSharpAcAuto,
+                                    kSharpAcCool, kSharpAcHeat,
+                                    kSharpAcDry, kSharpAcAuto);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -343,29 +343,10 @@ stdAc::state_t IRTcl112Ac::toCommon(void) {
 String IRTcl112Ac::toString(void) {
   String result = "";
   result.reserve(140);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(getMode());
-  switch (this->getMode()) {
-    case kTcl112AcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kTcl112AcCool:
-      result += F(" (COOL)");
-      break;
-    case kTcl112AcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kTcl112AcDry:
-      result += F(" (DRY)");
-      break;
-    case kTcl112AcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kTcl112AcAuto,
+                                    kTcl112AcCool, kTcl112AcHeat,
+                                    kTcl112AcDry, kTcl112AcFan);
   uint16_t nrHalfDegrees = this->getTemp() * 2;
   result += F(", Temp: ");
   result += uint64ToString(nrHalfDegrees / 2);
@@ -386,18 +367,12 @@ String IRTcl112Ac::toString(void) {
       result += F(" (High)");
       break;
   }
-  result += F(", Econo: ");
-  result += (this->getEcono() ? F("On") : F("Off"));
-  result += ", Health: ";
-  result += (this->getHealth() ? F("On") : F("Off"));
-  result += F(", Light: ");
-  result += (this->getLight() ? F("On") : F("Off"));
-  result += F(", Turbo: ");
-  result += (this->getTurbo() ? F("On") : F("Off"));
-  result += ", Swing (H): ";
-  result += (this->getSwingHorizontal() ? F("On") : F("Off"));
-  result += F(", Swing (V): ");
-  result += (this->getSwingVertical() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getEcono(), F("Econo"));
+  result += IRutils::acBoolToString(getHealth(), F("Health"));
+  result += IRutils::acBoolToString(getLight(), F("Light"));
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getSwingHorizontal(), F("Swing (H)"));
+  result += IRutils::acBoolToString(getSwingVertical(), F("Swing (V)"));
   return result;
 }
 

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -220,29 +220,10 @@ stdAc::state_t IRTecoAc::toCommon(void) {
 String IRTecoAc::toString(void) {
   String result = "";
   result.reserve(80);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kTecoAuto:
-      result += F(" (AUTO)");
-      break;
-    case kTecoCool:
-      result += F(" (COOL)");
-      break;
-    case kTecoHeat:
-      result += F(" (HEAT)");
-      break;
-    case kTecoDry:
-      result += F(" (DRY)");
-      break;
-    case kTecoFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kTecoAuto,
+                                    kTecoCool, kTecoHeat,
+                                    kTecoDry, kTecoFan);
   result += F(", Temp: ");
   result += uint64ToString(getTemp());
   result += F("C, Fan: ");
@@ -263,10 +244,8 @@ String IRTecoAc::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Sleep: ");
-  result += (this->getSleep() ? F("On") : F("Off"));
-  result += F(", Swing: ");
-  result += (this->getSwing() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
+  result += IRutils::acBoolToString(getSwing(), F("Swing"));
   return result;
 }
 

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -316,29 +316,10 @@ stdAc::state_t IRToshibaAC::toCommon(void) {
 String IRToshibaAC::toString(void) {
   String result = "";
   result.reserve(40);
-  result += F("Power: ");
-  if (this->getPower())
-    result += F("On");
-  else
-    result += F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kToshibaAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kToshibaAcCool:
-      result += F(" (COOL)");
-      break;
-    case kToshibaAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kToshibaAcDry:
-      result += F(" (DRY)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kToshibaAcAuto,
+                                    kToshibaAcCool, kToshibaAcHeat,
+                                    kToshibaAcDry, kToshibaAcAuto);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -229,26 +229,10 @@ stdAc::state_t IRTrotecESP::toCommon(void) {
 String IRTrotecESP::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kTrotecAuto:
-      result += F(" (AUTO)");
-      break;
-    case kTrotecCool:
-      result += F(" (COOL)");
-      break;
-    case kTrotecDry:
-      result += F(" (DRY)");
-      break;
-    case kTrotecFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kTrotecAuto,
+                                    kTrotecCool, kTrotecAuto,
+                                    kTrotecDry, kTrotecFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan Speed: ");
@@ -264,8 +248,7 @@ String IRTrotecESP::toString(void) {
       result += F(" (High)");
       break;
   }
-  result += F(", Sleep: ");
-  result += (this->getSleep() ? F("On") : F("Off"));
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
   return result;
 }
 

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -503,29 +503,10 @@ String IRVestelAc::toString(void) {
     return result;
   }
   // Not a time command, it's a normal command.
-  result += F("Power: ");
-  result += (this->getPower() ? F("On") : F("Off"));
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kVestelAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kVestelAcCool:
-      result += F(" (COOL)");
-      break;
-    case kVestelAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kVestelAcDry:
-      result += F(" (DRY)");
-      break;
-    case kVestelAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPower(), F("Power"), false);
+  result += IRutils::acModeToString(getMode(), kVestelAcAuto,
+                                    kVestelAcCool, kVestelAcHeat,
+                                    kVestelAcDry, kVestelAcFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
@@ -552,14 +533,10 @@ String IRVestelAc::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Sleep: ");
-  result += this->getSleep() ? F("On") : F("Off");
-  result += F(", Turbo: ");
-  result += this->getTurbo() ? F("On") : F("Off");
-  result += F(", Ion: ");
-  result += this->getIon() ? F("On") : F("Off");
-  result += F(", Swing: ");
-  result += this->getSwing() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
+  result += IRutils::acBoolToString(getTurbo(), F("Turbo"));
+  result += IRutils::acBoolToString(getIon(), F("Ion"));
+  result += IRutils::acBoolToString(getSwing(), F("Swing"));
   return result;
 }
 

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -504,29 +504,10 @@ String IRWhirlpoolAc::toString(void) {
     default:
       result += F(" (UNKNOWN)");
   }
-  result += F(", Power toggle: ");
-  result += this->getPowerToggle() ? F("On") : F("Off");
-  result += F(", Mode: ");
-  result += uint64ToString(this->getMode());
-  switch (this->getMode()) {
-    case kWhirlpoolAcHeat:
-      result += F(" (HEAT)");
-      break;
-    case kWhirlpoolAcAuto:
-      result += F(" (AUTO)");
-      break;
-    case kWhirlpoolAcCool:
-      result += F(" (COOL)");
-      break;
-    case kWhirlpoolAcDry:
-      result += F(" (DRY)");
-      break;
-    case kWhirlpoolAcFan:
-      result += F(" (FAN)");
-      break;
-    default:
-      result += F(" (UNKNOWN)");
-  }
+  result += IRutils::acBoolToString(getPowerToggle(), F("Power toggle"));
+  result += IRutils::acModeToString(getMode(), kWhirlpoolAcAuto,
+                                    kWhirlpoolAcCool, kWhirlpoolAcHeat,
+                                    kWhirlpoolAcDry, kWhirlpoolAcFan);
   result += F(", Temp: ");
   result += uint64ToString(this->getTemp());
   result += F("C, Fan: ");
@@ -548,10 +529,8 @@ String IRWhirlpoolAc::toString(void) {
       result += F(" (UNKNOWN)");
       break;
   }
-  result += F(", Swing: ");
-  result += this->getSwing() ? F("On") : F("Off");
-  result += F(", Light: ");
-  result += this->getLight() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getSwing(), F("Swing"));
+  result += IRutils::acBoolToString(getLight(), F("Light"));
   result += F(", Clock: ");
   result += this->timeToString(this->getClock());
   result += F(", On Timer: ");
@@ -564,10 +543,8 @@ String IRWhirlpoolAc::toString(void) {
     result += this->timeToString(this->getOffTimer());
   else
     result += F("Off");
-  result += F(", Sleep: ");
-  result += this->getSleep() ? F("On") : F("Off");
-  result += F(", Super: ");
-  result += this->getSuper() ? F("On") : F("Off");
+  result += IRutils::acBoolToString(getSleep(), F("Sleep"));
+  result += IRutils::acBoolToString(getSuper(), F("Super"));
   result += F(", Command: ");
   result += uint64ToString(this->getCommand());
   switch (this->getCommand()) {

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -342,7 +342,7 @@ TEST(TestIRac, HaierYrwo2) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Button: 5 (Power), Mode: 2 (Cool), Temp: 23C, Fan: 4 (Med), "
+      "Power: On, Button: 5 (Power), Mode: 2 (COOL), Temp: 23C, Fan: 4 (Med), "
       "Turbo: 1 (High), Swing: 1 (Top), Sleep: On, Health: On";
 
   ac.begin();
@@ -451,7 +451,7 @@ TEST(TestIRac, Mitsubishi) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On (COOL), Temp: 20C, FAN: 2, VANE: AUTO, Time: 14:30, "
+      "Power: On, Mode: 24 (COOL), Temp: 20C, FAN: 2, VANE: AUTO, Time: 14:30, "
       "On timer: 00:00, Off timer: 00:00, Timer: -";
 
   ac.begin();
@@ -477,7 +477,7 @@ TEST(TestIRac, MitsubishiHeavy88) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Mode: 1 (Cool), Temp: 21C, Fan: 3 (Med), "
+      "Power: On, Mode: 1 (COOL), Temp: 21C, Fan: 3 (Med), "
       "Swing (V): 16 (Auto), Swing (H): 0 (Off), Turbo: Off, Econo: Off, "
       "3D: Off, Clean: On";
 
@@ -506,7 +506,7 @@ TEST(TestIRac, MitsubishiHeavy152) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 6 (Econo), "
+      "Power: On, Mode: 1 (COOL), Temp: 20C, Fan: 6 (Econo), "
       "Swing (V): 6 (Off), Swing (H): 0 (Auto), Silent: On, Turbo: Off, "
       "Econo: On, Night: On, Filter: On, 3D: Off, Clean: Off";
 

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -683,7 +683,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
   IRHaierACYRW02 haier(0);
 
   EXPECT_EQ(
-      "Power: On, Button: 5 (Power), Mode: 0 (Auto), Temp: 25C,"
+      "Power: On, Button: 5 (Power), Mode: 0 (AUTO), Temp: 25C,"
       " Fan: 10 (Auto), Turbo: 0 (Off), Swing: 0 (Off), Sleep: Off,"
       " Health: On",
       haier.toString());
@@ -691,7 +691,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
   haier.setTemp(21);
   haier.setFan(kHaierAcYrw02FanHigh);
   EXPECT_EQ(
-      "Power: On, Button: 4 (Fan), Mode: 2 (Cool), Temp: 21C,"
+      "Power: On, Button: 4 (Fan), Mode: 2 (COOL), Temp: 21C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 0 (Off), Sleep: Off,"
       " Health: On",
       haier.toString());
@@ -701,7 +701,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
   haier.setSleep(true);
   haier.setTurbo(kHaierAcYrw02TurboHigh);
   EXPECT_EQ(
-      "Power: On, Button: 8 (Turbo), Mode: 2 (Cool), Temp: 21C,"
+      "Power: On, Button: 8 (Turbo), Mode: 2 (COOL), Temp: 21C,"
       " Fan: 2 (High), Turbo: 1 (High), Swing: 2 (Middle),"
       " Sleep: On, Health: Off",
       haier.toString());
@@ -716,7 +716,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
   IRHaierACYRW02 haier(0);
   haier.setRaw(expectedState1);
   EXPECT_EQ(
-      "Power: On, Button: 7 (Health), Mode: 8 (Heat), Temp: 30C,"
+      "Power: On, Button: 7 (Health), Mode: 8 (HEAT), Temp: 30C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 1 (Top), Sleep: Off,"
       " Health: Off",
       haier.toString());
@@ -726,7 +726,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       0x80, 0x00, 0x00, 0x00, 0x00, 0x05, 0x75};
   haier.setRaw(expectedState2);
   EXPECT_EQ(
-      "Power: Off, Button: 5 (Power), Mode: 8 (Heat), Temp: 30C,"
+      "Power: Off, Button: 5 (Power), Mode: 8 (HEAT), Temp: 30C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 0 (Off), Sleep: Off,"
       " Health: Off",
       haier.toString());
@@ -736,7 +736,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x2B};
   haier.setRaw(expectedState3);
   EXPECT_EQ(
-      "Power: On, Button: 1 (Temp Down), Mode: 2 (Cool), Temp: 16C,"
+      "Power: On, Button: 1 (Temp Down), Mode: 2 (COOL), Temp: 16C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 2 (Middle), Sleep: Off,"
       " Health: On",
       haier.toString());
@@ -747,7 +747,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       0x20, 0x80, 0x00, 0x00, 0x00, 0x0B, 0xD7};
   haier.setRaw(expectedState4);
   EXPECT_EQ(
-      "Power: On, Button: 11 (Sleep), Mode: 2 (Cool), Temp: 25C,"
+      "Power: On, Button: 11 (Sleep), Mode: 2 (COOL), Temp: 25C,"
       " Fan: 10 (Auto), Turbo: 0 (Off), Swing: 12 (Auto), Sleep: On,"
       " Health: On",
       haier.toString());
@@ -758,7 +758,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       0x20, 0x80, 0x00, 0x00, 0x00, 0x04, 0x85};
   haier.setRaw(expectedState5);
   EXPECT_EQ(
-      "Power: On, Button: 4 (Fan), Mode: 2 (Cool), Temp: 25C,"
+      "Power: On, Button: 4 (Fan), Mode: 2 (COOL), Temp: 25C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 12 (Auto), Sleep: On,"
       " Health: On",
       haier.toString());
@@ -985,7 +985,7 @@ TEST(TestDecodeHaierAC_YRW02, RealExample) {
   IRHaierACYRW02 haier(0);
   haier.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: On, Button: 5 (Power), Mode: 2 (Cool), Temp: 17C,"
+      "Power: On, Button: 5 (Power), Mode: 2 (COOL), Temp: 17C,"
       " Fan: 2 (High), Turbo: 0 (Off), Swing: 2 (Middle), Sleep: Off,"
       " Health: On",
       haier.toString());

--- a/test/ir_MitsubishiHeavy_test.cpp
+++ b/test/ir_MitsubishiHeavy_test.cpp
@@ -293,7 +293,7 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
   IRMitsubishiHeavy152Ac ac(0);
 
   EXPECT_EQ(
-      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Power: Off, Mode: 0 (AUTO), Temp: 17C, Fan: 0 (Auto), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -310,7 +310,7 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
   ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);
   ac.setSwingHorizontal(kMitsubishiHeavy152SwingHAuto);
   EXPECT_EQ(
-      "Power: On, Mode: 1 (Cool), Temp: 17C, Fan: 4 (Max), "
+      "Power: On, Mode: 1 (COOL), Temp: 17C, Fan: 4 (Max), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: On, Turbo: Off, "
       "Econo: Off, Night: On, Filter: On, 3D: On, Clean: Off",
       ac.toString());
@@ -327,7 +327,7 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
   ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftMax);
 
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Heat), Temp: 31C, Fan: 8 (Turbo), "
+      "Power: On, Mode: 4 (HEAT), Temp: 31C, Fan: 8 (Turbo), "
       "Swing (V): 5 (Lowest), Swing (H): 1 (Max Left), Silent: Off, Turbo: On, "
       "Econo: Off, Night: Off, Filter: On, 3D: Off, Clean: Off",
       ac.toString());
@@ -338,7 +338,7 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
   ac.setSwingVertical(kMitsubishiHeavy152SwingVOff);
 
   EXPECT_EQ(
-      "Power: On, Mode: 0 (Auto), Temp: 31C, Fan: 6 (Econo), "
+      "Power: On, Mode: 0 (AUTO), Temp: 31C, Fan: 6 (Econo), "
       "Swing (V): 6 (Off), Swing (H): 1 (Max Left), Silent: Off, "
       "Turbo: Off, Econo: On, Night: Off, Filter: On, 3D: Off, Clean: On",
       ac.toString());
@@ -349,7 +349,7 @@ TEST(TestMitsubishiHeavy152AcClass, HumanReadable) {
   ac.setMode(kMitsubishiHeavyDry);
   ac.setSwingHorizontal(kMitsubishiHeavy152SwingHLeftRight);
   EXPECT_EQ(
-      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Power: On, Mode: 2 (DRY), Temp: 25C, Fan: 0 (Auto), "
       "Swing (V): 6 (Off), Swing (H): 7 (Left Right), Silent: Off, "
       "Turbo: Off, Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -359,7 +359,7 @@ TEST(TestMitsubishiHeavy152AcClass, ReconstructKnownExample) {
   IRMitsubishiHeavy152Ac ac(0);
 
   EXPECT_EQ(
-      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Power: Off, Mode: 0 (AUTO), Temp: 17C, Fan: 0 (Auto), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -377,7 +377,7 @@ TEST(TestMitsubishiHeavy152AcClass, ReconstructKnownExample) {
   ac.setSwingVertical(kMitsubishiHeavy152SwingVAuto);
   ac.setSwingHorizontal(kMitsubishiHeavy152SwingHAuto);
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Power: On, Mode: 4 (HEAT), Temp: 24C, Fan: 4 (Max), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -635,7 +635,7 @@ TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
   IRMitsubishiHeavy88Ac ac(0);
 
   EXPECT_EQ(
-      "Power: Off, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto), "
+      "Power: Off, Mode: 0 (AUTO), Temp: 17C, Fan: 0 (Auto), "
       "Swing (V): 0 (Off), Swing (H): 0 (Off), "
       "Turbo: Off, Econo: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -648,7 +648,7 @@ TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
   ac.set3D(true);
   ac.setSwingVertical(kMitsubishiHeavy88SwingVAuto);
   EXPECT_EQ(
-      "Power: On, Mode: 1 (Cool), Temp: 17C, Fan: 4 (High), "
+      "Power: On, Mode: 1 (COOL), Temp: 17C, Fan: 4 (High), "
       "Swing (V): 16 (Auto), Swing (H): 200 (3D), "
       "Turbo: Off, Econo: Off, 3D: On, Clean: Off",
       ac.toString());
@@ -662,7 +662,7 @@ TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
   ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftMax);
 
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Heat), Temp: 31C, Fan: 6 (Turbo), "
+      "Power: On, Mode: 4 (HEAT), Temp: 31C, Fan: 6 (Turbo), "
       "Swing (V): 26 (Lowest), Swing (H): 4 (Max Left), Turbo: On, Econo: Off, "
       "3D: Off, Clean: Off",
       ac.toString());
@@ -673,7 +673,7 @@ TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
   ac.setSwingVertical(kMitsubishiHeavy88SwingVOff);
 
   EXPECT_EQ(
-      "Power: On, Mode: 0 (Auto), Temp: 31C, Fan: 7 (Econo), "
+      "Power: On, Mode: 0 (AUTO), Temp: 31C, Fan: 7 (Econo), "
       "Swing (V): 0 (Off), Swing (H): 4 (Max Left), Turbo: Off, Econo: On, "
       "3D: Off, Clean: On",
       ac.toString());
@@ -684,7 +684,7 @@ TEST(TestMitsubishiHeavy88AcClass, HumanReadable) {
   ac.setMode(kMitsubishiHeavyDry);
   ac.setSwingHorizontal(kMitsubishiHeavy88SwingHLeftRight);
   EXPECT_EQ(
-      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Power: On, Mode: 2 (DRY), Temp: 25C, Fan: 0 (Auto), "
       "Swing (V): 0 (Off), Swing (H): 72 (Left Right), Turbo: Off, Econo: Off, "
       "3D: Off, Clean: Off",
       ac.toString());
@@ -739,7 +739,7 @@ TEST(TestDecodeMitsubishiHeavy, ZmsRealExample) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Power: On, Mode: 4 (HEAT), Temp: 24C, Fan: 4 (Max), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -766,7 +766,7 @@ TEST(TestDecodeMitsubishiHeavy, ZmsSyntheticExample) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Power: On, Mode: 4 (HEAT), Temp: 24C, Fan: 4 (Max), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -819,7 +819,7 @@ TEST(TestDecodeMitsubishiHeavy, ZmsRealExample2) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: Off, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
+      "Power: Off, Mode: 4 (HEAT), Temp: 24C, Fan: 4 (Max), "
       "Swing (V): 0 (Auto), Swing (H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
       ac.toString());
@@ -844,7 +844,7 @@ TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
+      "Power: On, Mode: 2 (DRY), Temp: 25C, Fan: 0 (Auto), "
       "Swing (V): 0 (Off), Swing (H): 72 (Left Right), Turbo: Off, Econo: Off, "
       "3D: Off, Clean: Off",
       ac.toString());

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -984,7 +984,7 @@ TEST(TestDecodeMitsubishiAC, DecodeRealExampleRepeatNeededButError) {
 TEST(TestMitsubishiACClass, HumanReadable) {
   IRMitsubishiAC irMitsu(0);
   EXPECT_EQ(
-      "Power: On (HEAT), Temp: 22C, FAN: SILENT, VANE: AUTO, "
+      "Power: On, Mode: 8 (HEAT), Temp: 22C, FAN: SILENT, VANE: AUTO, "
       "Time: 17:10, On timer: 00:00, Off timer: 00:00, Timer: -",
       irMitsu.toString());
 }


### PR DESCRIPTION
* Reduce code duplication.
* Saves ~3.5K of program space if all A/C protocols are used/enabled.