### PR TITLE
Add ac.on() to decodeToState() for COOLIX

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -2232,6 +2232,7 @@ namespace IRAcUtils {
 #if DECODE_COOLIX
       case decode_type_t::COOLIX: {
         IRCoolixAC ac(kGpioUnused);
+        ac.on();
         ac.setRaw(decode->value);  // Uses value instead of state.
         *result = ac.toCommon(prev);
         break;


### PR DESCRIPTION
When decoding COOLIX received message, Power is always set to Off.

There is a difference between `resultAcToString()` and `decodeToState()`. `resultAcToString()` forces `ac.on()` for COOLIX, but it is missing in `decodeToState()` causing the COOLIX power to be always off.

Also see https://github.com/arendst/Tasmota/issues/7660

Can you please confirm this is the right fix?