### PR TITLE
Update platformio.ini files for PlatformIO v4.0.0

### DIFF
--- a/examples/ControlSamsungAC/platformio.ini
+++ b/examples/ControlSamsungAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/DumbIRRepeater/platformio.ini
+++ b/examples/DumbIRRepeater/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRGCSendDemo/platformio.ini
+++ b/examples/IRGCSendDemo/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRGCTCPServer/platformio.ini
+++ b/examples/IRGCTCPServer/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -1,10 +1,13 @@
 [platformio]
+src_dir = .
+
+[env]
 lib_extra_dirs = ../../
-src_dir=.
+lib_ldf_mode = deep+
+lib_ignore = examples
+build_flags = -DMQTT_MAX_PACKET_SIZE=768
 
 [common]
-build_flags = -DMQTT_MAX_PACKET_SIZE=768
-lib_ldf_mode = chain+
 lib_deps_builtin =
 lib_deps_external =
   PubSubClient
@@ -26,45 +29,34 @@ lib_deps_external =
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common_esp8266.lib_deps_external}
+lib_deps = ${common_esp8266.lib_deps_external}
 
 [env:d1_mini]
-platform=espressif8266
-framework=arduino
-board=d1_mini
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common_esp8266.lib_deps_external}
+platform = espressif8266
+framework = arduino
+board = d1_mini
+lib_deps = ${common_esp8266.lib_deps_external}
 
 [env:d1_mini_no_mqtt]
-platform=espressif8266
-framework=arduino
-board=d1_mini
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags} -DMQTT_ENABLE=false
-lib_deps =
-  ${common_esp8266.lib_deps_external}
+platform = espressif8266
+framework = arduino
+board = d1_mini
+build_flags =
+  ${env.build_flags}
+  -DMQTT_ENABLE=false
+lib_deps = ${common_esp8266.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common_esp32.lib_deps_external}
+lib_deps = ${common_esp32.lib_deps_external}
 
 [env:esp01_1m]
 platform = espressif8266
 framework = arduino
 board = esp01_1m
-lib_ldf_mode = ${common.lib_ldf_mode}
 build_flags =
-  ${common.build_flags}
+  ${env.build_flags}
   -Wl,-Teagle.flash.1m64.ld
-lib_deps =
-  ${common_esp8266.lib_deps_external}
+lib_deps = ${common_esp8266.lib_deps_external}

--- a/examples/IRServer/platformio.ini
+++ b/examples/IRServer/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRrecvDemo/platformio.ini
+++ b/examples/IRrecvDemo/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRrecvDump/platformio.ini
+++ b/examples/IRrecvDump/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRsendDemo/platformio.ini
+++ b/examples/IRsendDemo/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/IRsendProntoDemo/platformio.ini
+++ b/examples/IRsendProntoDemo/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/JVCPanasonicSendDemo/platformio.ini
+++ b/examples/JVCPanasonicSendDemo/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/LGACSend/platformio.ini
+++ b/examples/LGACSend/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/SmartIRRepeater/platformio.ini
+++ b/examples/SmartIRRepeater/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnArgoAC/platformio.ini
+++ b/examples/TurnOnArgoAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnDaikinAC/platformio.ini
+++ b/examples/TurnOnDaikinAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnFujitsuAC/platformio.ini
+++ b/examples/TurnOnFujitsuAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnKelvinatorAC/platformio.ini
+++ b/examples/TurnOnKelvinatorAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnMitsubishiAC/platformio.ini
+++ b/examples/TurnOnMitsubishiAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnMitsubishiHeavyAc/platformio.ini
+++ b/examples/TurnOnMitsubishiHeavyAc/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnPanasonicAC/platformio.ini
+++ b/examples/TurnOnPanasonicAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnToshibaAC/platformio.ini
+++ b/examples/TurnOnToshibaAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/examples/TurnOnTrotecAC/platformio.ini
+++ b/examples/TurnOnTrotecAC/platformio.ini
@@ -1,29 +1,18 @@
 [platformio]
-lib_extra_dirs = ../../
-src_dir=.
+src_dir = .
 
-[common]
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,39 +1,23 @@
 [platformio]
-lib_extra_dirs = .
 src_dir = examples/IRrecvDumpV2
 
-[common]
+[env]
+lib_extra_dirs = .
+lib_ldf_mode = deep+
+lib_ignore = examples
 build_flags =
-lib_deps_builtin =
-lib_deps_external =
-lib_ldf_mode = chain+
 
 [env:nodemcuv2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:d1_mini]
 platform = espressif8266
 framework = arduino
 board = d1_mini
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}
 
 [env:esp32dev]
 platform = espressif32
 framework = arduino
 board = esp32dev
-lib_ldf_mode = ${common.lib_ldf_mode}
-build_flags = ${common.build_flags}
-lib_deps =
-  ${common.lib_deps_builtin}
-  ${common.lib_deps_external}


### PR DESCRIPTION
Fix platformio.ini files to work correctly with Platformio v4.0.0
* Existing config was broken under 4.0.0 for IRMQTTServer at least.