### PR TITLE
Improve Common A/C api

### DIFF
--- a/examples/CommonAcControl/CommonAcControl.ino
+++ b/examples/CommonAcControl/CommonAcControl.ino
@@ -19,8 +19,6 @@
 
 const uint16_t kIrLed = 4;  // The ESP GPIO pin to use that controls the IR LED.
 IRac ac(kIrLed);  // Create a A/C object using GPIO to sending messages with.
-stdAc::state_t state;  // Where we will store the desired state of the A/C.
-stdAc::state_t prev;  // Where we will store the previous state of the A/C.
 
 void setup() {
   Serial.begin(115200);
@@ -29,26 +27,26 @@ void setup() {
   // Set up what we want to send.
   // See state_t, opmode_t, fanspeed_t, swingv_t, & swingh_t in IRsend.h for
   // all the various options.
-  state.protocol = decode_type_t::DAIKIN;  // Set a protocol to use.
-  state.model = 1;  // Some A/C's have different models. Let's try using just 1.
-  state.mode = stdAc::opmode_t::kCool;  // Run in cool mode initially.
-  state.celsius = true;  // Use Celsius for units of temp. False = Fahrenheit
-  state.degrees = 25;  // 25 degrees.
-  state.fanspeed = stdAc::fanspeed_t::kMedium;  // Start with the fan at medium.
-  state.swingv = stdAc::swingv_t::kOff;  // Don't swing the fan up or down.
-  state.swingh = stdAc::swingh_t::kOff;  // Don't swing the fan left or right.
-  state.light = false;  // Turn off any LED/Lights/Display that we can.
-  state.beep = false;  // Turn off any beep from the A/C if we can.
-  state.econo = false;  // Turn off any economy modes if we can.
-  state.filter = false;  // Turn off any Ion/Mold/Health filters if we can.
-  state.turbo = false;  // Don't use any turbo/powerful/etc modes.
-  state.quiet = false;  // Don't use any quiet/silent/etc modes.
-  state.sleep = -1;  // Don't set any sleep time or modes.
-  state.clean = false;  // Turn off any Cleaning options if we can.
-  state.clock = -1;  // Don't set any current time if we can avoid it.
-  state.power = false;  // Initially start with the unit off.
+  ac.next.protocol = decode_type_t::DAIKIN;  // Set a protocol to use.
+  ac.next.model = 1;  // Some A/Cs have different models. Try just the first.
+  ac.next.mode = stdAc::opmode_t::kCool;  // Run in cool mode initially.
+  ac.next.celsius = true;  // Use Celsius for temp units. False = Fahrenheit
+  ac.next.degrees = 25;  // 25 degrees.
+  ac.next.fanspeed = stdAc::fanspeed_t::kMedium;  // Start the fan at medium.
+  ac.next.swingv = stdAc::swingv_t::kOff;  // Don't swing the fan up or down.
+  ac.next.swingh = stdAc::swingh_t::kOff;  // Don't swing the fan left or right.
+  ac.next.light = false;  // Turn off any LED/Lights/Display that we can.
+  ac.next.beep = false;  // Turn off any beep from the A/C if we can.
+  ac.next.econo = false;  // Turn off any economy modes if we can.
+  ac.next.filter = false;  // Turn off any Ion/Mold/Health filters if we can.
+  ac.next.turbo = false;  // Don't use any turbo/powerful/etc modes.
+  ac.next.quiet = false;  // Don't use any quiet/silent/etc modes.
+  ac.next.sleep = -1;  // Don't set any sleep time or modes.
+  ac.next.clean = false;  // Turn off any Cleaning options if we can.
+  ac.next.clock = -1;  // Don't set any current time if we can avoid it.
+  ac.next.power = false;  // Initially start with the unit off.
 
-  prev = state;  // Make sure we have a valid previous state.
+  Serial.println("Try to turn on & off every supported A/C type ...");
 }
 
 void loop() {
@@ -57,23 +55,16 @@ void loop() {
     decode_type_t protocol = (decode_type_t)i;
     // If the protocol is supported by the IRac class ...
     if (ac.isProtocolSupported(protocol)) {
-      state.protocol = protocol;  // Change the protocol used.
-
       Serial.println("Protocol " + String(protocol) + " / " +
-                     typeToString(protocol));
-      state.power = true;  // We want to turn on the A/C unit.
-      // Have the IRac class create and send a message.
-      // We need a `prev` state as some A/Cs use toggle messages.
-      // e.g. On & Off are the same message. When given the previous state,
-      //      it will try to do the correct thing for you.
-      ac.sendAc(state, &prev);  // Construct and send the message.
-      Serial.println("Sent a message to turn ON the A/C unit.");
-      prev = state;  // Copy new state over the previous one.
+                     typeToString(protocol) + " is supported.");
+      ac.next.protocol = protocol;  // Change the protocol used.
+      ac.next.power = true;  // We want to turn on the A/C unit.
+      Serial.println("Sending a message to turn ON the A/C unit.");
+      ac.sendAc();  // Have the IRac class create and send a message.
       delay(5000);  // Wait 5 seconds.
-      state.power = false;  // Now we want to turn the A/C off.
-      ac.sendAc(state, &prev);  // Construct and send the message.
-      Serial.println("Sent a message to turn OFF the A/C unit.");
-      prev = state;  // Copy new state over the previous one.
+      ac.next.power = false;  // Now we want to turn the A/C off.
+      Serial.println("Send a message to turn OFF the A/C unit.");
+      ac.sendAc();  // Send the message.
       delay(1000);  // Wait 1 second.
     }
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -841,15 +841,10 @@ void IRac::samsung(IRSamsungAc *ac,
                    const float degrees,
                    const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                    const bool quiet, const bool turbo, const bool clean,
-<<<<<<< HEAD
-                   const bool beep, const bool forcepower) {
-  ac->begin();
-  ac->stateReset(forcepower);
-=======
                    const bool beep, const bool prevpower,
                    const bool forcepower) {
+  ac->begin();
   ac->stateReset(forcepower, prevpower);
->>>>>>> Improve Common A/C api
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -1246,13 +1241,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case ELECTRA_AC:
     {
       IRElectraAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      electra(&ac, on, mode, degC, fan, swingv, swingh);
-=======
-      ac.begin();
       electra(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
               send.swingh);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_ELECTRA_AC
@@ -1261,15 +1251,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRFujitsuAC ac(_pin, (fujitsu_ac_remote_model_t)send.model, _inverted,
                      _modulation);
-<<<<<<< HEAD
-      fujitsu(&ac, (fujitsu_ac_remote_model_t)model, on, mode, degC, fan,
-              swingv, swingh, quiet, turbo, econo, filter, clean);
-=======
-      ac.begin();
       fujitsu(&ac, (fujitsu_ac_remote_model_t)send.model, on, send.mode, degC,
               send.fanspeed, send.swingv, send.swingh, send.quiet, send.turbo,
-              send.econo);
->>>>>>> Improve Common A/C api
+              send.econo, send.filter, send.clean);
       break;
     }
 #endif  // SEND_FUJITSU_AC
@@ -1277,31 +1261,19 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case GOODWEATHER:
     {
       IRGoodweatherAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      goodweather(&ac, on, mode, degC, fan, swingv, turbo, light, sleep);
-=======
-      ac.begin();
       goodweather(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                   send.turbo, send.light, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_GOODWEATHER
 #if SEND_GREE
     case GREE:
     {
-<<<<<<< HEAD
-      IRGreeAC ac(_pin, (gree_ac_remote_model_t)model, _inverted, _modulation);
-      gree(&ac, (gree_ac_remote_model_t)model, on, mode, degC, fan, swingv,
-           turbo, light, clean, sleep);
-=======
       IRGreeAC ac(_pin, (gree_ac_remote_model_t)send.model, _inverted,
                   _modulation);
-      ac.begin();
       gree(&ac, (gree_ac_remote_model_t)send.model, on, send.mode, degC,
            send.fanspeed, send.swingv, send.turbo, send.light, send.clean,
            send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_GREE
@@ -1309,13 +1281,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case HAIER_AC:
     {
       IRHaierAC ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      haier(&ac, on, mode, degC, fan, swingv, filter, sleep, clock);
-=======
-      ac.begin();
       haier(&ac, on, send.mode, degC, send.fanspeed, send.swingv, send.filter,
             send.sleep, send.clock);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_HAIER_AC
@@ -1323,13 +1290,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case HAIER_AC_YRW02:
     {
       IRHaierACYRW02 ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      haierYrwo2(&ac, on, mode, degC, fan, swingv, turbo, filter, sleep);
-=======
-      ac.begin();
       haierYrwo2(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                  send.turbo, send.filter, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_HAIER_AC_YRW02
@@ -1337,13 +1299,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case HITACHI_AC:
     {
       IRHitachiAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      hitachi(&ac, on, mode, degC, fan, swingv, swingh);
-=======
-      ac.begin();
       hitachi(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
               send.swingh);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_HITACHI_AC
@@ -1351,15 +1308,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case KELVINATOR:
     {
       IRKelvinatorAC ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      kelvinator(&ac, on, mode, degC, fan, swingv, swingh, quiet, turbo,
-                 light, filter, clean);
-=======
-      ac.begin();
       kelvinator(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                  send.swingh, send.quiet, send.turbo, send.light, send.filter,
                  send.clean);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_KELVINATOR
@@ -1367,13 +1318,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case MIDEA:
     {
       IRMideaAC ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      midea(&ac, on, mode, celsius, degrees, fan, swingv, sleep);
-=======
-      ac.begin();
       midea(&ac, on, send.mode, send.celsius, send.degrees, send.fanspeed,
             send.swingv, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_MIDEA
@@ -1381,13 +1327,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case MITSUBISHI_AC:
     {
       IRMitsubishiAC ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      mitsubishi(&ac, on, mode, degC, fan, swingv, swingh, quiet, clock);
-=======
-      ac.begin();
       mitsubishi(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                  send.swingh, send.quiet, send.clock);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_MITSUBISHI_AC
@@ -1395,7 +1336,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case MITSUBISHI136:
     {
       IRMitsubishi136 ac(_pin, _inverted, _modulation);
-      mitsubishi136(&ac, on, mode, degC, fan, swingv, quiet);
+      mitsubishi136(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
+                    send.quiet);
       break;
     }
 #endif  // SEND_MITSUBISHI136
@@ -1403,28 +1345,16 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case MITSUBISHI_HEAVY_88:
     {
       IRMitsubishiHeavy88Ac ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      mitsubishiHeavy88(&ac, on, mode, degC, fan, swingv, swingh,
-                        turbo, econo, clean);
-=======
-      ac.begin();
       mitsubishiHeavy88(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                         send.swingh, send.turbo, send.econo, send.clean);
->>>>>>> Improve Common A/C api
       break;
     }
     case MITSUBISHI_HEAVY_152:
     {
       IRMitsubishiHeavy152Ac ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      mitsubishiHeavy152(&ac, on, mode, degC, fan, swingv, swingh,
-                         quiet, turbo, econo, filter, clean, sleep);
-=======
-      ac.begin();
       mitsubishiHeavy152(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                          send.swingh, send.quiet, send.turbo, send.econo,
                          send.filter, send.clean, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_MITSUBISHIHEAVY
@@ -1432,14 +1362,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case NEOCLIMA:
     {
       IRNeoclimaAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      neoclima(&ac, on, mode, degC, fan, swingv, swingh, turbo, light, filter,
-               sleep);
-=======
-      ac.begin();
       neoclima(&ac, on, send.mode, degC, send.fanspeed, send.swingv,
                send.swingh, send.turbo, send.light, send.filter, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_NEOCLIMA
@@ -1447,15 +1371,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case PANASONIC_AC:
     {
       IRPanasonicAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      panasonic(&ac, (panasonic_ac_remote_model_t)model, on, mode, degC, fan,
-                swingv, swingh, quiet, turbo, clock);
-=======
-      ac.begin();
       panasonic(&ac, (panasonic_ac_remote_model_t)send.model, on, send.mode,
                 degC, send.fanspeed, send.swingv, send.swingh, send.quiet,
                 send.turbo, send.clock);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_PANASONIC_AC
@@ -1463,13 +1381,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case SAMSUNG_AC:
     {
       IRSamsungAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      samsung(&ac, on, mode, degC, fan, swingv, quiet, turbo, clean, beep);
-=======
-      ac.begin();
       samsung(&ac, on, send.mode, degC, send.fanspeed, send.swingv, send.quiet,
               send.turbo, send.clean, send.beep, prev->power);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_SAMSUNG_AC
@@ -1477,12 +1390,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case SHARP_AC:
     {
       IRSharpAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      sharp(&ac, on, mode, degC, fan);
-=======
-      ac.begin();
       sharp(&ac, on, send.mode, degC, send.fanspeed);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_SHARP_AC
@@ -1490,14 +1398,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case TCL112AC:
     {
       IRTcl112Ac ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      tcl112(&ac, on, mode, degC, fan, swingv, swingh, turbo, light, econo,
-             filter);
-=======
-      ac.begin();
       tcl112(&ac, on, send.mode, degC, send.fanspeed, send.swingv, send.swingh,
              send.turbo, send.light, send.econo, send.filter);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_TCL112AC
@@ -1505,13 +1407,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case TECO:
     {
       IRTecoAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      teco(&ac, on, mode, degC, fan, swingv, light, sleep);
-=======
-      ac.begin();
       teco(&ac, on, send.mode, degC, send.fanspeed, send.swingv, send.light,
            send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_TECO
@@ -1519,12 +1416,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case TOSHIBA_AC:
     {
       IRToshibaAC ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      toshiba(&ac, on, mode, degC, fan);
-=======
-      ac.begin();
       toshiba(&ac, on, send.mode, degC, send.fanspeed);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_TOSHIBA_AC
@@ -1532,12 +1424,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case TROTEC:
     {
       IRTrotecESP ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      trotec(&ac, on, mode, degC, fan, sleep);
-=======
-      ac.begin();
       trotec(&ac, on, send.mode, degC, send.fanspeed, send.sleep);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_TROTEC
@@ -1545,13 +1432,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case VESTEL_AC:
     {
       IRVestelAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      vestel(&ac, on, mode, degC, fan, swingv, turbo, filter, sleep, clock);
-=======
-      ac.begin();
       vestel(&ac, on, send.mode, degC, send.fanspeed, send.swingv, send.turbo,
              send.filter, send.sleep, send.clock);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_VESTEL_AC
@@ -1559,15 +1441,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case WHIRLPOOL_AC:
     {
       IRWhirlpoolAc ac(_pin, _inverted, _modulation);
-<<<<<<< HEAD
-      whirlpool(&ac, (whirlpool_ac_remote_model_t)model, on, mode, degC, fan,
-                swingv, turbo, light, sleep, clock);
-=======
-      ac.begin();
       whirlpool(&ac, (whirlpool_ac_remote_model_t)send.model, on, send.mode,
                 degC, send.fanspeed, send.swingv, send.turbo, send.light,
                 send.sleep, send.clock);
->>>>>>> Improve Common A/C api
       break;
     }
 #endif  // SEND_WHIRLPOOL_AC

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -46,8 +46,6 @@ IRac::IRac(const uint16_t pin, const bool inverted, const bool use_modulation) {
   _prev = next;
 }
 
-uint16_t IRac::getGpio(void) { return _pin; }
-
 void IRac::initState(stdAc::state_t *state,
                      const decode_type_t vendor, const int16_t model,
                      const bool power, const stdAc::opmode_t mode,
@@ -87,6 +85,7 @@ void IRac::initState(stdAc::state_t *state) {
 }
 
 stdAc::state_t IRac::getState(void) { return next; }
+
 stdAc::state_t IRac::getStatePrev(void) { return _prev; }
 
 // Is the given protocol supported by the IRac class?
@@ -1479,11 +1478,6 @@ bool IRac::cmpStates(const stdAc::state_t a, const stdAc::state_t b) {
       a.econo != b.econo || a.light != b.light || a.filter != b.filter ||
       a.clean != b.clean || a.beep != b.beep || a.sleep != b.sleep;
 }
-
-// Compare a AirCon state with the current internal state..
-// Returns: True if they differ, False if they don't.
-// Note: Excludes clock.
-bool IRac::cmpState(const stdAc::state_t a) { return cmpStates(a, next); }
 
 bool IRac::hasStateChanged(void) { return cmpStates(next, _prev); }
 

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1046,11 +1046,11 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
 }
 #endif  // SEND_WHIRLPOOL_AC
 
-// Create a new state base on next & previous states but handle
+// Create a new state base on desired & previous states but handle
 // any state changes for options that need to be toggled.
 // Args:
-//   next: The state_t structure describing the desired a/c state.
-//   prev: Ptr to the previous state_t structure.
+//   desired: The state_t structure describing the desired a/c state.
+//   prev:    Ptr to the previous state_t structure.
 //
 // Returns:
 //   A stdAc::state_t with the needed settings.

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -42,8 +42,8 @@ IRac::IRac(const uint16_t pin, const bool inverted, const bool use_modulation) {
   _pin = pin;
   _inverted = inverted;
   _modulation = use_modulation;
-  initState(&desired);
-  _prev = desired;
+  initState(&next);
+  _prev = next;
 }
 
 void IRac::initState(stdAc::state_t *state,
@@ -1046,11 +1046,11 @@ void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
 }
 #endif  // SEND_WHIRLPOOL_AC
 
-// Create a new state base on desired & previous states but handle
+// Create a new state base on next & previous states but handle
 // any state changes for options that need to be toggled.
 // Args:
-//   desired: The state_t structure describing the desired a/c state.
-//   prev:    Ptr to the previous state_t structure.
+//   next: The state_t structure describing the desired a/c state.
+//   prev: Ptr to the previous state_t structure.
 //
 // Returns:
 //   A stdAc::state_t with the needed settings.
@@ -1458,8 +1458,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
 // Returns:
 //   boolean: True, if accepted/converted/attempted. False, if unsupported.
 bool IRac::sendAc(void) {
-  bool success = this->sendAc(desired, &_prev);
-  _prev = desired;
+  bool success = this->sendAc(next, &_prev);
+  _prev = next;
   return success;
 }
 

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -46,6 +46,8 @@ IRac::IRac(const uint16_t pin, const bool inverted, const bool use_modulation) {
   _prev = next;
 }
 
+uint16_t IRac::getGpio(void) { return _pin; }
+
 void IRac::initState(stdAc::state_t *state,
                      const decode_type_t vendor, const int16_t model,
                      const bool power, const stdAc::opmode_t mode,
@@ -83,6 +85,9 @@ void IRac::initState(stdAc::state_t *state) {
             stdAc::swingh_t::kOff, false, false, false, false, false, false,
             false, -1, -1);
 }
+
+stdAc::state_t IRac::getState(void) { return next; }
+stdAc::state_t IRac::getStatePrev(void) { return _prev; }
 
 // Is the given protocol supported by the IRac class?
 bool IRac::isProtocolSupported(const decode_type_t protocol) {
@@ -1474,6 +1479,13 @@ bool IRac::cmpStates(const stdAc::state_t a, const stdAc::state_t b) {
       a.econo != b.econo || a.light != b.light || a.filter != b.filter ||
       a.clean != b.clean || a.beep != b.beep || a.sleep != b.sleep;
 }
+
+// Compare a AirCon state with the current internal state..
+// Returns: True if they differ, False if they don't.
+// Note: Excludes clock.
+bool IRac::cmpState(const stdAc::state_t a) { return cmpStates(a, next); }
+
+bool IRac::hasStateChanged(void) { return cmpStates(next, _prev); }
 
 stdAc::opmode_t IRac::strToOpmode(const char *str,
                                 const stdAc::opmode_t def) {

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -80,7 +80,7 @@ class IRac {
   static String fanspeedToString(const stdAc::fanspeed_t speed);
   static String swingvToString(const stdAc::swingv_t swingv);
   static String swinghToString(const stdAc::swingh_t swingh);
-  stdAc::state_t desired;
+  stdAc::state_t next;
 #ifndef UNIT_TEST
 
  private:

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -64,6 +64,7 @@ class IRac {
               const bool beep, const int16_t sleep = -1,
               const int16_t clock = -1);
   static bool cmpStates(const stdAc::state_t a, const stdAc::state_t b);
+  bool cmpState(const stdAc::state_t a);
   static bool strToBool(const char *str, const bool def = false);
   static int16_t strToModel(const char *str, const int16_t def = -1);
   static stdAc::opmode_t strToOpmode(
@@ -80,6 +81,10 @@ class IRac {
   static String fanspeedToString(const stdAc::fanspeed_t speed);
   static String swingvToString(const stdAc::swingv_t swingv);
   static String swinghToString(const stdAc::swingh_t swingh);
+  stdAc::state_t getState(void);
+  stdAc::state_t getStatePrev(void);
+  bool hasStateChanged(void);
+  uint16_t getGpio(void);
   stdAc::state_t next;
 #ifndef UNIT_TEST
 

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -64,7 +64,6 @@ class IRac {
               const bool beep, const int16_t sleep = -1,
               const int16_t clock = -1);
   static bool cmpStates(const stdAc::state_t a, const stdAc::state_t b);
-  bool cmpState(const stdAc::state_t a);
   static bool strToBool(const char *str, const bool def = false);
   static int16_t strToModel(const char *str, const int16_t def = -1);
   static stdAc::opmode_t strToOpmode(
@@ -84,8 +83,7 @@ class IRac {
   stdAc::state_t getState(void);
   stdAc::state_t getStatePrev(void);
   bool hasStateChanged(void);
-  uint16_t getGpio(void);
-  stdAc::state_t next;
+  stdAc::state_t next;  // The state we want the device to be in after we send.
 #ifndef UNIT_TEST
 
  private:
@@ -93,7 +91,7 @@ class IRac {
   uint16_t _pin;
   bool _inverted;
   bool _modulation;
-  stdAc::state_t _prev;
+  stdAc::state_t _prev;  // The state we expect the device to currently be in.
 #if SEND_AMCOR
   void amcor(IRAmcorAc *ac,
              const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -41,6 +41,20 @@ class IRac {
   explicit IRac(const uint16_t pin, const bool inverted = false,
                 const bool use_modulation = true);
   static bool isProtocolSupported(const decode_type_t protocol);
+  static void initState(stdAc::state_t *state,
+                        const decode_type_t vendor, const int16_t model,
+                        const bool power, const stdAc::opmode_t mode,
+                        const float degrees, const bool celsius,
+                        const stdAc::fanspeed_t fan,
+                        const stdAc::swingv_t swingv,
+                        const stdAc::swingh_t swingh,
+                        const bool quiet, const bool turbo, const bool econo,
+                        const bool light, const bool filter, const bool clean,
+                        const bool beep, const int16_t sleep,
+                        const int16_t clock);
+  static void initState(stdAc::state_t *state);
+  bool sendAc(void);
+  bool sendAc(const stdAc::state_t desired, const stdAc::state_t *prev = NULL);
   bool sendAc(const decode_type_t vendor, const int16_t model,
               const bool power, const stdAc::opmode_t mode, const float degrees,
               const bool celsius, const stdAc::fanspeed_t fan,
@@ -49,7 +63,6 @@ class IRac {
               const bool light, const bool filter, const bool clean,
               const bool beep, const int16_t sleep = -1,
               const int16_t clock = -1);
-  bool sendAc(const stdAc::state_t desired, const stdAc::state_t *prev = NULL);
   static bool cmpStates(const stdAc::state_t a, const stdAc::state_t b);
   static bool strToBool(const char *str, const bool def = false);
   static int16_t strToModel(const char *str, const int16_t def = -1);
@@ -67,6 +80,7 @@ class IRac {
   static String fanspeedToString(const stdAc::fanspeed_t speed);
   static String swingvToString(const stdAc::swingv_t swingv);
   static String swinghToString(const stdAc::swingh_t swingh);
+  stdAc::state_t desired;
 #ifndef UNIT_TEST
 
  private:
@@ -74,6 +88,7 @@ class IRac {
   uint16_t _pin;
   bool _inverted;
   bool _modulation;
+  stdAc::state_t _prev;
 #if SEND_AMCOR
   void amcor(IRAmcorAc *ac,
              const bool on, const stdAc::opmode_t mode, const float degrees,
@@ -254,7 +269,8 @@ void electra(IRElectraAc *ac,
                const bool on, const stdAc::opmode_t mode, const float degrees,
                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                const bool quiet, const bool turbo, const bool clean,
-               const bool beep, const bool forcepower = true);
+               const bool beep, const bool prevpower = true,
+               const bool forcepower = true);
 #endif  // SEND_SAMSUNG_AC
 #if SEND_SHARP_AC
   void sharp(IRSharpAc *ac,

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -300,7 +300,7 @@ IRSamsungAc::IRSamsungAc(const uint16_t pin, const bool inverted,
 // Args:
 //   forcepower: A flag indicating if force sending a special power message
 //              with the first `send()` call. Default: true
-void IRSamsungAc::stateReset(const bool forcepower) {
+void IRSamsungAc::stateReset(const bool forcepower, const bool initialPower) {
   for (uint8_t i = 0; i < kSamsungAcExtendedStateLength; i++)
     remote_state[i] = 0x0;
   remote_state[0] = 0x02;
@@ -314,7 +314,8 @@ void IRSamsungAc::stateReset(const bool forcepower) {
   remote_state[12] = 0x15;
   remote_state[13] = 0xF0;
   _forcepower = forcepower;
-  _lastsentpowerstate = this->getPower();
+  _lastsentpowerstate = initialPower;
+  setPower(initialPower);
 }
 
 void IRSamsungAc::begin(void) { _irsend.begin(); }

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -65,7 +65,7 @@ class IRSamsungAc {
   explicit IRSamsungAc(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
 
-  void stateReset(const bool forcepower = true);
+  void stateReset(const bool forcepower = true, const bool initialPower = true);
 #if SEND_SAMSUNG_AC
   void send(const uint16_t repeat = kSamsungAcDefaultRepeat,
             const bool calcchecksum = true);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -807,6 +807,7 @@ TEST(TestIRac, Samsung) {
                false,                       // Turbo
                true,                        // Clean
                true,                        // Beep
+               true,                        // Previous power state
                false);                      // with dopower Off
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
@@ -826,6 +827,7 @@ TEST(TestIRac, Samsung) {
                false,                       // Turbo
                true,                        // Clean
                true,                        // Beep
+               true,                        // Previous power state
                true);                       // with dopower On
   ASSERT_EQ(expected, ac.toString());  // Class should be in the desired mode.
   ac._irsend.makeDecodeResult();


### PR DESCRIPTION
* Allow an internal a/c state (inc. previous state) for `sendAc()`
* Handle Power on/off better for SamsungAc.
* Update _CommonAcControl.ino_ example code to use new API.