### PR TITLE
Add note to avoid GPIO16 on the ESP8266 for receiving.

### DIFF
--- a/examples/DumbIRRepeater/DumbIRRepeater.ino
+++ b/examples/DumbIRRepeater/DumbIRRepeater.ino
@@ -37,6 +37,8 @@
  *     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
  *     * Pin 1/TX/TXD0: Any serial transmissions from the ESP will interfere.
  *     * Pin 3/RX/RXD0: Any serial transmissions to the ESP will interfere.
+ *     * Pin 16/D0: Has no interrupts on the ESP8266, so can't be used for IR
+ *       receiving with this library.
  *   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
  *     for your first time. e.g. ESP-12 etc.
  *
@@ -54,6 +56,7 @@
 // ==================== start of TUNEABLE PARAMETERS ====================
 
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 const uint16_t kRecvPin = 14;
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -47,6 +47,7 @@ const int8_t kDefaultIrLed = 4;  // <=- CHANGE_ME (optional)
 const bool kInvertTxOutput = false;
 
 // Default GPIO the IR demodulator is connected to/controlled by. GPIO 14 = D5.
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 const int8_t kDefaultIrRx = 14;  // <=- CHANGE_ME (optional)
 
 // Enable/disable receiving/decoding IR messages entirely.

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -23,6 +23,7 @@
 
 // An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU
 // board).
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 const uint16_t kRecvPin = 14;
 
 IRrecv irrecv(kRecvPin);

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -34,6 +34,7 @@
 // ==================== start of TUNEABLE PARAMETERS ====================
 // An IR detector/demodulator is connected to GPIO pin 14
 // e.g. D5 on a NodeMCU board.
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 const uint16_t kRecvPin = 14;
 
 // The Serial connection baud rate.

--- a/examples/SmartIRRepeater/SmartIRRepeater.ino
+++ b/examples/SmartIRRepeater/SmartIRRepeater.ino
@@ -40,6 +40,8 @@
  *     * Pin 0/D3: Can interfere with the boot/program mode & support circuits.
  *     * Pin 1/TX/TXD0: Any serial transmissions from the ESP will interfere.
  *     * Pin 3/RX/RXD0: Any serial transmissions to the ESP will interfere.
+ *     * Pin 16/D0: Has no interrupts on the ESP8266, so can't be used for IR
+ *       receiving with this library.
  *   * ESP-01 modules are tricky. We suggest you use a module with more GPIOs
  *     for your first time. e.g. ESP-12 etc.
  *
@@ -57,6 +59,7 @@
 // ==================== start of TUNEABLE PARAMETERS ====================
 
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 const uint16_t kRecvPin = 14;
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).


### PR DESCRIPTION
GPIO16 has no interrupt support on the ESP8266.
Thus it can't be used to receive IR messages.

Fixes #1015