### PR TITLE
Fixed Coolix kCoolixDefaultState (file Update ir_Coolix.h)

### DIFF
--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -81,7 +81,7 @@ const uint32_t kCoolixTurbo = 0b101101011111010110100010;  // 0xB5F5A2
 const uint32_t kCoolixLed = 0b101101011111010110100101;    // 0xB5F5A5
 const uint32_t kCoolixClean = 0b101101011111010110101010;  // 0xB5F5AA
 // On, 25C, Mode: Auto, Fan: Auto, Zone Follow: Off, Sensor Temp: Ignore.
-const uint32_t kCoolixDefaultState = 0b101100101011111111001000;  // 0xB2BFC8
+const uint32_t kCoolixDefaultState = 0b101100100001111111001000; // 0xB21FC8
 
 // Classes
 class IRCoolixAC {

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -81,7 +81,7 @@ const uint32_t kCoolixTurbo = 0b101101011111010110100010;  // 0xB5F5A2
 const uint32_t kCoolixLed = 0b101101011111010110100101;    // 0xB5F5A5
 const uint32_t kCoolixClean = 0b101101011111010110101010;  // 0xB5F5AA
 // On, 25C, Mode: Auto, Fan: Auto, Zone Follow: Off, Sensor Temp: Ignore.
-const uint32_t kCoolixDefaultState = 0b101100100001111111001000; // 0xB21FC8
+const uint32_t kCoolixDefaultState = 0b101100100001111111001000;  // 0xB21FC8
 
 // Classes
 class IRCoolixAC {

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -483,7 +483,7 @@ TEST(TestCoolixACClass, HumanReadable) {
 
   // Initial starting point.
   EXPECT_EQ(
-      "Power: On, Mode: 2 (Auto), Fan: 5 (Auto), Temp: 25C, "
+      "Power: On, Mode: 2 (Auto), Fan: 0 (Auto0), Temp: 25C, "
       "Zone Follow: Off, Sensor Temp: Ignored",
       ircoolix.toString());
 
@@ -572,10 +572,10 @@ TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
   ac.begin();
   // Default
   EXPECT_EQ(
-      "Power: On, Mode: 2 (Auto), Fan: 5 (Auto), Temp: 25C, Zone Follow: Off, "
+      "Power: On, Mode: 2 (Auto), Fan: 0 (Auto0), Temp: 25C, Zone Follow: Off, "
       "Sensor Temp: Ignored",
       ac.toString());
-  EXPECT_EQ(0xB2BFC8, ac.getRaw());
+  EXPECT_EQ(0xB21FC8, ac.getRaw());
   // Change of settings.
   ac.setPower(true);
   ac.setTemp(24);


### PR DESCRIPTION
Closes #937: Coolix kCoolixDefaultState has wrong Fan definition.
Ref #932 