### PR TITLE
Create de_CH locale

### DIFF
--- a/src/locale/de_CH.h
+++ b/src/locale/de_CH.h
@@ -1,0 +1,10 @@
+// Copyright 2019 - Martin (@finfinack)
+// Locale/language file for German / Switzerland.
+// This file will override the default values located in `defaults.h`.
+#ifndef LOCALE_DE_CH_H_
+#define LOCALE_DE_CH_H_
+
+// Import German / Germany as default overwrites.
+#include "locale/de_DE.h"
+
+#endif  // LOCALE_DE_CH_H_


### PR DESCRIPTION
This creates a default de_CH locale based on the de_DE one. For now, no additional overwrites.