### PR TITLE
Allow protocols to be enabled or disabled with compiler flags.

### DIFF
--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -59,215 +59,511 @@
 #define _IR_LOCALE_ en-AU
 #endif  // _IR_LOCALE_
 
+// Do we enable all the protocols by default (true), or disable them (false)?
+// This allows users of the library to disable or enable all protocols at
+// compile-time with `-D_IR_ENABLE_DEFAULT_=true` or
+// `-D_IR_ENABLE_DEFAULT_=false` compiler flags respectively.
+// Everything is included by default.
+// e.g. If you only want to enable use of he NEC protocol to save program space,
+//      you would use something like:
+//        `-D_IR_ENABLE_DEFAULT_=false -DDECODE_NEC=true -DSEND_NEC=true`
+//
+//      or alter your 'platform.ini' file accordingly:
+//        ```
+//        build_flags = -D_IR_ENABLE_DEFAULT_=false
+//                      -DDECODE_NEC=true
+//                      -DSEND_NEC=true
+//        ```
+//      If you want to enable support for every protocol *except* _decoding_ the
+//      Kelvinator protocol, you would use:
+//        `-DDECODE_KELVINATOR=false`
+#ifndef _IR_ENABLE_DEFAULT_
+#define _IR_ENABLE_DEFAULT_ true  // Unless set externally, the default is on.
+#endif  // _IR_ENABLE_DEFAULT_
+
 // Supported IR protocols
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to false) all the protocols you do not need/want!
 // The Air Conditioner protocols are the most expensive memory-wise.
 //
-#define DECODE_HASH            true  // Semi-unique code for unknown messages
 
-#define SEND_RAW               true
-
-#define DECODE_NEC             true
-#define SEND_NEC               true
-
-#define DECODE_SHERWOOD        true  // Doesn't exist. Actually is DECODE_NEC
-#define SEND_SHERWOOD          true
-
-#define DECODE_RC5             true
-#define SEND_RC5               true
-
-#define DECODE_RC6             true
-#define SEND_RC6               true
-
-#define DECODE_RCMM            true
-#define SEND_RCMM              true
-
-#define DECODE_SONY            true
-#define SEND_SONY              true
-
-#define DECODE_PANASONIC       true
-#define SEND_PANASONIC         true
-
-#define DECODE_JVC             true
-#define SEND_JVC               true
-
-#define DECODE_SAMSUNG         true
-#define SEND_SAMSUNG           true
-
-#define DECODE_SAMSUNG36       true
-#define SEND_SAMSUNG36         true
-
-#define DECODE_SAMSUNG_AC      true
-#define SEND_SAMSUNG_AC        true
-
-#define DECODE_WHYNTER         true
-#define SEND_WHYNTER           true
-
-#define DECODE_AIWA_RC_T501    true
-#define SEND_AIWA_RC_T501      true
-
-#define DECODE_LG              true
-#define SEND_LG                true
-
-#define DECODE_SANYO           true
-#define SEND_SANYO             true
-
-#define DECODE_MITSUBISHI      true
-#define SEND_MITSUBISHI        true
-
-#define DECODE_MITSUBISHI2     true
-#define SEND_MITSUBISHI2       true
-
-#define DECODE_DISH            true
-#define SEND_DISH              true
-
-#define DECODE_SHARP           true
-#define SEND_SHARP             true
-
-#define DECODE_SHARP_AC        true
-#define SEND_SHARP_AC          true
-
-#define DECODE_DENON           true
-#define SEND_DENON             true
-
-#define DECODE_KELVINATOR      true
-#define SEND_KELVINATOR        true
-
-#define DECODE_MITSUBISHI_AC   true  // Beta.
-#define SEND_MITSUBISHI_AC     true
-
-#define DECODE_MITSUBISHI136   true
-#define SEND_MITSUBISHI136     true
-
-#define DECODE_MITSUBISHI112   true
-#define SEND_MITSUBISHI112     true
-
-#define DECODE_FUJITSU_AC      true
-#define SEND_FUJITSU_AC        true
-
-#define DECODE_INAX            true
-#define SEND_INAX              true
-
-#define DECODE_DAIKIN          true
-#define SEND_DAIKIN            true
-
-#define DECODE_COOLIX          true
-#define SEND_COOLIX            true
-
-#define DECODE_GLOBALCACHE     false  // Not written.
-#define SEND_GLOBALCACHE       true
-
-#define DECODE_GOODWEATHER     true
-#define SEND_GOODWEATHER       true
-
-#define DECODE_GREE            true
-#define SEND_GREE              true
-
-#define DECODE_PRONTO          false  // Not written.
-#define SEND_PRONTO            true
-
-#define DECODE_ARGO            true  // Experimental
-#define SEND_ARGO              true
-
-#define DECODE_TROTEC          true
-#define SEND_TROTEC            true
-
-#define DECODE_NIKAI           true
-#define SEND_NIKAI             true
-
-#define DECODE_TOSHIBA_AC      true
-#define SEND_TOSHIBA_AC        true
-
-#define DECODE_MAGIQUEST       true
-#define SEND_MAGIQUEST         true
-
-#define DECODE_MIDEA           true
-#define SEND_MIDEA             true
-
-#define DECODE_LASERTAG        true
-#define SEND_LASERTAG          true
-
-#define DECODE_CARRIER_AC      true
-#define SEND_CARRIER_AC        true
-
-#define DECODE_HAIER_AC        true
-#define SEND_HAIER_AC          true
-
-#define DECODE_HITACHI_AC      true
-#define SEND_HITACHI_AC        true
-
-#define DECODE_HITACHI_AC1     true
-#define SEND_HITACHI_AC1       true
-
-#define DECODE_HITACHI_AC2     true
-#define SEND_HITACHI_AC2       true
-
-#define DECODE_GICABLE         true
-#define SEND_GICABLE           true
-
-#define DECODE_HAIER_AC_YRW02  true
-#define SEND_HAIER_AC_YRW02    true
-
-#define DECODE_WHIRLPOOL_AC    true
-#define SEND_WHIRLPOOL_AC      true
-
-#define DECODE_LUTRON          true
-#define SEND_LUTRON            true
-
-#define DECODE_ELECTRA_AC      true
-#define SEND_ELECTRA_AC        true
-
-#define DECODE_PANASONIC_AC    true
-#define SEND_PANASONIC_AC      true
-
-#define DECODE_MWM             true
-#define SEND_MWM               true
-
-#define DECODE_PIONEER         true
-#define SEND_PIONEER           true
-
-#define DECODE_DAIKIN2         true
-#define SEND_DAIKIN2           true
-
-#define DECODE_VESTEL_AC       true
-#define SEND_VESTEL_AC         true
-
-#define DECODE_TECO            true
-#define SEND_TECO              true
-
-#define DECODE_TCL112AC        true
-#define SEND_TCL112AC          true
-
-#define DECODE_LEGOPF          true
-#define SEND_LEGOPF            true
-
-#define DECODE_MITSUBISHIHEAVY true
-#define SEND_MITSUBISHIHEAVY   true
-
-#define DECODE_DAIKIN216       true
-#define SEND_DAIKIN216         true
-
-#define DECODE_DAIKIN160       true
-#define SEND_DAIKIN160         true
-
-#define DECODE_NEOCLIMA        true
-#define SEND_NEOCLIMA          true
-
-#define DECODE_DAIKIN176       true
-#define SEND_DAIKIN176         true
-
-#define DECODE_DAIKIN128       true
-#define SEND_DAIKIN128         true
-
-#define DECODE_AMCOR           true
-#define SEND_AMCOR             true
-
-#define DECODE_DAIKIN152       true
-#define SEND_DAIKIN152         true
-
-#define DECODE_HITACHI_AC424   true
-#define SEND_HITACHI_AC424     true
+// Semi-unique code for unknown messages
+#ifndef DECODE_HASH
+#define DECODE_HASH            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HASH
+
+#ifndef SEND_RAW
+#define SEND_RAW               _IR_ENABLE_DEFAULT_
+#endif  // SEND_RAW
+
+#ifndef DECODE_NEC
+#define DECODE_NEC             _IR_ENABLE_DEFAULT_
+#endif  // DECODE_NEC
+#ifndef SEND_NEC
+#define SEND_NEC               _IR_ENABLE_DEFAULT_
+#endif  // SEND_NEC
+
+#ifndef DECODE_SHERWOOD
+#define DECODE_SHERWOOD        false  // Not applicable. Actually is DECODE_NEC
+#endif  // DECODE_SHERWOOD
+#ifndef SEND_SHERWOOD
+#define SEND_SHERWOOD          _IR_ENABLE_DEFAULT_
+#endif  // SEND_SHERWOOD
+
+#ifndef DECODE_RC5
+#define DECODE_RC5             _IR_ENABLE_DEFAULT_
+#endif  // DECODE_RC5
+#ifndef SEND_RC5
+#define SEND_RC5               _IR_ENABLE_DEFAULT_
+#endif  // SEND_RC5
+
+#ifndef DECODE_RC6
+#define DECODE_RC6             _IR_ENABLE_DEFAULT_
+#endif  // DECODE_RC6
+#ifndef SEND_RC6
+#define SEND_RC6               _IR_ENABLE_DEFAULT_
+#endif  // SEND_RC6
+
+#ifndef DECODE_RCMM
+#define DECODE_RCMM            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_RCMM
+#ifndef SEND_RCMM
+#define SEND_RCMM              _IR_ENABLE_DEFAULT_
+#endif  // SEND_RCMM
+
+#ifndef DECODE_SONY
+#define DECODE_SONY            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SONY
+#ifndef SEND_SONY
+#define SEND_SONY              _IR_ENABLE_DEFAULT_
+#endif  // SEND_SONY
+
+#ifndef DECODE_PANASONIC
+#define DECODE_PANASONIC       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_PANASONIC
+#ifndef SEND_PANASONIC
+#define SEND_PANASONIC         _IR_ENABLE_DEFAULT_
+#endif  // SEND_PANASONIC
+
+#ifndef DECODE_JVC
+#define DECODE_JVC             _IR_ENABLE_DEFAULT_
+#endif  // DECODE_JVC
+#ifndef SEND_JVC
+#define SEND_JVC               _IR_ENABLE_DEFAULT_
+#endif  // SEND_JVC
+
+#ifndef DECODE_SAMSUNG
+#define DECODE_SAMSUNG         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SAMSUNG
+#ifndef SEND_SAMSUNG
+#define SEND_SAMSUNG           _IR_ENABLE_DEFAULT_
+#endif  // SEND_SAMSUNG
+
+#ifndef DECODE_SAMSUNG36
+#define DECODE_SAMSUNG36       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SAMSUNG36
+#ifndef SEND_SAMSUNG36
+#define SEND_SAMSUNG36         _IR_ENABLE_DEFAULT_
+#endif  // SEND_SAMSUNG36
+
+#ifndef DECODE_SAMSUNG_AC
+#define DECODE_SAMSUNG_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SAMSUNG_AC
+#ifndef SEND_SAMSUNG_AC
+#define SEND_SAMSUNG_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_SAMSUNG_AC
+
+#ifndef DECODE_WHYNTER
+#define DECODE_WHYNTER         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_WHYNTER
+#ifndef SEND_WHYNTER
+#define SEND_WHYNTER           _IR_ENABLE_DEFAULT_
+#endif  // SEND_WHYNTER
+
+#ifndef DECODE_AIWA_RC_T501
+#define DECODE_AIWA_RC_T501    _IR_ENABLE_DEFAULT_
+#endif  // DECODE_AIWA_RC_T501
+#ifndef SEND_AIWA_RC_T501
+#define SEND_AIWA_RC_T501      _IR_ENABLE_DEFAULT_
+#endif  // SEND_AIWA_RC_T501
+
+#ifndef DECODE_LG
+#define DECODE_LG              _IR_ENABLE_DEFAULT_
+#endif  // DECODE_LG
+#ifndef SEND_LG
+#define SEND_LG                _IR_ENABLE_DEFAULT_
+#endif  // SEND_LG
+
+#ifndef DECODE_SANYO
+#define DECODE_SANYO           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SANYO
+#ifndef SEND_SANYO
+#define SEND_SANYO             _IR_ENABLE_DEFAULT_
+#endif  // SEND_SANYO
+
+#ifndef DECODE_MITSUBISHI
+#define DECODE_MITSUBISHI      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHI
+#ifndef SEND_MITSUBISHI
+#define SEND_MITSUBISHI        _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHI
+
+#ifndef DECODE_MITSUBISHI2
+#define DECODE_MITSUBISHI2     _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHI2
+#ifndef SEND_MITSUBISHI2
+#define SEND_MITSUBISHI2       _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHI2
+
+#ifndef DECODE_DISH
+#define DECODE_DISH            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DISH
+#ifndef SEND_DISH
+#define SEND_DISH              _IR_ENABLE_DEFAULT_
+#endif  // SEND_DISH
+
+#ifndef DECODE_SHARP
+#define DECODE_SHARP           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SHARP
+#ifndef SEND_SHARP
+#define SEND_SHARP             _IR_ENABLE_DEFAULT_
+#endif  // SEND_SHARP
+
+#ifndef DECODE_SHARP_AC
+#define DECODE_SHARP_AC        _IR_ENABLE_DEFAULT_
+#endif  // DECODE_SHARP_AC
+#ifndef SEND_SHARP_AC
+#define SEND_SHARP_AC          _IR_ENABLE_DEFAULT_
+#endif  // SEND_SHARP_AC
+
+#ifndef DECODE_DENON
+#define DECODE_DENON           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DENON
+#ifndef SEND_DENON
+#define SEND_DENON             _IR_ENABLE_DEFAULT_
+#endif  // SEND_DENON
+
+#ifndef DECODE_KELVINATOR
+#define DECODE_KELVINATOR      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_KELVINATOR
+#ifndef SEND_KELVINATOR
+#define SEND_KELVINATOR        _IR_ENABLE_DEFAULT_
+#endif  // SEND_KELVINATOR
+
+#ifndef DECODE_MITSUBISHI_AC
+#define DECODE_MITSUBISHI_AC   _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHI_AC
+#ifndef SEND_MITSUBISHI_AC
+#define SEND_MITSUBISHI_AC     _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHI_AC
+
+#ifndef DECODE_MITSUBISHI136
+#define DECODE_MITSUBISHI136   _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHI136
+#ifndef SEND_MITSUBISHI136
+#define SEND_MITSUBISHI136     _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHI136
+
+#ifndef DECODE_MITSUBISHI112
+#define DECODE_MITSUBISHI112   _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHI112
+#ifndef SEND_MITSUBISHI112
+#define SEND_MITSUBISHI112     _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHI112
+
+#ifndef DECODE_FUJITSU_AC
+#define DECODE_FUJITSU_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_FUJITSU_AC
+#ifndef SEND_FUJITSU_AC
+#define SEND_FUJITSU_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_FUJITSU_AC
+
+#ifndef DECODE_INAX
+#define DECODE_INAX            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_INAX
+#ifndef SEND_INAX
+#define SEND_INAX              _IR_ENABLE_DEFAULT_
+#endif  // SEND_INAX
+
+#ifndef DECODE_DAIKIN
+#define DECODE_DAIKIN          _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN
+#ifndef SEND_DAIKIN
+#define SEND_DAIKIN            _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN
+
+#ifndef DECODE_COOLIX
+#define DECODE_COOLIX          _IR_ENABLE_DEFAULT_
+#endif  // DECODE_COOLIX
+#ifndef SEND_COOLIX
+#define SEND_COOLIX            _IR_ENABLE_DEFAULT_
+#endif  // SEND_COOLIX
+
+#ifndef DECODE_GLOBALCACHE
+#define DECODE_GLOBALCACHE     false  // Not applicable.
+#endif  // DECODE_GLOBALCACHE
+#ifndef SEND_GLOBALCACHE
+#define SEND_GLOBALCACHE       _IR_ENABLE_DEFAULT_
+#endif  // SEND_GLOBALCACHE
+
+#ifndef DECODE_GOODWEATHER
+#define DECODE_GOODWEATHER     _IR_ENABLE_DEFAULT_
+#endif  // DECODE_GOODWEATHER
+#ifndef SEND_GOODWEATHER
+#define SEND_GOODWEATHER       _IR_ENABLE_DEFAULT_
+#endif  // SEND_GOODWEATHER
+
+#ifndef DECODE_GREE
+#define DECODE_GREE            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_GREE
+#ifndef SEND_GREE
+#define SEND_GREE              _IR_ENABLE_DEFAULT_
+#endif  // SEND_GREE
+
+#ifndef DECODE_PRONTO
+#define DECODE_PRONTO          false  // Not applicable.
+#endif  // DECODE_PRONTO
+#ifndef SEND_PRONTO
+#define SEND_PRONTO            _IR_ENABLE_DEFAULT_
+#endif  // SEND_PRONTO
+
+#ifndef DECODE_ARGO
+#define DECODE_ARGO            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_ARGO
+#ifndef SEND_ARGO
+#define SEND_ARGO              _IR_ENABLE_DEFAULT_
+#endif  // SEND_ARGO
+
+#ifndef DECODE_TROTEC
+#define DECODE_TROTEC          _IR_ENABLE_DEFAULT_
+#endif  // DECODE_TROTEC
+#ifndef SEND_TROTEC
+#define SEND_TROTEC            _IR_ENABLE_DEFAULT_
+#endif  // SEND_TROTEC
+
+#ifndef DECODE_NIKAI
+#define DECODE_NIKAI           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_NIKAI
+#ifndef SEND_NIKAI
+#define SEND_NIKAI             _IR_ENABLE_DEFAULT_
+#endif  // SEND_NIKAI
+
+#ifndef DECODE_TOSHIBA_AC
+#define DECODE_TOSHIBA_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_TOSHIBA_AC
+#ifndef SEND_TOSHIBA_AC
+#define SEND_TOSHIBA_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_TOSHIBA_AC
+
+#ifndef DECODE_MAGIQUEST
+#define DECODE_MAGIQUEST       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MAGIQUEST
+#ifndef SEND_MAGIQUEST
+#define SEND_MAGIQUEST         _IR_ENABLE_DEFAULT_
+#endif  // SEND_MAGIQUEST
+
+#ifndef DECODE_MIDEA
+#define DECODE_MIDEA           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MIDEA
+#ifndef SEND_MIDEA
+#define SEND_MIDEA             _IR_ENABLE_DEFAULT_
+#endif  // SEND_MIDEA
+
+#ifndef DECODE_LASERTAG
+#define DECODE_LASERTAG        _IR_ENABLE_DEFAULT_
+#endif  // DECODE_LASERTAG
+#ifndef SEND_LASERTAG
+#define SEND_LASERTAG          _IR_ENABLE_DEFAULT_
+#endif  // SEND_LASERTAG
+
+#ifndef DECODE_CARRIER_AC
+#define DECODE_CARRIER_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_CARRIER_AC
+#ifndef SEND_CARRIER_AC
+#define SEND_CARRIER_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_CARRIER_AC
+
+#ifndef DECODE_HAIER_AC
+#define DECODE_HAIER_AC        _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HAIER_AC
+#ifndef SEND_HAIER_AC
+#define SEND_HAIER_AC          _IR_ENABLE_DEFAULT_
+#endif  // SEND_HAIER_AC
+
+#ifndef DECODE_HITACHI_AC
+#define DECODE_HITACHI_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HITACHI_AC
+#ifndef SEND_HITACHI_AC
+#define SEND_HITACHI_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_HITACHI_AC
+
+#ifndef DECODE_HITACHI_AC1
+#define DECODE_HITACHI_AC1     _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HITACHI_AC1
+#ifndef SEND_HITACHI_AC1
+#define SEND_HITACHI_AC1       _IR_ENABLE_DEFAULT_
+#endif  // SEND_HITACHI_AC1
+
+#ifndef DECODE_HITACHI_AC2
+#define DECODE_HITACHI_AC2     _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HITACHI_AC2
+#ifndef SEND_HITACHI_AC2
+#define SEND_HITACHI_AC2       _IR_ENABLE_DEFAULT_
+#endif  // SEND_HITACHI_AC2
+
+#ifndef DECODE_GICABLE
+#define DECODE_GICABLE         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_GICABLE
+#ifndef SEND_GICABLE
+#define SEND_GICABLE           _IR_ENABLE_DEFAULT_
+#endif  // SEND_GICABLE
+
+#ifndef DECODE_HAIER_AC_YRW02
+#define DECODE_HAIER_AC_YRW02  _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HAIER_AC_YRW02
+#ifndef SEND_HAIER_AC_YRW02
+#define SEND_HAIER_AC_YRW02    _IR_ENABLE_DEFAULT_
+#endif  // SEND_HAIER_AC_YRW02
+
+#ifndef DECODE_WHIRLPOOL_AC
+#define DECODE_WHIRLPOOL_AC    _IR_ENABLE_DEFAULT_
+#endif  // DECODE_WHIRLPOOL_AC
+#ifndef SEND_WHIRLPOOL_AC
+#define SEND_WHIRLPOOL_AC      _IR_ENABLE_DEFAULT_
+#endif  // SEND_WHIRLPOOL_AC
+
+#ifndef DECODE_LUTRON
+#define DECODE_LUTRON          _IR_ENABLE_DEFAULT_
+#endif  // DECODE_LUTRON
+#ifndef SEND_LUTRON
+#define SEND_LUTRON            _IR_ENABLE_DEFAULT_
+#endif  // SEND_LUTRON
+
+#ifndef DECODE_ELECTRA_AC
+#define DECODE_ELECTRA_AC      _IR_ENABLE_DEFAULT_
+#endif  // DECODE_ELECTRA_AC
+#ifndef SEND_ELECTRA_AC
+#define SEND_ELECTRA_AC        _IR_ENABLE_DEFAULT_
+#endif  // SEND_ELECTRA_AC
+
+#ifndef DECODE_PANASONIC_AC
+#define DECODE_PANASONIC_AC    _IR_ENABLE_DEFAULT_
+#endif  // DECODE_PANASONIC_AC
+#ifndef SEND_PANASONIC_AC
+#define SEND_PANASONIC_AC      _IR_ENABLE_DEFAULT_
+#endif  // SEND_PANASONIC_AC
+
+#ifndef DECODE_MWM
+#define DECODE_MWM             _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MWM
+#ifndef SEND_MWM
+#define SEND_MWM               _IR_ENABLE_DEFAULT_
+#endif  // SEND_MWM
+
+#ifndef DECODE_PIONEER
+#define DECODE_PIONEER         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_PIONEER
+#ifndef SEND_PIONEER
+#define SEND_PIONEER           _IR_ENABLE_DEFAULT_
+#endif  // SEND_PIONEER
+
+#ifndef DECODE_DAIKIN2
+#define DECODE_DAIKIN2         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN2
+#ifndef SEND_DAIKIN2
+#define SEND_DAIKIN2           _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN2
+
+#ifndef DECODE_VESTEL_AC
+#define DECODE_VESTEL_AC       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_VESTEL_AC
+#ifndef SEND_VESTEL_AC
+#define SEND_VESTEL_AC         _IR_ENABLE_DEFAULT_
+#endif  // SEND_VESTEL_AC
+
+#ifndef DECODE_TECO
+#define DECODE_TECO            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_TECO
+#ifndef SEND_TECO
+#define SEND_TECO              _IR_ENABLE_DEFAULT_
+#endif  // SEND_TECO
+
+#ifndef DECODE_TCL112AC
+#define DECODE_TCL112AC        _IR_ENABLE_DEFAULT_
+#endif  // DECODE_TCL112AC
+#ifndef SEND_TCL112AC
+#define SEND_TCL112AC          _IR_ENABLE_DEFAULT_
+#endif  // SEND_TCL112AC
+
+#ifndef DECODE_LEGOPF
+#define DECODE_LEGOPF          _IR_ENABLE_DEFAULT_
+#endif  // DECODE_LEGOPF
+#ifndef SEND_LEGOPF
+#define SEND_LEGOPF            _IR_ENABLE_DEFAULT_
+#endif  // SEND_LEGOPF
+
+#ifndef DECODE_MITSUBISHIHEAVY
+#define DECODE_MITSUBISHIHEAVY _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MITSUBISHIHEAVY
+#ifndef SEND_MITSUBISHIHEAVY
+#define SEND_MITSUBISHIHEAVY   _IR_ENABLE_DEFAULT_
+#endif  // SEND_MITSUBISHIHEAVY
+
+#ifndef DECODE_DAIKIN216
+#define DECODE_DAIKIN216       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN216
+#ifndef SEND_DAIKIN216
+#define SEND_DAIKIN216         _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN216
+
+#ifndef DECODE_DAIKIN160
+#define DECODE_DAIKIN160       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN160
+#ifndef SEND_DAIKIN160
+#define SEND_DAIKIN160         _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN160
+
+#ifndef DECODE_NEOCLIMA
+#define DECODE_NEOCLIMA        _IR_ENABLE_DEFAULT_
+#endif  // DECODE_NEOCLIMA
+#ifndef SEND_NEOCLIMA
+#define SEND_NEOCLIMA          _IR_ENABLE_DEFAULT_
+#endif  // SEND_NEOCLIMA
+
+#ifndef DECODE_DAIKIN176
+#define DECODE_DAIKIN176       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN176
+#ifndef SEND_DAIKIN176
+#define SEND_DAIKIN176         _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN176
+
+#ifndef DECODE_DAIKIN128
+#define DECODE_DAIKIN128       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN128
+#ifndef SEND_DAIKIN128
+#define SEND_DAIKIN128         _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN128
+
+#ifndef DECODE_AMCOR
+#define DECODE_AMCOR           _IR_ENABLE_DEFAULT_
+#endif  // DECODE_AMCOR
+#ifndef SEND_AMCOR
+#define SEND_AMCOR             _IR_ENABLE_DEFAULT_
+#endif  // SEND_AMCOR
+
+#ifndef DECODE_DAIKIN152
+#define DECODE_DAIKIN152       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_DAIKIN152
+#ifndef SEND_DAIKIN152
+#define SEND_DAIKIN152         _IR_ENABLE_DEFAULT_
+#endif  // SEND_DAIKIN152
+
+#ifndef DECODE_HITACHI_AC424
+#define DECODE_HITACHI_AC424   _IR_ENABLE_DEFAULT_
+#endif  // DECODE_HITACHI_AC424
+#ifndef SEND_HITACHI_AC424
+#define SEND_HITACHI_AC424     _IR_ENABLE_DEFAULT_
+#endif  // SEND_HITACHI_AC424
 
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
@@ -289,7 +585,9 @@
 // Note: If you plan to send IR messages in the callbacks of the AsyncWebserver
 //       library, you need to set ALLOW_DELAY_CALLS to false.
 //       Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/430
+#ifndef ALLOW_DELAY_CALLS
 #define ALLOW_DELAY_CALLS true
+#endif  // ALLOW_DELAY_CALLS
 
 /*
  * Always add to the end of the list and should never remove entries


### PR DESCRIPTION
Allow users of the library to externally control which protocols are 
used/enabled/compiled without having to modify the `IRremoteESP8266.h` 
file.
i.e. `SEND_BLAH` & `DECODE_BLAH` can be controled with preprocessor 
compiler flags (see 
https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html)
e.g. `-DDECODE_KELVINATOR=false`

Fixes #1012