### PR TITLE
Coolix: Better `toCommon()` support.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -206,7 +206,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.3.1"
+#define _MY_VERSION_ "v1.3.2-testing"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2980,7 +2980,7 @@ bool decodeCommonAc(const decode_results *decode) {
   }
   stdAc::state_t state = climate;
   debug("Converting inbound IR A/C message to common A/C");
-  if (!IRAcUtils::decodeToState(decode, &state)) {
+  if (!IRAcUtils::decodeToState(decode, &state, &climate)) {
       debug("Failed to convert to common A/C.");  // This shouldn't happen!
       return false;
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1716,9 +1716,11 @@ namespace IRAcUtils {
   // Args:
   //   decode: A PTR to a successful raw IR decode object.
   //   result: A PTR to a state structure to store the result in.
+  //   prev:   A PTR to a state structure which has the prev. state. (optional)
   // Returns:
   //   A boolean indicating success or failure.
-  bool decodeToState(const decode_results *decode, stdAc::state_t *result) {
+  bool decodeToState(const decode_results *decode, stdAc::state_t *result,
+                     const stdAc::state_t *prev) {
     if (decode == NULL || result == NULL) return false;  // Safety check.
     switch (decode->decode_type) {
 #if DECODE_ARGO
@@ -1733,7 +1735,7 @@ namespace IRAcUtils {
       case decode_type_t::COOLIX: {
         IRCoolixAC ac(kGpioUnused);
         ac.setRaw(decode->value);  // Uses value instead of state.
-        *result = ac.toCommon();
+        *result = ac.toCommon(prev);
         break;
       }
 #endif  // DECODE_COOLIX

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -282,6 +282,7 @@ static stdAc::state_t handleToggles(const stdAc::state_t desired,
 
 namespace IRAcUtils {
   String resultAcToString(const decode_results * const results);
-  bool decodeToState(const decode_results *decode, stdAc::state_t *result);
+  bool decodeToState(const decode_results *decode, stdAc::state_t *result,
+                     const stdAc::state_t *prev = NULL);
 }  // namespace IRAcUtils
 #endif  // IRAC_H_

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -446,7 +446,6 @@ stdAc::state_t IRCoolixAC::toCommon(const stdAc::state_t *prev) {
   }
   // Back to "normal" stateful messages.
   result.mode = this->toCommonMode(this->getMode());
-  result.celsius = true;
   result.degrees = this->getTemp();
   result.fanspeed = this->toCommonFanSpeed(this->getFan());
   return result;

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -396,30 +396,59 @@ stdAc::fanspeed_t IRCoolixAC::toCommonFanSpeed(const uint8_t speed) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
-stdAc::state_t IRCoolixAC::toCommon(void) {
+// Convert the A/C state to it's common equivalent. Utilise the previous
+// state if supplied.
+stdAc::state_t IRCoolixAC::toCommon(const stdAc::state_t *prev) {
   stdAc::state_t result;
-  result.protocol = decode_type_t::COOLIX;
-  result.model = -1;  // No models used.
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
-  result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFan());
-  result.swingv = this->getSwing() ? stdAc::swingv_t::kAuto :
-                                     stdAc::swingv_t::kOff;
-  result.swingh = this->getSwing() ? stdAc::swingh_t::kAuto :
-                                     stdAc::swingh_t::kOff;
-  result.turbo = this->getTurbo();
-  result.sleep = this->getSleep() ? 0 : -1;
-  result.light = this->getLed();
-  result.clean = this->getClean();
+  // Start with the previous state if given it.
+  if (prev != NULL) {
+    result = *prev;
+  } else {
+    // Set defaults for non-zero values that are not implicitly set for when
+    // there is no previous state.
+    result.swingv = stdAc::swingv_t::kOff;
+    result.sleep = -1;
+  }
   // Not supported.
+  result.model = -1;  // No models used.
+  result.swingh = stdAc::swingh_t::kOff;
   result.quiet = false;
   result.econo = false;
   result.filter = false;
   result.beep = false;
   result.clock = -1;
+
+  // Supported.
+  result.protocol = decode_type_t::COOLIX;
+  result.celsius = true;
+  result.power = this->getPower();
+  // Power off state no other state info. Use the previous state if we have it.
+  if (!result.power) return result;
+  // Handle the special single command (Swing/Turbo/Light/Clean/Sleep) toggle
+  // messages. These have no other state info so use the rest of the previous
+  // state if we have it for them.
+  if (this->getSwing()) {
+    result.swingv = result.swingv != stdAc::swingv_t::kOff ?
+        stdAc::swingv_t::kOff : stdAc::swingv_t::kAuto;  // Invert swing.
+    return result;
+  } else if (this->getTurbo()) {
+    result.turbo = !result.turbo;
+    return result;
+  } else if (this->getLed()) {
+    result.light = !result.light;
+    return result;
+  } else if (this->getClean()) {
+    result.clean = !result.clean;
+    return result;
+  } else if (this->getSleep()) {
+    result.sleep = result.sleep >= 0 ? -1 : 0;  // Invert sleep.
+    return result;
+  }
+  // Back to "normal" stateful messages.
+  result.mode = this->toCommonMode(this->getMode());
+  result.celsius = true;
+  result.degrees = this->getTemp();
+  result.fanspeed = this->toCommonFanSpeed(this->getFan());
   return result;
 }
 

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -125,7 +125,7 @@ class IRCoolixAC {
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void);
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
   String toString();
 #ifndef UNIT_TEST
 


### PR DESCRIPTION
Try to address issues in #821
* Try to work around the deficiencies in the Coolix protocol where special
  messages don't have all the required state in them.