### PR TITLE
[Bug] Coolix: `setRaw()` doesn't update power state.

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -130,6 +130,7 @@ void IRCoolixAC::send(const uint16_t repeat) {
 uint32_t IRCoolixAC::getRaw() { return remote_state; }
 
 void IRCoolixAC::setRaw(const uint32_t new_code) {
+  powerFlag = true;  // Everything that is not the special power off mesg is On.
   if (!handleSpecialState(new_code)) {
     // it isn`t special so might affect Temp|mode|Fan
     if (new_code == kCoolixCmdFan) {


### PR DESCRIPTION
Coolix's `setRaw()` didn't update the internal power state for the 
object if it was NOT a power off message.
Coolix is unusual in that there is no On flag/bit. Everything is an ON 
message unless is the special OFF message.

Replaces #1040 (which was a superficial fix)
Ref: https://github.com/arendst/Tasmota/issues/7660