### PR TITLE
A/C setRaw/getRaw/stateReset() cleanup.

### DIFF
--- a/src/ir_Amcor.cpp
+++ b/src/ir_Amcor.cpp
@@ -7,6 +7,7 @@
 
 #include "ir_Amcor.h"
 #include <algorithm>
+#include <cstring>
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRtext.h"
@@ -106,8 +107,7 @@ void IRAmcorAc::begin(void) { _irsend.begin(); }
 
 #if SEND_AMCOR
 void IRAmcorAc::send(const uint16_t repeat) {
-  this->checksum();  // Create valid checksum before sending
-  _irsend.sendAmcor(remote_state, kAmcorStateLength, repeat);
+  _irsend.sendAmcor(getRaw(), kAmcorStateLength, repeat);
 }
 #endif  // SEND_AMCOR
 
@@ -138,7 +138,7 @@ uint8_t* IRAmcorAc::getRaw(void) {
 }
 
 void IRAmcorAc::setRaw(const uint8_t state[]) {
-  for (uint8_t i = 0; i < kAmcorStateLength; i++) remote_state[i] = state[i];
+  memcpy(remote_state, state, kAmcorStateLength);
 }
 
 void IRAmcorAc::on(void) { setPower(true); }

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -7,6 +7,7 @@ Copyright 2019 crankyoldgit
 
 #include "ir_Argo.h"
 #include <algorithm>
+#include <cstring>
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif  // UNIT_TEST
@@ -58,8 +59,7 @@ void IRArgoAC::begin(void) { _irsend.begin(); }
 
 #if SEND_ARGO
 void IRArgoAC::send(const uint16_t repeat) {
-  this->checksum();  // Create valid checksum before sending
-  _irsend.sendArgo(argo, kArgoStateLength, repeat);
+  _irsend.sendArgo(getRaw(), kArgoStateLength, repeat);
 }
 #endif  // SEND_ARGO
 
@@ -108,7 +108,7 @@ uint8_t* IRArgoAC::getRaw(void) {
 }
 
 void IRArgoAC::setRaw(const uint8_t state[]) {
-  for (uint8_t i = 0; i < kArgoStateLength; i++) argo[i] = state[i];
+  memcpy(argo, state, kArgoStateLength);
 }
 
 void IRArgoAC::on(void) { setPower(true); }

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -11,6 +11,7 @@ Copyright 2019 pasna (IRDaikin160 class / Daikin176 class)
 
 #include "ir_Daikin.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -105,8 +106,7 @@ void IRDaikinESP::begin(void) { _irsend.begin(); }
 
 #if SEND_DAIKIN
 void IRDaikinESP::send(const uint16_t repeat) {
-  this->checksum();
-  _irsend.sendDaikin(remote, kDaikinStateLength, repeat);
+  _irsend.sendDaikin(getRaw(), kDaikinStateLength, repeat);
 }
 #endif  // SEND_DAIKIN
 
@@ -638,8 +638,7 @@ void IRDaikin2::begin(void) { _irsend.begin(); }
 
 #if SEND_DAIKIN2
 void IRDaikin2::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin2(remote_state, kDaikin2StateLength, repeat);
+  _irsend.sendDaikin2(getRaw(), kDaikin2StateLength, repeat);
 }
 #endif  // SEND_DAIKIN2
 
@@ -711,8 +710,7 @@ uint8_t *IRDaikin2::getRaw(void) {
 }
 
 void IRDaikin2::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin2StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin2StateLength);
 }
 
 void IRDaikin2::on(void) { setPower(true); }
@@ -1320,8 +1318,7 @@ void IRDaikin216::begin(void) { _irsend.begin(); }
 
 #if SEND_DAIKIN216
 void IRDaikin216::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin216(remote_state, kDaikin216StateLength, repeat);
+  _irsend.sendDaikin216(getRaw(), kDaikin216StateLength, repeat);
 }
 #endif  // SEND_DAIKIN216
 
@@ -1373,8 +1370,7 @@ uint8_t *IRDaikin216::getRaw(void) {
 }
 
 void IRDaikin216::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin216StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin216StateLength);
 }
 
 
@@ -1710,14 +1706,12 @@ uint8_t *IRDaikin160::getRaw(void) {
 }
 
 void IRDaikin160::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin160StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin160StateLength);
 }
 
 #if SEND_DAIKIN160
 void IRDaikin160::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin160(remote_state, kDaikin160StateLength, repeat);
+  _irsend.sendDaikin160(getRaw(), kDaikin160StateLength, repeat);
 }
 #endif  // SEND_DAIKIN160
 
@@ -2060,15 +2054,13 @@ uint8_t *IRDaikin176::getRaw(void) {
 }
 
 void IRDaikin176::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin176StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin176StateLength);
   _saved_temp = getTemp();
 }
 
 #if SEND_DAIKIN176
 void IRDaikin176::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin176(remote_state, kDaikin176StateLength, repeat);
+  _irsend.sendDaikin176(getRaw(), kDaikin176StateLength, repeat);
 }
 #endif  // SEND_DAIKIN176
 
@@ -2427,14 +2419,12 @@ uint8_t *IRDaikin128::getRaw(void) {
 }
 
 void IRDaikin128::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin128StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin128StateLength);
 }
 
 #if SEND_DAIKIN128
 void IRDaikin128::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin128(remote_state, kDaikin128StateLength, repeat);
+  _irsend.sendDaikin128(getRaw(), kDaikin128StateLength, repeat);
 }
 #endif  // SEND_DAIKIN128
 
@@ -2941,8 +2931,7 @@ void IRDaikin152::begin(void) { _irsend.begin(); }
 
 #if SEND_DAIKIN152
 void IRDaikin152::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendDaikin152(remote_state, kDaikin152StateLength, repeat);
+  _irsend.sendDaikin152(getRaw(), kDaikin152StateLength, repeat);
 }
 #endif  // SEND_DAIKIN152
 
@@ -2980,6 +2969,5 @@ uint8_t *IRDaikin152::getRaw(void) {
 }
 
 void IRDaikin152::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kDaikin152StateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, kDaikin152StateLength);
 }

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -2,6 +2,7 @@
 
 #include "ir_Electra.h"
 #include <algorithm>
+#include <cstring>
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRtext.h"
@@ -63,8 +64,7 @@ IRElectraAc::IRElectraAc(const uint16_t pin, const bool inverted,
 }
 
 void IRElectraAc::stateReset(void) {
-  for (uint8_t i = 1; i < kElectraAcStateLength - 2; i++)
-    remote_state[i] = 0;
+  for (uint8_t i = 1; i < kElectraAcStateLength - 2; i++) remote_state[i] = 0;
   remote_state[0] = 0xC3;
   remote_state[11] = 0x08;
   // [12] is the checksum.
@@ -103,8 +103,7 @@ uint8_t *IRElectraAc::getRaw(void) {
 }
 
 void IRElectraAc::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kElectraAcStateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, std::min(length, kElectraAcStateLength));
 }
 
 void IRElectraAc::on(void) { this->setPower(true); }

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -9,6 +9,7 @@
 
 #include "ir_Gree.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -155,9 +156,7 @@ uint8_t* IRGreeAC::getRaw(void) {
 }
 
 void IRGreeAC::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kGreeStateLength; i++) {
-    remote_state[i] = new_code[i];
-  }
+  memcpy(remote_state, new_code, kGreeStateLength);
   // We can only detect the difference between models when the power is on.
   if (getPower()) {
     if (GETBIT8(remote_state[2], kGreePower2Offset))

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -5,6 +5,7 @@
 // * YR-W02/HSU-09HMC203 by non7top.
 
 #include "ir_Haier.h"
+#include <cstring>
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
@@ -93,8 +94,7 @@ void IRHaierAC::begin(void) { _irsend.begin(); }
 
 #if SEND_HAIER_AC
 void IRHaierAC::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendHaierAC(remote_state, kHaierACStateLength, repeat);
+  _irsend.sendHaierAC(getRaw(), kHaierACStateLength, repeat);
 }
 #endif  // SEND_HAIER_AC
 
@@ -126,9 +126,7 @@ uint8_t* IRHaierAC::getRaw(void) {
 }
 
 void IRHaierAC::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kHaierACStateLength; i++) {
-    remote_state[i] = new_code[i];
-  }
+  memcpy(remote_state, new_code, kHaierACStateLength);
 }
 
 void IRHaierAC::setCommand(const uint8_t command) {
@@ -476,8 +474,7 @@ void IRHaierACYRW02::begin(void) { _irsend.begin(); }
 
 #if SEND_HAIER_AC_YRW02
 void IRHaierACYRW02::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendHaierACYRW02(remote_state, kHaierACYRW02StateLength, repeat);
+  _irsend.sendHaierACYRW02(getRaw(), kHaierACYRW02StateLength, repeat);
 }
 #endif  // SEND_HAIER_AC_YRW02
 
@@ -511,9 +508,7 @@ uint8_t* IRHaierACYRW02::getRaw(void) {
 }
 
 void IRHaierACYRW02::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kHaierACYRW02StateLength; i++) {
-    remote_state[i] = new_code[i];
-  }
+  memcpy(remote_state, new_code, kHaierACYRW02StateLength);
 }
 
 void IRHaierACYRW02::setButton(uint8_t button) {

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -7,6 +7,7 @@
 
 #include "ir_Hitachi.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -159,14 +160,12 @@ uint8_t *IRHitachiAc::getRaw(void) {
 }
 
 void IRHitachiAc::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kHitachiAcStateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, std::min(length, kHitachiAcStateLength));
 }
 
 #if SEND_HITACHI_AC
 void IRHitachiAc::send(const uint16_t repeat) {
-  checksum();
-  _irsend.sendHitachiAC(remote_state, kHitachiAcStateLength, repeat);
+  _irsend.sendHitachiAC(getRaw(), kHitachiAcStateLength, repeat);
 }
 #endif  // SEND_HITACHI_AC
 

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -16,6 +16,7 @@
 
 #include "ir_Kelvinator.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -153,9 +154,7 @@ uint8_t *IRKelvinatorAC::getRaw(void) {
 }
 
 void IRKelvinatorAC::setRaw(const uint8_t new_code[]) {
-  for (uint8_t i = 0; i < kKelvinatorStateLength; i++) {
-    remote_state[i] = new_code[i];
-  }
+  memcpy(remote_state, new_code, kKelvinatorStateLength);
 }
 
 uint8_t IRKelvinatorAC::calcBlockChecksum(const uint8_t *block,

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -15,6 +15,7 @@
 
 #include "ir_MitsubishiHeavy.h"
 #include <algorithm>
+#include <cstring>
 #include "IRremoteESP8266.h"
 #include "IRtext.h"
 #include "IRutils.h"
@@ -97,10 +98,9 @@ void IRMitsubishiHeavy152Ac::send(const uint16_t repeat) {
 #endif  // SEND_MITSUBISHIHEAVY
 
 void IRMitsubishiHeavy152Ac::stateReset(void) {
-  uint8_t i = 0;
-  for (; i < kMitsubishiHeavySigLength; i++)
-    remote_state[i] = kMitsubishiHeavyZmsSig[i];
-  for (; i < kMitsubishiHeavy152StateLength - 3; i += 2) remote_state[i] = 0;
+  memcpy(remote_state, kMitsubishiHeavyZmsSig, kMitsubishiHeavySigLength);
+  for (uint8_t i = kMitsubishiHeavySigLength;
+       i < kMitsubishiHeavy152StateLength - 3; i += 2) remote_state[i] = 0;
   remote_state[17] = 0x80;
 }
 
@@ -110,8 +110,7 @@ uint8_t *IRMitsubishiHeavy152Ac::getRaw(void) {
 }
 
 void IRMitsubishiHeavy152Ac::setRaw(const uint8_t *data) {
-  for (uint8_t i = 0; i < kMitsubishiHeavy152StateLength; i++)
-    remote_state[i] = data[i];
+  memcpy(remote_state, data, kMitsubishiHeavy152StateLength);
 }
 
 void IRMitsubishiHeavy152Ac::on(void) { setPower(true); }
@@ -541,10 +540,9 @@ void IRMitsubishiHeavy88Ac::send(const uint16_t repeat) {
 #endif  // SEND_MITSUBISHIHEAVY
 
 void IRMitsubishiHeavy88Ac::stateReset(void) {
-  uint8_t i = 0;
-  for (; i < kMitsubishiHeavySigLength; i++)
-    remote_state[i] = kMitsubishiHeavyZjsSig[i];
-  for (; i < kMitsubishiHeavy88StateLength; i++) remote_state[i] = 0;
+  memcpy(remote_state, kMitsubishiHeavyZjsSig, kMitsubishiHeavySigLength);
+  for (uint8_t i = kMitsubishiHeavySigLength; i < kMitsubishiHeavy88StateLength;
+       i++) remote_state[i] = 0;
 }
 
 uint8_t *IRMitsubishiHeavy88Ac::getRaw(void) {
@@ -553,8 +551,7 @@ uint8_t *IRMitsubishiHeavy88Ac::getRaw(void) {
 }
 
 void IRMitsubishiHeavy88Ac::setRaw(const uint8_t *data) {
-  for (uint8_t i = 0; i < kMitsubishiHeavy88StateLength; i++)
-    remote_state[i] = data[i];
+  memcpy(remote_state, data, kMitsubishiHeavy88StateLength);
 }
 
 void IRMitsubishiHeavy88Ac::on(void) { setPower(true); }

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -15,6 +15,7 @@
 
 #include "ir_Neoclima.h"
 #include <algorithm>
+#include <cstring>
 #include "IRrecv.h"
 #include "IRsend.h"
 #include "IRtext.h"
@@ -76,13 +77,9 @@ IRNeoclimaAc::IRNeoclimaAc(const uint16_t pin, const bool inverted,
 }
 
 void IRNeoclimaAc::stateReset(void) {
-  for (uint8_t i = 0; i < kNeoclimaStateLength; i++)
-    remote_state[i] = 0x0;
-  remote_state[7] = 0x6A;
-  remote_state[8] = 0x00;
-  remote_state[9] = 0x2A;
-  remote_state[10] = 0xA5;
-  // [11] is the checksum.
+  static const uint8_t kReset[kNeoclimaStateLength] = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6A, 0x00, 0x2A, 0xA5, 0x00};
+  memcpy(remote_state, kReset, kNeoclimaStateLength);
 }
 
 void IRNeoclimaAc::begin(void) { _irsend.begin(); }
@@ -107,8 +104,7 @@ void IRNeoclimaAc::checksum(uint16_t length) {
 
 #if SEND_NEOCLIMA
 void IRNeoclimaAc::send(const uint16_t repeat) {
-  this->checksum();
-  _irsend.sendNeoclima(remote_state, kNeoclimaStateLength, repeat);
+  _irsend.sendNeoclima(getRaw(), kNeoclimaStateLength, repeat);
 }
 #endif  // SEND_NEOCLIMA
 
@@ -118,8 +114,7 @@ uint8_t *IRNeoclimaAc::getRaw(void) {
 }
 
 void IRNeoclimaAc::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kNeoclimaStateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, std::min(length, kNeoclimaStateLength));
 }
 
 

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -78,8 +78,8 @@ IRNeoclimaAc::IRNeoclimaAc(const uint16_t pin, const bool inverted,
 
 void IRNeoclimaAc::stateReset(void) {
   static const uint8_t kReset[kNeoclimaStateLength] = {
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6A, 0x00, 0x2A, 0xA5, 0x00};
-  memcpy(remote_state, kReset, kNeoclimaStateLength);
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6A, 0x00, 0x2A, 0xA5};
+  setRaw(kReset);
 }
 
 void IRNeoclimaAc::begin(void) { _irsend.begin(); }

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -5,6 +5,7 @@
 
 #include "ir_Panasonic.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -232,8 +233,7 @@ IRPanasonicAc::IRPanasonicAc(const uint16_t pin, const bool inverted,
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
 void IRPanasonicAc::stateReset(void) {
-  for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)
-    remote_state[i] = kPanasonicKnownGoodState[i];
+  memcpy(remote_state, kPanasonicKnownGoodState, kPanasonicAcStateLength);
   _temp = 25;  // An initial saved desired temp. Completely made up.
   _swingh = kPanasonicAcSwingHMiddle;  // A similar made up value for H Swing.
 }
@@ -262,8 +262,7 @@ void IRPanasonicAc::fixChecksum(const uint16_t length) {
 
 #if SEND_PANASONIC_AC
 void IRPanasonicAc::send(const uint16_t repeat) {
-  this->fixChecksum();
-  _irsend.sendPanasonicAC(remote_state, kPanasonicAcStateLength, repeat);
+  _irsend.sendPanasonicAC(getRaw(), kPanasonicAcStateLength, repeat);
 }
 #endif  // SEND_PANASONIC_AC
 
@@ -336,8 +335,7 @@ uint8_t *IRPanasonicAc::getRaw(void) {
 }
 
 void IRPanasonicAc::setRaw(const uint8_t state[]) {
-  for (uint8_t i = 0; i < kPanasonicAcStateLength; i++)
-    remote_state[i] = state[i];
+  memcpy(remote_state, state, kPanasonicAcStateLength);
 }
 
 // Control the power state of the A/C unit.

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -5,6 +5,7 @@
 
 #include "ir_Sharp.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -280,8 +281,7 @@ void IRSharpAc::begin(void) { _irsend.begin(); }
 
 #if SEND_SHARP_AC
 void IRSharpAc::send(const uint16_t repeat) {
-  this->checksum();
-  _irsend.sendSharpAc(remote, kSharpAcStateLength, repeat);
+  _irsend.sendSharpAc(getRaw(), kSharpAcStateLength, repeat);
 }
 #endif  // SEND_SHARP_AC
 
@@ -319,7 +319,7 @@ void IRSharpAc::stateReset(void) {
   static const uint8_t reset[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0x00, 0x01, 0x00, 0x00, 0x08, 0x80, 0x00, 0xE0,
       0x01};
-  for (uint8_t i = 0; i < kSharpAcStateLength; i++) remote[i] = reset[i];
+  memcpy(remote, reset, kSharpAcStateLength);
 }
 
 uint8_t *IRSharpAc::getRaw(void) {
@@ -328,8 +328,7 @@ uint8_t *IRSharpAc::getRaw(void) {
 }
 
 void IRSharpAc::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kSharpAcStateLength; i++)
-    remote[i] = new_code[i];
+  memcpy(remote, new_code, std::min(length, kSharpAcStateLength));
 }
 
 void IRSharpAc::on(void) { setPower(true); }

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -2,6 +2,7 @@
 
 #include "ir_Tcl.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -39,8 +40,7 @@ void IRTcl112Ac::begin(void) { this->_irsend.begin(); }
 
 #if SEND_TCL112AC
 void IRTcl112Ac::send(const uint16_t repeat) {
-  this->checksum();
-  this->_irsend.sendTcl112Ac(remote_state, kTcl112AcStateLength, repeat);
+  this->_irsend.sendTcl112Ac(getRaw(), kTcl112AcStateLength, repeat);
 }
 #endif  // SEND_TCL112AC
 
@@ -50,8 +50,7 @@ void IRTcl112Ac::send(const uint16_t repeat) {
 //   length: The size of the array.
 // Returns:
 //   The 8 bit checksum value.
-uint8_t IRTcl112Ac::calcChecksum(uint8_t state[],
-                                 const uint16_t length) {
+uint8_t IRTcl112Ac::calcChecksum(uint8_t state[], const uint16_t length) {
   if (length)
     return sumBytes(state, length - 1);
   else
@@ -76,18 +75,11 @@ bool IRTcl112Ac::validChecksum(uint8_t state[], const uint16_t length) {
 }
 
 void IRTcl112Ac::stateReset(void) {
-  for (uint8_t i = 0; i < kTcl112AcStateLength; i++)
-    remote_state[i] = 0x0;
   // A known good state. (On, Cool, 24C)
-  remote_state[0] =  0x23;
-  remote_state[1] =  0xCB;
-  remote_state[2] =  0x26;
-  remote_state[3] =  0x01;
-  remote_state[5] =  0x24;
-  remote_state[6] =  0x03;
-  remote_state[7] =  0x07;
-  remote_state[8] =  0x40;
-  remote_state[13] = 0x03;
+  static const uint8_t reset[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03, 0x07, 0x40, 0x00, 0x00, 0x00,
+      0x00, 0x03};
+  memcpy(remote_state, reset, kTcl112AcStateLength);
 }
 
 uint8_t* IRTcl112Ac::getRaw(void) {
@@ -96,9 +88,7 @@ uint8_t* IRTcl112Ac::getRaw(void) {
 }
 
 void IRTcl112Ac::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kTcl112AcStateLength; i++) {
-    remote_state[i] = new_code[i];
-  }
+  memcpy(remote_state, new_code, std::min(length, kTcl112AcStateLength));
 }
 
 // Set the requested power state of the A/C to on.

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -3,6 +3,7 @@
 
 #include "ir_Trotec.h"
 #include <algorithm>
+#include <cstring>
 #ifndef UNIT_TEST
 #include <Arduino.h>
 #endif
@@ -93,7 +94,7 @@ uint8_t* IRTrotecESP::getRaw(void) {
 }
 
 void IRTrotecESP::setRaw(const uint8_t state[]) {
-  for (uint16_t i = 0; i < kTrotecStateLength; i++) remote_state[i] = state[i];
+  memcpy(remote_state, state, kTrotecStateLength);
 }
 
 void IRTrotecESP::setPower(const bool on) {

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -16,6 +16,7 @@
 
 #include "ir_Whirlpool.h"
 #include <algorithm>
+#include <cstring>
 #ifndef ARDUINO
 #include <string>
 #endif
@@ -147,8 +148,7 @@ uint8_t *IRWhirlpoolAc::getRaw(const bool calcchecksum) {
 }
 
 void IRWhirlpoolAc::setRaw(const uint8_t new_code[], const uint16_t length) {
-  for (uint8_t i = 0; i < length && i < kWhirlpoolAcStateLength; i++)
-    remote_state[i] = new_code[i];
+  memcpy(remote_state, new_code, std::min(length, kWhirlpoolAcStateLength));
 }
 
 whirlpool_ac_remote_model_t IRWhirlpoolAc::getModel(void) {


### PR DESCRIPTION
* Use `memcpy()` where appropriate.
* Reduce some code duplication.
* Use static arrays rather than adhoc assignments for state resets when 
it's worth it.