### PR TITLE
 Midea: Support native temp units of Celsius & SwingV.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -533,11 +533,13 @@ void IRac::kelvinator(IRKelvinatorAC *ac,
 
 #if SEND_MIDEA
 void IRac::midea(IRMideaAC *ac,
-                 const bool on, const stdAc::opmode_t mode, const float degrees,
-                 const stdAc::fanspeed_t fan, const int16_t sleep) {
+                 const bool on, const stdAc::opmode_t mode, const bool celsius,
+                 const float degrees, const stdAc::fanspeed_t fan,
+                 const int16_t sleep) {
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
-  ac->setTemp(degrees, true);  // true means use Celsius.
+  ac->setUseCelsius(celsius);
+  ac->setTemp(degrees, celsius);
   ac->setFan(ac->convertFan(fan));
   // No Vertical swing setting available.
   // No Horizontal swing setting available.
@@ -1109,7 +1111,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
     {
       IRMideaAC ac(_pin, _inverted, _modulation);
       ac.begin();
-      midea(&ac, on, mode, degC, fan, sleep);
+      midea(&ac, on, mode, celsius, degrees, fan, sleep);
       break;
     }
 #endif  // SEND_MIDEA

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -185,8 +185,9 @@ void electra(IRElectraAc *ac,
 #endif  // SEND_KELVINATOR
 #if SEND_MIDEA
   void midea(IRMideaAC *ac,
-             const bool on, const stdAc::opmode_t mode, const float degrees,
-             const stdAc::fanspeed_t fan, const int16_t sleep = -1);
+             const bool on, const stdAc::opmode_t mode, const bool celsius,
+             const float degrees, const stdAc::fanspeed_t fan,
+             const int16_t sleep = -1);
 #endif  // SEND_MIDEA
 #if SEND_MITSUBISHI_AC
   void mitsubishi(IRMitsubishiAC *ac,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -187,7 +187,7 @@ void electra(IRElectraAc *ac,
   void midea(IRMideaAC *ac,
              const bool on, const stdAc::opmode_t mode, const bool celsius,
              const float degrees, const stdAc::fanspeed_t fan,
-             const int16_t sleep = -1);
+             const stdAc::swingv_t swingv, const int16_t sleep = -1);
 #endif  // SEND_MIDEA
 #if SEND_MITSUBISHI_AC
   void mitsubishi(IRMitsubishiAC *ac,

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -4,6 +4,8 @@
 // Supports:
 //   Brand: Pioneer System,  Model: RYBO12GMFILCAD A/C (12K BTU)
 //   Brand: Pioneer System,  Model: RUBO18GMFILCAD A/C (18K BTU)
+//   Brand: Comfee, Model: MPD1-12CRN7 A/C
+//   Brand: Keystone, Model: RG57H4(B)BGEF remote
 
 #ifndef IR_MIDEA_H_
 #define IR_MIDEA_H_

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -47,6 +47,7 @@ const uint64_t kMideaACTempMask =     0x0000FFFFE0FFFFFF;
 const uint64_t kMideaACFanMask =      0x0000FFC7FFFFFFFF;
 const uint64_t kMideaACModeMask =     0x0000FFF8FFFFFFFF;
 const uint64_t kMideaACChecksumMask = 0x0000FFFFFFFFFF00;
+const uint64_t kMideaACToggleSwingV = 0x0000A201FFFFFF7C;
 
 // Legacy defines. (Deprecated)
 #define MIDEA_AC_COOL kMideaACCool
@@ -93,11 +94,14 @@ class IRMideaAC {
   static bool validChecksum(const uint64_t state);
   void setSleep(const bool on);
   bool getSleep(void);
+  bool isSwingVToggle(void);
+  void setSwingVToggle(const bool on);
+  bool getSwingVToggle(void);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void);
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
   String toString(void);
 #ifndef UNIT_TEST
 
@@ -107,6 +111,7 @@ class IRMideaAC {
   IRsendTest _irsend;
 #endif
   uint64_t remote_state;
+  bool _SwingVToggle;
   void checksum(void);
   static uint8_t calcChecksum(const uint64_t state);
 };

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -37,12 +37,13 @@ const uint64_t kMideaACPower = 1ULL << 39;
 const uint64_t kMideaACSleep = 1ULL << 38;
 const uint8_t kMideaACMinTempF = 62;  // Fahrenheit
 const uint8_t kMideaACMaxTempF = 86;  // Fahrenheit
-const uint8_t kMideaACMinTempC = 16;  // Celsius
+const uint8_t kMideaACMinTempC = 17;  // Celsius
 const uint8_t kMideaACMaxTempC = 30;  // Celsius
-const uint64_t kMideaACStateMask = 0x0000FFFFFFFFFFFF;
-const uint64_t kMideaACTempMask = 0x0000FFFFE0FFFFFF;
-const uint64_t kMideaACFanMask = 0x0000FFC7FFFFFFFF;
-const uint64_t kMideaACModeMask = 0x0000FFF8FFFFFFFF;
+const uint64_t kMideaACStateMask =    0x0000FFFFFFFFFFFF;
+const uint64_t kMideaACCelsiusBit =   0x0000000020000000;
+const uint64_t kMideaACTempMask =     0x0000FFFFE0FFFFFF;
+const uint64_t kMideaACFanMask =      0x0000FFC7FFFFFFFF;
+const uint64_t kMideaACModeMask =     0x0000FFF8FFFFFFFF;
 const uint64_t kMideaACChecksumMask = 0x0000FFFFFFFFFF00;
 
 // Legacy defines. (Deprecated)
@@ -77,6 +78,8 @@ class IRMideaAC {
   void off(void);
   void setPower(const bool on);
   bool getPower(void);
+  bool getUseCelsius(void);
+  void setUseCelsius(const bool celsius);
   void setTemp(const uint8_t temp, const bool useCelsius = false);
   uint8_t getTemp(const bool useCelsius = false);
   void setFan(const uint8_t fan);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -473,7 +473,7 @@ TEST(TestIRac, Midea) {
   IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 1 (DRY), Celsius: On, Temp: 27C/80F, Fan: 2 (Medium), "
-      "Sleep: On";
+      "Sleep: On, Swing(V) Toggle: Off";
 
   ac.begin();
   irac.midea(&ac,
@@ -482,6 +482,7 @@ TEST(TestIRac, Midea) {
              true,                        // Celsius
              27,                          // Degrees
              stdAc::fanspeed_t::kMedium,  // Fan speed
+             stdAc::swingv_t::kOff,       // Swing (V)
              8 * 60 + 0);                 // Sleep time
 
   ASSERT_EQ(expected, ac.toString());

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -472,13 +472,15 @@ TEST(TestIRac, Midea) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Mode: 1 (DRY), Temp: 27C/81F, Fan: 2 (Medium), Sleep: On";
+      "Power: On, Mode: 1 (DRY), Celsius: On, Temp: 27C/80F, Fan: 2 (Medium), "
+      "Sleep: On";
 
   ac.begin();
   irac.midea(&ac,
              true,                        // Power
              stdAc::opmode_t::kDry,       // Mode
-             27,                          // Celsius
+             true,                        // Celsius
+             27,                          // Degrees
              stdAc::fanspeed_t::kMedium,  // Fan speed
              8 * 60 + 0);                 // Sleep time
 

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -446,7 +446,7 @@ TEST(TestMideaACClass, HumanReadableOutput) {
   ac.setRaw(0xA1826FFFFF62);
   EXPECT_EQ(
       "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (Auto), "
-      "Sleep: Off", ac.toString());
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.off();
   ac.setTemp(25, true);
   ac.setFan(kMideaACFanHigh);
@@ -454,16 +454,16 @@ TEST(TestMideaACClass, HumanReadableOutput) {
   ac.setSleep(true);
   EXPECT_EQ(
       "Power: Off, Mode: 1 (DRY), Celsius: Off, Temp: 25C/77F, Fan: 3 (High), "
-      "Sleep: On", ac.toString());
+      "Sleep: On, Swing(V) Toggle: Off", ac.toString());
   ac.setUseCelsius(true);
   EXPECT_EQ(
       "Power: Off, Mode: 1 (DRY), Celsius: On, Temp: 25C/77F, Fan: 3 (High), "
-      "Sleep: On", ac.toString());
+      "Sleep: On, Swing(V) Toggle: Off", ac.toString());
 
   ac.setRaw(0xA19867FFFF7E);
   EXPECT_EQ(
       "Power: On, Mode: 0 (COOL), Celsius: Off, Temp: 21C/69F, Fan: 3 (High), "
-      "Sleep: Off", ac.toString());
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
 }
 
 // Tests for decodeMidea().
@@ -677,8 +677,8 @@ TEST(TestMideaACClass, toCommon) {
   ASSERT_EQ(20, ac.toCommon().degrees);
   ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
   ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
-  // Unsupported.
   ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
+  // Unsupported.
   ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
   ASSERT_FALSE(ac.toCommon().turbo);
   ASSERT_FALSE(ac.toCommon().clean);
@@ -706,13 +706,13 @@ TEST(TestMideaACClass, CelsiusRemoteTemp) {
   EXPECT_EQ(on_cool_low_17c, ac.getRaw());
   EXPECT_EQ(
       "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
-      "Sleep: Off", ac.toString());
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.setRaw(on_cool_low_17c);
   EXPECT_EQ(17, ac.getTemp(true));
   EXPECT_EQ(62, ac.getTemp(false));
   EXPECT_EQ(
       "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
-      "Sleep: Off", ac.toString());
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.setTemp(17, true);
   EXPECT_EQ(17, ac.getTemp(true));
   EXPECT_EQ(62, ac.getTemp(false));
@@ -721,5 +721,24 @@ TEST(TestMideaACClass, CelsiusRemoteTemp) {
   ac.setRaw(on_cool_low_30c);
   EXPECT_EQ(
       "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 30C/86F, Fan: 1 (LOW), "
-      "Sleep: Off", ac.toString());
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
+}
+
+// https://github.com/crankyoldgit/IRremoteESP8266/issues/819
+TEST(TestMideaACClass, SwingV) {
+  IRMideaAC ac(0);
+  ac.setSwingVToggle(false);
+  ASSERT_FALSE(ac.getSwingVToggle());
+  ac.setSwingVToggle(true);
+  ASSERT_TRUE(ac.getSwingVToggle());
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (AUTO), "
+      "Sleep: Off, Swing(V) Toggle: On", ac.toString());
+  ac.setSwingVToggle(false);
+  ASSERT_FALSE(ac.getSwingVToggle());
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (AUTO), "
+      "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
+  ac.setRaw(kMideaACToggleSwingV);
+  EXPECT_EQ("Swing(V) Toggle: On", ac.toString());
 }

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -397,13 +397,13 @@ TEST(TestMideaACClass, Temperature) {
   EXPECT_EQ(kMideaACMaxTempF, midea.getTemp(false));
 
   // General changes.
-  midea.setTemp(17, true);              // C
-  EXPECT_EQ(17, midea.getTemp(true));   // C
-  EXPECT_EQ(63, midea.getTemp(false));  // F
+  midea.setTemp(18, true);              // C
+  EXPECT_EQ(18, midea.getTemp(true));   // C
+  EXPECT_EQ(64, midea.getTemp(false));  // F
 
   midea.setTemp(21, true);              // C
   EXPECT_EQ(21, midea.getTemp(true));   // C
-  EXPECT_EQ(70, midea.getTemp(false));  // F
+  EXPECT_EQ(69, midea.getTemp(false));  // F
 
   midea.setTemp(25, true);              // C
   EXPECT_EQ(25, midea.getTemp(true));   // C
@@ -414,7 +414,7 @@ TEST(TestMideaACClass, Temperature) {
   EXPECT_EQ(86, midea.getTemp(false));  // F
 
   midea.setTemp(80, false);             // F
-  EXPECT_EQ(26, midea.getTemp(true));   // C
+  EXPECT_EQ(27, midea.getTemp(true));   // C
   EXPECT_EQ(80, midea.getTemp(false));  // F
 
   midea.setTemp(70);                    // F
@@ -440,27 +440,30 @@ TEST(TestMideaACClass, Sleep) {
 }
 
 TEST(TestMideaACClass, HumanReadableOutput) {
-  IRMideaAC midea(0);
-  midea.begin();
+  IRMideaAC ac(0);
+  ac.begin();
 
-  midea.setRaw(0xA1826FFFFF62);
+  ac.setRaw(0xA1826FFFFF62);
   EXPECT_EQ(
-      "Power: On, Mode: 2 (AUTO), Temp: 25C/77F, Fan: 0 (Auto), "
-      "Sleep: Off",
-      midea.toString());
-  midea.off();
-  midea.setTemp(25);
-  midea.setFan(kMideaACFanHigh);
-  midea.setMode(kMideaACDry);
-  midea.setSleep(true);
+      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (Auto), "
+      "Sleep: Off", ac.toString());
+  ac.off();
+  ac.setTemp(25, true);
+  ac.setFan(kMideaACFanHigh);
+  ac.setMode(kMideaACDry);
+  ac.setSleep(true);
   EXPECT_EQ(
-      "Power: Off, Mode: 1 (DRY), Temp: 16C/62F, Fan: 3 (High), Sleep: On",
-      midea.toString());
+      "Power: Off, Mode: 1 (DRY), Celsius: Off, Temp: 25C/77F, Fan: 3 (High), "
+      "Sleep: On", ac.toString());
+  ac.setUseCelsius(true);
+  EXPECT_EQ(
+      "Power: Off, Mode: 1 (DRY), Celsius: On, Temp: 25C/77F, Fan: 3 (High), "
+      "Sleep: On", ac.toString());
 
-  midea.setRaw(0xA19867FFFF7E);
+  ac.setRaw(0xA19867FFFF7E);
   EXPECT_EQ(
-      "Power: On, Mode: 0 (COOL), Temp: 20C/69F, Fan: 3 (High), Sleep: Off",
-      midea.toString());
+      "Power: On, Mode: 0 (COOL), Celsius: Off, Temp: 21C/69F, Fan: 3 (High), "
+      "Sleep: Off", ac.toString());
 }
 
 // Tests for decodeMidea().
@@ -663,6 +666,7 @@ TEST(TestMideaACClass, toCommon) {
   IRMideaAC ac(0);
   ac.setPower(true);
   ac.setMode(kMideaACCool);
+  ac.setUseCelsius(true);
   ac.setTemp(20, true);
   ac.setFan(kMideaACFanHigh);
   // Now test it.
@@ -685,4 +689,37 @@ TEST(TestMideaACClass, toCommon) {
   ASSERT_FALSE(ac.toCommon().beep);
   ASSERT_EQ(-1, ac.toCommon().sleep);
   ASSERT_EQ(-1, ac.toCommon().clock);
+}
+
+// https://github.com/crankyoldgit/IRremoteESP8266/issues/819
+TEST(TestMideaACClass, CelsiusRemoteTemp) {
+  IRMideaAC ac(0);
+  uint64_t on_cool_low_17c = 0xA18840FFFF56;
+  uint64_t on_cool_low_30c = 0xA1884DFFFF5D;
+  ac.on();
+  ac.setMode(kMideaACCool);
+  ac.setFan(kMideaACFanLow);
+  ac.setTemp(17, true);
+  EXPECT_FALSE(ac.getUseCelsius());
+  ac.setUseCelsius(true);
+  EXPECT_TRUE(ac.getUseCelsius());
+  EXPECT_EQ(on_cool_low_17c, ac.getRaw());
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
+      "Sleep: Off", ac.toString());
+  ac.setRaw(on_cool_low_17c);
+  EXPECT_EQ(17, ac.getTemp(true));
+  EXPECT_EQ(62, ac.getTemp(false));
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
+      "Sleep: Off", ac.toString());
+  ac.setTemp(17, true);
+  EXPECT_EQ(17, ac.getTemp(true));
+  EXPECT_EQ(62, ac.getTemp(false));
+  EXPECT_EQ(on_cool_low_17c, ac.getRaw());
+
+  ac.setRaw(on_cool_low_30c);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 30C/86F, Fan: 1 (LOW), "
+      "Sleep: Off", ac.toString());
 }

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -705,13 +705,13 @@ TEST(TestMideaACClass, CelsiusRemoteTemp) {
   EXPECT_TRUE(ac.getUseCelsius());
   EXPECT_EQ(on_cool_low_17c, ac.getRaw());
   EXPECT_EQ(
-      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (Low), "
       "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.setRaw(on_cool_low_17c);
   EXPECT_EQ(17, ac.getTemp(true));
   EXPECT_EQ(62, ac.getTemp(false));
   EXPECT_EQ(
-      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (LOW), "
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 17C/62F, Fan: 1 (Low), "
       "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.setTemp(17, true);
   EXPECT_EQ(17, ac.getTemp(true));
@@ -720,7 +720,7 @@ TEST(TestMideaACClass, CelsiusRemoteTemp) {
 
   ac.setRaw(on_cool_low_30c);
   EXPECT_EQ(
-      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 30C/86F, Fan: 1 (LOW), "
+      "Power: On, Mode: 0 (COOL), Celsius: On, Temp: 30C/86F, Fan: 1 (Low), "
       "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
 }
 
@@ -732,12 +732,12 @@ TEST(TestMideaACClass, SwingV) {
   ac.setSwingVToggle(true);
   ASSERT_TRUE(ac.getSwingVToggle());
   EXPECT_EQ(
-      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (AUTO), "
+      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (Auto), "
       "Sleep: Off, Swing(V) Toggle: On", ac.toString());
   ac.setSwingVToggle(false);
   ASSERT_FALSE(ac.getSwingVToggle());
   EXPECT_EQ(
-      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (AUTO), "
+      "Power: On, Mode: 2 (AUTO), Celsius: Off, Temp: 25C/77F, Fan: 0 (Auto), "
       "Sleep: Off, Swing(V) Toggle: Off", ac.toString());
   ac.setRaw(kMideaACToggleSwingV);
   EXPECT_EQ("Swing(V) Toggle: On", ac.toString());


### PR DESCRIPTION
We now know how to use Celsius internally. Make the needed changes to add native support.
This should allow the A/C to display the correct temp in the desired units.

Swing is a special toggle-only command on Midea. Thus we need to try to 
code around it if we want to preserve state etc.
Try to do this as best as we can.
Handle toggle operation in IRMQTTServer & IRac common a/c etc.

Fixes #819