### PR TITLE
feat: add invert flag support to Samsung AC

### DIFF
--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -283,7 +283,8 @@ void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
 }
 #endif  // SEND_SAMSUNG_AC
 
-IRSamsungAc::IRSamsungAc(const uint16_t pin) : _irsend(pin) {
+IRSamsungAc::IRSamsungAc(const uint16_t pin, bool inverted)
+  : _irsend(pin, inverted) {
   this->stateReset();
 }
 

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -62,7 +62,7 @@ const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 // Classes
 class IRSamsungAc {
  public:
-  explicit IRSamsungAc(const uint16_t pin);
+  explicit IRSamsungAc(const uint16_t pin, bool inverted = false);
 
   void stateReset(void);
 #if SEND_SAMSUNG_AC


### PR DESCRIPTION
Currently it's impossible to pass an invert flag to IRsend instance of a IRSamsungAc class. This update introduces an optional constructor parameter to let a client decide if it's required to invert the output or not.