### PR TITLE
Basic support for Daikin152 A/C protocol.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -655,6 +655,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting Amcor decode");
   if (decodeAmcor(results)) return true;
 #endif  // DECODE_AMCOR
+#if DECODE_DAIKIN152
+  DPRINTLN("Attempting Daikin152 decode");
+  if (decodeDaikin152(results)) return true;
+#endif  // DECODE_DAIKIN152
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -348,6 +348,11 @@ class IRrecv {
                        const uint16_t nbits = kDaikin128Bits,
                        const bool strict = true);
 #endif  // DECODE_DAIKIN128
+#if DECODE_DAIKIN152
+  bool decodeDaikin152(decode_results *results,
+                       const uint16_t nbits = kDaikin152Bits,
+                       const bool strict = true);
+#endif  // DECODE_DAIKIN152
 #if DECODE_DAIKIN160
   bool decodeDaikin160(decode_results *results,
                        const uint16_t nbits = kDaikin160Bits,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -250,6 +250,9 @@
 #define DECODE_AMCOR           true
 #define SEND_AMCOR             true
 
+#define DECODE_DAIKIN152       true
+#define SEND_DAIKIN152         true
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
@@ -258,7 +261,8 @@
      DECODE_PANASONIC_AC || DECODE_MWM || DECODE_DAIKIN2 || \
      DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY || \
      DECODE_DAIKIN216 || DECODE_SHARP_AC || DECODE_DAIKIN160 || \
-     DECODE_NEOCLIMA || DECODE_DAIKIN176 || DECODE_DAIKIN128 || DECODE_AMCOR)
+     DECODE_NEOCLIMA || DECODE_DAIKIN176 || DECODE_DAIKIN128 || \
+     DECODE_AMCOR || DECODE_DAIKIN152)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -347,8 +351,9 @@ enum decode_type_t {
   DAIKIN176,
   DAIKIN128,
   AMCOR,
+  DAIKIN152,  // 70
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = AMCOR,
+  kLastDecodeType = DAIKIN152,
 };
 
 // Message lengths & required repeat values
@@ -381,6 +386,9 @@ const uint16_t kDaikin160DefaultRepeat = kNoRepeat;
 const uint16_t kDaikin128StateLength = 16;
 const uint16_t kDaikin128Bits = kDaikin128StateLength * 8;
 const uint16_t kDaikin128DefaultRepeat = kNoRepeat;
+const uint16_t kDaikin152StateLength = 19;
+const uint16_t kDaikin152Bits = kDaikin152StateLength * 8;
+const uint16_t kDaikin152DefaultRepeat = kNoRepeat;
 const uint16_t kDaikin176StateLength = 22;
 const uint16_t kDaikin176Bits = kDaikin176StateLength * 8;
 const uint16_t kDaikin176DefaultRepeat = kNoRepeat;

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -584,6 +584,8 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
       return kDaikinBits;
     case DAIKIN128:
       return kDaikin128Bits;
+    case DAIKIN152:
+      return kDaikin152Bits;
     case DAIKIN160:
       return kDaikin160Bits;
     case DAIKIN176:
@@ -863,6 +865,11 @@ bool IRsend::send(const decode_type_t type, const unsigned char *state,
         sendDaikin128(state, nbytes);
         break;
 #endif  // SEND_DAIKIN128
+#if SEND_DAIKIN152
+    case DAIKIN152:
+        sendDaikin152(state, nbytes);
+        break;
+#endif  // SEND_DAIKIN152
 #if SEND_DAIKIN160
     case DAIKIN160:
       sendDaikin160(state, nbytes);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -320,6 +320,11 @@ class IRsend {
                      const uint16_t nbytes = kDaikin128StateLength,
                      const uint16_t repeat = kDaikin128DefaultRepeat);
 #endif  // SEND_DAIKIN128
+#if SEND_DAIKIN152
+  void sendDaikin152(const unsigned char data[],
+                     const uint16_t nbytes = kDaikin152StateLength,
+                     const uint16_t repeat = kDaikin152DefaultRepeat);
+#endif  // SEND_DAIKIN152
 #if SEND_DAIKIN160
   void sendDaikin160(const unsigned char data[],
                      const uint16_t nbytes = kDaikin160StateLength,

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -107,6 +107,8 @@ decode_type_t strToDecodeType(const char * const str) {
     return decode_type_t::DAIKIN;
   else if (!strcasecmp(str, "DAIKIN128"))
     return decode_type_t::DAIKIN128;
+  else if (!strcasecmp(str, "DAIKIN152"))
+    return decode_type_t::DAIKIN152;
   else if (!strcasecmp(str, "DAIKIN160"))
     return decode_type_t::DAIKIN160;
   else if (!strcasecmp(str, "DAIKIN176"))
@@ -273,6 +275,9 @@ String typeToString(const decode_type_t protocol, const bool isRepeat) {
       break;
     case DAIKIN128:
       result = F("DAIKIN128");
+      break;
+    case DAIKIN152:
+      result = F("DAIKIN152");
       break;
     case DAIKIN160:
       result = F("DAIKIN160");
@@ -476,6 +481,7 @@ bool hasACState(const decode_type_t protocol) {
     case ARGO:
     case DAIKIN:
     case DAIKIN128:
+    case DAIKIN152:
     case DAIKIN160:
     case DAIKIN176:
     case DAIKIN2:

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -2913,3 +2913,156 @@ bool IRrecv::decodeDaikin128(decode_results *results, const uint16_t nbits,
   return true;
 }
 #endif  // DECODE_DAIKIN128
+
+#if SEND_DAIKIN152
+// Send a Daikin 152 bit A/C message.
+//
+// Args:
+//   data: An array of kDaikin152StateLength bytes containing the IR command.
+//
+// Supported devices:
+// - Daikin ARC480A5 remote.
+//
+// Status: Beta / Probably working.
+//
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/873
+void IRsend::sendDaikin152(const unsigned char data[], const uint16_t nbytes,
+                           const uint16_t repeat) {
+  for (uint16_t r = 0; r <= repeat; r++) {
+    // Leader
+    sendGeneric(0, 0, kDaikin152BitMark, kDaikin152OneSpace,
+                kDaikin152BitMark, kDaikin152ZeroSpace,
+                kDaikin152BitMark, kDaikin152Gap,
+                (uint64_t)0, kDaikin152LeaderBits,
+                kDaikin152Freq, false, 0, kDutyDefault);
+    // Header + Data + Footer
+    sendGeneric(kDaikin152HdrMark, kDaikin152HdrSpace, kDaikin152BitMark,
+                kDaikin152OneSpace, kDaikin152BitMark, kDaikin152ZeroSpace,
+                kDaikin152BitMark, kDaikin152Gap, data,
+                nbytes, kDaikin152Freq, false, 0, kDutyDefault);
+  }
+}
+#endif  // SEND_DAIKIN152
+
+#if DECODE_DAIKIN152
+// Decode the supplied Daikin 152 bit A/C message.
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of bits to expect in the data portion. (kDaikin152Bits)
+//   strict:  Flag to indicate if we strictly adhere to the specification.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Supported devices:
+// - Daikin ARC480A5 remote.
+//
+// Status: Beta / Probably working.
+//
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/873
+bool IRrecv::decodeDaikin152(decode_results *results, const uint16_t nbits,
+                             const bool strict) {
+  if (results->rawlen < 2 * (5 + nbits + kFooter) + kHeader - 1)
+    return false;
+  if (nbits / 8 < kDaikin152StateLength) return false;
+
+  // Compliance
+  if (strict && nbits != kDaikin152Bits) return false;
+
+  uint16_t offset = kStartOffset;
+  uint16_t used;
+
+  // Leader
+  uint64_t leader = 0;
+  used = matchGeneric(results->rawbuf + offset, &leader,
+                      results->rawlen - offset, kDaikin152LeaderBits,
+                      0, 0,  // No Header
+                      kDaikin152BitMark, kDaikin152OneSpace,
+                      kDaikin152BitMark, kDaikin152ZeroSpace,
+                      kDaikin152BitMark, kDaikin152Gap,  // Footer gap
+                      false, kTolerance, kMarkExcess, false);
+  if (used == 0 || leader != 0) return false;
+  offset += used;
+
+  // Header + Data + Footer
+  used = matchGeneric(results->rawbuf + offset, results->state,
+                      results->rawlen - offset, nbits,
+                      kDaikin152HdrMark, kDaikin152HdrSpace,
+                      kDaikin152BitMark, kDaikin152OneSpace,
+                      kDaikin152BitMark, kDaikin152ZeroSpace,
+                      kDaikin152BitMark, kDaikin152Gap,
+                      true, kTolerance, kMarkExcess, false);
+  if (used == 0) return false;
+
+  // Compliance
+  if (strict) {
+    if (!IRDaikin152::validChecksum(results->state)) return false;
+  }
+
+  // Success
+  results->decode_type = decode_type_t::DAIKIN152;
+  results->bits = nbits;
+  // No need to record the state as we stored it as we decoded it.
+  // As we use result->state, we don't record value, address, or command as it
+  // is a union data type.
+  return true;
+}
+#endif  // DECODE_DAIKIN152
+
+// Class for handling Daikin 152 bit / 19 byte A/C messages.
+//
+// Code by crankyoldgit.
+//
+// Supported Remotes: Daikin ARC480A5 remote
+//
+// Ref:
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/873
+IRDaikin152::IRDaikin152(const uint16_t pin, const bool inverted,
+                         const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
+
+void IRDaikin152::begin() { _irsend.begin(); }
+
+#if SEND_DAIKIN152
+void IRDaikin152::send(const uint16_t repeat) {
+  checksum();
+  _irsend.sendDaikin152(remote_state, kDaikin152StateLength, repeat);
+}
+#endif  // SEND_DAIKIN152
+
+// Verify the checksum is valid for a given state.
+// Args:
+//   state:  The array to verify the checksum of.
+//   length: The size of the state.
+// Returns:
+//   A boolean.
+bool IRDaikin152::validChecksum(uint8_t state[], const uint16_t length) {
+  // Validate the checksum of the given state.
+  if (length <= 1 || state[length - 1] != sumBytes(state, length - 1))
+    return false;
+  else
+    return true;
+}
+
+// Calculate and set the checksum values for the internal state.
+void IRDaikin152::checksum() {
+  remote_state[kDaikin152StateLength - 1] = sumBytes(
+      remote_state, kDaikin152StateLength - 1);
+}
+
+void IRDaikin152::stateReset() {
+  for (uint8_t i = 3; i < kDaikin152StateLength; i++) remote_state[i] = 0x00;
+  remote_state[0] =  0x11;
+  remote_state[1] =  0xDA;
+  remote_state[2] =  0x27;
+  // remote_state[19] is a checksum byte, it will be set by checksum().
+}
+
+uint8_t *IRDaikin152::getRaw() {
+  checksum();  // Ensure correct settings before sending.
+  return remote_state;
+}
+
+void IRDaikin152::setRaw(const uint8_t new_code[]) {
+  for (uint8_t i = 0; i < kDaikin152StateLength; i++)
+    remote_state[i] = new_code[i];
+}

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -16,7 +16,7 @@
 //   Brand: Daikin,  Model: FTXB12AXVJU A/C (DAIKIN128)
 //   Brand: Daikin,  Model: FTXB09AXVJU A/C (DAIKIN128)
 //   Brand: Daikin,  Model: BRC52B63 remote (DAIKIN128)
-
+//   Brand: Daikin,  Model: ARC480A5 remote (DAIKIN152)
 
 #ifndef IR_DAIKIN_H_
 #define IR_DAIKIN_H_
@@ -32,7 +32,7 @@
 #endif
 
 /*
-        Daikin AC map
+        Daikin AC map (i.e. DAIKIN, not the other variants)
         byte 6=
           b4:Comfort
         byte 7= checksum of the first part (and last byte before a 29ms pause)
@@ -328,6 +328,17 @@ const uint8_t kDaikin128BitWall =         0b00001000;
 const uint8_t kDaikin128BitCeiling =      0b00000001;
 const uint8_t kDaikin128MaskLight = kDaikin128BitWall | kDaikin128BitCeiling;
 
+// Another variant of the protocol for the Daikin ARC480A5 remote.
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/873
+const uint16_t kDaikin152Freq = 38000;  // Modulation Frequency in Hz.
+const uint8_t  kDaikin152LeaderBits = 5;
+const uint16_t kDaikin152HdrMark = 3492;
+const uint16_t kDaikin152HdrSpace = 1718;
+const uint16_t kDaikin152BitMark = 433;
+const uint16_t kDaikin152OneSpace = 1529;
+const uint16_t kDaikin152ZeroSpace = kDaikin152BitMark;
+const uint16_t kDaikin152Gap = 25182;
+
 // Legacy defines.
 #define DAIKIN_COOL kDaikinCool
 #define DAIKIN_HEAT kDaikinHeat
@@ -603,6 +614,7 @@ class IRDaikin160 {
   void stateReset();
   void checksum();
 };
+
 // Class to emulate a Daikin BRC4C153 remote.
 class IRDaikin176 {
  public:
@@ -721,4 +733,31 @@ class IRDaikin128 {
   void clearSleepTimerFlag(void);
 };
 
+// Class to emulate a Daikin ARC480A5 remote.
+class IRDaikin152 {
+ public:
+  explicit IRDaikin152(const uint16_t pin, const bool inverted = false,
+                       const bool use_modulation = true);
+
+#if SEND_DAIKIN152
+  void send(const uint16_t repeat = kDaikin152DefaultRepeat);
+  uint8_t calibrate(void) { return _irsend.calibrate(); }
+#endif
+  void begin();
+  uint8_t* getRaw();
+  void setRaw(const uint8_t new_code[]);
+  static bool validChecksum(uint8_t state[],
+                            const uint16_t length = kDaikin152StateLength);
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  // # of bytes per command
+  uint8_t remote_state[kDaikin152StateLength];
+  void stateReset();
+  void checksum();
+};
 #endif  // IR_DAIKIN_H_


### PR DESCRIPTION
* Basic support (send & capture) for Daikin152 protcol (Daikin ARC480A5 remote)
* Unit tests to cover decoding a real message & self-decoding.

For #873