### PR TITLE
SamsungAc: Only send power on/off code if it's needed

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -749,9 +749,9 @@ void IRac::samsung(IRSamsungAc *ac,
                    const float degrees,
                    const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                    const bool quiet, const bool turbo, const bool clean,
-                   const bool beep, const bool dopower) {
-  // dopower is for unit testing only. It should only ever be false in tests.
-  if (dopower) ac->setPower(on);
+                   const bool beep, const bool forcepower) {
+  ac->stateReset(forcepower);
+  ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -247,7 +247,7 @@ void electra(IRElectraAc *ac,
                const bool on, const stdAc::opmode_t mode, const float degrees,
                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                const bool quiet, const bool turbo, const bool clean,
-               const bool beep, const bool dopower = true);
+               const bool beep, const bool forcepower = true);
 #endif  // SEND_SAMSUNG_AC
 #if SEND_SHARP_AC
   void sharp(IRSharpAc *ac,

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -426,12 +426,16 @@ void IRSamsungAc::setRaw(const uint8_t new_code[], const uint16_t length) {
 }
 
 void IRSamsungAc::on(void) {
+  if (getPower())
+    return;
   remote_state[1] &= ~kSamsungAcPowerMask1;  // Bit needs to be cleared.
   remote_state[6] |= kSamsungAcPowerMask6;  // Bit needs to be set.
   _sendpower = true;  // Flag that we need to send the special power message(s).
 }
 
 void IRSamsungAc::off(void) {
+  if (!getPower())
+    return;
   remote_state[1] |= kSamsungAcPowerMask1;  // Bit needs to be set.
   remote_state[6] &= ~kSamsungAcPowerMask6;  // Bit needs to be cleared.
   _sendpower = true;  // Flag that we need to send the special power message(s).

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -296,7 +296,11 @@ IRSamsungAc::IRSamsungAc(const uint16_t pin, const bool inverted,
   this->stateReset();
 }
 
-void IRSamsungAc::stateReset(void) {
+// Reset the internal state of the emulation.
+// Args:
+//   forcepower: A flag indicating if force sending a special power message
+//              with the first `send()` call. Default: true
+void IRSamsungAc::stateReset(const bool forcepower) {
   for (uint8_t i = 0; i < kSamsungAcExtendedStateLength; i++)
     remote_state[i] = 0x0;
   remote_state[0] = 0x02;
@@ -309,7 +313,8 @@ void IRSamsungAc::stateReset(void) {
   remote_state[10] = 0x71;
   remote_state[12] = 0x15;
   remote_state[13] = 0xF0;
-  _sendpower = false;
+  _forcepower = forcepower;
+  _lastsentpowerstate = this->getPower();
 }
 
 void IRSamsungAc::begin(void) { _irsend.begin(); }
@@ -354,12 +359,13 @@ void IRSamsungAc::checksum(uint16_t length) {
 // i.e. When the device is already running.
 void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) this->checksum();
-  if (_sendpower) {  // Do we need to send a the special power on/off message?
-    _sendpower = false;  // It will now been sent.
+  // Do we need to send a the special power on/off message?
+  if (this->getPower() != _lastsentpowerstate || _forcepower) {
+    _forcepower = false;  // It will now been sent, so clear the flag if set.
     if (this->getPower()) {
-      this->sendOn();
+      this->sendOn(repeat);
     } else {
-      this->sendOff();
+      this->sendOff(repeat);
       return;  // No point sending anything else if we are turning the unit off.
     }
   }
@@ -395,6 +401,7 @@ void IRSamsungAc::sendOn(const uint16_t repeat) {
       0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
       0x01, 0xE2, 0xFE, 0x71, 0x80, 0x11, 0xF0};
   _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
+  _lastsentpowerstate = true;  // On
 }
 
 // Send the special extended "Off" message as the library can't seem to
@@ -406,6 +413,7 @@ void IRSamsungAc::sendOff(const uint16_t repeat) {
       0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
       0x01, 0x02, 0xFF, 0x71, 0x80, 0x11, 0xC0};
   _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
+  _lastsentpowerstate = false;  // Off
 }
 #endif  // SEND_SAMSUNG_AC
 
@@ -426,19 +434,13 @@ void IRSamsungAc::setRaw(const uint8_t new_code[], const uint16_t length) {
 }
 
 void IRSamsungAc::on(void) {
-  if (getPower())
-    return;
   remote_state[1] &= ~kSamsungAcPowerMask1;  // Bit needs to be cleared.
   remote_state[6] |= kSamsungAcPowerMask6;  // Bit needs to be set.
-  _sendpower = true;  // Flag that we need to send the special power message(s).
 }
 
 void IRSamsungAc::off(void) {
-  if (!getPower())
-    return;
   remote_state[1] |= kSamsungAcPowerMask1;  // Bit needs to be set.
   remote_state[6] &= ~kSamsungAcPowerMask6;  // Bit needs to be cleared.
-  _sendpower = true;  // Flag that we need to send the special power message(s).
 }
 
 void IRSamsungAc::setPower(const bool on) {

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -65,7 +65,7 @@ class IRSamsungAc {
   explicit IRSamsungAc(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
 
-  void stateReset(void);
+  void stateReset(const bool forcepower = true);
 #if SEND_SAMSUNG_AC
   void send(const uint16_t repeat = kSamsungAcDefaultRepeat,
             const bool calcchecksum = true);
@@ -118,7 +118,8 @@ class IRSamsungAc {
 #endif
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kSamsungAcExtendedStateLength];
-  bool _sendpower;  // Hack to know when we need to send a special power mesg.
+  bool _forcepower;  // Hack to know when we need to send a special power mesg.
+  bool _lastsentpowerstate;
   void checksum(const uint16_t length = kSamsungAcStateLength);
 };
 


### PR DESCRIPTION
Now instead of always sending the special power code it's sent only if the power state has been changed