### PR TITLE
Basic support for Mitsubishi136 A/C protocol.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -669,6 +669,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   DPRINTLN("Attempting Daikin152 decode");
   if (decodeDaikin152(results)) return true;
 #endif  // DECODE_DAIKIN152
+#if DECODE_MITSUBISHI136
+  DPRINTLN("Attempting Mitsubishi136 decode");
+  if (decodeMitsubishi136(results)) return true;
+#endif  // DECODE_MITSUBISHI136
 #if DECODE_HASH
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -254,6 +254,11 @@ class IRrecv {
                           uint16_t nbits = kMitsubishiACBits,
                           bool strict = false);
 #endif
+#if DECODE_MITSUBISHI136
+  bool decodeMitsubishi136(decode_results *results,
+                           const uint16_t nbits = kMitsubishi136Bits,
+                           const bool strict = true);
+#endif
 #if DECODE_MITSUBISHIHEAVY
   bool decodeMitsubishiHeavy(decode_results *results, const uint16_t nbits,
                              const bool strict = true);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -130,6 +130,9 @@
 #define DECODE_MITSUBISHI_AC   true  // Beta.
 #define SEND_MITSUBISHI_AC     true
 
+#define DECODE_MITSUBISHI136   true
+#define SEND_MITSUBISHI136     true
+
 #define DECODE_FUJITSU_AC      true
 #define SEND_FUJITSU_AC        true
 
@@ -262,7 +265,7 @@
      DECODE_VESTEL_AC || DECODE_TCL112AC || DECODE_MITSUBISHIHEAVY || \
      DECODE_DAIKIN216 || DECODE_SHARP_AC || DECODE_DAIKIN160 || \
      DECODE_NEOCLIMA || DECODE_DAIKIN176 || DECODE_DAIKIN128 || \
-     DECODE_AMCOR || DECODE_DAIKIN152)
+     DECODE_AMCOR || DECODE_DAIKIN152 || DECODE_MITSUBISHI136)
 #define DECODE_AC true  // We need some common infrastructure for decoding A/Cs.
 #else
 #define DECODE_AC false   // We don't need that infrastructure.
@@ -352,8 +355,9 @@ enum decode_type_t {
   DAIKIN128,
   AMCOR,
   DAIKIN152,  // 70
+  MITSUBISHI136,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = DAIKIN152,
+  kLastDecodeType = MITSUBISHI136,
 };
 
 // Message lengths & required repeat values
@@ -451,6 +455,9 @@ const uint16_t kMitsubishiMinRepeat = kSingleRepeat;
 const uint16_t kMitsubishiACStateLength = 18;
 const uint16_t kMitsubishiACBits = kMitsubishiACStateLength * 8;
 const uint16_t kMitsubishiACMinRepeat = kSingleRepeat;
+const uint16_t kMitsubishi136StateLength = 17;
+const uint16_t kMitsubishi136Bits = kMitsubishi136StateLength * 8;
+const uint16_t kMitsubishi136MinRepeat = kNoRepeat;
 const uint16_t kMitsubishiHeavy88StateLength = 11;
 const uint16_t kMitsubishiHeavy88Bits = kMitsubishiHeavy88StateLength * 8;
 const uint16_t kMitsubishiHeavy88MinRepeat = kNoRepeat;

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -612,6 +612,8 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
       return kKelvinatorBits;
     case MITSUBISHI_AC:
       return kMitsubishiACBits;
+    case MITSUBISHI136:
+      return kMitsubishi136Bits;
     case MITSUBISHI_HEAVY_152:
       return kMitsubishiHeavy152Bits;
     case MITSUBISHI_HEAVY_88:
@@ -940,6 +942,11 @@ bool IRsend::send(const decode_type_t type, const unsigned char *state,
       sendMitsubishiAC(state, nbytes);
       break;
 #endif  // SEND_MITSUBISHI_AC
+#if SEND_MITSUBISHI136
+    case MITSUBISHI136:
+      sendMitsubishi136(state, nbytes);
+      break;
+#endif  // SEND_MITSUBISHI136
 #if SEND_MITSUBISHIHEAVY
     case MITSUBISHI_HEAVY_88:
       sendMitsubishiHeavy88(state, nbytes);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -275,6 +275,11 @@ class IRsend {
   void sendMitsubishi(uint64_t data, uint16_t nbits = kMitsubishiBits,
                       uint16_t repeat = kMitsubishiMinRepeat);
 #endif
+#if SEND_MITSUBISHI136
+  void sendMitsubishi136(const unsigned char data[],
+                         const uint16_t nbytes = kMitsubishi136StateLength,
+                         const uint16_t repeat = kMitsubishi136MinRepeat);
+#endif
 #if SEND_MITSUBISHI2
   void sendMitsubishi2(uint64_t data, uint16_t nbits = kMitsubishiBits,
                        uint16_t repeat = kMitsubishiMinRepeat);

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -169,6 +169,8 @@ decode_type_t strToDecodeType(const char * const str) {
     return decode_type_t::MITSUBISHI2;
   else if (!strcasecmp(str, "MITSUBISHI_AC"))
     return decode_type_t::MITSUBISHI_AC;
+  else if (!strcasecmp(str, "MITSUBISHI136"))
+    return decode_type_t::MITSUBISHI136;
   else if (!strcasecmp(str, "MITSUBISHI_HEAVY_88"))
     return decode_type_t::MITSUBISHI_HEAVY_88;
   else if (!strcasecmp(str, "MITSUBISHI_HEAVY_152"))
@@ -369,6 +371,9 @@ String typeToString(const decode_type_t protocol, const bool isRepeat) {
     case MITSUBISHI_AC:
       result = F("MITSUBISHI_AC");
       break;
+    case MITSUBISHI136:
+      result = F("MITSUBISHI136");
+      break;
     case MITSUBISHI_HEAVY_88:
       result = F("MITSUBISHI_HEAVY_88");
       break;
@@ -495,6 +500,7 @@ bool hasACState(const decode_type_t protocol) {
     case HITACHI_AC1:
     case HITACHI_AC2:
     case KELVINATOR:
+    case MITSUBISHI136:
     case MITSUBISHI_AC:
     case MITSUBISHI_HEAVY_88:
     case MITSUBISHI_HEAVY_152:

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -859,7 +859,7 @@ void IRsend::sendMitsubishi136(const unsigned char data[],
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: Beta / Probably works.
+// Status: STABLE / Reported as working.
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/888

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -1,5 +1,5 @@
 // Copyright 2009 Ken Shirriff
-// Copyright 2017-2018 David Conran
+// Copyright 2017-2019 David Conran
 // Copyright 2018 Denes Varga
 
 // Mitsubishi
@@ -58,6 +58,17 @@ const uint16_t kMitsubishiAcOneSpace = 1300;
 const uint16_t kMitsubishiAcZeroSpace = 420;
 const uint16_t kMitsubishiAcRptMark = 440;
 const uint16_t kMitsubishiAcRptSpace = 17100;
+
+// Mitsubishi 136 bit A/C
+// Ref:
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/888
+
+const uint16_t kMitsubishi136HdrMark = 3324;
+const uint16_t kMitsubishi136HdrSpace = 1474;
+const uint16_t kMitsubishi136BitMark = 467;
+const uint16_t kMitsubishi136OneSpace = 1137;
+const uint16_t kMitsubishi136ZeroSpace = 351;
+const uint32_t kMitsubishi136Gap = kDefaultMessageGap;
 
 using irutils::addBoolToString;
 using irutils::addFanToString;
@@ -809,3 +820,73 @@ String IRMitsubishiAC::toString(void) {
   }
   return result;
 }
+
+
+#if SEND_MITSUBISHI136
+// Send a Mitsubishi136 A/C message.
+//
+// Args:
+//   data: An array of bytes containing the IR command.
+//   nbytes: Nr. of bytes of data in the array. (>=kMitsubishi136StateLength)
+//   repeat: Nr. of times the message is to be repeated.
+//          (Default = kMitsubishi136MinRepeat).
+//
+// Status: ALPHA / Probably working. Needs to be tested against a real device.
+//
+// Ref:
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/888
+void IRsend::sendMitsubishi136(const unsigned char data[],
+                               const uint16_t nbytes,
+                               const uint16_t repeat) {
+  if (nbytes < kMitsubishi136StateLength)
+    return;  // Not enough bytes to send a proper message.
+
+  sendGeneric(kMitsubishi136HdrMark, kMitsubishi136HdrSpace,
+              kMitsubishi136BitMark, kMitsubishi136OneSpace,
+              kMitsubishi136BitMark, kMitsubishi136ZeroSpace,
+              kMitsubishi136BitMark, kMitsubishi136Gap,
+              data, nbytes, 38, false, repeat, 50);
+}
+#endif  // SEND_MITSUBISHI136
+
+#if DECODE_MITSUBISHI136
+// Decode the supplied Mitsubishi136 message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   Nr. of data bits to expect.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Beta / Probably works.
+//
+// Ref:
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/888
+bool IRrecv::decodeMitsubishi136(decode_results *results, const uint16_t nbits,
+                                 const bool strict) {
+  // Too short to match?
+  if (results->rawlen < (2 * nbits) + kHeader + kFooter - 1) return false;
+  if (nbits % 8 != 0) return false;  // Not a multiple of an 8 bit byte.
+  if (strict) {  // Do checks to see if it matches the spec.
+    if (nbits != kMitsubishi136Bits) return false;
+  }
+  uint16_t used = matchGeneric(results->rawbuf + kStartOffset, results->state,
+                               results->rawlen - kStartOffset, nbits,
+                               kMitsubishi136HdrMark, kMitsubishi136HdrSpace,
+                               kMitsubishi136BitMark, kMitsubishi136OneSpace,
+                               kMitsubishi136BitMark, kMitsubishi136ZeroSpace,
+                               kMitsubishi136BitMark, kMitsubishi136Gap,
+                               true, _tolerance, 0, false);
+  if (!used) return false;
+  if (strict) {
+    // Header validation: Codes start with 0x23CB26
+    if (results->state[0] != 0x23 || results->state[1] != 0xCB ||
+        results->state[2] != 0x26) return false;
+    // TODO(someone): Add checksum validation if/when supported.
+  }
+  results->decode_type = MITSUBISHI136;
+  results->bits = nbits;
+  return true;
+}
+#endif  // DECODE_MITSUBISHI136

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -1,11 +1,13 @@
 // Copyright 2009 Ken Shirriff
-// Copyright 2017 David Conran
+// Copyright 2017-2019 David Conran
 
 // Mitsubishi
 
 // Supports:
 //   Brand: Mitsubishi,  Model: TV
 //   Brand: Mitsubishi,  Model: HC3000 Projector
+//   Brand: Mitsubishi Electric,  Model: PEAD-RP71JAA Ducted A/C
+//   Brand: Mitsubishi Electric,  Model: 001CP T7WE10714 remote
 
 #ifndef IR_MITSUBISHI_H_
 #define IR_MITSUBISHI_H_

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -1,7 +1,8 @@
-// Copyright 2017 David Conran
+// Copyright 2017-2019 David Conran
 // Copyright 2018 denxhun
 
 #include "ir_Mitsubishi.h"
+#include "IRac.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
 #include "IRsend_test.h"
@@ -1227,4 +1228,23 @@ TEST(TestDecodeMitsubishi136, SyntheticExample) {
   ASSERT_EQ(MITSUBISHI136, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishi136Bits, irsend.capture.bits);
   EXPECT_STATE_EQ(expected, irsend.capture.state, kMitsubishi136Bits);
+}
+
+// General housekeeping
+TEST(TestMitsubishi, Housekeeping) {
+  ASSERT_EQ("MITSUBISHI", typeToString(decode_type_t::MITSUBISHI));
+  ASSERT_FALSE(hasACState(decode_type_t::MITSUBISHI));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::MITSUBISHI));
+
+  ASSERT_EQ("MITSUBISHI2", typeToString(decode_type_t::MITSUBISHI2));
+  ASSERT_FALSE(hasACState(decode_type_t::MITSUBISHI2));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::MITSUBISHI2));
+
+  ASSERT_EQ("MITSUBISHI_AC", typeToString(decode_type_t::MITSUBISHI_AC));
+  ASSERT_TRUE(hasACState(decode_type_t::MITSUBISHI_AC));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::MITSUBISHI_AC));
+
+  ASSERT_EQ("MITSUBISHI136", typeToString(decode_type_t::MITSUBISHI136));
+  ASSERT_TRUE(hasACState(decode_type_t::MITSUBISHI136));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::MITSUBISHI136));
 }

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -1163,3 +1163,68 @@ TEST(TestMitsubishiACClass, toCommon) {
   ASSERT_EQ(-1, ac.toCommon().sleep);
   ASSERT_EQ(-1, ac.toCommon().clock);
 }
+
+// Decode a 'real' example.
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/888
+TEST(TestDecodeMitsubishi136, DecodeRealExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Mitsubishi Electric Ducted A/C - ON, 20C, Cooling, MaxFan.
+  uint16_t rawData[275] = {
+      3324, 1474, 520, 1110, 492, 1110, 524, 314, 498, 318, 466, 336, 474, 1124,
+      514, 322, 464, 338, 472, 1124, 516, 1112, 482, 342, 480, 1118, 488, 338,
+      466, 344, 480, 1124, 480, 1124, 510, 328, 484, 1114, 480, 1132, 510, 330,
+      456, 344, 464, 1134, 506, 334, 452, 346, 462, 1136, 504, 336, 450, 348,
+      460, 350, 472, 338, 474, 1124, 472, 352, 472, 340, 474, 342, 446, 354,
+      454, 354, 468, 344, 470, 344, 442, 356, 450, 358, 466, 346, 466, 348, 440,
+      360, 448, 360, 462, 350, 464, 352, 438, 360, 434, 1162, 490, 350, 438,
+      1148, 486, 350, 464, 352, 436, 362, 432, 376, 462, 352, 462, 1138, 448,
+      376, 460, 1142, 462, 1150, 484, 1140, 462, 360, 446, 1152, 492, 1132, 460,
+      362, 466, 348, 466, 348, 438, 360, 446, 1152, 492, 348, 436, 360, 434,
+      374, 462, 350, 464, 350, 436, 362, 434, 376, 460, 352, 462, 352, 434, 364,
+      432, 378, 458, 354, 460, 356, 434, 364, 430, 380, 456, 356, 458, 356, 432,
+      366, 428, 382, 454, 358, 456, 358, 430, 1158, 476, 1146, 458, 1156, 478,
+      1150, 454, 1154, 480, 1142, 460, 362, 434, 1164, 488, 352, 436, 1148, 488,
+      1140, 462, 1144, 490, 1136, 466, 1142, 492, 346, 466, 1132, 462, 360, 466,
+      348, 466, 350, 438, 1152, 482, 348, 464, 350, 438, 1144, 490, 1142, 462,
+      1148, 486, 1138, 466, 354, 450, 1146, 496, 1132, 460, 1150, 494, 1130,
+      464, 1146, 498, 1130, 464, 1144, 498, 1130, 462, 1144, 500, 1126, 468,
+      1142, 502, 1122, 470, 1142, 502, 1130, 464, 1140, 504, 1124, 468, 1140,
+      504, 1122, 472, 1142, 502, 1122, 472, 1138, 506};  // UNKNOWN 66B4490E
+
+  irsend.sendRaw(rawData, 275, 38);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI136, irsend.capture.decode_type);
+  EXPECT_EQ(kMitsubishi136Bits, irsend.capture.bits);
+  uint8_t expected[kMitsubishi136StateLength] = {
+      0x23, 0xCB, 0x26, 0x21, 0x00, 0x40, 0x41, 0x37, 0x04,
+      0x00, 0x00, 0xBF, 0xBE, 0xC8, 0xFB, 0xFF, 0xFF};
+  EXPECT_STATE_EQ(expected, irsend.capture.state, kMitsubishi136Bits);
+}
+
+// Self decode a synthetic example.
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/888
+TEST(TestDecodeMitsubishi136, SyntheticExample) {
+  IRsendTest irsend(0);
+  IRrecv irrecv(0);
+  irsend.begin();
+
+  irsend.reset();
+  // Mitsubishi Electric Ducted A/C - ON, 20C, Cooling, MaxFan.
+  uint8_t expected[kMitsubishi136StateLength] = {
+      0x23, 0xCB, 0x26, 0x21, 0x00, 0x40, 0x41, 0x37, 0x04,
+      0x00, 0x00, 0xBF, 0xBE, 0xC8, 0xFB, 0xFF, 0xFF};
+
+  irsend.sendMitsubishi136(expected);
+  irsend.makeDecodeResult();
+
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(MITSUBISHI136, irsend.capture.decode_type);
+  EXPECT_EQ(kMitsubishi136Bits, irsend.capture.bits);
+  EXPECT_STATE_EQ(expected, irsend.capture.state, kMitsubishi136Bits);
+}


### PR DESCRIPTION
* `sendMitsubishi136()` & `decodeMitsubishi136()` support only.
* No detailed support as yet.
* Supporting unit tests and relevant supporting code changes.

For #888