### PR TITLE
Improve/fix `swingh_t::kWide` support

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -913,7 +913,7 @@ String htmlSelectGpio(const String name, const int16_t def,
 
 String htmlSelectMode(const String name, const stdAc::opmode_t def) {
   String html = "<select name='" + name + "'>";
-  for (int8_t i = -1; i <= 4; i++) {
+  for (int8_t i = -1; i <= (int8_t)stdAc::opmode_t::kLastOpmodeEnum; i++) {
     String mode = IRac::opmodeToString((stdAc::opmode_t)i);
     html += htmlOptionItem(mode, mode, (stdAc::opmode_t)i == def);
   }
@@ -923,7 +923,7 @@ String htmlSelectMode(const String name, const stdAc::opmode_t def) {
 
 String htmlSelectFanspeed(const String name, const stdAc::fanspeed_t def) {
   String html = "<select name='" + name + "'>";
-  for (int8_t i = 0; i <= 5; i++) {
+  for (int8_t i = 0; i <= (int8_t)stdAc::fanspeed_t::kLastFanspeedEnum; i++) {
     String speed = IRac::fanspeedToString((stdAc::fanspeed_t)i);
     html += htmlOptionItem(speed, speed, (stdAc::fanspeed_t)i == def);
   }
@@ -933,7 +933,7 @@ String htmlSelectFanspeed(const String name, const stdAc::fanspeed_t def) {
 
 String htmlSelectSwingv(const String name, const stdAc::swingv_t def) {
   String html = "<select name='" + name + "'>";
-  for (int8_t i = -1; i <= 5; i++) {
+  for (int8_t i = -1; i <= (int8_t)stdAc::swingv_t::kLastSwingvEnum; i++) {
     String swing = IRac::swingvToString((stdAc::swingv_t)i);
     html += htmlOptionItem(swing, swing, (stdAc::swingv_t)i == def);
   }
@@ -943,7 +943,7 @@ String htmlSelectSwingv(const String name, const stdAc::swingv_t def) {
 
 String htmlSelectSwingh(const String name, const stdAc::swingh_t def) {
   String html = "<select name='" + name + "'>";
-  for (int8_t i = -1; i <= 5; i++) {
+  for (int8_t i = -1; i <= (int8_t)stdAc::swingh_t::kLastSwinghEnum; i++) {
     String swing = IRac::swinghToString((stdAc::swingh_t)i);
     html += htmlOptionItem(swing, swing, (stdAc::swingh_t)i == def);
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1545,7 +1545,7 @@ String IRac::swinghToString(const stdAc::swingh_t swingh) {
     case stdAc::swingh_t::kRightMax:
       return F("rightmax");
     case stdAc::swingh_t::kWide:
-      return F("leftright");
+      return F("wide");
     default:
       return F("unknown");
   }

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -49,6 +49,8 @@ namespace stdAc {
     kHeat =  2,
     kDry  =  3,
     kFan  =  4,
+    // Add new entries before this one, and update it to point to the last entry
+    kLastOpmodeEnum = kFan,
   };
 
   enum class fanspeed_t {
@@ -58,6 +60,8 @@ namespace stdAc {
     kMedium = 3,
     kHigh =   4,
     kMax =    5,
+    // Add new entries before this one, and update it to point to the last entry
+    kLastFanspeedEnum = kMax,
   };
 
   enum class swingv_t {
@@ -68,6 +72,8 @@ namespace stdAc {
     kMiddle =  3,
     kLow =     4,
     kLowest =  5,
+    // Add new entries before this one, and update it to point to the last entry
+    kLastSwingvEnum = kLowest,
   };
 
   enum class swingh_t {
@@ -78,7 +84,9 @@ namespace stdAc {
     kMiddle =   3,
     kRight =    4,
     kRightMax = 5,
-    kWide =     6,
+    kWide =     6,  // a.k.a. left & right at the same time.
+    // Add new entries before this one, and update it to point to the last entry
+    kLastSwinghEnum = kWide,
   };
 
   // Structure to hold a common A/C state.

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1220,6 +1220,7 @@ TEST(TestIRac, swinghToString) {
   EXPECT_EQ("off", IRac::swinghToString(stdAc::swingh_t::kOff));
   EXPECT_EQ("left", IRac::swinghToString(stdAc::swingh_t::kLeft));
   EXPECT_EQ("auto", IRac::swinghToString(stdAc::swingh_t::kAuto));
+  EXPECT_EQ("wide", IRac::swinghToString(stdAc::swingh_t::kWide));
   EXPECT_EQ("unknown", IRac::swinghToString((stdAc::swingh_t)500));
 }
 


### PR DESCRIPTION
* Change text reported to 'wide'.
* Add entries for the end of ac enum types.
* Use end of the enum entries for loop maximums in IRMQTTServer so all 
options are listed.

Ref: #844 FYI @jorgecis