### PR TITLE
Fujitsu: Ensure `on()` is called in common a/c framework.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -425,6 +425,7 @@ void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
     // No Beep setting available.
     // No Sleep setting available.
     // No Clock setting available.
+    ac->on();  // Ref: Issue #860
   } else {
     // Off is special case/message. We don't need to send other messages.
     ac->off();

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -267,9 +267,6 @@ bool IRFujitsuAC::setRaw(const uint8_t newState[], const uint16_t length) {
   return true;
 }
 
-// Set the requested power state of the A/C to off.
-void IRFujitsuAC::off(void) { this->setCmd(kFujitsuAcCmdTurnOff); }
-
 void IRFujitsuAC::stepHoriz(void) { this->setCmd(kFujitsuAcCmdStepHoriz); }
 
 void IRFujitsuAC::toggleSwingHoriz(const bool update) {
@@ -335,6 +332,17 @@ uint8_t IRFujitsuAC::getCmd(const bool raw) {
   if (raw) return remote_state[5];
   return _cmd;
 }
+
+// Set the requested power state of the A/C.
+void IRFujitsuAC::setPower(const bool on) {
+  this->setCmd(on ? kFujitsuAcCmdTurnOn : kFujitsuAcCmdTurnOff);
+}
+
+// Set the requested power state of the A/C to off.
+void IRFujitsuAC::off(void) { this->setPower(false); }
+
+// Set the requested power state of the A/C to on.
+void IRFujitsuAC::on(void) { this->setPower(true); }
 
 bool IRFujitsuAC::getPower(void) { return _cmd != kFujitsuAcCmdTurnOff; }
 

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -104,7 +104,6 @@ class IRFujitsuAC {
   uint8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_FUJITSU_AC
   void begin(void);
-  void off(void);
   void stepHoriz(void);
   void toggleSwingHoriz(const bool update = true);
   void stepVert(void);
@@ -123,6 +122,9 @@ class IRFujitsuAC {
   bool setRaw(const uint8_t newState[], const uint16_t length);
   uint8_t getStateLength(void);
   static bool validChecksum(uint8_t* state, const uint16_t length);
+  void setPower(const bool on);
+  void off(void);
+  void on(void);
   bool getPower(void);
   void setOutsideQuiet(const bool on);
 


### PR DESCRIPTION
Fixes #860