### PR TITLE
[Fujitsu] Add support for ARRY4 remote.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1454,7 +1454,7 @@ stdAc::swingh_t IRac::strToSwingH(const char *str,
     return def;
 }
 
-// Assumes str is the model or an integer >= 1.
+// Assumes str is the model code or an integer >= 1.
 int16_t IRac::strToModel(const char *str, const int16_t def) {
   // Gree
   if (!strcasecmp(str, "YAW1F")) {
@@ -1470,6 +1470,8 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return fujitsu_ac_remote_model_t::ARREB1E;
   } else if (!strcasecmp(str, "ARJW2")) {
     return fujitsu_ac_remote_model_t::ARJW2;
+  } else if (!strcasecmp(str, "ARRY4")) {
+    return fujitsu_ac_remote_model_t::ARRY4;
   // Panasonic A/C families
   } else if (!strcasecmp(str, "LKE") || !strcasecmp(str, "PANASONICLKE")) {
     return panasonic_ac_remote_model_t::kPanasonicLke;

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -388,7 +388,8 @@ void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
                    const bool on, const stdAc::opmode_t mode,
                    const float degrees, const stdAc::fanspeed_t fan,
                    const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-                   const bool quiet, const bool turbo, const bool econo) {
+                   const bool quiet, const bool turbo, const bool econo,
+                   const bool filter, const bool clean) {
   ac->setModel(model);
   if (on) {
     // Do all special messages (except "Off") first,
@@ -420,8 +421,8 @@ void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
     ac->setSwing(swing);
     if (quiet) ac->setFanSpeed(kFujitsuAcFanQuiet);
     // No Light setting available.
-    // No Filter setting available.
-    // No Clean setting available.
+    ac->setFilter(filter);
+    ac->setClean(clean);
     // No Beep setting available.
     // No Sleep setting available.
     // No Clock setting available.
@@ -1132,7 +1133,7 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
                      _modulation);
       ac.begin();
       fujitsu(&ac, (fujitsu_ac_remote_model_t)model, on, mode, degC, fan,
-              swingv, swingh, quiet, turbo, econo);
+              swingv, swingh, quiet, turbo, econo, filter, clean);
       break;
     }
 #endif  // SEND_FUJITSU_AC

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -151,7 +151,8 @@ void electra(IRElectraAc *ac,
                const bool on, const stdAc::opmode_t mode, const float degrees,
                const stdAc::fanspeed_t fan,
                const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-               const bool quiet, const bool turbo, const bool econo);
+               const bool quiet, const bool turbo, const bool econo,
+               const bool filter, const bool clean);
 #endif  // SEND_FUJITSU_AC
 #if SEND_GOODWEATHER
   void goodweather(IRGoodweatherAc *ac,

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -72,13 +72,14 @@ IRFujitsuAC::IRFujitsuAC(const uint16_t pin,
 void IRFujitsuAC::setModel(const fujitsu_ac_remote_model_t model) {
   _model = model;
   switch (model) {
-    case ARDB1:
-    case ARJW2:
+    case fujitsu_ac_remote_model_t::ARDB1:
+    case fujitsu_ac_remote_model_t::ARJW2:
       _state_length = kFujitsuAcStateLength - 1;
       _state_length_short = kFujitsuAcStateLengthShort - 1;
       break;
-    case ARRAH2E:
-    case ARREB1E:
+    case fujitsu_ac_remote_model_t::ARRY4:
+    case fujitsu_ac_remote_model_t::ARRAH2E:
+    case fujitsu_ac_remote_model_t::ARREB1E:
     default:
       _state_length = kFujitsuAcStateLength;
       _state_length_short = kFujitsuAcStateLengthShort;
@@ -94,6 +95,8 @@ void IRFujitsuAC::stateReset(void) {
   _mode = kFujitsuAcModeCool;
   _swingMode = kFujitsuAcSwingBoth;
   _cmd = kFujitsuAcCmdTurnOn;
+  _filter = false;
+  _clean = false;
   this->buildState();
 }
 
@@ -127,12 +130,13 @@ void IRFujitsuAC::buildState(void) {
       break;
     default:
       switch (_model) {
-        case ARRAH2E:
-        case ARREB1E:
+        case fujitsu_ac_remote_model_t::ARRY4:
+        case fujitsu_ac_remote_model_t::ARRAH2E:
+        case fujitsu_ac_remote_model_t::ARREB1E:
           remote_state[5] = 0xFE;
           break;
-        case ARDB1:
-        case ARJW2:
+        case fujitsu_ac_remote_model_t::ARDB1:
+        case fujitsu_ac_remote_model_t::ARJW2:
           remote_state[5] = 0xFC;
           break;
       }
@@ -151,19 +155,27 @@ void IRFujitsuAC::buildState(void) {
     remote_state[11] = 0;  // timerOff values
     remote_state[12] = 0;  // timerOff/On values
     remote_state[13] = 0;  // timerOn values
-    remote_state[14] = 0;
+    switch (_model) {
+      case fujitsu_ac_remote_model_t::ARRY4:
+        remote_state[14] = _filter << 3;
+        remote_state[9] |= (_clean << 3);
+        break;
+      default:
+        remote_state[14] = 0;
+    }
     uint8_t checksum = 0;
     uint8_t checksum_complement = 0;
     switch (_model) {
-      case ARDB1:
-      case ARJW2:
+      case fujitsu_ac_remote_model_t::ARDB1:
+      case fujitsu_ac_remote_model_t::ARJW2:
         checksum = sumBytes(remote_state, _state_length - 1);
         checksum_complement = 0x9B;
         break;
-      case ARREB1E:
+      case fujitsu_ac_remote_model_t::ARREB1E:
         remote_state[14] |= (_outsideQuiet << 7);
         // FALL THRU
-      case ARRAH2E:
+      case fujitsu_ac_remote_model_t::ARRAH2E:
+      case fujitsu_ac_remote_model_t::ARRY4:
         remote_state[14] |= 0x20;
         remote_state[10] |= _swingMode << 4;
         // FALL THRU
@@ -175,8 +187,9 @@ void IRFujitsuAC::buildState(void) {
     remote_state[_state_length - 1] = checksum_complement - checksum;
   } else {  // short codes
     switch (_model) {
-      case ARRAH2E:
-      case ARREB1E:
+      case fujitsu_ac_remote_model_t::ARRY4:
+      case fujitsu_ac_remote_model_t::ARRAH2E:
+      case fujitsu_ac_remote_model_t::ARREB1E:
         // The last byte is the inverse of penultimate byte
         remote_state[_state_length_short - 1] =
             ~remote_state[_state_length_short - 2];
@@ -192,8 +205,12 @@ void IRFujitsuAC::buildState(void) {
 
 uint8_t IRFujitsuAC::getStateLength(void) {
   this->buildState();  // Force an update of the internal state.
-  if (((_model == ARRAH2E || _model == ARREB1E) && remote_state[5] != 0xFE) ||
-      ((_model == ARDB1 || _model == ARJW2) && remote_state[5] != 0xFC))
+  if (((_model == fujitsu_ac_remote_model_t::ARRAH2E ||
+        _model == fujitsu_ac_remote_model_t::ARREB1E ||
+        _model == fujitsu_ac_remote_model_t::ARRY4) &&
+       remote_state[5] != 0xFE) ||
+      ((_model == fujitsu_ac_remote_model_t::ARDB1 ||
+        _model == fujitsu_ac_remote_model_t::ARJW2) && remote_state[5] != 0xFC))
     return _state_length_short;
   else
     return _state_length;
@@ -209,9 +226,10 @@ void IRFujitsuAC::buildFromState(const uint16_t length) {
   switch (length) {
     case kFujitsuAcStateLength - 1:
     case kFujitsuAcStateLengthShort - 1:
-      this->setModel(ARDB1);
+      this->setModel(fujitsu_ac_remote_model_t::ARDB1);
       // ARJW2 has horizontal swing.
-      if (this->getSwing(true) > kFujitsuAcSwingVert) this->setModel(ARJW2);
+      if (this->getSwing(true) > kFujitsuAcSwingVert)
+        this->setModel(fujitsu_ac_remote_model_t::ARJW2);
       break;
     default:
       switch (this->getCmd(true)) {
@@ -226,11 +244,11 @@ void IRFujitsuAC::buildFromState(const uint16_t length) {
   switch (remote_state[6]) {
     case 8:
       if (this->getModel() != fujitsu_ac_remote_model_t::ARJW2)
-        this->setModel(ARDB1);
+        this->setModel(fujitsu_ac_remote_model_t::ARDB1);
       break;
     case 9:
       if (this->getModel() != fujitsu_ac_remote_model_t::ARREB1E)
-        this->setModel(ARRAH2E);
+        this->setModel(fujitsu_ac_remote_model_t::ARRAH2E);
       break;
   }
   setTemp((remote_state[8] >> 4) + kFujitsuAcMinTemp);
@@ -238,9 +256,16 @@ void IRFujitsuAC::buildFromState(const uint16_t length) {
     setCmd(kFujitsuAcCmdTurnOn);
   else
     setCmd(kFujitsuAcCmdStayOn);
-  setMode(remote_state[9] & 0b111);
+  setMode(remote_state[9] & 0b00000111);
   setFanSpeed(remote_state[10] & 0b111);
   setSwing(remote_state[10] >> 4);
+  setClean(getClean(true));
+  setFilter(getFilter(true));
+  // Currently the only way we know how to tell ARRAH2E & ARRY4 apart is if
+  // either the raw Filter or Clean setting is on.
+  if (getModel() == fujitsu_ac_remote_model_t::ARRAH2E && (getFilter(true) ||
+                                                           getClean(true)))
+      setModel(fujitsu_ac_remote_model_t::ARRY4);
   switch (remote_state[5]) {
     case kFujitsuAcCmdTurnOff:
     case kFujitsuAcCmdStepHoriz:
@@ -299,8 +324,9 @@ void IRFujitsuAC::setCmd(const uint8_t cmd) {
     case kFujitsuAcCmdToggleSwingHoriz:
       switch (_model) {
         // Only these remotes have step horizontal.
-        case ARRAH2E:
-        case ARJW2:
+        case fujitsu_ac_remote_model_t::ARRY4:
+        case fujitsu_ac_remote_model_t::ARRAH2E:
+        case fujitsu_ac_remote_model_t::ARJW2:
           _cmd = cmd;
           break;
         default:
@@ -400,14 +426,15 @@ void IRFujitsuAC::setSwing(const uint8_t swingMode) {
   _swingMode = swingMode;
   switch (_model) {
     // No Horizontal support.
-    case ARDB1:
-    case ARREB1E:
+    case fujitsu_ac_remote_model_t::ARDB1:
+    case fujitsu_ac_remote_model_t::ARREB1E:
       // Set the mode to max if out of range
       if (swingMode > kFujitsuAcSwingVert) _swingMode = kFujitsuAcSwingVert;
       break;
     // Has Horizontal support.
-    case ARRAH2E:
-    case ARJW2:
+    case fujitsu_ac_remote_model_t::ARRY4:
+    case fujitsu_ac_remote_model_t::ARRAH2E:
+    case fujitsu_ac_remote_model_t::ARJW2:
     default:
       // Set the mode to max if out of range
       if (swingMode > kFujitsuAcSwingBoth) _swingMode = kFujitsuAcSwingBoth;
@@ -425,18 +452,54 @@ uint8_t IRFujitsuAC::getSwing(const bool raw) {
   return _swingMode;
 }
 
+void IRFujitsuAC::setClean(const bool on) {
+  _clean = on;
+  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+}
+
+bool IRFujitsuAC::getClean(const bool raw) {
+  if (raw) {
+    return remote_state[9] & 0b00001000;
+  } else {
+    switch (getModel()) {
+      case fujitsu_ac_remote_model_t::ARRY4:
+        return _clean;
+      default:
+        return false;
+    }
+  }
+}
+
+void IRFujitsuAC::setFilter(const bool on) {
+  _filter = on;
+  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+}
+
+bool IRFujitsuAC::getFilter(const bool raw) {
+  if (raw) {
+    return remote_state[14] & 0b00001000;
+  } else {
+    switch (getModel()) {
+      case fujitsu_ac_remote_model_t::ARRY4:
+        return _filter;
+      default:
+        return false;
+    }
+  }
+}
+
 bool IRFujitsuAC::validChecksum(uint8_t state[], const uint16_t length) {
   uint8_t sum = 0;
   uint8_t sum_complement = 0;
   uint8_t checksum = state[length - 1];
   switch (length) {
-    case kFujitsuAcStateLengthShort:  // ARRAH2E & ARREB1E
+    case kFujitsuAcStateLengthShort:  // ARRAH2E, ARREB1E, & ARRY4
       return state[length - 1] == (uint8_t)~state[length - 2];
     case kFujitsuAcStateLength - 1:  // ARDB1 & ARJW2
       sum = sumBytes(state, length - 1);
       sum_complement = 0x9B;
       break;
-    case kFujitsuAcStateLength:  // ARRAH2E & ARREB1E
+    case kFujitsuAcStateLength:  // ARRAH2E, ARRY4, & ARREB1E
       sum = sumBytes(state + kFujitsuAcStateLengthShort,
                      length - 1 - kFujitsuAcStateLengthShort);
       break;
@@ -515,6 +578,9 @@ stdAc::state_t IRFujitsuAC::toCommon(void) {
   switch (result.model) {
     case fujitsu_ac_remote_model_t::ARREB1E:
     case fujitsu_ac_remote_model_t::ARRAH2E:
+    case fujitsu_ac_remote_model_t::ARRY4:
+      result.clean = _clean;
+      result.filter = _filter;
       result.swingv = (swing & kFujitsuAcSwingVert) ? stdAc::swingv_t::kAuto :
                                                       stdAc::swingv_t::kOff;
       result.swingh = (swing & kFujitsuAcSwingHoriz) ? stdAc::swingh_t::kAuto :
@@ -551,6 +617,7 @@ String IRFujitsuAC::toString(void) {
     case fujitsu_ac_remote_model_t::ARDB1: result += F(" (ARDB1)"); break;
     case fujitsu_ac_remote_model_t::ARREB1E: result += F(" (ARREB1E)"); break;
     case fujitsu_ac_remote_model_t::ARJW2: result += F(" (ARJW2)"); break;
+    case fujitsu_ac_remote_model_t::ARRY4: result += F(" (ARRY4)"); break;
     default: result += F(" (UNKNOWN)");
   }
   result += addBoolToString(getPower(), F("Power"));
@@ -562,11 +629,13 @@ String IRFujitsuAC::toString(void) {
                            kFujitsuAcFanAuto, kFujitsuAcFanQuiet,
                            kFujitsuAcFanMed);
   switch (model) {
-    // These models have no internal swing state.
+    // These models have no internal swing, clean. or filter state.
     case fujitsu_ac_remote_model_t::ARDB1:
     case fujitsu_ac_remote_model_t::ARJW2:
       break;
     default:  // Assume everything else does.
+      result += addBoolToString(getClean(), F("Clean"));
+      result += addBoolToString(getFilter(), F("Filter"));
       result += F(", Swing: ");
       switch (this->getSwing()) {
         case kFujitsuAcSwingOff:

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -9,6 +9,10 @@
 //   Brand: Fujitsu,  Model: AR-REB1E remote
 //   Brand: Fujitsu,  Model: ASYG7LMCA A/C
 //   Brand: Fujitsu,  Model: AR-RAE1E remote
+//   Brand: Fujitsu,  Model: AGTV14LAC A/C
+//   Brand: Fujitsu,  Model: AR-RAC1E remote
+//   Brand: Fujitsu,  Model: ASTB09LBC A/C
+//   Brand: Fujitsu,  Model: AR-RY4 remote
 //   Brand: Fujitsu General,  Model: AR-JW2 remote
 
 #ifndef IR_FUJITSU_H_
@@ -83,10 +87,11 @@ const uint8_t kFujitsuAcSwingBoth = 0x03;
 #define FUJITSU_AC_SWING_BOTH kFujitsuAcSwingBoth
 
 enum fujitsu_ac_remote_model_t {
-  ARRAH2E = 1,  // (1) AR-RAH2E, AR-RAE1E (Default)
+  ARRAH2E = 1,  // (1) AR-RAH2E, AR-RAC1E, AR-RAE1E (Default)
   ARDB1,        // (2) AR-DB1
   ARREB1E,      // (3) AR-REB1E
   ARJW2,        // (4) AR-JW2  (Same as ARDB1 but with horiz control)
+  ARRY4,        // (5) AR-RY4 (Same as AR-RAH2E but with clean & filter)
 };
 
 class IRFujitsuAC {
@@ -126,6 +131,10 @@ class IRFujitsuAC {
   void off(void);
   void on(void);
   bool getPower(void);
+  void setClean(const bool on);
+  bool getClean(const bool raw = false);
+  void setFilter(const bool on);
+  bool getFilter(const bool raw = false);
   void setOutsideQuiet(const bool on);
 
   bool getOutsideQuiet(const bool raw = false);
@@ -153,6 +162,8 @@ class IRFujitsuAC {
   uint8_t _state_length;
   uint8_t _state_length_short;
   bool _outsideQuiet;
+  bool _clean;
+  bool _filter;
   void buildState(void);
   void buildFromState(const uint16_t length);
 };

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -337,8 +337,10 @@ TEST(TestIRac, Fujitsu) {
       "Fan: 2 (Medium), Command: N/A";
   std::string arrah2e_expected =
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 19C, "
-      "Fan: 2 (Medium), Swing: Off, Command: N/A";
-
+      "Fan: 2 (Medium), Clean: Off, Filter: Off, Swing: Off, Command: N/A";
+  std::string arry4_expected =
+          "Model: 5 (ARRY4), Power: On, Mode: 1 (COOL), Temp: 19C, "
+          "Fan: 2 (Medium), Clean: On, Filter: On, Swing: Off, Command: N/A";
   ac.begin();
   irac.fujitsu(&ac,
                ARDB1,                       // Model
@@ -350,7 +352,9 @@ TEST(TestIRac, Fujitsu) {
                stdAc::swingh_t::kOff,       // Horizontal swing
                false,                       // Quiet
                false,                       // Turbo (Powerful)
-               false);                      // Econo
+               false,                       // Econo
+               true,                        // Filter
+               true);                       // Clean
   ASSERT_EQ(ardb1_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -369,13 +373,35 @@ TEST(TestIRac, Fujitsu) {
                stdAc::swingh_t::kOff,       // Horizontal swing
                false,                       // Quiet
                false,                       // Turbo (Powerful)
-               false);                      // Econo
+               false,                       // Econo
+               true,                        // Filter
+               true);                       // Clean
   ASSERT_EQ(arrah2e_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(arrah2e_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ac._irsend.reset();
+  irac.fujitsu(&ac,
+               fujitsu_ac_remote_model_t::ARRY4,  // Model
+               true,                        // Power
+               stdAc::opmode_t::kCool,      // Mode
+               19,                          // Celsius
+               stdAc::fanspeed_t::kMedium,  // Fan speed
+               stdAc::swingv_t::kOff,       // Veritcal swing
+               stdAc::swingh_t::kOff,       // Horizontal swing
+               false,                       // Quiet
+               false,                       // Turbo (Powerful)
+               false,                       // Econo
+               true,                        // Filter
+               true);                       // Clean
+  ASSERT_EQ(arry4_expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
+  ASSERT_EQ(arry4_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 
 TEST(TestIRac, Goodweather) {

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -22,7 +22,8 @@ TEST(TestIRFujitsuACClass, GetRawDefault) {
   EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 16 * 8);
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (High), Swing: Vert + Horiz, Command: N/A",
+            "Fan: 1 (High), Clean: Off, Filter: Off, "
+            "Swing: Vert + Horiz, Command: N/A",
             ac.toString());
 
   uint8_t expected_ardb1[15] = {
@@ -44,7 +45,8 @@ TEST(TestIRFujitsuACClass, GetRawTurnOff) {
   EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 7 * 8);
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: Off, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (High), Swing: Vert + Horiz, Command: N/A",
+            "Fan: 1 (High), Clean: Off, Filter: Off, "
+            "Swing: Vert + Horiz, Command: N/A",
             ac.toString());
 
   ac.setModel(ARDB1);
@@ -64,7 +66,8 @@ TEST(TestIRFujitsuACClass, GetRawStepHoriz) {
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-      "Fan: 1 (High), Swing: Vert + Horiz, Command: Step vane horizontally",
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: Vert + Horiz, "
+      "Command: Step vane horizontally",
       ac.toString());
 }
 
@@ -76,7 +79,8 @@ TEST(TestIRFujitsuACClass, GetRawStepVert) {
   EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 7 * 8);
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (High), Swing: Vert + Horiz, Command: Step vane vertically",
+            "Fan: 1 (High), Clean: Off, Filter: Off, Swing: Vert + Horiz, "
+            "Command: Step vane vertically",
             ac.toString());
 
   ac.setModel(ARDB1);
@@ -101,7 +105,8 @@ TEST(TestIRFujitsuACClass, GetRawWithSwingHoriz) {
                           0x90, 0x1, 0x24, 0x0, 0x0, 0x0, 0x20, 0xFB};
   EXPECT_STATE_EQ(expected, ac.getRaw(), 16 * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 25C, "
-            "Fan: 4 (Quiet), Swing: Horiz, Command: N/A",
+            "Fan: 4 (Quiet), Clean: Off, Filter: Off, "
+            "Swing: Horiz, Command: N/A",
             ac.toString());
 }
 
@@ -120,7 +125,9 @@ TEST(TestIRFujitsuACClass, GetRawWithFan) {
   EXPECT_STATE_EQ(expected_arrah2e, ac.getRaw(), 16 * 8);
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 3 (FAN), Temp: 20C, "
-            "Fan: 2 (Medium), Swing: Horiz, Command: N/A", ac.toString());
+            "Fan: 2 (Medium), Clean: Off, Filter: Off, "
+            "Swing: Horiz, Command: N/A",
+            ac.toString());
 
   ac.setModel(ARDB1);
   uint8_t expected_ardb1[15] = {
@@ -141,7 +148,8 @@ TEST(TestIRFujitsuACClass, SetRaw) {
   EXPECT_STATE_EQ(expected_default_arrah2e, ac.getRaw(),
                   ac.getStateLength() * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-            "Fan: 1 (High), Swing: Vert + Horiz, Command: N/A",
+            "Fan: 1 (High), Clean: Off, Filter: Off, "
+            "Swing: Vert + Horiz, Command: N/A",
             ac.toString());
   // Now set a new state via setRaw();
   // This state is a real state from an AR-DB1 remote.
@@ -348,7 +356,9 @@ TEST(TestDecodeFujitsuAC, SyntheticLongMessages) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 18C, "
-            "Fan: 4 (Quiet), Swing: Vert, Command: N/A", ac.toString());
+            "Fan: 4 (Quiet), Clean: Off, Filter: Off, "
+            "Swing: Vert, Command: N/A",
+            ac.toString());
 
   irsend.reset();
 
@@ -520,7 +530,8 @@ TEST(TestDecodeFujitsuAC, Issue414) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 4 (HEAT), Temp: 24C, "
-            "Fan: 0 (Auto), Swing: Off, Command: N/A", ac.toString());
+            "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
+            ac.toString());
 
   // Resend it using the state this time.
   irsend.reset();
@@ -595,7 +606,8 @@ TEST(TestIRFujitsuACClass, toCommon) {
   // Now test it.
   EXPECT_EQ(    // Off mode technically has no temp, mode, fan, etc.
       "Model: 1 (ARRAH2E), Power: Off, Mode: 0 (AUTO), Temp: 16C, "
-      "Fan: 0 (Auto), Swing: Off, Command: N/A", ac.toString());
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
   ASSERT_EQ(decode_type_t::FUJITSU_AC, ac.toCommon().protocol);
   ASSERT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.toCommon().model);
   ASSERT_FALSE(ac.toCommon().power);
@@ -649,7 +661,8 @@ TEST(TestDecodeFujitsuAC, Issue716) {
   EXPECT_EQ(fujitsu_ac_remote_model_t::ARREB1E, ac.getModel());
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 3 (ARREB1E), Power: On, Mode: 0 (AUTO), Temp: 16C, "
-            "Fan: 0 (Auto), Swing: Off, Command: Powerful, Outside Quiet: Off",
+            "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, "
+            "Command: Powerful, Outside Quiet: Off",
             ac.toString());
 
   // Economy (just from the state)
@@ -663,7 +676,8 @@ TEST(TestDecodeFujitsuAC, Issue716) {
   EXPECT_EQ(fujitsu_ac_remote_model_t::ARREB1E, ac.getModel());
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 3 (ARREB1E), Power: On, Mode: 0 (AUTO), Temp: 16C, "
-            "Fan: 0 (Auto), Swing: Off, Command: Economy, Outside Quiet: Off",
+            "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, "
+            "Command: Economy, Outside Quiet: Off",
             ac.toString());
 }
 
@@ -694,11 +708,13 @@ TEST(TestIRFujitsuACClass, OutsideQuiet) {
   // the option is set. Otheriwse they appear the same.
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-      "Fan: 0 (Auto), Swing: Off, Command: N/A", ac.toString());
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, "
+      "Command: N/A", ac.toString());
   ac.setModel(fujitsu_ac_remote_model_t::ARREB1E);
   EXPECT_EQ(
       "Model: 3 (ARREB1E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-      "Fan: 0 (Auto), Swing: Off, Command: N/A, Outside Quiet: Off",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, "
+      "Command: N/A, Outside Quiet: Off",
       ac.toString());
 
   // Make sure we can't accidentally inherit the correct model.
@@ -709,7 +725,8 @@ TEST(TestIRFujitsuACClass, OutsideQuiet) {
   EXPECT_TRUE(ac.getOutsideQuiet());
   EXPECT_EQ(
       "Model: 3 (ARREB1E), Power: On, Mode: 1 (COOL), Temp: 24C, "
-      "Fan: 0 (Auto), Swing: Off, Command: N/A, Outside Quiet: On",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, "
+      "Command: N/A, Outside Quiet: On",
       ac.toString());
 
   ac.setOutsideQuiet(false);
@@ -793,6 +810,92 @@ TEST(TestDecodeFujitsuAC, Issue726) {
   EXPECT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.getModel());
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 0 (AUTO), Temp: 24C, "
-            "Fan: 0 (Auto), Swing: Off, Command: N/A",
+            "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
             ac.toString());
+}
+
+TEST(TestIRFujitsuACClass, Clean) {
+  IRFujitsuAC ac(0);
+  // Data from:
+  //  https://docs.google.com/spreadsheets/d/1f8EGfIbBUo2B-CzUFdrgKQprWakoYNKM80IKZN4KXQE/edit#gid=646887633&range=A27:B30
+  uint8_t clean_off[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x10};
+  uint8_t clean_on[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x08, 0x00, 0x00, 0x00, 0x00, 0x20, 0x08};
+  ac.setRaw(clean_on, kFujitsuAcStateLength);
+  EXPECT_TRUE(ac.getClean());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(
+      "Model: 5 (ARRY4), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: On, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
+  ac.setClean(false);
+  EXPECT_FALSE(ac.getClean());
+  EXPECT_STATE_EQ(clean_off, ac.getRaw(), ac.getStateLength() * 8)
+  ac.setClean(true);
+  EXPECT_TRUE(ac.getClean());
+  EXPECT_STATE_EQ(clean_on, ac.getRaw(), ac.getStateLength() * 8)
+  ac.setRaw(clean_off, kFujitsuAcStateLength);
+  EXPECT_FALSE(ac.getClean());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
+  // Now it is in ARRAH2E model mode, it shouldn't accept setting it on.
+  ac.setClean(true);
+  EXPECT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.getModel());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
+  // But ARRY4 does.
+  ac.setModel(fujitsu_ac_remote_model_t::ARRY4);
+  EXPECT_TRUE(ac.getClean());
+  EXPECT_EQ(
+      "Model: 5 (ARRY4), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: On, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
+}
+
+TEST(TestIRFujitsuACClass, Filter) {
+  IRFujitsuAC ac(0);
+  // Data from:
+  //  https://docs.google.com/spreadsheets/d/1f8EGfIbBUo2B-CzUFdrgKQprWakoYNKM80IKZN4KXQE/edit#gid=646887633&range=A27:B30
+  uint8_t filter_on[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x07};
+  uint8_t filter_off[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x10};
+  ac.setRaw(filter_on, kFujitsuAcStateLength);
+  EXPECT_TRUE(ac.getFilter());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(
+      "Model: 5 (ARRY4), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: On, Swing: Off, Command: N/A",
+      ac.toString());
+  ac.setFilter(false);
+  EXPECT_FALSE(ac.getFilter());
+  ac.setFilter(true);
+  EXPECT_TRUE(ac.getFilter());
+  ac.setRaw(filter_off, kFujitsuAcStateLength);
+  EXPECT_FALSE(ac.getFilter());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: Off, Command: N/A",
+      ac.toString());
+  // Now it is in ARRAH2E model mode, it shouldn't accept setting it on.
+  ac.setFilter(true);
+  EXPECT_FALSE(ac.getFilter());
+  // But ARRY4 does.
+  ac.setModel(fujitsu_ac_remote_model_t::ARRY4);
+  EXPECT_TRUE(ac.getFilter());
+  EXPECT_EQ(
+      "Model: 5 (ARRY4), Power: On, Mode: 0 (AUTO), Temp: 26C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: On, Swing: Off, Command: N/A",
+      ac.toString());
 }


### PR DESCRIPTION
* New model ARRY4 (5)
* Add support for Clean and Filter for that model.
* Unit tests for the above.
* Code style cleanup.

Note: AR-RY4 appears to be the same as AR-RAH2E but has clean & filter 
settings. Thus auto detection won't always get it correct.

For #894