### PR TITLE
Show available sketch space for OTA uploads.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -334,6 +334,7 @@ void setup_wifi(void);
 void init_vars(void);
 void setup(void);
 void loop(void);
+uint32_t maxSketchSpace(void);
 uint64_t getUInt64fromHex(char const *str);
 bool sendIRCode(IRsend *irsend, int const ir_type,
                 uint64_t const code, char const * code_str, uint16_t bits,

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -57,3 +57,14 @@ lib_ldf_mode = ${common.lib_ldf_mode}
 build_flags = ${common.build_flags}
 lib_deps =
   ${common_esp32.lib_deps_external}
+
+[env:esp01_1m]
+platform = espressif8266
+framework = arduino
+board = esp01_1m
+lib_ldf_mode = ${common.lib_ldf_mode}
+build_flags =
+  ${common.build_flags}
+  -Wl,-Teagle.flash.1m64.ld
+lib_deps =
+  ${common_esp8266.lib_deps_external}


### PR DESCRIPTION
* Update docs/comments for dealing with low flash memory boards.
* Add a Platformio build environment for ESP8266s with
  1M of flash and minimal SPIFFS space.

Fixes #785