### PR TITLE
IRMQTTServer: Add flag & documentation for Home Assistant mode.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -100,6 +100,11 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 #define MQTT_CLIMATE_STAT "stat"  // Sub-topic for the climate stat topics.
 // Enable sending/receiving climate via JSON. `true` cost ~5k of program space.
 #define MQTT_CLIMATE_JSON false
+// Use Home Assistant-style operation modes.
+// i.e. Change the climate mode to "off" when turning the power "off".
+// See: https://www.home-assistant.io/components/climate.mqtt/#modes
+// Change to false, if your home automation system doesn't like this.
+#define MQTT_CLIMATE_HA_MODE true
 // Do we send an IR message when we reboot and recover the existing A/C state?
 // If set to `false` you may miss requested state changes while the ESP was
 // down. If set to `true`, it will resend the previous desired state sent to the
@@ -328,7 +333,8 @@ void doBroadcast(TimerMs *timer, const uint32_t interval,
 #if MQTT_CLIMATE_JSON
 stdAc::state_t jsonToState(const stdAc::state_t current, const char *str);
 void sendJsonState(const stdAc::state_t state, const String topic,
-                   const bool retain = false, const bool ha_mode = true);
+                   const bool retain = false,
+                   const bool ha_mode = MQTT_CLIMATE_HA_MODE);
 #endif  // MQTT_CLIMATE_JSON
 #endif  // MQTT_ENABLE
 #if REPORT_VCC

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2937,6 +2937,8 @@ bool sendClimate(const stdAc::state_t prev, const stdAc::state_t next,
     diff = true;
     success &= sendInt(topic_prefix + KEY_MODEL, next.model, retain);
   }
+#if MQTT_CLIMATE_HA_MODE
+  // Home Assistant want's these two bound together.
   if (prev.power != next.power || prev.mode != next.mode || forceMQTT) {
     diff = true;
     success &= sendBool(topic_prefix + KEY_POWER, next.power, retain);
@@ -2945,6 +2947,18 @@ bool sendClimate(const stdAc::state_t prev, const stdAc::state_t next,
                                       : F("off")),
                           retain);
   }
+#else  // MQTT_CLIMATE_HA_MODE
+  // In non-Home Assistant mode, power and mode are not bound together.
+  if (prev.power != next.power || forceMQTT) {
+    diff = true;
+    success &= sendBool(topic_prefix + KEY_POWER, next.power, retain);
+  }
+  if (prev.mode != next.mode || forceMQTT) {
+    diff = true;
+    success &= sendString(topic_prefix + KEY_MODE,
+                          IRac::opmodeToString(next.mode), retain);
+  }
+#endif  // MQTT_CLIMATE_HA_MODE
   if (prev.degrees != next.degrees || forceMQTT) {
     diff = true;
     success &= sendFloat(topic_prefix + KEY_TEMP, next.degrees, retain);


### PR DESCRIPTION
* `MQTT_CLIMATE_HA_MODE` setting controls if we use HA mode. Default: 
Yes, we do!

Fixes #918