### PR TITLE
Change `ControlSamsungAC` example to not use `sendExtended()`

### DIFF
--- a/examples/ControlSamsungAC/ControlSamsungAC.ino
+++ b/examples/ControlSamsungAC/ControlSamsungAC.ino
@@ -55,31 +55,29 @@ void setup() {
 }
 
 void loop() {
-  // Turn the A/C unit on and set to cooling mode.
-  // Power changes require we send an extended message.
-  Serial.println("Sending an extended IR command to A/C ...");
+  // Turn the A/C unit on
+  Serial.println("Turn on the A/C ...");
   ac.on();
+  ac.send();
+  printState();
+  delay(15000);  // wait 15 seconds
+  // and set to cooling mode.
+  Serial.println("Set the A/C mode to cooling ...");
   ac.setMode(kSamsungAcCool);
-  ac.sendExtended();
+  ac.send();
   printState();
   delay(15000);  // wait 15 seconds
 
   // Increase the fan speed.
-  Serial.println("Sending a normal IR command to A/C ...");
+  Serial.println("Set the fan to high and the swing on ...");
   ac.setFan(kSamsungAcFanHigh);
-  ac.send();
-  printState();
-  delay(15000);
-
-  // Change to swing the fan.
-  Serial.println("Sending a normal IR command to A/C ...");
   ac.setSwing(true);
   ac.send();
   printState();
   delay(15000);
 
   // Change to Fan mode, lower the speed, and stop the swing.
-  Serial.println("Sending a normal IR command to A/C ...");
+  Serial.println("Set the A/C to fan only with a low speed, & no swing ...");
   ac.setSwing(false);
   ac.setMode(kSamsungAcFan);
   ac.setFan(kSamsungAcFanLow);
@@ -88,10 +86,9 @@ void loop() {
   delay(15000);
 
   // Turn the A/C unit off.
-  // Power changes require we send an extended message.
-  Serial.println("Sending an extended IR command to A/C ...");
+  Serial.println("Turn off the A/C ...");
   ac.off();
-  ac.sendExtended();
+  ac.send();
   printState();
   delay(15000);  // wait 15 seconds
 }

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -346,11 +346,13 @@ void IRSamsungAc::checksum(uint16_t length) {
 void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) this->checksum();
   if (_sendpower) {  // Do we need to send a the special power on/off message?
-    if (this->getPower())
+    _sendpower = false;  // It will now been sent.
+    if (this->getPower()) {
       this->sendOn();
-    else
+    } else {
       this->sendOff();
-    _sendpower = false;  // It's now been sent.
+      return;  // No point sending anything else if we are turning the unit off.
+    }
   }
   _irsend.sendSamsungAC(remote_state, kSamsungAcStateLength, repeat);
 }

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -20,6 +20,7 @@
 //   Brand: Samsung,  Model: UA55H6300 TV
 //   Brand: Samsung,  Model: IEC-R03 remote
 //   Brand: Samsung,  Model: AR12KSFPEWQNET A/C
+//   Brand: Samsung,  Model: AR12HSSDBWKNEU A/C
 
 // Ref:
 //   https://github.com/markszabo/IRremoteESP8266/issues/505


### PR DESCRIPTION
* Don't send normal state when powering off.

Fixes #791