### PR TITLE
IRMQTTServer: Add ability to report Vcc at the ESP chip.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -156,6 +156,16 @@ const uint16_t kMinUnknownSize = 2 * 10;
 
 // ------------------------ Advanced Usage Only --------------------------------
 
+// Reports the input voltage to the ESP chip. **NOT** the input voltage
+// to the development board (e.g. NodeMCU, D1 Mini etc) which are typically
+// powered by USB (5V) which is then lowered to 3V via a Low Drop Out (LDO)
+// Voltage regulator. Hence, this feature is turned off by default as it
+// make little sense for most users as it really isn't the actual input voltage.
+// E.g. For purposes of monitoring a battery etc.
+// Note: Turning on the feature costs ~250 bytes of prog space.
+#define REPORT_VCC false  // Do we report Vcc via html info page & MQTT?
+
+// Keywords for MQTT topics, html arguments, or config file.
 #define KEY_PROTOCOL "protocol"
 #define KEY_MODEL "model"
 #define KEY_POWER "power"
@@ -175,6 +185,7 @@ const uint16_t kMinUnknownSize = 2 * 10;
 #define KEY_CELSIUS "use_celsius"
 #define KEY_JSON "json"
 #define KEY_RESEND "resend"
+#define KEY_VCC "vcc"
 
 // HTML arguments we will parse for IR code information.
 #define KEY_TYPE "type"  // KEY_PROTOCOL is also checked too.
@@ -297,6 +308,9 @@ void sendJsonState(const stdAc::state_t state, const String topic,
                    const bool retain = false, const bool ha_mode = true);
 #endif  // MQTT_CLIMATE_JSON
 #endif  // MQTT_ENABLE
+#if REPORT_VCC
+String vccToString(void);
+#endif  // REPORT_VCC
 bool isSerialGpioUsedByIr(void);
 void debug(const char *str);
 void saveWifiConfigCallback(void);

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -347,6 +347,10 @@
 
 using irutils::msToString;
 
+#if REPORT_VCC
+  ADC_MODE(ADC_VCC);
+#endif  // REPORT_VCC
+
 // Globals
 #if defined(ESP8266)
 ESP8266WebServer server(kHttpPort);
@@ -1121,6 +1125,10 @@ uint32_t maxSketchSpace(void) {
 #endif  // defined(ESP8266)
 }
 
+#if REPORT_VCC
+String vccToString(void) { return String(ESP.getVcc() / 1000.0); }
+#endif  // REPORT_VCC
+
 // Info web page
 void handleInfo(void) {
   String html = htmlHeader(F("IR MQTT server info"));
@@ -1175,6 +1183,11 @@ void handleInfo(void) {
         "Off"
 #endif  // DEBUG
         "<br>"
+#if REPORT_VCC
+    "Vcc: ";
+    html += vccToString();
+    html += "V<br>"
+#endif  // REPORT_VCC
     "</p>"
 #if MQTT_ENABLE
     "<h4>MQTT Information</h4>"
@@ -2167,6 +2180,9 @@ void doBroadcast(TimerMs *timer, const uint32_t interval,
     debug("Sending MQTT stat update broadcast.");
     sendClimate(state, state, MqttClimateStat,
                 retain, true, false);
+#if REPORT_VCC
+    sendString(MqttClimateStat + KEY_VCC, vccToString(), false);
+#endif  // REPORT_VCC
 #if MQTT_CLIMATE_JSON
     sendJsonState(state, MqttClimateStat + KEY_JSON);
 #endif  // MQTT_CLIMATE_JSON


### PR DESCRIPTION
* Controlled by `#define REPORT_VCC`
* Turned off by default. Compile time option.
* Costs about 250 bytes of prog space when enabled.

Fixes #842