### PR TITLE
IRMQTTServer: Move from ArduinoJson v5 to v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - ln -s $PWD /usr/local/share/arduino/libraries/
   - git clone https://github.com/tzapu/WiFiManager.git /usr/local/share/arduino/libraries/WiFiManager
   - git clone https://github.com/knolleary/pubsubclient.git /usr/local/share/arduino/libraries/PubSubClient
-  - git clone https://github.com/bblanchon/ArduinoJson.git --branch 5.x /usr/local/share/arduino/libraries/ArduinoJson
+  - git clone https://github.com/bblanchon/ArduinoJson.git --branch 6.x /usr/local/share/arduino/libraries/ArduinoJson
   - arduino --pref "boardsmanager.additional.urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json" --save-prefs
   - arduino --install-boards esp8266:esp8266
   - arduino --board $BD --save-prefs

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -225,7 +225,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.3.5-alpha"
+#define _MY_VERSION_ "v1.4.0-alpha"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -209,6 +209,11 @@ const uint8_t kPortLength = 5;  // Largest value of uint16_t is "65535".
 const uint8_t kUsernameLength = 15;
 const uint8_t kPasswordLength = 20;
 
+// -------------------------- Json Settings ------------------------------------
+
+const uint16_t kJsonConfigMaxSize = 512;    // Bytes
+const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
+
 // -------------------------- Debug Settings -----------------------------------
 // Debug output is disabled if any of the IR pins are on the TX (D1) pin.
 // See `isSerialGpioUsedByIr()`.
@@ -220,7 +225,7 @@ const uint8_t kPasswordLength = 20;
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.3.4"
+#define _MY_VERSION_ "v1.3.5-alpha"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -31,7 +31,7 @@
  *
  * - Arduino IDE:
  *   o Install the following libraries via Library Manager
- *     - ArduinoJson (https://arduinojson.org/) (Version >= 5.0 and < 6.0)
+ *     - ArduinoJson (https://arduinojson.org/) (Version >= 6.0)
  *     - PubSubClient (https://pubsubclient.knolleary.net/)
  *     - WiFiManager (https://github.com/tzapu/WiFiManager)
  *                   (ESP8266: Version >= 0.14, ESP32: 'development' branch.)
@@ -502,8 +502,7 @@ bool mountSpiffs(void) {
 bool saveConfig(void) {
   debug("Saving the config.");
   bool success = false;
-  DynamicJsonBuffer jsonBuffer;
-  JsonObject& json = jsonBuffer.createObject();
+  DynamicJsonDocument json(kJsonConfigMaxSize);
 #if MQTT_ENABLE
   json[kMqttServerKey] = MqttServer;
   json[kMqttPortKey] = MqttPort;
@@ -528,7 +527,7 @@ bool saveConfig(void) {
       debug("Failed to open config file for writing.");
     } else {
       debug("Writing out the config file.");
-      json.printTo(configFile);
+      serializeJson(json, configFile);
       configFile.close();
       debug("Finished writing config file.");
       success = true;
@@ -553,9 +552,8 @@ bool loadConfigFile(void) {
         std::unique_ptr<char[]> buf(new char[size]);
 
         configFile.readBytes(buf.get(), size);
-        DynamicJsonBuffer jsonBuffer;
-        JsonObject& json = jsonBuffer.parseObject(buf.get());
-        if (json.success()) {
+        DynamicJsonDocument json(kJsonConfigMaxSize);
+        if (!deserializeJson(json, buf.get(), kJsonConfigMaxSize)) {
           debug("Json config file parsed ok.");
 #if MQTT_ENABLE
           strncpy(MqttServer, json[kMqttServerKey] | "", kHostnameLength);
@@ -2641,8 +2639,7 @@ bool sendFloat(const String topic, const float_t temp, const bool retain) {
 #if MQTT_CLIMATE_JSON
 void sendJsonState(const stdAc::state_t state, const String topic,
                    const bool retain, const bool ha_mode) {
-  DynamicJsonBuffer jsonBuffer;
-  JsonObject& json = jsonBuffer.createObject();
+  DynamicJsonDocument json(kJsonAcStateMaxSize);
   json[KEY_PROTOCOL] = typeToString(state.protocol);
   json[KEY_MODEL] = state.model;
   json[KEY_POWER] = IRac::boolToString(state.power);
@@ -2668,14 +2665,13 @@ void sendJsonState(const stdAc::state_t state, const String topic,
 
   String payload = "";
   payload.reserve(200);
-  json.printTo(payload);
+  serializeJson(json, payload);
   sendString(topic, payload, retain);
 }
 
 stdAc::state_t jsonToState(const stdAc::state_t current, const String str) {
-  DynamicJsonBuffer jsonBuffer;
-  JsonObject& json = jsonBuffer.parseObject(str);
-  if (!json.success()) {
+  DynamicJsonDocument json(kJsonAcStateMaxSize);
+  if (deserializeJson(json, str, kJsonAcStateMaxSize)) {
     debug("json MQTT message did not parse. Skipping!");
     return current;
   }

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -11,7 +11,7 @@ build_flags = -DMQTT_MAX_PACKET_SIZE=768
 lib_deps_builtin =
 lib_deps_external =
   PubSubClient
-  ArduinoJson@<6.0
+  ArduinoJson@>=6.0
 
 [common_esp8266]
 lib_deps_external =


### PR DESCRIPTION
Note: This costs about ~1.3k of prog space.

Fixes #876

@sillyfrog Your thoughts wanted in addition to a code review:
I'm of two minds about this, moving to v6 means more modern code (v5 is still maintained/patched etc) and it's what users are likely to install by default, but it comes with a cost of increased space.
There is no "need" to make these changes.

The json version won't affect EasyESP but asking @jimmys01 for his thoughts too in cause they have had this similar dilemma too