### PR TITLE
Add Vertical Swing ability for Hitachi424Ac

### DIFF
--- a/src/IRac.h
+++ b/src/IRac.h
@@ -219,7 +219,8 @@ void electra(IRElectraAc *ac,
 #if SEND_HITACHI_AC424
   void hitachi424(IRHitachiAc424 *ac,
                   const bool on, const stdAc::opmode_t mode,
-                  const float degrees, const stdAc::fanspeed_t fan);
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv);
 #endif  // SEND_HITACHI_AC424
 #if SEND_KELVINATOR
   void kelvinator(IRKelvinatorAC *ac,

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -645,6 +645,9 @@ void IRHitachiAc424::setFan(const uint8_t speed) {
   }
 
   newSpeed = std::min(newSpeed, fanMax);
+  // Handle the setting the button value if we are going to change the value.
+  if (newSpeed != getFan()) setButton(kHitachiAc424ButtonFan);
+  // Set the values
   setBits(&remote_state[kHitachiAc424FanByte], kHighNibble, kNibbleSize,
           newSpeed);
   remote_state[9] = 0x92;

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -579,7 +579,7 @@ bool IRHitachiAc424::getPower(void) {
 }
 
 void IRHitachiAc424::setPower(const bool on) {
-  setButton(kHitachiAc424ButtonPower);
+  setButton(kHitachiAc424ButtonPowerMode);
   remote_state[kHitachiAc424PowerByte] = on ? kHitachiAc424PowerOn
     : kHitachiAc424PowerOff;
 }
@@ -678,7 +678,7 @@ void IRHitachiAc424::setSwingVToggle(const bool on) {
     button = kHitachiAc424ButtonSwingV;  // Set the button to SwingV.
   else if (button == kHitachiAc424ButtonSwingV)  // Asked to unset it
     // It was set previous, so use Power as a default
-    button = kHitachiAc424ButtonPower;
+    button = kHitachiAc424ButtonPowerMode;
   setButton(button);
 }
 
@@ -784,9 +784,9 @@ String IRHitachiAc424::toString(void) {
   result += addIntToString(getButton(), kButtonStr);
   result += kSpaceLBraceStr;
   switch (getButton()) {
-    case kHitachiAc424ButtonPower:    result += kPowerStr; break;
-    // TODO(jamsinclair): Get correct value for Mode Button.
-    // case kHitachiAc424ButtonMode:     result += kModeStr; break;
+    case kHitachiAc424ButtonPowerMode:
+      result += kPowerStr + '/' + kModeStr;
+      break;
     case kHitachiAc424ButtonFan:      result += kFanStr; break;
     case kHitachiAc424ButtonSwingV:   result += kSwingVStr; break;
     case kHitachiAc424ButtonTempDown: result += kTempDownStr; break;

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -606,6 +606,7 @@ void IRHitachiAc424::setMode(const uint8_t mode) {
           newMode);
   if (newMode != kHitachiAc424Fan) setTemp(_previoustemp);
   setFan(getFan());  // Reset the fan speed after the mode change.
+  setButton(kHitachiAc424ButtonPowerMode);
 }
 
 uint8_t IRHitachiAc424::getTemp(void) {

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -726,10 +726,8 @@ stdAc::state_t IRHitachiAc424::toCommon(void) {
   result.degrees = this->getTemp();
   result.fanspeed = this->toCommonFanSpeed(this->getFan());
 
-  // TODO(jamsinclair): Add support.
-  result.swingv = stdAc::swingv_t::kOff;
-
   // Not supported.
+  result.swingv = stdAc::swingv_t::kOff;
   result.swingh = stdAc::swingh_t::kOff;
   result.quiet = false;
   result.turbo = false;

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -537,7 +537,6 @@ void IRHitachiAc424::stateReset(void) {
   remote_state[3]  = 0x40;
   remote_state[5]  = 0xFF;
   remote_state[7]  = 0xCC;
-  remote_state[11] = 0x13;  // Button Action
   remote_state[33] = 0x80;
   remote_state[35] = 0x03;
   remote_state[37] = 0x01;
@@ -581,6 +580,7 @@ bool IRHitachiAc424::getPower(void) {
 }
 
 void IRHitachiAc424::setPower(const bool on) {
+  setButton(kHitachiAc424ButtonPower);
   setBit(&remote_state[kHitachiAc424PowerByte], kHitachiAc424PowerOffset, on);
 }
 

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -654,6 +654,21 @@ void IRHitachiAc424::setFan(const uint8_t speed) {
   }
 }
 
+uint8_t IRHitachiAc424::getButton(void) {
+  return remote_state[kHitachiAc424ButtonByte];
+}
+
+// The remote sends the type of button pressed on send
+void IRHitachiAc424::setButton(const uint8_t type) {
+  remote_state[kHitachiAc424ButtonByte] = type;
+}
+
+// The remote does not keep state of the vertical swing.
+// A byte is sent indicating the swing button is pressed on the remote
+void IRHitachiAc424::toggleSwingVertical(void) {
+  setButton(kHitachiAc424ButtonVSwing);
+}
+
 // Convert a standard A/C mode into its native mode.
 uint8_t IRHitachiAc424::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -147,6 +147,9 @@ class IRHitachiAc424 {
   uint8_t getTemp(void);
   void setFan(const uint8_t speed);
   uint8_t getFan(void);
+  uint8_t getButton(void);
+  void setButton(const uint8_t type);
+  void toggleSwingVertical(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
   uint8_t* getRaw(void);

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -43,9 +43,7 @@ const uint8_t kHitachiAcSwingOffset = 7;
 // HitachiAc424
 // Byte[11]
 const uint8_t kHitachiAc424ButtonByte = 11;
-const uint8_t kHitachiAc424ButtonPower = 0x13;
-// TODO(jamsinclair): Get correct value for Mode Button. Currently same as Power
-// const uint8_t kHitachiAc424ButtonMode = 0x13;
+const uint8_t kHitachiAc424ButtonPowerMode = 0x13;
 const uint8_t kHitachiAc424ButtonFan = 0x42;
 const uint8_t kHitachiAc424ButtonTempDown = 0x43;
 const uint8_t kHitachiAc424ButtonTempUp = 0x44;

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -41,6 +41,15 @@ const uint8_t kHitachiAcPowerOffset = 0;
 const uint8_t kHitachiAcSwingOffset = 7;
 
 // HitachiAc424
+// Byte[11]
+const uint8_t kHitachiAc424ButtonByte = 11;
+const uint8_t kHitachiAc424ButtonPower = 0x13;
+const uint8_t kHitachiAc424ButtonMode = 0x13;
+const uint8_t kHitachiAc424ButtonFan = 0x42;
+const uint8_t kHitachiAc424ButtonTempDown = 0x43;
+const uint8_t kHitachiAc424ButtonTempUp = 0x44;
+const uint8_t kHitachiAc424ButtonVSwing = 0x81;
+
 // Byte[13]
 const uint8_t kHitachiAc424TempByte = 13;
 const uint8_t kHitachiAc424TempOffset = 2;

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -44,11 +44,12 @@ const uint8_t kHitachiAcSwingOffset = 7;
 // Byte[11]
 const uint8_t kHitachiAc424ButtonByte = 11;
 const uint8_t kHitachiAc424ButtonPower = 0x13;
-const uint8_t kHitachiAc424ButtonMode = 0x13;
+// TODO(jamsinclair): Get correct value for Mode Button. Currently same as Power
+// const uint8_t kHitachiAc424ButtonMode = 0x13;
 const uint8_t kHitachiAc424ButtonFan = 0x42;
 const uint8_t kHitachiAc424ButtonTempDown = 0x43;
 const uint8_t kHitachiAc424ButtonTempUp = 0x44;
-const uint8_t kHitachiAc424ButtonVSwing = 0x81;
+const uint8_t kHitachiAc424ButtonSwingV = 0x81;
 
 // Byte[13]
 const uint8_t kHitachiAc424TempByte = 13;
@@ -148,8 +149,9 @@ class IRHitachiAc424 {
   void setFan(const uint8_t speed);
   uint8_t getFan(void);
   uint8_t getButton(void);
-  void setButton(const uint8_t type);
-  void toggleSwingVertical(void);
+  void setButton(const uint8_t button);
+  void setSwingVToggle(const bool on);
+  bool getSwingVToggle(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
   uint8_t* getRaw(void);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -573,7 +573,7 @@ TEST(TestIRac, Hitachi424) {
   IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Swing(V) Toggle: Off, Button: 19 (Power)";
+      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)";
   char expected_swingv[] =
       "Power: On, Mode: 3 (Cool), Temp: 26C, Fan: 1 (Min), "
       "Swing(V) Toggle: On, Button: 129 (Swing(V))";

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -572,14 +572,19 @@ TEST(TestIRac, Hitachi424) {
   IRac irac(0);
   IRrecv capture(0);
   char expected[] =
-      "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max)";
+      "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
+      "Swing(V) Toggle: Off, Button: 19 (Power)";
+  char expected_swingv[] =
+      "Power: On, Mode: 3 (Cool), Temp: 26C, Fan: 1 (Min), "
+      "Swing(V) Toggle: On, Button: 129 (Swing(V))";
 
   ac.begin();
   irac.hitachi424(&ac,
                   true,                         // Power
                   stdAc::opmode_t::kHeat,       // Mode
                   25,                           // Celsius
-                  stdAc::fanspeed_t::kMax);     // Fan speed
+                  stdAc::fanspeed_t::kMax,      // Fan speed
+                  stdAc::swingv_t::kOff);       // Swing(V)
 
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
@@ -587,6 +592,21 @@ TEST(TestIRac, Hitachi424) {
   ASSERT_EQ(HITACHI_AC424, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAc424Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+
+  ac._irsend.reset();
+  irac.hitachi424(&ac,
+                  true,                         // Power
+                  stdAc::opmode_t::kCool,       // Mode
+                  26,                           // Celsius
+                  stdAc::fanspeed_t::kMin,      // Fan speed
+                  stdAc::swingv_t::kAuto);      // Swing(V)
+
+  ASSERT_EQ(expected_swingv, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HITACHI_AC424, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHitachiAc424Bits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected_swingv, IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 
 TEST(TestIRac, Kelvinator) {

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1017,6 +1017,7 @@ TEST(TestIRHitachiAc424Class, SetAndGetFan) {
   EXPECT_EQ(kHitachiAc424FanAuto, ac.getFan());
   ac.setFan(kHitachiAc424FanLow);
   EXPECT_EQ(kHitachiAc424FanLow, ac.getFan());
+  EXPECT_EQ(kHitachiAc424ButtonFan, ac.getButton());
   ac.setFan(kHitachiAc424FanHigh);
   EXPECT_EQ(kHitachiAc424FanHigh, ac.getFan());
   ac.setFan(kHitachiAc424FanMax + 1);
@@ -1085,7 +1086,7 @@ TEST(TestIRHitachiAc424Class, HumanReadable) {
   ac.setFan(kHitachiAc424FanHigh);
   EXPECT_EQ(
       "Power: On, Mode: 6 (Heat), Temp: 32C, Fan: 4 (High), "
-      "Swing(V) Toggle: Off, Button: 19 (Power)",
+      "Swing(V) Toggle: Off, Button: 66 (Fan)",
       ac.toString());
   ac.setMode(kHitachiAc424Cool);
   ac.setFan(kHitachiAc424FanMin);

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -970,10 +970,10 @@ TEST(TestIRHitachiAc424Class, SetAndGetPower) {
   EXPECT_FALSE(ac.getPower());
   ac.setPower(true);
   EXPECT_TRUE(ac.getPower());
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPowerMode);
   ac.setPower(false);
   EXPECT_FALSE(ac.getPower());
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPowerMode);
 }
 
 TEST(TestIRHitachiAc424Class, SetAndGetTemp) {
@@ -1058,7 +1058,7 @@ TEST(TestIRHitachiAc424Class, SetAndGetFan) {
 TEST(TestIRHitachiAc424Class, SetAndGetButton) {
   IRHitachiAc424 ac(0);
   ac.on();
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPowerMode);
   ac.setButton(kHitachiAc424ButtonTempUp);
   EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonTempUp);
   ac.setButton(kHitachiAc424ButtonSwingV);
@@ -1068,13 +1068,13 @@ TEST(TestIRHitachiAc424Class, SetAndGetButton) {
 TEST(TestIRHitachiAc424Class, ToggleSwingVertical) {
   IRHitachiAc424 ac(0);
   ac.on();
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPowerMode);
   ac.setSwingVToggle(true);
   EXPECT_TRUE(ac.getSwingVToggle());
   EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonSwingV);
   ac.setSwingVToggle(false);
   EXPECT_FALSE(ac.getSwingVToggle());
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPowerMode);
 }
 
 TEST(TestIRHitachiAc424Class, HumanReadable) {

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -912,7 +912,8 @@ TEST(TestDecodeHitachiAc424, RealExample) {
   IRHitachiAc ac(0);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 5 (Auto)",
+      "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 5 (Auto), "
+      "Swing(V) Toggle: Off, Button: 19 (Power)",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -1059,16 +1060,20 @@ TEST(TestIRHitachiAc424Class, SetAndGetButton) {
   EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
   ac.setButton(kHitachiAc424ButtonTempUp);
   EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonTempUp);
-  ac.setButton(kHitachiAc424ButtonVSwing);
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonVSwing);
+  ac.setButton(kHitachiAc424ButtonSwingV);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonSwingV);
 }
 
 TEST(TestIRHitachiAc424Class, ToggleSwingVertical) {
   IRHitachiAc424 ac(0);
   ac.on();
   EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
-  ac.toggleSwingVertical();
-  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonVSwing);
+  ac.setSwingVToggle(true);
+  EXPECT_TRUE(ac.getSwingVToggle());
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonSwingV);
+  ac.setSwingVToggle(false);
+  EXPECT_FALSE(ac.getSwingVToggle());
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
 }
 
 TEST(TestIRHitachiAc424Class, HumanReadable) {
@@ -1079,13 +1084,30 @@ TEST(TestIRHitachiAc424Class, HumanReadable) {
   ac.on();
   ac.setFan(kHitachiAc424FanHigh);
   EXPECT_EQ(
-      "Power: On, Mode: 6 (Heat), Temp: 32C, Fan: 4 (High)",
+      "Power: On, Mode: 6 (Heat), Temp: 32C, Fan: 4 (High), "
+      "Swing(V) Toggle: Off, Button: 19 (Power)",
       ac.toString());
   ac.setMode(kHitachiAc424Cool);
-  ac.setTemp(kHitachiAc424MinTemp);
   ac.setFan(kHitachiAc424FanMin);
+  ac.setTemp(kHitachiAc424MinTemp);
   EXPECT_EQ(
-      "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min)",
+      "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
+      "Swing(V) Toggle: Off, Button: 67 (Temp Down)",
+      ac.toString());
+  ac.setSwingVToggle(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
+      "Swing(V) Toggle: On, Button: 129 (Swing(V))",
+      ac.toString());
+  ac.setTemp(ac.getTemp() + 1);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Cool), Temp: 17C, Fan: 1 (Min), "
+      "Swing(V) Toggle: Off, Button: 68 (Temp Up)",
+      ac.toString());
+  ac.setTemp(ac.getTemp() - 1);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
+      "Swing(V) Toggle: Off, Button: 67 (Temp Down)",
       ac.toString());
 }
 

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1103,9 +1103,8 @@ TEST(TestIRHitachiAcClass424, toCommon) {
   ASSERT_EQ(20, ac.toCommon().degrees);
   ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
   ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
-  // TODO(jamsinclair): Add support.
-  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
   // Unsupported.
+  ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
   ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
   ASSERT_FALSE(ac.toCommon().turbo);
   ASSERT_FALSE(ac.toCommon().clean);

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -969,8 +969,10 @@ TEST(TestIRHitachiAc424Class, SetAndGetPower) {
   EXPECT_FALSE(ac.getPower());
   ac.setPower(true);
   EXPECT_TRUE(ac.getPower());
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
   ac.setPower(false);
   EXPECT_FALSE(ac.getPower());
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
 }
 
 TEST(TestIRHitachiAc424Class, SetAndGetTemp) {
@@ -1050,6 +1052,16 @@ TEST(TestIRHitachiAc424Class, SetAndGetFan) {
   EXPECT_EQ(ac.getRaw()[29], 0x00);
 }
 
+
+TEST(TestIRHitachiAc424Class, SetAndGetButton) {
+  IRHitachiAc424 ac(0);
+  ac.on();
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  ac.setButton(kHitachiAc424ButtonTempUp);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonTempUp);
+  ac.setButton(kHitachiAc424ButtonVSwing);
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonVSwing);
+}
 
 TEST(TestIRHitachiAc424Class, ToggleSwingVertical) {
   IRHitachiAc424 ac(0);

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -913,7 +913,7 @@ TEST(TestDecodeHitachiAc424, RealExample) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 5 (Auto), "
-      "Swing(V) Toggle: Off, Button: 19 (Power)",
+      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1050,6 +1050,15 @@ TEST(TestIRHitachiAc424Class, SetAndGetFan) {
   EXPECT_EQ(ac.getRaw()[29], 0x00);
 }
 
+
+TEST(TestIRHitachiAc424Class, ToggleSwingVertical) {
+  IRHitachiAc424 ac(0);
+  ac.on();
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonPower);
+  ac.toggleSwingVertical();
+  EXPECT_EQ(ac.getButton(), kHitachiAc424ButtonVSwing);
+}
+
 TEST(TestIRHitachiAc424Class, HumanReadable) {
   IRHitachiAc424 ac(0);
 


### PR DESCRIPTION
## Changes
- Add button constants
- Add `getButton` and `setButton` methods
- Add `toggleVerticalSwing`

The vertical swing is interesting, the remote does not keep track of its state.
It relies on sending the type of button pressed to toggle it. 

Other methods like `setTemp` or `setFan`, could also set button values, but then users of the class would have to be aware of the execution order. Thoughts?