### PR TITLE
 IRrecv: Allow tolerance percentage to be set at run-time.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -182,6 +182,7 @@ IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
 #if DECODE_HASH
   _unknown_threshold = kUnknownThreshold;
 #endif  // DECODE_HASH
+  _tolerance = kTolerance;
 }
 
 // Class destructor
@@ -296,6 +297,15 @@ void IRrecv::setUnknownThreshold(const uint16_t length) {
   _unknown_threshold = length;
 }
 #endif  // DECODE_HASH
+
+
+// Set the base tolerance percentage for matching incoming IR messages.
+void IRrecv::setTolerance(const uint8_t percent) {
+  _tolerance = std::min(percent, (uint8_t)100);
+}
+
+// Get the base tolerance percentage for matching incoming IR messages.
+uint8_t IRrecv::getTolerance(void) { return _tolerance; }
 
 // Decodes the received IR message.
 // If the interrupt state is saved, we will immediately resume waiting
@@ -669,6 +679,11 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   return false;
 }
 
+// Convert the tolerance percentage into something valid.
+uint8_t IRrecv::_validTolerance(const uint8_t percentage) {
+    return (percentage > 100) ? _tolerance : percentage;
+}
+
 // Calculate the lower bound of the nr. of ticks.
 //
 // Args:
@@ -677,10 +692,12 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
 //   delta:  A non-scaling amount to reduce usecs by.
 // Returns:
 //   Nr. of ticks.
-uint32_t IRrecv::ticksLow(uint32_t usecs, uint8_t tolerance, uint16_t delta) {
+uint32_t IRrecv::ticksLow(const uint32_t usecs, const uint8_t tolerance,
+                          const uint16_t delta) {
   // max() used to ensure the result can't drop below 0 before the cast.
   return ((uint32_t)std::max(
-      (int32_t)(usecs * (1.0 - tolerance / 100.0) - delta), 0));
+      (int32_t)(usecs * (1.0 - _validTolerance(tolerance) / 100.0) - delta),
+      0));
 }
 
 // Calculate the upper bound of the nr. of ticks.
@@ -691,8 +708,10 @@ uint32_t IRrecv::ticksLow(uint32_t usecs, uint8_t tolerance, uint16_t delta) {
 //   delta:  A non-scaling amount to increase usecs by.
 // Returns:
 //   Nr. of ticks.
-uint32_t IRrecv::ticksHigh(uint32_t usecs, uint8_t tolerance, uint16_t delta) {
-  return ((uint32_t)(usecs * (1.0 + tolerance / 100.0)) + 1 + delta);
+uint32_t IRrecv::ticksHigh(const uint32_t usecs, const uint8_t tolerance,
+                           const uint16_t delta) {
+  return ((uint32_t)(usecs * (1.0 + _validTolerance(tolerance) / 100.0)) + 1 +
+          delta);
 }
 
 // Check if we match a pulse(measured) with the desired within
@@ -840,7 +859,7 @@ bool IRrecv::matchSpace(uint32_t measured, uint32_t desired, uint8_t tolerance,
 // Compare two tick values, returning 0 if newval is shorter,
 // 1 if newval is equal, and 2 if newval is longer
 // Use a tolerance of 20%
-int16_t IRrecv::compare(uint16_t oldval, uint16_t newval) {
+uint16_t IRrecv::compare(const uint16_t oldval, const uint16_t newval) {
   if (newval < oldval * 0.8)
     return 0;
   else if (oldval < newval * 0.8)
@@ -863,7 +882,7 @@ bool IRrecv::decodeHash(decode_results *results) {
   // however it is left this way for compatibility with previously captured
   // values.
   for (uint16_t i = 1; i < results->rawlen - 2; i++) {
-    int16_t value = compare(results->rawbuf[i], results->rawbuf[i + 2]);
+    uint16_t value = compare(results->rawbuf[i], results->rawbuf[i + 2]);
     // Add value into the hash
     hash = (hash * kFnvPrime32) ^ value;
   }
@@ -887,7 +906,7 @@ bool IRrecv::decodeHash(decode_results *results) {
 //   onespace:  Nr. of uSeconds in an expected space signal for a '1' bit.
 //   zeromark:  Nr. of uSeconds in an expected mark signal for a '0' bit.
 //   zerospace: Nr. of uSeconds in an expected space signal for a '0' bit.
-//   tolerance: Percentage error margin to allow. (Def: kTolerance)
+//   tolerance: Percentage error margin to allow. (Def: kUseDefTol)
 //   excess:  Nr. of useconds. (Def: kMarkExcess)
 //   MSBfirst: Bit order to save the data in. (Def: true)
 // Returns:
@@ -932,7 +951,7 @@ match_result_t IRrecv::matchData(
 //   onespace:  Nr. of uSeconds in an expected space signal for a '1' bit.
 //   zeromark:  Nr. of uSeconds in an expected mark signal for a '0' bit.
 //   zerospace: Nr. of uSeconds in an expected space signal for a '0' bit.
-//   tolerance: Percentage error margin to allow. (Def: kTolerance)
+//   tolerance: Percentage error margin to allow. (Def: kUseDefTol)
 //   excess:  Nr. of useconds. (Def: kMarkExcess)
 //   MSBfirst: Bit order to save the data in. (Def: true)
 // Returns:
@@ -979,7 +998,7 @@ uint16_t IRrecv::matchBytes(volatile uint16_t *data_ptr, uint8_t *result_ptr,
 //   footermark:   Nr. of uSeconds for the expected footer mark signal.
 //   footerspace:  Nr. of uSeconds for the expected footer space/gap signal.
 //   atleast:      Is the match on the footerspace a matchAtLeast or matchSpace?
-//   tolerance: Percentage error margin to allow. (Def: kTolerance)
+//   tolerance: Percentage error margin to allow. (Def: kUseDefTol)
 //   excess:  Nr. of useconds. (Def: kMarkExcess)
 //   MSBfirst: Bit order to save the data in. (Def: true)
 // Returns:
@@ -1078,7 +1097,7 @@ uint16_t IRrecv::_matchGeneric(volatile uint16_t *data_ptr,
 //   footermark:   Nr. of uSeconds for the expected footer mark signal.
 //   footerspace:  Nr. of uSeconds for the expected footer space/gap signal.
 //   atleast:      Is the match on the footerspace a matchAtLeast or matchSpace?
-//   tolerance: Percentage error margin to allow. (Def: kTolerance)
+//   tolerance: Percentage error margin to allow. (Def: kUseDefTol)
 //   excess:  Nr. of useconds. (Def: kMarkExcess)
 //   MSBfirst: Bit order to save the data in. (Def: true)
 // Returns:
@@ -1125,7 +1144,7 @@ uint16_t IRrecv::matchGeneric(volatile uint16_t *data_ptr,
 //   footermark:   Nr. of uSeconds for the expected footer mark signal.
 //   footerspace:  Nr. of uSeconds for the expected footer space/gap signal.
 //   atleast:      Is the match on the footerspace a matchAtLeast or matchSpace?
-//   tolerance: Percentage error margin to allow. (Def: kTolerance)
+//   tolerance: Percentage error margin to allow. (Def: kUseDefTol)
 //   excess:  Nr. of useconds. (Def: kMarkExcess)
 //   MSBfirst: Bit order to save the data in. (Def: true)
 // Returns:

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -32,8 +32,9 @@ const uint8_t kIdleState = 2;
 const uint8_t kMarkState = 3;
 const uint8_t kSpaceState = 4;
 const uint8_t kStopState = 5;
-const uint8_t kTolerance = 25;  // default percent tolerance in measurements.
-const uint16_t kRawTick = 2;    // Capture tick to uSec factor.
+const uint8_t kTolerance = 25;   // default percent tolerance in measurements.
+const uint8_t kUseDefTol = 255;  // Indicate to use the class default tolerance.
+const uint16_t kRawTick = 2;     // Capture tick to uSec factor.
 #define RAWTICK kRawTick  // Deprecated. For legacy user code support only.
 // How long (ms) before we give up wait for more data?
 // Don't exceed kMaxTimeoutMs without a good reason.
@@ -122,6 +123,8 @@ class IRrecv {
                   const bool save_buffer = false);                // Constructor
 #endif  // ESP32
   ~IRrecv(void);                                                  // Destructor
+  void setTolerance(const uint8_t percent = kTolerance);
+  uint8_t getTolerance(void);
   bool decode(decode_results *results, irparams_t *save = NULL);
   void enableIRIn(const bool pullup = false);
   void disableIRIn(void);
@@ -130,32 +133,40 @@ class IRrecv {
 #if DECODE_HASH
   void setUnknownThreshold(const uint16_t length);
 #endif
-  static bool match(uint32_t measured, uint32_t desired,
-                    uint8_t tolerance = kTolerance, uint16_t delta = 0);
-  static bool matchMark(uint32_t measured, uint32_t desired,
-                        uint8_t tolerance = kTolerance,
-                        int16_t excess = kMarkExcess);
-  static bool matchSpace(uint32_t measured, uint32_t desired,
-                         uint8_t tolerance = kTolerance,
-                         int16_t excess = kMarkExcess);
+  bool match(const uint32_t measured, const uint32_t desired,
+             const uint8_t tolerance = kUseDefTol,
+             const uint16_t delta = 0);
+  bool matchMark(const uint32_t measured, const uint32_t desired,
+                 const uint8_t tolerance = kUseDefTol,
+                 const int16_t excess = kMarkExcess);
+  bool matchSpace(const uint32_t measured, const uint32_t desired,
+                  const uint8_t tolerance = kUseDefTol,
+                  const int16_t excess = kMarkExcess);
 #ifndef UNIT_TEST
 
  private:
 #endif
   irparams_t *irparams_save;
+  uint8_t _tolerance;
+#if defined(ESP32)
   uint8_t _timer_num;
+#endif  // defined(ESP32)
 #if DECODE_HASH
   uint16_t _unknown_threshold;
 #endif
   // These are called by decode
+  uint8_t _validTolerance(const uint8_t percentage);
   void copyIrParams(volatile irparams_t *src, irparams_t *dst);
-  int16_t compare(uint16_t oldval, uint16_t newval);
-  static uint32_t ticksLow(uint32_t usecs, uint8_t tolerance = kTolerance,
-                           uint16_t delta = 0);
-  static uint32_t ticksHigh(uint32_t usecs, uint8_t tolerance = kTolerance,
-                            uint16_t delta = 0);
-  bool matchAtLeast(uint32_t measured, uint32_t desired,
-                    uint8_t tolerance = kTolerance, uint16_t delta = 0);
+  uint16_t compare(const uint16_t oldval, const uint16_t newval);
+  uint32_t ticksLow(const uint32_t usecs,
+                    const uint8_t tolerance = kUseDefTol,
+                    const uint16_t delta = 0);
+  uint32_t ticksHigh(const uint32_t usecs,
+                     const uint8_t tolerance = kUseDefTol,
+                     const uint16_t delta = 0);
+  bool matchAtLeast(const uint32_t measured, const uint32_t desired,
+                    const uint8_t tolerance = kUseDefTol,
+                    const uint16_t delta = 0);
   uint16_t _matchGeneric(volatile uint16_t *data_ptr,
                          uint64_t *result_bits_ptr,
                          uint8_t *result_ptr,
@@ -171,20 +182,20 @@ class IRrecv {
                          const uint16_t footermark,
                          const uint32_t footerspace,
                          const bool atleast = false,
-                         const uint8_t tolerance = kTolerance,
+                         const uint8_t tolerance = kUseDefTol,
                          const int16_t excess = kMarkExcess,
                          const bool MSBfirst = true);
   match_result_t matchData(volatile uint16_t *data_ptr, const uint16_t nbits,
                            const uint16_t onemark, const uint32_t onespace,
                            const uint16_t zeromark, const uint32_t zerospace,
-                           const uint8_t tolerance = kTolerance,
+                           const uint8_t tolerance = kUseDefTol,
                            const int16_t excess = kMarkExcess,
                            const bool MSBfirst = true);
   uint16_t matchBytes(volatile uint16_t *data_ptr, uint8_t *result_ptr,
                       const uint16_t remaining, const uint16_t nbytes,
                       const uint16_t onemark, const uint32_t onespace,
                       const uint16_t zeromark, const uint32_t zerospace,
-                      const uint8_t tolerance = kTolerance,
+                      const uint8_t tolerance = kUseDefTol,
                       const int16_t excess = kMarkExcess,
                       const bool MSBfirst = true);
   uint16_t matchGeneric(volatile uint16_t *data_ptr,
@@ -195,7 +206,7 @@ class IRrecv {
                         const uint16_t zeromark, const uint32_t zerospace,
                         const uint16_t footermark, const uint32_t footerspace,
                         const bool atleast = false,
-                        const uint8_t tolerance = kTolerance,
+                        const uint8_t tolerance = kUseDefTol,
                         const int16_t excess = kMarkExcess,
                         const bool MSBfirst = true);
   uint16_t matchGeneric(volatile uint16_t *data_ptr, uint8_t *result_ptr,
@@ -206,7 +217,7 @@ class IRrecv {
                         const uint16_t footermark,
                         const uint32_t footerspace,
                         const bool atleast = false,
-                        const uint8_t tolerance = kTolerance,
+                        const uint8_t tolerance = kUseDefTol,
                         const int16_t excess = kMarkExcess,
                         const bool MSBfirst = true);
   bool decodeHash(decode_results *results);
@@ -249,7 +260,7 @@ class IRrecv {
 #endif
 #if (DECODE_RC5 || DECODE_R6 || DECODE_LASERTAG || DECODE_MWM)
   int16_t getRClevel(decode_results *results, uint16_t *offset, uint16_t *used,
-                     uint16_t bitTime, uint8_t tolerance = kTolerance,
+                     uint16_t bitTime, uint8_t tolerance = kUseDefTol,
                      int16_t excess = kMarkExcess, uint16_t delta = 0,
                      uint8_t maxwidth = 3);
 #endif

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -422,7 +422,7 @@ bool IRrecv::decodeArgo(decode_results *results, const uint16_t nbits,
                     kArgoBitMark, kArgoOneSpace,
                     kArgoBitMark, kArgoZeroSpace,
                     0, 0,  // Footer (None, allegedly. This seems very wrong.)
-                    true, kTolerance, 0, false)) return false;
+                    true, _tolerance, 0, false)) return false;
 
   // Compliance
   // Verify we got a valid checksum.

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -1275,9 +1275,9 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
 
   // Leader
   if (!matchMark(results->rawbuf[offset++], kDaikin2LeaderMark,
-                 kDaikin2Tolerance)) return false;
+                 _tolerance + kDaikin2Tolerance)) return false;
   if (!matchSpace(results->rawbuf[offset++], kDaikin2LeaderSpace,
-                  kDaikin2Tolerance)) return false;
+                  _tolerance + kDaikin2Tolerance)) return false;
 
   // Sections
   uint16_t pos = 0;
@@ -1291,7 +1291,8 @@ bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
                         kDaikin2BitMark, kDaikin2ZeroSpace,
                         kDaikin2BitMark, kDaikin2Gap,
                         section >= kDaikin2Sections - 1,
-                        kDaikin2Tolerance, kDaikinMarkExcess, false);
+                        _tolerance + kDaikin2Tolerance, kDaikinMarkExcess,
+                        false);
     if (used == 0) return false;
     offset += used;
     pos += ksectionSize[section];

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -176,7 +176,7 @@ const uint16_t kDaikin2ZeroSpace = 420;
 const uint16_t kDaikin2Sections = 2;
 const uint16_t kDaikin2Section1Length = 20;
 const uint16_t kDaikin2Section2Length = 19;
-const uint8_t kDaikin2Tolerance = kTolerance + 5;
+const uint8_t kDaikin2Tolerance = 5;  // Extra percentage tolerance
 
 const uint8_t kDaikin2BitSleepTimer = 0b00100000;
 const uint8_t kDaikin2BitPurify = 0b00010000;

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -317,7 +317,7 @@ bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
                     kElectraAcBitMark, kElectraAcOneSpace,
                     kElectraAcBitMark, kElectraAcZeroSpace,
                     kElectraAcBitMark, kElectraAcMessageGap, true,
-                    kTolerance, 0, false)) return false;
+                    _tolerance, 0, false)) return false;
 
   // Compliance
   if (strict) {

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -649,7 +649,7 @@ bool IRrecv::decodeFujitsuAC(decode_results* results, uint16_t nbits,
   match_result_t data_result =
       matchData(&(results->rawbuf[offset]), kFujitsuAcMinBits - 8,
                 kFujitsuAcBitMark, kFujitsuAcOneSpace, kFujitsuAcBitMark,
-                kFujitsuAcZeroSpace, kTolerance, kMarkExcess, false);
+                kFujitsuAcZeroSpace, _tolerance, kMarkExcess, false);
   if (data_result.success == false) return false;      // Fail
   if (data_result.data != 0x1010006314) return false;  // Signature failed.
   dataBitsSoFar += kFujitsuAcMinBits - 8;
@@ -666,7 +666,7 @@ bool IRrecv::decodeFujitsuAC(decode_results* results, uint16_t nbits,
        i++, dataBitsSoFar += 8, offset += data_result.used) {
     data_result = matchData(
         &(results->rawbuf[offset]), 8, kFujitsuAcBitMark, kFujitsuAcOneSpace,
-        kFujitsuAcBitMark, kFujitsuAcZeroSpace, kTolerance, kMarkExcess, false);
+        kFujitsuAcBitMark, kFujitsuAcZeroSpace, _tolerance, kMarkExcess, false);
     if (data_result.success == false) break;  // Fail
     results->state[i] = data_result.data;
   }

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -419,7 +419,7 @@ bool IRrecv::decodeGoodweather(decode_results* results,
     data_result = matchData(&(results->rawbuf[offset]), 8,
                             kGoodweatherBitMark, kGoodweatherOneSpace,
                             kGoodweatherBitMark, kGoodweatherZeroSpace,
-                            kTolerance, kMarkExcess, false);
+                            _tolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     DPRINTLN("DEBUG: Normal byte read okay.");
     offset += data_result.used;
@@ -428,7 +428,7 @@ bool IRrecv::decodeGoodweather(decode_results* results,
     data_result = matchData(&(results->rawbuf[offset]), 8,
                             kGoodweatherBitMark, kGoodweatherOneSpace,
                             kGoodweatherBitMark, kGoodweatherZeroSpace,
-                            kTolerance, kMarkExcess, false);
+                            _tolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     DPRINTLN("DEBUG: Inverted byte read okay.");
     offset += data_result.used;

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -583,7 +583,7 @@ bool IRrecv::decodeGree(decode_results* results, uint16_t nbits, bool strict) {
                       kGreeBitMark, kGreeOneSpace,
                       kGreeBitMark, kGreeZeroSpace,
                       0, 0, false,
-                      kTolerance, kMarkExcess, false);
+                      _tolerance, kMarkExcess, false);
   if (used == 0) return false;
   offset += used;
 
@@ -591,7 +591,7 @@ bool IRrecv::decodeGree(decode_results* results, uint16_t nbits, bool strict) {
   match_result_t data_result;
   data_result = matchData(&(results->rawbuf[offset]), kGreeBlockFooterBits,
                           kGreeBitMark, kGreeOneSpace, kGreeBitMark,
-                          kGreeZeroSpace, kTolerance, kMarkExcess, false);
+                          kGreeZeroSpace, _tolerance, kMarkExcess, false);
   if (data_result.success == false) return false;
   if (data_result.data != kGreeBlockFooter) return false;
   offset += data_result.used;
@@ -603,7 +603,7 @@ bool IRrecv::decodeGree(decode_results* results, uint16_t nbits, bool strict) {
                     kGreeBitMark, kGreeOneSpace,
                     kGreeBitMark, kGreeZeroSpace,
                     kGreeBitMark, kGreeMsgSpace, true,
-                    kTolerance, kMarkExcess, false)) return false;
+                    _tolerance, kMarkExcess, false)) return false;
 
   // Compliance
   if (strict) {

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -933,7 +933,7 @@ bool IRrecv::decodeHaierAC(decode_results* results, uint16_t nbits,
                     kHaierAcBitMark, kHaierAcOneSpace,
                     kHaierAcBitMark, kHaierAcZeroSpace,
                     kHaierAcBitMark, kHaierAcMinGap, true,
-                    kTolerance, kMarkExcess)) return false;
+                    _tolerance, kMarkExcess)) return false;
 
   // Compliance
   if (strict) {

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -382,7 +382,7 @@ String IRHitachiAc::toString(void) {
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/453
 bool IRrecv::decodeHitachiAC(decode_results *results, const uint16_t nbits,
                              const bool strict) {
-  const uint8_t kTolerance = 30;
+  const uint8_t k_tolerance = _tolerance + 5;
   if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
     return false;  // Can't possibly be a valid HitachiAC message.
   if (strict) {
@@ -412,7 +412,7 @@ bool IRrecv::decodeHitachiAC(decode_results *results, const uint16_t nbits,
                     kHitachiAcBitMark, kHitachiAcOneSpace,
                     kHitachiAcBitMark, kHitachiAcZeroSpace,
                     kHitachiAcBitMark, kHitachiAcMinGap, true,
-                    kTolerance)) return false;
+                    k_tolerance)) return false;
 
   // Compliance
   if (strict) {

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -475,7 +475,7 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                         kKelvinatorBitMark, kKelvinatorOneSpace,
                         kKelvinatorBitMark, kKelvinatorZeroSpace,
                         0, 0, false,
-                        kTolerance, kMarkExcess, false);
+                        _tolerance, kMarkExcess, false);
     if (used == 0) return false;
     offset += used;
     pos += 4;
@@ -485,7 +485,7 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
         &(results->rawbuf[offset]), kKelvinatorCmdFooterBits,
         kKelvinatorBitMark, kKelvinatorOneSpace,
         kKelvinatorBitMark, kKelvinatorZeroSpace,
-        kTolerance, kMarkExcess, false);
+        _tolerance, kMarkExcess, false);
     if (data_result.success == false) return false;
     if (data_result.data != kKelvinatorCmdFooter) return false;
     offset += data_result.used;
@@ -498,7 +498,7 @@ bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
                         kKelvinatorBitMark, kKelvinatorZeroSpace,
                         kKelvinatorBitMark, kKelvinatorGapSpace * 2,
                         s > 0,
-                        kTolerance, kMarkExcess, false);
+                        _tolerance, kMarkExcess, false);
     if (used == 0) return false;
     offset += used;
     pos += 4;

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -237,7 +237,7 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t nbits, bool strict) {
   match_result_t data_result =
       matchData(&(results->rawbuf[offset]), nbits, bitmarkticks * m_tick,
                 kLgOneSpaceTicks * s_tick, bitmarkticks * m_tick,
-                kLgZeroSpaceTicks * s_tick, kTolerance, 0);
+                kLgZeroSpaceTicks * s_tick, _tolerance, 0);
   if (data_result.success == false) return false;
   data = data_result.data;
   offset += data_result.used;

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -302,7 +302,7 @@ bool IRrecv::decodeMitsubishiAC(decode_results *results, uint16_t nbits,
       data_result =
           matchData(&(results->rawbuf[offset]), 8, kMitsubishiAcBitMark,
                     kMitsubishiAcOneSpace, kMitsubishiAcBitMark,
-                    kMitsubishiAcZeroSpace, kTolerance, kMarkExcess, false);
+                    kMitsubishiAcZeroSpace, _tolerance, kMarkExcess, false);
       if (data_result.success == false) {
         failure = true;
         DPRINT("Byte decode failed at #");
@@ -365,7 +365,7 @@ bool IRrecv::decodeMitsubishiAC(decode_results *results, uint16_t nbits,
         data_result =
             matchData(&(results->rawbuf[offset]), 8, kMitsubishiAcBitMark,
                       kMitsubishiAcOneSpace, kMitsubishiAcBitMark,
-                      kMitsubishiAcZeroSpace, kTolerance, kMarkExcess, false);
+                      kMitsubishiAcZeroSpace, _tolerance, kMarkExcess, false);
         if (data_result.success == false ||
             data_result.data != results->state[i]) {
           DPRINTLN("Repeat payload error.");

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -1045,7 +1045,7 @@ bool IRrecv::decodeMitsubishiHeavy(decode_results* results,
                       kMitsubishiHeavyBitMark, kMitsubishiHeavyOneSpace,
                       kMitsubishiHeavyBitMark, kMitsubishiHeavyZeroSpace,
                       kMitsubishiHeavyBitMark, kMitsubishiHeavyGap, true,
-                      kTolerance, 0, false);
+                      _tolerance, 0, false);
   if (used == 0) return false;
   offset += used;
   // Compliance

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -528,7 +528,7 @@ bool IRrecv::decodeNeoclima(decode_results *results, const uint16_t nbits,
                       kNeoclimaBitMark, kNeoclimaOneSpace,
                       kNeoclimaBitMark, kNeoclimaZeroSpace,
                       kNeoclimaBitMark, kNeoclimaHdrSpace, false,
-                      kTolerance, 0, false);
+                      _tolerance, 0, false);
   if (!used) return false;
   offset += used;
   // Extra footer.

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -141,11 +141,9 @@ bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
     data <<= 2;
     // Use non-default tolerance & excess for matching some of the spaces as the
     // defaults are too generous and causes mis-matches in some cases.
-    if (match(results->rawbuf[offset], kRcmmBitSpace0Ticks * s_tick,
-              kTolerance))
+    if (match(results->rawbuf[offset], kRcmmBitSpace0Ticks * s_tick))
       data += 0;
-    else if (match(results->rawbuf[offset], kRcmmBitSpace1Ticks * s_tick,
-                   kTolerance))
+    else if (match(results->rawbuf[offset], kRcmmBitSpace1Ticks * s_tick))
       data += 1;
     else if (match(results->rawbuf[offset], kRcmmBitSpace2Ticks * s_tick,
                    kRcmmTolerance))

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -742,7 +742,7 @@ bool IRrecv::decodeSamsungAC(decode_results *results, const uint16_t nbits,
                         kSamsungAcBitMark, kSamsungAcZeroSpace,
                         kSamsungAcBitMark, kSamsungAcSectionGap,
                         pos + kSamsungACSectionLength >= nbits / 8,
-                        kTolerance, 0, false);
+                        _tolerance, 0, false);
     if (used == 0) return false;
     offset += used;
   }

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -538,7 +538,7 @@ bool IRrecv::decodeSharpAc(decode_results *results, const uint16_t nbits,
                       kSharpAcBitMark, kSharpAcOneSpace,
                       kSharpAcBitMark, kSharpAcZeroSpace,
                       kSharpAcBitMark, kSharpAcGap, true,
-                      kTolerance, kMarkExcess, false);
+                      _tolerance, kMarkExcess, false);
   if (used == 0) return false;
   offset += used;
   // Compliance

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -396,7 +396,7 @@ bool IRrecv::decodeTcl112Ac(decode_results *results, const uint16_t nbits,
                     kTcl112AcBitMark, kTcl112AcOneSpace,
                     kTcl112AcBitMark, kTcl112AcZeroSpace,
                     kTcl112AcBitMark, kTcl112AcGap, true,
-                    kTcl112AcTolerance, 0, false)) return false;
+                    _tolerance + kTcl112AcTolerance, 0, false)) return false;
   // Compliance
   // Verify we got a valid checksum.
   if (strict && !IRTcl112Ac::validChecksum(results->state)) return false;

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -23,7 +23,7 @@ const uint16_t kTcl112AcBitMark = 500;
 const uint16_t kTcl112AcOneSpace = 1050;
 const uint16_t kTcl112AcZeroSpace = 325;
 const uint32_t kTcl112AcGap = kDefaultMessageGap;  // Just a guess.
-const uint8_t kTcl112AcTolerance = kTolerance + 5;  // Percent
+const uint8_t kTcl112AcTolerance = 5;  // Extra Percent
 
 const uint8_t kTcl112AcHeat = 1;
 const uint8_t kTcl112AcDry =  2;

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -264,7 +264,7 @@ bool IRrecv::decodeTeco(decode_results* results,
                     kTecoBitMark, kTecoOneSpace,
                     kTecoBitMark, kTecoZeroSpace,
                     kTecoBitMark, kTecoGap, true,
-                    kTolerance, kMarkExcess, false)) return false;
+                    _tolerance, kMarkExcess, false)) return false;
 
   // Success
   results->decode_type = TECO;

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -362,7 +362,7 @@ bool IRrecv::decodeToshibaAC(decode_results* results, const uint16_t nbits,
                     kToshibaAcBitMark, kToshibaAcOneSpace,
                     kToshibaAcBitMark, kToshibaAcZeroSpace,
                     kToshibaAcBitMark, kToshibaAcMinGap, true,
-                    kTolerance, kMarkExcess)) return false;
+                    _tolerance, kMarkExcess)) return false;
   // Compliance
   if (strict) {
     // Check that the checksum of the message is correct.

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -274,7 +274,7 @@ bool IRrecv::decodeTrotec(decode_results *results, const uint16_t nbits,
                       kTrotecBitMark, kTrotecOneSpace,
                       kTrotecBitMark, kTrotecZeroSpace,
                       kTrotecBitMark, kTrotecGap, true,
-                      kTolerance, 0, false);
+                      _tolerance, 0, false);
   if (used == 0) return false;
   offset += used;
 

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -607,7 +607,7 @@ bool IRrecv::decodeWhirlpoolAC(decode_results *results, const uint16_t nbits,
                         kWhirlpoolAcBitMark, kWhirlpoolAcZeroSpace,
                         kWhirlpoolAcBitMark, kWhirlpoolAcGap,
                         section >= kWhirlpoolAcSections - 1,
-                        kTolerance, kMarkExcess, false);
+                        _tolerance, kMarkExcess, false);
     if (used == 0) return false;
     offset += used;
     pos += sectionSize[section];


### PR DESCRIPTION
* Add `setTolerance()` and `getTolerance()` to `IRrecv` class.
  - Allows default tolerance to be changed without a recompile for most protocols. i.e. `kTolerance` doesn't need to be changed.
* Unit test coverage for above.