### PR TITLE
Add setting of output options to A/C classes.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -33,6 +33,15 @@ const uint8_t kNrOfIrTxGpios = 1;
 // For an ESP-01 we suggest you use RX/GPIO3/Pin 7. i.e. kDefaultIrLed = 3
 // Note: A value of -1 means unused.
 const int8_t kDefaultIrLed = 4;  // <=- CHANGE_ME (optional)
+
+// **DANGER** Optional flag to invert the output. (default = false)
+//            `false`: The LED is illuminated when the GPIO is HIGH.
+//            `true`: The LED is illuminated when GPIO is LOW rather than HIGH.
+//            Setting this to something other than the default could
+//            easily destroy your IR LED if you are overdriving it.
+//            Unless you *REALLY* know what you are doing, don't change this.
+const bool kInvertTxOutput = false;
+
 // Default GPIO the IR demodulator is connected to/controlled by. GPIO 14 = D5.
 const int8_t kDefaultIrRx = 14;  // <=- CHANGE_ME (optional)
 
@@ -197,7 +206,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.3.0"
+#define _MY_VERSION_ "v1.3.1"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1249,6 +1249,8 @@ void handleInfo(void) {
 #endif  // ESP32
     "Cpu Freq: " + String(ESP.getCpuFreqMHz()) + "MHz<br>"
     "IR Send GPIO(s): " + listOfTxGpios() + "<br>"
+    + IRutils::acBoolToString(kInvertTxOutput,
+                              "Inverting GPIO output", false) + "<br>"
     "Total send requests: " + String(sendReqCounter) + "<br>"
     "Last message sent: " + String(lastSendSucceeded ? "Ok" : "FAILED") +
     " <i>(" + timeSince(lastSendTime) + ")</i><br>"
@@ -2021,7 +2023,7 @@ void setup(void) {
     if (txGpioTable[i] == kGpioUnused) {
       IrSendTable[i] = NULL;
     } else {
-      IrSendTable[i] = new IRsend(txGpioTable[i]);
+      IrSendTable[i] = new IRsend(txGpioTable[i], kInvertTxOutput);
       if (IrSendTable[i] == NULL) break;
       IrSendTable[i]->begin();
       offset = IrSendTable[i]->calibrate();
@@ -2038,7 +2040,7 @@ void setup(void) {
     irrecv->enableIRIn(IR_RX_PULLUP);  // Start the receiver
   }
 #endif  // IR_RX
-  commonAc = new IRac(txGpioTable[0]);
+  commonAc = new IRac(txGpioTable[0], kInvertTxOutput);
 
   // Wait a bit for things to settle.
   delay(500);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -37,7 +37,11 @@
 #include "ir_Vestel.h"
 #include "ir_Whirlpool.h"
 
-IRac::IRac(uint8_t pin) { _pin = pin; }
+IRac::IRac(const uint16_t pin, const bool inverted, const bool use_modulation) {
+  _pin = pin;
+  _inverted = inverted;
+  _modulation = use_modulation;
+}
 
 // Is the given protocol supported by the IRac class?
 bool IRac::isProtocolSupported(const decode_type_t protocol) {
@@ -952,7 +956,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_ARGO
     case ARGO:
     {
-      IRArgoAC ac(_pin);
+      IRArgoAC ac(_pin, _inverted, _modulation);
       argo(&ac, on, mode, degC, fan, swingv, turbo, sleep);
       break;
     }
@@ -960,7 +964,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_COOLIX
     case COOLIX:
     {
-      IRCoolixAC ac(_pin);
+      IRCoolixAC ac(_pin, _inverted, _modulation);
       coolix(&ac, on, mode, degC, fan, swingv, swingh,
              quiet, turbo, econo, clean);
       break;
@@ -969,7 +973,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_DAIKIN
     case DAIKIN:
     {
-      IRDaikinESP ac(_pin);
+      IRDaikinESP ac(_pin, _inverted, _modulation);
       daikin(&ac, on, mode, degC, fan, swingv, swingh,
              quiet, turbo, econo, clean);
       break;
@@ -978,7 +982,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_DAIKIN160
     case DAIKIN160:
     {
-      IRDaikin160 ac(_pin);
+      IRDaikin160 ac(_pin, _inverted, _modulation);
       daikin160(&ac, on, mode, degC, fan, swingv);
       break;
     }
@@ -986,7 +990,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_DAIKIN2
     case DAIKIN2:
     {
-      IRDaikin2 ac(_pin);
+      IRDaikin2 ac(_pin, _inverted, _modulation);
       daikin2(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo,
               light, econo, filter, clean, beep, sleep, clock);
       break;
@@ -995,7 +999,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_DAIKIN216
     case DAIKIN216:
     {
-      IRDaikin216 ac(_pin);
+      IRDaikin216 ac(_pin, _inverted, _modulation);
       daikin216(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo);
       break;
     }
@@ -1003,7 +1007,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_ELECTRA_AC
     case ELECTRA_AC:
     {
-      IRElectraAc ac(_pin);
+      IRElectraAc ac(_pin, _inverted, _modulation);
       ac.begin();
       electra(&ac, on, mode, degC, fan, swingv, swingh);
       break;
@@ -1012,7 +1016,8 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_FUJITSU_AC
     case FUJITSU_AC:
     {
-      IRFujitsuAC ac(_pin);
+      IRFujitsuAC ac(_pin, (fujitsu_ac_remote_model_t)model, _inverted,
+                     _modulation);
       ac.begin();
       fujitsu(&ac, (fujitsu_ac_remote_model_t)model, on, mode, degC, fan,
               swingv, swingh, quiet, turbo, econo);
@@ -1022,7 +1027,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_GOODWEATHER
     case GOODWEATHER:
     {
-      IRGoodweatherAc ac(_pin);
+      IRGoodweatherAc ac(_pin, _inverted, _modulation);
       ac.begin();
       goodweather(&ac, on, mode, degC, fan, swingv, turbo, light, sleep);
       break;
@@ -1031,7 +1036,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_GREE
     case GREE:
     {
-      IRGreeAC ac(_pin);
+      IRGreeAC ac(_pin, _inverted, _modulation);
       ac.begin();
       gree(&ac, on, mode, degC, fan, swingv, light, turbo, clean, sleep);
       break;
@@ -1040,7 +1045,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_HAIER_AC
     case HAIER_AC:
     {
-      IRHaierAC ac(_pin);
+      IRHaierAC ac(_pin, _inverted, _modulation);
       ac.begin();
       haier(&ac, on, mode, degC, fan, swingv, filter, sleep, clock);
       break;
@@ -1049,7 +1054,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_HAIER_AC_YRW02
     case HAIER_AC_YRW02:
     {
-      IRHaierACYRW02 ac(_pin);
+      IRHaierACYRW02 ac(_pin, _inverted, _modulation);
       ac.begin();
       haierYrwo2(&ac, on, mode, degC, fan, swingv, turbo, filter, sleep);
       break;
@@ -1058,7 +1063,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_HITACHI_AC
     case HITACHI_AC:
     {
-      IRHitachiAc ac(_pin);
+      IRHitachiAc ac(_pin, _inverted, _modulation);
       ac.begin();
       hitachi(&ac, on, mode, degC, fan, swingv, swingh);
       break;
@@ -1067,7 +1072,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_KELVINATOR
     case KELVINATOR:
     {
-      IRKelvinatorAC ac(_pin);
+      IRKelvinatorAC ac(_pin, _inverted, _modulation);
       ac.begin();
       kelvinator(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo,
                  light, filter, clean);
@@ -1077,7 +1082,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_MIDEA
     case MIDEA:
     {
-      IRMideaAC ac(_pin);
+      IRMideaAC ac(_pin, _inverted, _modulation);
       ac.begin();
       midea(&ac, on, mode, degC, fan, sleep);
       break;
@@ -1086,7 +1091,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_MITSUBISHI_AC
     case MITSUBISHI_AC:
     {
-      IRMitsubishiAC ac(_pin);
+      IRMitsubishiAC ac(_pin, _inverted, _modulation);
       ac.begin();
       mitsubishi(&ac, on, mode, degC, fan, swingv, quiet, clock);
       break;
@@ -1095,7 +1100,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_MITSUBISHIHEAVY
     case MITSUBISHI_HEAVY_88:
     {
-      IRMitsubishiHeavy88Ac ac(_pin);
+      IRMitsubishiHeavy88Ac ac(_pin, _inverted, _modulation);
       ac.begin();
       mitsubishiHeavy88(&ac, on, mode, degC, fan, swingv, swingh,
                         turbo, econo, clean);
@@ -1103,7 +1108,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
     }
     case MITSUBISHI_HEAVY_152:
     {
-      IRMitsubishiHeavy152Ac ac(_pin);
+      IRMitsubishiHeavy152Ac ac(_pin, _inverted, _modulation);
       ac.begin();
       mitsubishiHeavy152(&ac, on, mode, degC, fan, swingv, swingh,
                          quiet, turbo, econo, filter, clean, sleep);
@@ -1113,7 +1118,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_NEOCLIMA
     case NEOCLIMA:
     {
-      IRNeoclimaAc ac(_pin);
+      IRNeoclimaAc ac(_pin, _inverted, _modulation);
       ac.begin();
       neoclima(&ac, on, mode, degC, fan, swingv, swingh, turbo, light, filter,
                sleep);
@@ -1123,7 +1128,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_PANASONIC_AC
     case PANASONIC_AC:
     {
-      IRPanasonicAc ac(_pin);
+      IRPanasonicAc ac(_pin, _inverted, _modulation);
       ac.begin();
       panasonic(&ac, (panasonic_ac_remote_model_t)model, on, mode, degC, fan,
                 swingv, swingh, quiet, turbo, clock);
@@ -1133,7 +1138,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_SAMSUNG_AC
     case SAMSUNG_AC:
     {
-      IRSamsungAc ac(_pin);
+      IRSamsungAc ac(_pin, _inverted, _modulation);
       ac.begin();
       samsung(&ac, on, mode, degC, fan, swingv, quiet, turbo, clean, beep);
       break;
@@ -1142,7 +1147,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_SHARP_AC
     case SHARP_AC:
     {
-      IRSharpAc ac(_pin);
+      IRSharpAc ac(_pin, _inverted, _modulation);
       ac.begin();
       sharp(&ac, on, mode, degC, fan);
       break;
@@ -1151,7 +1156,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_TCL112AC
     case TCL112AC:
     {
-      IRTcl112Ac ac(_pin);
+      IRTcl112Ac ac(_pin, _inverted, _modulation);
       ac.begin();
       tcl112(&ac, on, mode, degC, fan, swingv, swingh, turbo, light, econo,
              filter);
@@ -1161,7 +1166,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_TECO
     case TECO:
     {
-      IRTecoAc ac(_pin);
+      IRTecoAc ac(_pin, _inverted, _modulation);
       ac.begin();
       teco(&ac, on, mode, degC, fan, swingv, sleep);
       break;
@@ -1170,7 +1175,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_TOSHIBA_AC
     case TOSHIBA_AC:
     {
-      IRToshibaAC ac(_pin);
+      IRToshibaAC ac(_pin, _inverted, _modulation);
       ac.begin();
       toshiba(&ac, on, mode, degC, fan);
       break;
@@ -1179,7 +1184,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_TROTEC
     case TROTEC:
     {
-      IRTrotecESP ac(_pin);
+      IRTrotecESP ac(_pin, _inverted, _modulation);
       ac.begin();
       trotec(&ac, on, mode, degC, fan, sleep);
       break;
@@ -1188,7 +1193,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_VESTEL_AC
     case VESTEL_AC:
     {
-      IRVestelAc ac(_pin);
+      IRVestelAc ac(_pin, _inverted, _modulation);
       ac.begin();
       vestel(&ac, on, mode, degC, fan, swingv, turbo, filter, sleep, clock);
       break;
@@ -1197,7 +1202,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 #if SEND_WHIRLPOOL_AC
     case WHIRLPOOL_AC:
     {
-      IRWhirlpoolAc ac(_pin);
+      IRWhirlpoolAc ac(_pin, _inverted, _modulation);
       ac.begin();
       whirlpool(&ac, (whirlpool_ac_remote_model_t)model, on, mode, degC, fan,
                 swingv, turbo, light, sleep, clock);

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -37,7 +37,8 @@ const int8_t kGpioUnused = -1;
 // Class
 class IRac {
  public:
-  explicit IRac(uint8_t pin);
+  explicit IRac(const uint16_t pin, const bool inverted = false,
+                const bool use_modulation = true);
   static bool isProtocolSupported(const decode_type_t protocol);
   bool sendAc(const decode_type_t vendor, const int16_t model,
               const bool power, const stdAc::opmode_t mode, const float degrees,
@@ -69,7 +70,9 @@ class IRac {
 
  private:
 #endif
-  uint8_t _pin;
+  uint16_t _pin;
+  bool _inverted;
+  bool _modulation;
 #if SEND_ARGO
   void argo(IRArgoAC *ac,
             const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -41,7 +41,9 @@ void IRsend::sendArgo(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_ARGO
 
-IRArgoAC::IRArgoAC(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
+IRArgoAC::IRArgoAC(const uint16_t pin, const bool inverted,
+                   const bool use_modulation)
+      : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRArgoAC::begin(void) { _irsend.begin(); }
 

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -110,7 +110,8 @@ const uint8_t kArgoFlapFull = 7;  // 0b111
 
 class IRArgoAC {
  public:
-  explicit IRArgoAC(const uint16_t pin);
+  explicit IRArgoAC(const uint16_t pin, const bool inverted = false,
+                    const bool use_modulation = true);
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -89,7 +89,9 @@ void IRsend::sendCOOLIX(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   RG57K7(B)/BGEF remote control for Beko BINR 070/071 split-type aircon.
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/484
-IRCoolixAC::IRCoolixAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRCoolixAC::IRCoolixAC(const uint16_t pin, const bool inverted,
+                       const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRCoolixAC::stateReset() { setRaw(kCoolixDefaultState); }
 

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -86,7 +86,8 @@ const uint32_t kCoolixDefaultState = 0b101100101011111111001000;  // 0xB2BFC8
 // Classes
 class IRCoolixAC {
  public:
-  explicit IRCoolixAC(uint16_t pin);
+  explicit IRCoolixAC(const uint16_t pin, const bool inverted = false,
+                      const bool use_modulation = true);
 
   void stateReset();
 #if SEND_COOLIX

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -81,7 +81,9 @@ void IRsend::sendDaikin(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_DAIKIN
 
-IRDaikinESP::IRDaikinESP(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRDaikinESP::IRDaikinESP(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+      : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRDaikinESP::begin(void) { _irsend.begin(); }
 
@@ -697,7 +699,9 @@ void IRsend::sendDaikin2(const unsigned char data[], const uint16_t nbytes,
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/582
 //   https://docs.google.com/spreadsheets/d/1f8EGfIbBUo2B-CzUFdrgKQprWakoYNKM80IKZN4KXQE/edit?usp=sharing
 //   https://www.daikin.co.nz/sites/default/files/daikin-split-system-US7-FTXZ25-50NV1B.pdf
-IRDaikin2::IRDaikin2(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRDaikin2::IRDaikin2(const uint16_t pin, const bool inverted,
+                     const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRDaikin2::begin() { _irsend.begin(); }
 
@@ -1406,7 +1410,9 @@ void IRsend::sendDaikin216(const unsigned char data[], const uint16_t nbytes,
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/689
 //   https://github.com/danny-source/Arduino_DY_IRDaikin
-IRDaikin216::IRDaikin216(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRDaikin216::IRDaikin216(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRDaikin216::begin() { _irsend.begin(); }
 
@@ -1769,7 +1775,9 @@ void IRsend::sendDaikin160(const unsigned char data[], const uint16_t nbytes,
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/731
-IRDaikin160::IRDaikin160(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRDaikin160::IRDaikin160(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRDaikin160::begin() { _irsend.begin(); }
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -259,7 +259,8 @@ const uint8_t kDaikin160SwingVAuto =    0xF;
 
 class IRDaikinESP {
  public:
-  explicit IRDaikinESP(uint16_t pin);
+  explicit IRDaikinESP(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
 #if SEND_DAIKIN
   void send(const uint16_t repeat = kDaikinDefaultRepeat);
@@ -334,7 +335,8 @@ class IRDaikinESP {
 // Class to emulate a Daikin ARC477A1 remote.
 class IRDaikin2 {
  public:
-  explicit IRDaikin2(uint16_t pin);
+  explicit IRDaikin2(const uint16_t pin, const bool inverted = false,
+                     const bool use_modulation = true);
 
 #if SEND_DAIKIN2
   void send(const uint16_t repeat = kDaikin2DefaultRepeat);
@@ -427,7 +429,8 @@ class IRDaikin2 {
 // Class to emulate a Daikin ARC433B69 remote.
 class IRDaikin216 {
  public:
-  explicit IRDaikin216(uint16_t pin);
+  explicit IRDaikin216(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
 #if SEND_DAIKIN216
   void send(const uint16_t repeat = kDaikin216DefaultRepeat);
@@ -477,7 +480,8 @@ class IRDaikin216 {
 // Class to emulate a Daikin ARC423A5 remote.
 class IRDaikin160 {
  public:
-  explicit IRDaikin160(uint16_t pin);
+  explicit IRDaikin160(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
 #if SEND_DAIKIN160
   void send(const uint16_t repeat = kDaikin160DefaultRepeat);

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -46,7 +46,9 @@ void IRsend::sendElectraAC(const uint8_t data[], const uint16_t nbytes,
 #endif
 
 
-IRElectraAc::IRElectraAc(const uint16_t pin) : _irsend(pin) {
+IRElectraAc::IRElectraAc(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
   this->stateReset();
 }
 

--- a/src/ir_Electra.h
+++ b/src/ir_Electra.h
@@ -52,7 +52,8 @@ const uint8_t kElectraAcPowerMask =  0b00100000;
 // Classes
 class IRElectraAc {
  public:
-  explicit IRElectraAc(const uint16_t pin);
+  explicit IRElectraAc(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_ELECTRA_AC

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -55,8 +55,9 @@ void IRsend::sendFujitsuAC(const unsigned char data[], const uint16_t nbytes,
 
 // Initialise the object.
 IRFujitsuAC::IRFujitsuAC(const uint16_t pin,
-                         const fujitsu_ac_remote_model_t model)
-    : _irsend(pin) {
+                         const fujitsu_ac_remote_model_t model,
+                         const bool inverted, const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
   this->setModel(model);
   this->stateReset();
 }

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -92,7 +92,9 @@ enum fujitsu_ac_remote_model_t {
 class IRFujitsuAC {
  public:
   explicit IRFujitsuAC(const uint16_t pin,
-                       const fujitsu_ac_remote_model_t model = ARRAH2E);
+                       const fujitsu_ac_remote_model_t model = ARRAH2E,
+                       const bool inverted = false,
+                       const bool use_modulation = true);
 
   void setModel(const fujitsu_ac_remote_model_t model);
   fujitsu_ac_remote_model_t getModel(void);

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -57,7 +57,9 @@ void IRsend::sendGoodweather(const uint64_t data, const uint16_t nbits,
 }
 #endif  // SEND_GOODWEATHER
 
-IRGoodweatherAc::IRGoodweatherAc(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRGoodweatherAc::IRGoodweatherAc(const uint16_t pin, const bool inverted,
+                                 const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRGoodweatherAc::stateReset(void) {
 }

--- a/src/ir_Goodweather.h
+++ b/src/ir_Goodweather.h
@@ -87,7 +87,8 @@ const uint8_t kGoodweatherCmdLight    = 0x0B;
 // Classes
 class IRGoodweatherAc {
  public:
-  explicit IRGoodweatherAc(uint16_t pin);
+  explicit IRGoodweatherAc(const uint16_t pin, const bool inverted = false,
+                           const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_GOODWEATHER

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -106,7 +106,9 @@ void IRsend::sendGree(const uint64_t data, const uint16_t nbits,
 }
 #endif  // SEND_GREE
 
-IRGreeAC::IRGreeAC(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRGreeAC::IRGreeAC(const uint16_t pin, const bool inverted,
+                   const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRGreeAC::stateReset(void) {
   // This resets to a known-good state to Power Off, Fan Auto, Mode Auto, 25C.

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -86,7 +86,8 @@ const uint8_t kGreeSwingUpAuto = 0b00001011;
 // Classes
 class IRGreeAC {
  public:
-  explicit IRGreeAC(uint16_t pin);
+  explicit IRGreeAC(const uint16_t pin, const bool inverted = false,
+                    const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_GREE

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -74,7 +74,9 @@ void IRsend::sendHaierACYRW02(const unsigned char data[], const uint16_t nbytes,
 #endif  // SEND_HAIER_AC_YRW02
 
 // Class for emulating a Haier HSU07-HEA03 remote
-IRHaierAC::IRHaierAC(const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRHaierAC::IRHaierAC(const uint16_t pin, const bool inverted,
+                     const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRHaierAC::begin(void) { _irsend.begin(); }
 
@@ -513,7 +515,9 @@ String IRHaierAC::toString(void) {
 // End of IRHaierAC class.
 
 // Class for emulating a Haier YRW02 remote
-IRHaierACYRW02::IRHaierACYRW02(uint16_t pin) : _irsend(pin) { stateReset(); }
+IRHaierACYRW02::IRHaierACYRW02(const uint16_t pin, const bool inverted,
+                               const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRHaierACYRW02::begin(void) { _irsend.begin(); }
 

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -187,7 +187,8 @@ const uint8_t kHaierAcYrw02ButtonSleep = 0xB;
 
 class IRHaierAC {
  public:
-  explicit IRHaierAC(const uint16_t pin);
+  explicit IRHaierAC(const uint16_t pin, const bool inverted = false,
+                     const bool use_modulation = true);
 
 #if SEND_HAIER_AC
   void send(const uint16_t repeat = kHaierAcDefaultRepeat);
@@ -253,7 +254,8 @@ class IRHaierAC {
 
 class IRHaierACYRW02 {
  public:
-  explicit IRHaierACYRW02(uint16_t pin);
+  explicit IRHaierACYRW02(const uint16_t pin, const bool inverted = false,
+                          const bool use_modulation = true);
 
 #if SEND_HAIER_AC_YRW02
   void send(const uint16_t repeat = kHaierAcYrw02DefaultRepeat);

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -104,7 +104,9 @@ void IRsend::sendHitachiAC2(const unsigned char data[], const uint16_t nbytes,
 // Inspired by:
 // https://github.com/ToniA/arduino-heatpumpir/blob/master/HitachiHeatpumpIR.cpp
 
-IRHitachiAc::IRHitachiAc(const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRHitachiAc::IRHitachiAc(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRHitachiAc::stateReset(void) {
   remote_state[0] = 0x80;

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -37,7 +37,8 @@ const uint8_t kHitachiAcAutoTemp = 23;  // 23C
 // Classes
 class IRHitachiAc {
  public:
-  explicit IRHitachiAc(const uint16_t pin);
+  explicit IRHitachiAc(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_HITACHI_AC

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -118,9 +118,9 @@ void IRsend::sendKelvinator(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_KELVINATOR
 
-IRKelvinatorAC::IRKelvinatorAC(uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRKelvinatorAC::IRKelvinatorAC(const uint16_t pin, const bool inverted,
+                               const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRKelvinatorAC::stateReset(void) {
   for (uint8_t i = 0; i < kKelvinatorStateLength; i++) remote_state[i] = 0x0;

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -133,7 +133,8 @@ const uint8_t kKelvinatorAutoTemp = 25;  // 25C
 // Classes
 class IRKelvinatorAC {
  public:
-  explicit IRKelvinatorAC(uint16_t pin);
+  explicit IRKelvinatorAC(const uint16_t pin, const bool inverted = false,
+                          const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_KELVINATOR

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -86,7 +86,9 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Warning: Consider this very alpha code.
 
 // Initialise the object.
-IRMideaAC::IRMideaAC(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
+IRMideaAC::IRMideaAC(const uint16_t pin, const bool inverted,
+                     const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 // Reset the state of the remote to a known good state/sequence.
 void IRMideaAC::stateReset(void) {

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -64,7 +64,8 @@ const uint64_t kMideaACChecksumMask = 0x0000FFFFFFFFFF00;
 
 class IRMideaAC {
  public:
-  explicit IRMideaAC(const uint16_t pin);
+  explicit IRMideaAC(const uint16_t pin, const bool inverted = false,
+                     const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_MIDEA

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -382,9 +382,9 @@ bool IRrecv::decodeMitsubishiAC(decode_results *results, uint16_t nbits,
 // Equipment it seems compatible with:
 //  * <Add models (A/C & remotes) you've gotten it working with here>
 // Initialise the object.
-IRMitsubishiAC::IRMitsubishiAC(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRMitsubishiAC::IRMitsubishiAC(const uint16_t pin, const bool inverted,
+                               const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 // Reset the state of the remote to a known good state/sequence.
 void IRMitsubishiAC::stateReset(void) {

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -60,7 +60,8 @@ const uint8_t kMitsubishiAcStartStopTimer = 7;
 
 class IRMitsubishiAC {
  public:
-  explicit IRMitsubishiAC(const uint16_t pin);
+  explicit IRMitsubishiAC(const uint16_t pin, const bool inverted = false,
+                          const bool use_modulation = true);
 
   static uint8_t calculateChecksum(const uint8_t* data);
 

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -73,8 +73,10 @@ void IRsend::sendMitsubishiHeavy152(const unsigned char data[],
 #endif  // SEND_MITSUBISHIHEAVY
 
 // Class for decoding and constructing MitsubishiHeavy152 AC messages.
-IRMitsubishiHeavy152Ac::IRMitsubishiHeavy152Ac(
-    const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRMitsubishiHeavy152Ac::IRMitsubishiHeavy152Ac(const uint16_t pin,
+                                               const bool inverted,
+                                               const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRMitsubishiHeavy152Ac::begin(void) { _irsend.begin(); }
 
@@ -560,8 +562,10 @@ String IRMitsubishiHeavy152Ac::toString(void) {
 
 
 // Class for decoding and constructing MitsubishiHeavy88 AC messages.
-IRMitsubishiHeavy88Ac::IRMitsubishiHeavy88Ac(
-    const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRMitsubishiHeavy88Ac::IRMitsubishiHeavy88Ac(const uint16_t pin,
+                                             const bool inverted,
+                                             const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRMitsubishiHeavy88Ac::begin(void) { _irsend.begin(); }
 

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -122,7 +122,9 @@ const uint8_t kMitsubishiHeavy88SwingVOff =       0b00000000;  // 0x00
 // Classes
 class IRMitsubishiHeavy152Ac {
  public:
-  explicit IRMitsubishiHeavy152Ac(const uint16_t pin);
+  explicit IRMitsubishiHeavy152Ac(const uint16_t pin,
+                                  const bool inverted = false,
+                                  const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_MITSUBISHIHEAVY
@@ -202,7 +204,9 @@ class IRMitsubishiHeavy152Ac {
 
 class IRMitsubishiHeavy88Ac {
  public:
-  explicit IRMitsubishiHeavy88Ac(const uint16_t pin);
+  explicit IRMitsubishiHeavy88Ac(const uint16_t pin,
+                                 const bool inverted = false,
+                                 const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_MITSUBISHIHEAVY

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -59,7 +59,9 @@ void IRsend::sendNeoclima(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_NEOCLIMA
 
-IRNeoclimaAc::IRNeoclimaAc(const uint16_t pin) : _irsend(pin) {
+IRNeoclimaAc::IRNeoclimaAc(const uint16_t pin, const bool inverted,
+                           const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
   this->stateReset();
 }
 

--- a/src/ir_Neoclima.h
+++ b/src/ir_Neoclima.h
@@ -82,7 +82,8 @@ const uint8_t kNeoclimaHeat =     0b100;
 // Classes
 class IRNeoclimaAc {
  public:
-  explicit IRNeoclimaAc(const uint16_t pin);
+  explicit IRNeoclimaAc(const uint16_t pin, const bool inverted = false,
+                        const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_NEOCLIMA

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -215,9 +215,9 @@ void IRsend::sendPanasonicAC(const uint8_t data[], const uint16_t nbytes,
 }
 #endif  // SEND_PANASONIC_AC
 
-IRPanasonicAc::IRPanasonicAc(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRPanasonicAc::IRPanasonicAc(const uint16_t pin, const bool inverted,
+                             const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRPanasonicAc::stateReset(void) {
   for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -92,7 +92,8 @@ enum panasonic_ac_remote_model_t {
 
 class IRPanasonicAc {
  public:
-  explicit IRPanasonicAc(const uint16_t pin);
+  explicit IRPanasonicAc(const uint16_t pin, const bool inverted = false,
+                         const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_PANASONIC

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -283,8 +283,9 @@ void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
 }
 #endif  // SEND_SAMSUNG_AC
 
-IRSamsungAc::IRSamsungAc(const uint16_t pin, bool inverted)
-  : _irsend(pin, inverted) {
+IRSamsungAc::IRSamsungAc(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
   this->stateReset();
 }
 

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -62,7 +62,8 @@ const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 // Classes
 class IRSamsungAc {
  public:
-  explicit IRSamsungAc(const uint16_t pin, bool inverted = false);
+  explicit IRSamsungAc(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_SAMSUNG_AC

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -262,7 +262,9 @@ void IRsend::sendSharpAc(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_SHARP_AC
 
-IRSharpAc::IRSharpAc(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
+IRSharpAc::IRSharpAc(const uint16_t pin, const bool inverted,
+                     const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRSharpAc::begin(void) { _irsend.begin(); }
 

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -51,7 +51,8 @@ const uint8_t kSharpAcBitTempManual = 0b00000100;
 
 class IRSharpAc {
  public:
-  explicit IRSharpAc(const uint16_t pin);
+  explicit IRSharpAc(const uint16_t pin, const bool inverted = false,
+                     const bool use_modulation = true);
 
 #if SEND_SHARP_AC
   void send(const uint16_t repeat = kSharpAcDefaultRepeat);

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -22,7 +22,9 @@ void IRsend::sendTcl112Ac(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TCL112AC
 
-IRTcl112Ac::IRTcl112Ac(const uint16_t pin) : _irsend(pin) { stateReset(); }
+IRTcl112Ac::IRTcl112Ac(const uint16_t pin, const bool inverted,
+                       const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 void IRTcl112Ac::begin(void) { this->_irsend.begin(); }
 

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -51,7 +51,8 @@ const uint8_t kTcl112AcBitTurbo  = 0b01000000;
 
 class IRTcl112Ac {
  public:
-  explicit IRTcl112Ac(const uint16_t pin);
+  explicit IRTcl112Ac(const uint16_t pin, const bool inverted = false,
+                      const bool use_modulation = true);
 
 #if SEND_TCL112AC
   void send(const uint16_t repeat = kTcl112AcDefaultRepeat);

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -36,7 +36,9 @@ void IRsend::sendTeco(const uint64_t data, const uint16_t nbits,
 #endif  // SEND_TECO
 
 // Class for decoding and constructing Teco AC messages.
-IRTecoAc::IRTecoAc(const uint16_t pin) : _irsend(pin) { this->stateReset(); }
+IRTecoAc::IRTecoAc(const uint16_t pin, const bool inverted,
+                   const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRTecoAc::begin(void) { _irsend.begin(); }
 

--- a/src/ir_Teco.h
+++ b/src/ir_Teco.h
@@ -87,7 +87,8 @@ const uint64_t kTecoReset =      0b01001010000000000000010000000000000;
 // Classes
 class IRTecoAc {
  public:
-  explicit IRTecoAc(const uint16_t pin);
+  explicit IRTecoAc(const uint16_t pin, const bool inverted = false,
+                    const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_TECO

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -60,9 +60,9 @@ void IRsend::sendToshibaAC(const unsigned char data[], const uint16_t nbytes,
 // Status:  STABLE / Working.
 //
 // Initialise the object.
-IRToshibaAC::IRToshibaAC(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRToshibaAC::IRToshibaAC(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 // Reset the state of the remote to a known good state/sequence.
 void IRToshibaAC::stateReset(void) {

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -48,7 +48,8 @@ const uint8_t kToshibaAcMaxTemp = 30;  // 30C
 
 class IRToshibaAC {
  public:
-  explicit IRToshibaAC(const uint16_t pin);
+  explicit IRToshibaAC(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_TOSHIBA_AC

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -38,9 +38,9 @@ void IRsend::sendTrotec(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TROTEC
 
-IRTrotecESP::IRTrotecESP(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRTrotecESP::IRTrotecESP(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRTrotecESP::begin(void) { _irsend.begin(); }
 

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -59,7 +59,8 @@ const uint8_t kTrotecMaxTimer = 23;
 
 class IRTrotecESP {
  public:
-  explicit IRTrotecESP(uint16_t pin);
+  explicit IRTrotecESP(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
 
 #if SEND_TROTEC
   void send(const uint16_t repeat = kTrotecDefaultRepeat);

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -45,9 +45,9 @@ void IRsend::sendVestelAc(const uint64_t data, const uint16_t nbits,
 // Code to emulate Vestel A/C IR remote control unit.
 
 // Initialise the object.
-IRVestelAc::IRVestelAc(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRVestelAc::IRVestelAc(const uint16_t pin, const bool inverted,
+                       const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 // Reset the state of the remote to a known good state/sequence.
 void IRVestelAc::stateReset(void) {

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -103,7 +103,8 @@ const uint64_t kVestelAcTimeStateDefault = 0x201ULL;
 
 class IRVestelAc {
  public:
-  explicit IRVestelAc(const uint16_t pin);
+  explicit IRVestelAc(const uint16_t pin, const bool inverted = false,
+                      const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_VESTEL_AC

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -79,9 +79,9 @@ void IRsend::sendWhirlpoolAC(const unsigned char data[], const uint16_t nbytes,
 // Decoding help from:
 //   @redmusicxd, @josh929800, @raducostea
 
-IRWhirlpoolAc::IRWhirlpoolAc(const uint16_t pin) : _irsend(pin) {
-  this->stateReset();
-}
+IRWhirlpoolAc::IRWhirlpoolAc(const uint16_t pin, const bool inverted,
+                             const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRWhirlpoolAc::stateReset(void) {
   for (uint8_t i = 2; i < kWhirlpoolAcStateLength; i++) remote_state[i] = 0x0;

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -89,7 +89,8 @@ enum whirlpool_ac_remote_model_t {
 // Classes
 class IRWhirlpoolAc {
  public:
-  explicit IRWhirlpoolAc(const uint16_t pin);
+  explicit IRWhirlpoolAc(const uint16_t pin, const bool inverted = false,
+                         const bool use_modulation = true);
 
   void stateReset(void);
 #if SEND_WHIRLPOOL_AC


### PR DESCRIPTION
Ref: #807
* Allow output of A/C classes to be inverted.
* Allow output of A/C classes to not have freq modulation.
* Defaults set to normal operation.
* Add a compile-time variable to control if output is inverted for 
IRMQTTServer.

FYI & H/T to @sskorol for #807 which pointed out this was missing.