### PR TITLE
Fix Incorrect Hitachi424Ac Power Byte Values

### DIFF
--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -576,12 +576,12 @@ void IRHitachiAc424::send(const uint16_t repeat) {
 #endif  // SEND_HITACHI_AC424
 
 bool IRHitachiAc424::getPower(void) {
-  return GETBIT8(remote_state[kHitachiAc424PowerByte],
-                 kHitachiAc424PowerOffset);
+  return remote_state[kHitachiAc424PowerByte] == kHitachiAc424PowerOn;
 }
 
 void IRHitachiAc424::setPower(const bool on) {
-  setBit(&remote_state[kHitachiAc424PowerByte], kHitachiAc424PowerOffset, on);
+  remote_state[kHitachiAc424PowerByte] = on ? kHitachiAc424PowerOn
+    : kHitachiAc424PowerOff;
 }
 
 void IRHitachiAc424::on(void) { setPower(true); }

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -65,7 +65,8 @@ const uint8_t kHitachiAc424FanMax = 6;
 const uint8_t kHitachiAc424FanMaxDry = 2;
 // Byte[27]
 const uint8_t kHitachiAc424PowerByte = 27;
-const uint8_t kHitachiAc424PowerOffset = 4;
+const uint8_t kHitachiAc424PowerOn = 0xF1;
+const uint8_t kHitachiAc424PowerOff = 0xE1;
 
 // Classes
 class IRHitachiAc {

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1068,7 +1068,7 @@ TEST(TestIRHitachiAc424Class, HumanReadable) {
       ac.toString());
 }
 
-TEST(TestIRHitachiAcClass424, toCommon) {
+TEST(TestIRHitachiAc424Class, toCommon) {
   IRHitachiAc424 ac(0);
   ac.setPower(true);
   ac.setMode(kHitachiAc424Cool);


### PR DESCRIPTION
## Changes
- Add power constants
- Update get/set power methods to operate on constants
- Fix test name

Incorrect power byte values were being set. The power byte was not initialised correctly and we were inverting only one bit.

Refactored to set constant values, seemed simpler. 