### PR TITLE
Web-AC-control: Add platformio support files & Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
       - arduino --verify --board $BD $PWD/examples/TurnOnFujitsuAC/TurnOnFujitsuAC.ino 2> /dev/null
       - arduino --verify --board $BD $PWD/examples/TurnOnKelvinatorAC/TurnOnKelvinatorAC.ino 2> /dev/null
       - arduino --verify --board $BD $PWD/examples/TurnOnMitsubishiAC/TurnOnMitsubishiAC.ino 2> /dev/null
+      - arduino --verify --board $BD $PWD/examples/Web-AC-control/Web-AC-control.ino 2> /dev/null
     - script:
       # Check that everything compiles. (Part 2)
       - arduino --verify --board $BD $PWD/examples/IRsendProntoDemo/IRsendProntoDemo.ino 2> /dev/null

--- a/examples/Web-AC-control/platformio.ini
+++ b/examples/Web-AC-control/platformio.ini
@@ -1,0 +1,37 @@
+[platformio]
+src_dir = .
+
+[env]
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
+build_flags =
+
+[common]
+lib_deps_builtin =
+lib_deps_external =
+  ArduinoJson@>=6.0
+
+[common_esp8266]
+lib_deps_external =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}
+  WifiManager@>=0.14
+
+[common_esp32]
+lib_deps_external =
+  ${common.lib_deps_builtin}
+  ${common.lib_deps_external}
+  https://github.com/tzapu/WiFiManager.git#development
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+lib_deps = ${common_esp8266.lib_deps_external}
+
+[env:esp32dev]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_deps = ${common_esp32.lib_deps_external}


### PR DESCRIPTION
* Add a `.platformio.ini` file for example code
* Add support for ESP32.
  - **NOTE:** OTA update only available on ESP8266
* Add `Web-AC-control.ino` to Travis compilation checks.
* Fix compiler warning messages.

FYI @mariusmotea
Ref #880 