### PR TITLE
Add options to `decode()` to aid detection.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -307,7 +307,7 @@ void IRrecv::setTolerance(const uint8_t percent) {
 // Get the base tolerance percentage for matching incoming IR messages.
 uint8_t IRrecv::getTolerance(void) { return _tolerance; }
 
-#if ENABLE_HIGHPASS_FILTER_OPTION
+#if ENABLE_NOISE_FILTER_OPTION
 // Remove or merge pulses in the capture buffer that are too short.
 // Args:
 //   results:  Ptr to the decode_results we are going to filter/modify.
@@ -334,7 +334,7 @@ void IRrecv::crudeHighPassFilter(decode_results *results, const uint8_t floor) {
     }
   }
 }
-#endif  // ENABLE_HIGHPASS_FILTER_OPTION
+#endif  // ENABLE_NOISE_FILTER_OPTION
 
 // Decodes the received IR message.
 // If the interrupt state is saved, we will immediately resume waiting
@@ -426,9 +426,9 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
   results->command = 0;
   results->repeat = false;
 
-#if ENABLE_HIGHPASS_FILTER_OPTION
+#if ENABLE_NOISE_FILTER_OPTION
   crudeHighPassFilter(results, noise_floor);
-#endif  // ENABLE_HIGHPASS_FILTER_OPTION
+#endif  // ENABLE_NOISE_FILTER_OPTION
   // Keep looking for protocols until we've run out of entries to skip or we
   // find a valid protocol message.
   for (uint16_t offset = kStartOffset;

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -321,7 +321,7 @@ void IRrecv::crudeNoiseFilter(decode_results *results, const uint16_t floor) {
     uint16_t curr = results->rawbuf[offset];
     uint16_t next = results->rawbuf[offset + 1];
     uint16_t addition = curr + next;
-    if (curr < kTickFloor) {  // Is it to short?
+    if (curr < kTickFloor) {  // Is it too short?
       // Shuffle the buffer down. i.e. Remove the mark & space pair.
       // Note: `memcpy()` can't be used as rawbuf is `volatile`.
       for (uint16_t i = offset + 2; i <= results->rawlen && i < kBufSize; i++)

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -312,7 +312,7 @@ uint8_t IRrecv::getTolerance(void) { return _tolerance; }
 // Args:
 //   results:  Ptr to the decode_results we are going to filter/modify.
 //   floor:  Only allow values in the buffer large than this. (in micro seconds)
-void IRrecv::crudeHighPassFilter(decode_results *results, const uint8_t floor) {
+void IRrecv::crudeNoiseFilter(decode_results *results, const uint8_t floor) {
   if (floor == 0) return;  // Nothing to do.
   const uint8_t kTickFloor = floor / kRawTick;
   for (uint16_t offset = kStartOffset; offset + 1 < results->rawlen;) {
@@ -427,7 +427,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
   results->repeat = false;
 
 #if ENABLE_NOISE_FILTER_OPTION
-  crudeHighPassFilter(results, noise_floor);
+  crudeNoiseFilter(results, noise_floor);
 #endif  // ENABLE_NOISE_FILTER_OPTION
   // Keep looking for protocols until we've run out of entries to skip or we
   // find a valid protocol message.

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -307,6 +307,35 @@ void IRrecv::setTolerance(const uint8_t percent) {
 // Get the base tolerance percentage for matching incoming IR messages.
 uint8_t IRrecv::getTolerance(void) { return _tolerance; }
 
+#if ENABLE_HIGHPASS_FILTER_OPTION
+// Remove or merge pulses in the capture buffer that are too short.
+// Args:
+//   results:  Ptr to the decode_results we are going to filter/modify.
+//   floor:  Only allow values in the buffer large than this. (in micro seconds)
+void IRrecv::crudeHighPassFilter(decode_results *results, const uint8_t floor) {
+  if (floor == 0) return;  // Nothing to do.
+  const uint8_t kTickFloor = floor / kRawTick;
+  for (uint16_t offset = kStartOffset; offset + 1 < results->rawlen;) {
+    uint16_t curr = results->rawbuf[offset];
+    uint16_t next = results->rawbuf[offset + 1];
+    uint16_t addition = curr + next;
+    if (curr < kTickFloor) {  // Is it to short?
+      // Shuffle the buffer down. i.e. Remove the mark & space pair.
+      // Note: `memcpy()` can't be used as rawbuf is `volatile`.
+      for (uint16_t i = offset + 2; i < results->rawlen; i++)
+        results->rawbuf[i - 2] = results->rawbuf[i];
+      if (offset > 1) {  // There is a previous pair we can add to.
+        // Merge this pair into into the previous space.
+        results->rawbuf[offset - 1] += addition;
+      }
+      results->rawlen -= 2;  // Adjust the length.
+    } else {
+      offset++;  // Move along.
+    }
+  }
+}
+#endif  // ENABLE_HIGHPASS_FILTER_OPTION
+
 // Decodes the received IR message.
 // If the interrupt state is saved, we will immediately resume waiting
 // for the next IR message to avoid missing messages.
@@ -317,9 +346,41 @@ uint8_t IRrecv::getTolerance(void) { return _tolerance; }
 //   results:  A pointer to where the decoded IR message will be stored.
 //   save:  A pointer to an irparams_t instance in which to save
 //          the interrupt's memory/state. NULL means don't save it.
+//   max_skip:  Maximum Nr. of pulses at the begining of a capture we can skip
+//              when attempting to find a protocol we can successfully decode.
+//              This parameter can dramatically improve detection of protocols
+//              when there is light IR interference just before an incoming IR
+//              message, however, it comes at a steep performace price.
+//              CAUTION: Increasing this value will dramatically (linnearly)
+//                       increase the cpu time & usage to decode protocols.
+//                       e.g. 0 -> 1 will be a 2x increase in cpu usage/time.
+//                            0 -> 2 will be a 3x increase etc.
+//                       If you are going to do this, consider disabling
+//                       protocol decoding for protocols you are not expecting.
+//              (Default is 0. No skipping.)
+//   noise_floor:  Pulses below this size (in usecs) will be removed or merged
+//                 prior to any decoding. This is to try to remove noise/poor
+//                 readings & slighly increase the chances of a successful
+//                 decode but at the cost of data fidelity & integrity.
+//                 (Defaults to 0 usecs. i.e. Don't filter; which is safe!)
+//                 DANGER: **Here Be Dragons!**
+//                   If you set the `filter_floor` value too high, it **WILL**
+//                   break decoding of some protocols. You have been warned!
+//                   **Any** non-zero value has the potential to **cook** the
+//                   captured raw data. i.e. The data is going to lie to you.
+//                   It may obscure hardware, circuit, & environment issues thus
+//                   making it impossible to support you accurately or
+//                   confidently.
+//                   Values of <= 50 usecs will probably be safe.
+//                   51 - 100 usecs **might** be okay.
+//                   100 - 150 usecs is "Danger, Will Robinson!".
+//                   150 - 200 usecs expect broken protocols.
+//                   At 200+ usecs, you **have** protocols you can't decode!!
+//
 // Returns:
 //   A boolean indicating if an IR message is ready or not.
-bool IRrecv::decode(decode_results *results, irparams_t *save) {
+bool IRrecv::decode(decode_results *results, irparams_t *save,
+                    uint8_t max_skip, uint8_t noise_floor) {
   // Proceed only if an IR message been received.
 #ifndef UNIT_TEST
   if (irparams.rcvstate != kStopState) return false;
@@ -365,320 +426,334 @@ bool IRrecv::decode(decode_results *results, irparams_t *save) {
   results->command = 0;
   results->repeat = false;
 
+#if ENABLE_HIGHPASS_FILTER_OPTION
+  crudeHighPassFilter(results, noise_floor);
+#endif  // ENABLE_HIGHPASS_FILTER_OPTION
+  // Keep looking for protocols until we've run out of entries to skip or we
+  // find a valid protocol message.
+  for (uint16_t offset = kStartOffset;
+       offset <= (max_skip * 2) + kStartOffset;
+       offset += 2) {
 #if DECODE_AIWA_RC_T501
-  DPRINTLN("Attempting Aiwa RC T501 decode");
-  // Try decodeAiwaRCT501() before decodeSanyoLC7461() & decodeNEC()
-  // because the protocols are similar. This protocol is more specific than
-  // those ones, so should got before them.
-  if (decodeAiwaRCT501(results)) return true;
+    DPRINTLN("Attempting Aiwa RC T501 decode");
+    // Try decodeAiwaRCT501() before decodeSanyoLC7461() & decodeNEC()
+    // because the protocols are similar. This protocol is more specific than
+    // those ones, so should go before them.
+    if (decodeAiwaRCT501(results, offset)) return true;
 #endif
 #if DECODE_SANYO
-  DPRINTLN("Attempting Sanyo LC7461 decode");
-  // Try decodeSanyoLC7461() before decodeNEC() because the protocols are
-  // similar in timings & structure, but the Sanyo one is much longer than the
-  // NEC protocol (42 vs 32 bits) so this one should be tried first to try to
-  // reduce false detection as a NEC packet.
-  if (decodeSanyoLC7461(results)) return true;
+    DPRINTLN("Attempting Sanyo LC7461 decode");
+    // Try decodeSanyoLC7461() before decodeNEC() because the protocols are
+    // similar in timings & structure, but the Sanyo one is much longer than the
+    // NEC protocol (42 vs 32 bits) so this one should be tried first to try to
+    // reduce false detection as a NEC packet.
+    if (decodeSanyoLC7461(results, offset)) return true;
 #endif
 #if DECODE_CARRIER_AC
-  DPRINTLN("Attempting Carrier AC decode");
-  // Try decodeCarrierAC() before decodeNEC() because the protocols are
-  // similar in timings & structure, but the Carrier one is much longer than the
-  // NEC protocol (3x32 bits vs 1x32 bits) so this one should be tried first to
-  // try to reduce false detection as a NEC packet.
-  if (decodeCarrierAC(results)) return true;
+    DPRINTLN("Attempting Carrier AC decode");
+    // Try decodeCarrierAC() before decodeNEC() because the protocols are
+    // similar in timings & structure, but the Carrier one is much longer than
+    // the NEC protocol (3x32 bits vs 1x32 bits) so this one should be tried
+    // first to try to reduce false detection as a NEC packet.
+    if (decodeCarrierAC(results, offset)) return true;
 #endif
 #if DECODE_PIONEER
-  DPRINTLN("Attempting Pioneer decode");
-  // Try decodePioneer() before decodeNEC() because the protocols are
-  // similar in timings & structure, but the Pioneer one is much longer than the
-  // NEC protocol (2x32 bits vs 1x32 bits) so this one should be tried first to
-  // try to reduce false detection as a NEC packet.
-  if (decodePioneer(results)) return true;
+    DPRINTLN("Attempting Pioneer decode");
+    // Try decodePioneer() before decodeNEC() because the protocols are
+    // similar in timings & structure, but the Pioneer one is much longer than
+    // the NEC protocol (2x32 bits vs 1x32 bits) so this one should be tried
+    // first to try to reduce false detection as a NEC packet.
+    if (decodePioneer(results, offset)) return true;
 #endif
 #if DECODE_NEC
-  DPRINTLN("Attempting NEC decode");
-  if (decodeNEC(results)) return true;
+    DPRINTLN("Attempting NEC decode");
+    if (decodeNEC(results, offset)) return true;
 #endif
 #if DECODE_SONY
-  DPRINTLN("Attempting Sony decode");
-  if (decodeSony(results)) return true;
+    DPRINTLN("Attempting Sony decode");
+    if (decodeSony(results, offset)) return true;
 #endif
 #if DECODE_MITSUBISHI
-  DPRINTLN("Attempting Mitsubishi decode");
-  if (decodeMitsubishi(results)) return true;
+    DPRINTLN("Attempting Mitsubishi decode");
+    if (decodeMitsubishi(results, offset)) return true;
 #endif
 #if DECODE_MITSUBISHI_AC
-  DPRINTLN("Attempting Mitsubishi AC decode");
-  if (decodeMitsubishiAC(results)) return true;
+    DPRINTLN("Attempting Mitsubishi AC decode");
+    if (decodeMitsubishiAC(results, offset)) return true;
 #endif
 #if DECODE_MITSUBISHI2
-  DPRINTLN("Attempting Mitsubishi2 decode");
-  if (decodeMitsubishi2(results)) return true;
+    DPRINTLN("Attempting Mitsubishi2 decode");
+    if (decodeMitsubishi2(results, offset)) return true;
 #endif
 #if DECODE_RC5
-  DPRINTLN("Attempting RC5 decode");
-  if (decodeRC5(results)) return true;
+    DPRINTLN("Attempting RC5 decode");
+    if (decodeRC5(results, offset)) return true;
 #endif
 #if DECODE_RC6
-  DPRINTLN("Attempting RC6 decode");
-  if (decodeRC6(results)) return true;
+    DPRINTLN("Attempting RC6 decode");
+    if (decodeRC6(results, offset)) return true;
 #endif
 #if DECODE_RCMM
-  DPRINTLN("Attempting RC-MM decode");
-  if (decodeRCMM(results)) return true;
+    DPRINTLN("Attempting RC-MM decode");
+    if (decodeRCMM(results, offset)) return true;
 #endif
 #if DECODE_FUJITSU_AC
-  // Fujitsu A/C needs to precede Panasonic and Denon as it has a short
-  // message which looks exactly the same as a Panasonic/Denon message.
-  DPRINTLN("Attempting Fujitsu A/C decode");
-  if (decodeFujitsuAC(results)) return true;
+    // Fujitsu A/C needs to precede Panasonic and Denon as it has a short
+    // message which looks exactly the same as a Panasonic/Denon message.
+    DPRINTLN("Attempting Fujitsu A/C decode");
+    if (decodeFujitsuAC(results, offset)) return true;
 #endif
 #if DECODE_DENON
-  // Denon needs to precede Panasonic as it is a special case of Panasonic.
-  DPRINTLN("Attempting Denon decode");
-  if (decodeDenon(results, kDenon48Bits) || decodeDenon(results, kDenonBits) ||
-      decodeDenon(results, kDenonLegacyBits))
-    return true;
+    // Denon needs to precede Panasonic as it is a special case of Panasonic.
+    DPRINTLN("Attempting Denon decode");
+    if (decodeDenon(results, offset, kDenon48Bits) ||
+        decodeDenon(results, offset, kDenonBits) ||
+        decodeDenon(results, offset, kDenonLegacyBits))
+      return true;
 #endif
 #if DECODE_PANASONIC
-  DPRINTLN("Attempting Panasonic decode");
-  if (decodePanasonic(results)) return true;
+    DPRINTLN("Attempting Panasonic decode");
+    if (decodePanasonic(results, offset)) return true;
 #endif
 #if DECODE_LG
-  DPRINTLN("Attempting LG (28-bit) decode");
-  if (decodeLG(results, kLgBits, true)) return true;
-  DPRINTLN("Attempting LG (32-bit) decode");
-  // LG32 should be tried before Samsung
-  if (decodeLG(results, kLg32Bits, true)) return true;
+    DPRINTLN("Attempting LG (28-bit) decode");
+    if (decodeLG(results, offset, kLgBits, true)) return true;
+    DPRINTLN("Attempting LG (32-bit) decode");
+    // LG32 should be tried before Samsung
+    if (decodeLG(results, offset, kLg32Bits, true)) return true;
 #endif
 #if DECODE_GICABLE
-  // Note: Needs to happen before JVC decode, because it looks similar except
-  //       with a required NEC-like repeat code.
-  DPRINTLN("Attempting GICable decode");
-  if (decodeGICable(results)) return true;
+    // Note: Needs to happen before JVC decode, because it looks similar except
+    //       with a required NEC-like repeat code.
+    DPRINTLN("Attempting GICable decode");
+    if (decodeGICable(results, offset)) return true;
 #endif
 #if DECODE_JVC
-  DPRINTLN("Attempting JVC decode");
-  if (decodeJVC(results)) return true;
+    DPRINTLN("Attempting JVC decode");
+    if (decodeJVC(results, offset)) return true;
 #endif
 #if DECODE_SAMSUNG
-  DPRINTLN("Attempting SAMSUNG decode");
-  if (decodeSAMSUNG(results)) return true;
+    DPRINTLN("Attempting SAMSUNG decode");
+    if (decodeSAMSUNG(results, offset)) return true;
 #endif
 #if DECODE_SAMSUNG36
-  DPRINTLN("Attempting Samsung36 decode");
-  if (decodeSamsung36(results)) return true;
+    DPRINTLN("Attempting Samsung36 decode");
+    if (decodeSamsung36(results, offset)) return true;
 #endif
 #if DECODE_WHYNTER
-  DPRINTLN("Attempting Whynter decode");
-  if (decodeWhynter(results)) return true;
+    DPRINTLN("Attempting Whynter decode");
+    if (decodeWhynter(results, offset)) return true;
 #endif
 #if DECODE_DISH
-  DPRINTLN("Attempting DISH decode");
-  if (decodeDISH(results)) return true;
+    DPRINTLN("Attempting DISH decode");
+    if (decodeDISH(results, offset)) return true;
 #endif
 #if DECODE_SHARP
-  DPRINTLN("Attempting Sharp decode");
-  if (decodeSharp(results)) return true;
+    DPRINTLN("Attempting Sharp decode");
+    if (decodeSharp(results, offset)) return true;
 #endif
 #if DECODE_COOLIX
-  DPRINTLN("Attempting Coolix decode");
-  if (decodeCOOLIX(results)) return true;
+    DPRINTLN("Attempting Coolix decode");
+    if (decodeCOOLIX(results, offset)) return true;
 #endif
 #if DECODE_NIKAI
-  DPRINTLN("Attempting Nikai decode");
-  if (decodeNikai(results)) return true;
+    DPRINTLN("Attempting Nikai decode");
+    if (decodeNikai(results, offset)) return true;
 #endif
 #if DECODE_KELVINATOR
-  // Kelvinator based-devices use a similar code to Gree ones, to avoid false
-  // matches this needs to happen before decodeGree().
-  DPRINTLN("Attempting Kelvinator decode");
-  if (decodeKelvinator(results)) return true;
+    // Kelvinator based-devices use a similar code to Gree ones, to avoid false
+    // matches this needs to happen before decodeGree().
+    DPRINTLN("Attempting Kelvinator decode");
+    if (decodeKelvinator(results, offset)) return true;
 #endif
 #if DECODE_DAIKIN
-  DPRINTLN("Attempting Daikin decode");
-  if (decodeDaikin(results)) return true;
+    DPRINTLN("Attempting Daikin decode");
+    if (decodeDaikin(results, offset)) return true;
 #endif
 #if DECODE_DAIKIN2
-  DPRINTLN("Attempting Daikin2 decode");
-  if (decodeDaikin2(results)) return true;
+    DPRINTLN("Attempting Daikin2 decode");
+    if (decodeDaikin2(results, offset)) return true;
 #endif
 #if DECODE_DAIKIN216
-  DPRINTLN("Attempting Daikin216 decode");
-  if (decodeDaikin216(results)) return true;
+    DPRINTLN("Attempting Daikin216 decode");
+    if (decodeDaikin216(results, offset)) return true;
 #endif
 #if DECODE_TOSHIBA_AC
-  DPRINTLN("Attempting Toshiba AC decode");
-  if (decodeToshibaAC(results)) return true;
+    DPRINTLN("Attempting Toshiba AC decode");
+    if (decodeToshibaAC(results, offset)) return true;
 #endif
 #if DECODE_MIDEA
-  DPRINTLN("Attempting Midea decode");
-  if (decodeMidea(results)) return true;
+    DPRINTLN("Attempting Midea decode");
+    if (decodeMidea(results, offset)) return true;
 #endif
 #if DECODE_MAGIQUEST
-  DPRINTLN("Attempting Magiquest decode");
-  if (decodeMagiQuest(results)) return true;
+    DPRINTLN("Attempting Magiquest decode");
+    if (decodeMagiQuest(results, offset)) return true;
 #endif
-/* NOTE: Disabled due to poor quality.
+  /* NOTE: Disabled due to poor quality.
 #if DECODE_SANYO
-  // The Sanyo S866500B decoder is very poor quality & depricated.
-  // *IF* you are going to enable it, do it near last to avoid false positive
-  // matches.
-  DPRINTLN("Attempting Sanyo SA8650B decode");
-  if (decodeSanyo(results))
-    return true;
+    // The Sanyo S866500B decoder is very poor quality & depricated.
+    // *IF* you are going to enable it, do it near last to avoid false positive
+    // matches.
+    DPRINTLN("Attempting Sanyo SA8650B decode");
+    if (decodeSanyo(results, offset))
+      return true;
 #endif
-*/
+  */
 #if DECODE_NEC
-  // Some devices send NEC-like codes that don't follow the true NEC spec.
-  // This should detect those. e.g. Apple TV remote etc.
-  // This needs to be done after all other codes that use strict and some
-  // other protocols that are NEC-like as well, as turning off strict may
-  // cause this to match other valid protocols.
-  DPRINTLN("Attempting NEC (non-strict) decode");
-  if (decodeNEC(results, kNECBits, false)) {
-    results->decode_type = NEC_LIKE;
-    return true;
-  }
+    // Some devices send NEC-like codes that don't follow the true NEC spec.
+    // This should detect those. e.g. Apple TV remote etc.
+    // This needs to be done after all other codes that use strict and some
+    // other protocols that are NEC-like as well, as turning off strict may
+    // cause this to match other valid protocols.
+    DPRINTLN("Attempting NEC (non-strict) decode");
+    if (decodeNEC(results, offset, kNECBits, false)) {
+      results->decode_type = NEC_LIKE;
+      return true;
+    }
 #endif
 #if DECODE_LASERTAG
-  DPRINTLN("Attempting Lasertag decode");
-  if (decodeLasertag(results)) return true;
+    DPRINTLN("Attempting Lasertag decode");
+    if (decodeLasertag(results, offset)) return true;
 #endif
 #if DECODE_GREE
-  // Gree based-devices use a similar code to Kelvinator ones, to avoid false
-  // matches this needs to happen after decodeKelvinator().
-  DPRINTLN("Attempting Gree decode");
-  if (decodeGree(results)) return true;
+    // Gree based-devices use a similar code to Kelvinator ones, to avoid false
+    // matches this needs to happen after decodeKelvinator().
+    DPRINTLN("Attempting Gree decode");
+    if (decodeGree(results, offset)) return true;
 #endif
 #if DECODE_HAIER_AC
-  DPRINTLN("Attempting Haier AC decode");
-  if (decodeHaierAC(results)) return true;
+    DPRINTLN("Attempting Haier AC decode");
+    if (decodeHaierAC(results, offset)) return true;
 #endif
 #if DECODE_HAIER_AC_YRW02
-  DPRINTLN("Attempting Haier AC YR-W02 decode");
-  if (decodeHaierACYRW02(results)) return true;
+    DPRINTLN("Attempting Haier AC YR-W02 decode");
+    if (decodeHaierACYRW02(results, offset)) return true;
 #endif
 #if DECODE_HITACHI_AC424
-  // HitachiAc424 should be checked before HitachiAC & HitachiAC2
-  DPRINTLN("Attempting Hitachi AC 424 decode");
-  if (decodeHitachiAc424(results, kHitachiAc424Bits)) return true;
+    // HitachiAc424 should be checked before HitachiAC & HitachiAC2
+    DPRINTLN("Attempting Hitachi AC 424 decode");
+    if (decodeHitachiAc424(results, offset, kHitachiAc424Bits)) return true;
 #endif  // DECODE_HITACHI_AC2
 #if DECODE_HITACHI_AC2
-  // HitachiAC2 should be checked before HitachiAC
-  DPRINTLN("Attempting Hitachi AC2 decode");
-  if (decodeHitachiAC(results, kHitachiAc2Bits)) return true;
+    // HitachiAC2 should be checked before HitachiAC
+    DPRINTLN("Attempting Hitachi AC2 decode");
+    if (decodeHitachiAC(results, offset, kHitachiAc2Bits)) return true;
 #endif  // DECODE_HITACHI_AC2
 #if DECODE_HITACHI_AC
-  DPRINTLN("Attempting Hitachi AC decode");
-  if (decodeHitachiAC(results, kHitachiAcBits)) return true;
+    DPRINTLN("Attempting Hitachi AC decode");
+    if (decodeHitachiAC(results, offset, kHitachiAcBits)) return true;
 #endif
 #if DECODE_HITACHI_AC1
-  DPRINTLN("Attempting Hitachi AC1 decode");
-  if (decodeHitachiAC(results, kHitachiAc1Bits)) return true;
+    DPRINTLN("Attempting Hitachi AC1 decode");
+    if (decodeHitachiAC(results, offset, kHitachiAc1Bits)) return true;
 #endif
 #if DECODE_WHIRLPOOL_AC
-  DPRINTLN("Attempting Whirlpool AC decode");
-  if (decodeWhirlpoolAC(results)) return true;
+    DPRINTLN("Attempting Whirlpool AC decode");
+    if (decodeWhirlpoolAC(results, offset)) return true;
 #endif
 #if DECODE_SAMSUNG_AC
-  DPRINTLN("Attempting Samsung AC (extended) decode");
-  // Check the extended size first, as it should fail fast due to longer length.
-  if (decodeSamsungAC(results, kSamsungAcExtendedBits, false)) return true;
-  // Now check for the more common length.
-  DPRINTLN("Attempting Samsung AC decode");
-  if (decodeSamsungAC(results, kSamsungAcBits)) return true;
+    DPRINTLN("Attempting Samsung AC (extended) decode");
+    // Check the extended size first, as it should fail fast due to longer
+    // length.
+    if (decodeSamsungAC(results, offset, kSamsungAcExtendedBits, false))
+      return true;
+    // Now check for the more common length.
+    DPRINTLN("Attempting Samsung AC decode");
+    if (decodeSamsungAC(results, offset, kSamsungAcBits)) return true;
 #endif
 #if DECODE_ELECTRA_AC
-  DPRINTLN("Attempting Electra AC decode");
-  if (decodeElectraAC(results)) return true;
+    DPRINTLN("Attempting Electra AC decode");
+    if (decodeElectraAC(results, offset)) return true;
 #endif
 #if DECODE_PANASONIC_AC
-  DPRINTLN("Attempting Panasonic AC decode");
-  if (decodePanasonicAC(results)) return true;
-  DPRINTLN("Attempting Panasonic AC short decode");
-  if (decodePanasonicAC(results, kPanasonicAcShortBits)) return true;
+    DPRINTLN("Attempting Panasonic AC decode");
+    if (decodePanasonicAC(results, offset)) return true;
+    DPRINTLN("Attempting Panasonic AC short decode");
+    if (decodePanasonicAC(results, offset, kPanasonicAcShortBits)) return true;
 #endif
 #if DECODE_LUTRON
-  DPRINTLN("Attempting Lutron decode");
-  if (decodeLutron(results)) return true;
+    DPRINTLN("Attempting Lutron decode");
+    if (decodeLutron(results, offset)) return true;
 #endif
 #if DECODE_MWM
-  DPRINTLN("Attempting MWM decode");
-  if (decodeMWM(results)) return true;
+    DPRINTLN("Attempting MWM decode");
+    if (decodeMWM(results, offset)) return true;
 #endif
 #if DECODE_VESTEL_AC
-  DPRINTLN("Attempting Vestel AC decode");
-  if (decodeVestelAc(results)) return true;
+    DPRINTLN("Attempting Vestel AC decode");
+    if (decodeVestelAc(results, offset)) return true;
 #endif
 #if DECODE_MITSUBISHI112 || DECODE_TCL112AC
-  // Mitsubish112 and Tcl112 share the same decoder.
-  DPRINTLN("Attempting Mitsubishi112/TCL112AC decode");
-  if (decodeMitsubishi112(results)) return true;
+    // Mitsubish112 and Tcl112 share the same decoder.
+    DPRINTLN("Attempting Mitsubishi112/TCL112AC decode");
+    if (decodeMitsubishi112(results, offset)) return true;
 #endif  // DECODE_MITSUBISHI112 || DECODE_TCL112AC
 #if DECODE_TECO
-  DPRINTLN("Attempting Teco decode");
-  if (decodeTeco(results)) return true;
+    DPRINTLN("Attempting Teco decode");
+    if (decodeTeco(results, offset)) return true;
 #endif
 #if DECODE_LEGOPF
-  DPRINTLN("Attempting LEGOPF decode");
-  if (decodeLegoPf(results)) return true;
+    DPRINTLN("Attempting LEGOPF decode");
+    if (decodeLegoPf(results, offset)) return true;
 #endif
 #if DECODE_MITSUBISHIHEAVY
-  DPRINTLN("Attempting MITSUBISHIHEAVY (152 bit) decode");
-  if (decodeMitsubishiHeavy(results, kMitsubishiHeavy152Bits)) return true;
-  DPRINTLN("Attempting MITSUBISHIHEAVY (88 bit) decode");
-  if (decodeMitsubishiHeavy(results, kMitsubishiHeavy88Bits)) return true;
+    DPRINTLN("Attempting MITSUBISHIHEAVY (152 bit) decode");
+    if (decodeMitsubishiHeavy(results, offset, kMitsubishiHeavy152Bits))
+      return true;
+    DPRINTLN("Attempting MITSUBISHIHEAVY (88 bit) decode");
+    if (decodeMitsubishiHeavy(results, offset, kMitsubishiHeavy88Bits))
+      return true;
 #endif
 #if DECODE_ARGO
-  DPRINTLN("Attempting Argo decode");
-  if (decodeArgo(results)) return true;
+    DPRINTLN("Attempting Argo decode");
+    if (decodeArgo(results, offset)) return true;
 #endif  // DECODE_ARGO
 #if DECODE_SHARP_AC
-  DPRINTLN("Attempting SHARP_AC decode");
-  if (decodeSharpAc(results)) return true;
+    DPRINTLN("Attempting SHARP_AC decode");
+    if (decodeSharpAc(results, offset)) return true;
 #endif
 #if DECODE_GOODWEATHER
-  DPRINTLN("Attempting GOODWEATHER decode");
-  if (decodeGoodweather(results)) return true;
+    DPRINTLN("Attempting GOODWEATHER decode");
+    if (decodeGoodweather(results, offset)) return true;
 #endif  // DECODE_GOODWEATHER
 #if DECODE_INAX
-  DPRINTLN("Attempting Inax decode");
-  if (decodeInax(results)) return true;
+    DPRINTLN("Attempting Inax decode");
+    if (decodeInax(results, offset)) return true;
 #endif  // DECODE_INAX
 #if DECODE_TROTEC
-  DPRINTLN("Attempting Trotec decode");
-  if (decodeTrotec(results)) return true;
+    DPRINTLN("Attempting Trotec decode");
+    if (decodeTrotec(results, offset)) return true;
 #endif  // DECODE_TROTEC
 #if DECODE_DAIKIN160
-  DPRINTLN("Attempting Daikin160 decode");
-  if (decodeDaikin160(results)) return true;
+    DPRINTLN("Attempting Daikin160 decode");
+    if (decodeDaikin160(results, offset)) return true;
 #endif  // DECODE_DAIKIN160
 #if DECODE_NEOCLIMA
-  DPRINTLN("Attempting Neoclima decode");
-  if (decodeNeoclima(results)) return true;
+    DPRINTLN("Attempting Neoclima decode");
+    if (decodeNeoclima(results, offset)) return true;
 #endif  // DECODE_NEOCLIMA
 #if DECODE_DAIKIN176
-  DPRINTLN("Attempting Daikin176 decode");
-  if (decodeDaikin176(results)) return true;
+    DPRINTLN("Attempting Daikin176 decode");
+    if (decodeDaikin176(results, offset)) return true;
 #endif  // DECODE_DAIKIN176
 #if DECODE_DAIKIN128
-  DPRINTLN("Attempting Daikin128 decode");
-  if (decodeDaikin128(results)) return true;
+    DPRINTLN("Attempting Daikin128 decode");
+    if (decodeDaikin128(results, offset)) return true;
 #endif  // DECODE_DAIKIN128
 #if DECODE_AMCOR
-  DPRINTLN("Attempting Amcor decode");
-  if (decodeAmcor(results)) return true;
+    DPRINTLN("Attempting Amcor decode");
+    if (decodeAmcor(results, offset)) return true;
 #endif  // DECODE_AMCOR
 #if DECODE_DAIKIN152
-  DPRINTLN("Attempting Daikin152 decode");
-  if (decodeDaikin152(results)) return true;
+    DPRINTLN("Attempting Daikin152 decode");
+    if (decodeDaikin152(results, offset)) return true;
 #endif  // DECODE_DAIKIN152
 #if DECODE_MITSUBISHI136
-  DPRINTLN("Attempting Mitsubishi136 decode");
-  if (decodeMitsubishi136(results)) return true;
+    DPRINTLN("Attempting Mitsubishi136 decode");
+    if (decodeMitsubishi136(results, offset)) return true;
 #endif  // DECODE_MITSUBISHI136
+  }
   // Typically new protocols are added above this line.
 #if DECODE_HASH
   // decodeHash returns a hash on any input.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -126,7 +126,7 @@ class IRrecv {
   void setTolerance(const uint8_t percent = kTolerance);
   uint8_t getTolerance(void);
   bool decode(decode_results *results, irparams_t *save = NULL,
-              uint8_t max_skip = 0, uint8_t noise_floor = 0);
+              uint8_t max_skip = 0, uint16_t noise_floor = 0);
   void enableIRIn(const bool pullup = false);
   void disableIRIn(void);
   void resume(void);
@@ -221,7 +221,7 @@ class IRrecv {
                         const uint8_t tolerance = kUseDefTol,
                         const int16_t excess = kMarkExcess,
                         const bool MSBfirst = true);
-  void crudeNoiseFilter(decode_results *results, const uint8_t floor = 0);
+  void crudeNoiseFilter(decode_results *results, const uint16_t floor = 0);
   bool decodeHash(decode_results *results);
 #if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || SEND_SANYO)
   bool decodeNEC(decode_results *results, uint16_t offset = kStartOffset,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -221,7 +221,7 @@ class IRrecv {
                         const uint8_t tolerance = kUseDefTol,
                         const int16_t excess = kMarkExcess,
                         const bool MSBfirst = true);
-  void crudeHighPassFilter(decode_results *results, const uint8_t floor = 0);
+  void crudeNoiseFilter(decode_results *results, const uint8_t floor = 0);
   bool decodeHash(decode_results *results);
 #if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || SEND_SANYO)
   bool decodeNEC(decode_results *results, uint16_t offset = kStartOffset,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -125,7 +125,8 @@ class IRrecv {
   ~IRrecv(void);                                                  // Destructor
   void setTolerance(const uint8_t percent = kTolerance);
   uint8_t getTolerance(void);
-  bool decode(decode_results *results, irparams_t *save = NULL);
+  bool decode(decode_results *results, irparams_t *save = NULL,
+              uint8_t max_skip = 0, uint8_t noise_floor = 0);
   void enableIRIn(const bool pullup = false);
   void disableIRIn(void);
   void resume(void);
@@ -220,52 +221,64 @@ class IRrecv {
                         const uint8_t tolerance = kUseDefTol,
                         const int16_t excess = kMarkExcess,
                         const bool MSBfirst = true);
+  void crudeHighPassFilter(decode_results *results, const uint8_t floor = 0);
   bool decodeHash(decode_results *results);
 #if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || SEND_SANYO)
-  bool decodeNEC(decode_results *results, uint16_t nbits = kNECBits,
-                 bool strict = true);
+  bool decodeNEC(decode_results *results, uint16_t offset = kStartOffset,
+                 const uint16_t nbits = kNECBits, const bool strict = true);
 #endif
 #if DECODE_ARGO
-  bool decodeArgo(decode_results *results, const uint16_t nbits = kArgoBits,
-                  const bool strict = true);
+  bool decodeArgo(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kArgoBits, const bool strict = true);
 #endif  // DECODE_ARGO
 #if DECODE_SONY
-  bool decodeSony(decode_results *results, uint16_t nbits = kSonyMinBits,
-                  bool strict = false);
+  bool decodeSony(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kSonyMinBits,
+                  const bool strict = false);
 #endif
 #if DECODE_SANYO
   // DISABLED due to poor quality.
-  // bool decodeSanyo(decode_results *results,
+  // bool decodeSanyo(decode_results *results, uint16_t offset = kStartOffset,
   //                  uint16_t nbits = kSanyoSA8650BBits,
   //                  bool strict = false);
   bool decodeSanyoLC7461(decode_results *results,
-                         uint16_t nbits = kSanyoLC7461Bits, bool strict = true);
+                         uint16_t offset = kStartOffset,
+                         const uint16_t nbits = kSanyoLC7461Bits,
+                         bool strict = true);
 #endif
 #if DECODE_MITSUBISHI
-  bool decodeMitsubishi(decode_results *results,
-                        uint16_t nbits = kMitsubishiBits, bool strict = true);
+  bool decodeMitsubishi(decode_results *results, uint16_t offset = kStartOffset,
+                        const uint16_t nbits = kMitsubishiBits,
+                        const bool strict = true);
 #endif
 #if DECODE_MITSUBISHI2
   bool decodeMitsubishi2(decode_results *results,
-                         uint16_t nbits = kMitsubishiBits, bool strict = true);
+                         uint16_t offset = kStartOffset,
+                         const uint16_t nbits = kMitsubishiBits,
+                         const bool strict = true);
 #endif
 #if DECODE_MITSUBISHI_AC
   bool decodeMitsubishiAC(decode_results *results,
-                          uint16_t nbits = kMitsubishiACBits,
-                          bool strict = false);
+                          uint16_t offset = kStartOffset,
+                          const uint16_t nbits = kMitsubishiACBits,
+                          const bool strict = false);
 #endif
 #if DECODE_MITSUBISHI136
   bool decodeMitsubishi136(decode_results *results,
+                           uint16_t offset = kStartOffset,
                            const uint16_t nbits = kMitsubishi136Bits,
                            const bool strict = true);
 #endif
 #if DECODE_MITSUBISHI112
   bool decodeMitsubishi112(decode_results *results,
+                           uint16_t offset = kStartOffset,
                            const uint16_t nbits = kMitsubishi112Bits,
                            const bool strict = true);
 #endif
 #if DECODE_MITSUBISHIHEAVY
-  bool decodeMitsubishiHeavy(decode_results *results, const uint16_t nbits,
+  bool decodeMitsubishiHeavy(decode_results *results,
+                             uint16_t offset = kStartOffset,
+                             const uint16_t nbits = kMitsubishiHeavy152Bits,
                              const bool strict = true);
 #endif
 #if (DECODE_RC5 || DECODE_R6 || DECODE_LASERTAG || DECODE_MWM)
@@ -275,233 +288,268 @@ class IRrecv {
                      uint8_t maxwidth = 3);
 #endif
 #if DECODE_RC5
-  bool decodeRC5(decode_results *results, uint16_t nbits = kRC5XBits,
-                 bool strict = true);
+  bool decodeRC5(decode_results *results, uint16_t offset = kStartOffset,
+                 const uint16_t nbits = kRC5XBits,
+                 const bool strict = true);
 #endif
 #if DECODE_RC6
-  bool decodeRC6(decode_results *results, uint16_t nbits = kRC6Mode0Bits,
-                 bool strict = false);
+  bool decodeRC6(decode_results *results, uint16_t offset = kStartOffset,
+                 const uint16_t nbits = kRC6Mode0Bits,
+                 const bool strict = false);
 #endif
 #if DECODE_RCMM
-  bool decodeRCMM(decode_results *results, uint16_t nbits = kRCMMBits,
-                  bool strict = false);
+  bool decodeRCMM(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kRCMMBits,
+                  const bool strict = false);
 #endif
 #if (DECODE_PANASONIC || DECODE_DENON)
-  bool decodePanasonic(decode_results *results,
+  bool decodePanasonic(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kPanasonicBits,
                        const bool strict = false,
                        const uint32_t manufacturer = kPanasonicManufacturer);
 #endif
 #if DECODE_LG
-  bool decodeLG(decode_results *results, uint16_t nbits = kLgBits,
-                bool strict = false);
+  bool decodeLG(decode_results *results, uint16_t offset = kStartOffset,
+                const uint16_t nbits = kLgBits,
+                const bool strict = false);
 #endif
 #if DECODE_INAX
-  bool decodeInax(decode_results *results, const uint16_t nbits = kInaxBits,
+  bool decodeInax(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kInaxBits,
                   const bool strict = true);
 #endif  // DECODE_INAX
 #if DECODE_JVC
-  bool decodeJVC(decode_results *results, uint16_t nbits = kJvcBits,
-                 bool strict = true);
+  bool decodeJVC(decode_results *results, uint16_t offset = kStartOffset,
+                 const uint16_t nbits = kJvcBits,
+                 const bool strict = true);
 #endif
 #if DECODE_SAMSUNG
-  bool decodeSAMSUNG(decode_results *results,
+  bool decodeSAMSUNG(decode_results *results, uint16_t offset = kStartOffset,
                      const uint16_t nbits = kSamsungBits,
                      const bool strict = true);
 #endif
 #if DECODE_SAMSUNG
-  bool decodeSamsung36(decode_results *results,
+  bool decodeSamsung36(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kSamsung36Bits,
                        const bool strict = true);
 #endif
 #if DECODE_SAMSUNG_AC
-  bool decodeSamsungAC(decode_results *results,
+  bool decodeSamsungAC(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kSamsungAcBits,
                        const bool strict = true);
 #endif
 #if DECODE_WHYNTER
-  bool decodeWhynter(decode_results *results, uint16_t nbits = kWhynterBits,
-                     bool strict = true);
+  bool decodeWhynter(decode_results *results, uint16_t offset = kStartOffset,
+                     const uint16_t nbits = kWhynterBits,
+                     const bool strict = true);
 #endif
 #if DECODE_COOLIX
-  bool decodeCOOLIX(decode_results *results, uint16_t nbits = kCoolixBits,
-                    bool strict = true);
+  bool decodeCOOLIX(decode_results *results, uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kCoolixBits,
+                    const bool strict = true);
 #endif
 #if DECODE_DENON
-  bool decodeDenon(decode_results *results, uint16_t nbits = kDenonBits,
-                   bool strict = true);
+  bool decodeDenon(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kDenonBits,
+                   const bool strict = true);
 #endif
 #if DECODE_DISH
-  bool decodeDISH(decode_results *results, uint16_t nbits = kDishBits,
-                  bool strict = true);
+  bool decodeDISH(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kDishBits,
+                  const bool strict = true);
 #endif
 #if (DECODE_SHARP || DECODE_DENON)
-  bool decodeSharp(decode_results *results, const uint16_t nbits = kSharpBits,
+  bool decodeSharp(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kSharpBits,
                    const bool strict = true, const bool expansion = true);
 #endif
 #if DECODE_SHARP_AC
-  bool decodeSharpAc(decode_results *results,
+  bool decodeSharpAc(decode_results *results, uint16_t offset = kStartOffset,
                      const uint16_t nbits = kSharpAcBits,
                      const bool strict = true);
 #endif
 #if DECODE_AIWA_RC_T501
-  bool decodeAiwaRCT501(decode_results *results,
-                        uint16_t nbits = kAiwaRcT501Bits, bool strict = true);
+  bool decodeAiwaRCT501(decode_results *results, uint16_t offset = kStartOffset,
+                        const uint16_t nbits = kAiwaRcT501Bits,
+                        const bool strict = true);
 #endif
 #if DECODE_NIKAI
-  bool decodeNikai(decode_results *results, uint16_t nbits = kNikaiBits,
-                   bool strict = true);
+  bool decodeNikai(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kNikaiBits,
+                   const bool strict = true);
 #endif
 #if DECODE_MAGIQUEST
-  bool decodeMagiQuest(decode_results *results, uint16_t nbits = kMagiquestBits,
-                       bool strict = true);
+  bool decodeMagiQuest(decode_results *results, uint16_t offset = kStartOffset,
+                       const uint16_t nbits = kMagiquestBits,
+                       const bool strict = true);
 #endif
 #if DECODE_KELVINATOR
-  bool decodeKelvinator(decode_results *results,
-                        uint16_t nbits = kKelvinatorBits, bool strict = true);
+  bool decodeKelvinator(decode_results *results, uint16_t offset = kStartOffset,
+                        const uint16_t nbits = kKelvinatorBits,
+                        const bool strict = true);
 #endif
 #if DECODE_DAIKIN
-  bool decodeDaikin(decode_results *results, const uint16_t nbits = kDaikinBits,
+  bool decodeDaikin(decode_results *results, uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kDaikinBits,
                     const bool strict = true);
 #endif
 #if DECODE_DAIKIN128
-  bool decodeDaikin128(decode_results *results,
+  bool decodeDaikin128(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kDaikin128Bits,
                        const bool strict = true);
 #endif  // DECODE_DAIKIN128
 #if DECODE_DAIKIN152
-  bool decodeDaikin152(decode_results *results,
+  bool decodeDaikin152(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kDaikin152Bits,
                        const bool strict = true);
 #endif  // DECODE_DAIKIN152
 #if DECODE_DAIKIN160
-  bool decodeDaikin160(decode_results *results,
+  bool decodeDaikin160(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kDaikin160Bits,
                        const bool strict = true);
 #endif  // DECODE_DAIKIN160
 #if DECODE_DAIKIN176
-  bool decodeDaikin176(decode_results *results,
+  bool decodeDaikin176(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kDaikin176Bits,
                        const bool strict = true);
 #endif  // DECODE_DAIKIN176
 #if DECODE_DAIKIN2
-  bool decodeDaikin2(decode_results *results, uint16_t nbits = kDaikin2Bits,
-                     bool strict = true);
+  bool decodeDaikin2(decode_results *results, uint16_t offset = kStartOffset,
+                     const uint16_t nbits = kDaikin2Bits,
+                     const bool strict = true);
 #endif
 #if DECODE_DAIKIN216
-  bool decodeDaikin216(decode_results *results,
+  bool decodeDaikin216(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kDaikin216Bits,
                        const bool strict = true);
 #endif
 #if DECODE_TOSHIBA_AC
-  bool decodeToshibaAC(decode_results *results,
+  bool decodeToshibaAC(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbytes = kToshibaACBits,
                        const bool strict = true);
 #endif
 #if DECODE_TROTEC
-  bool decodeTrotec(decode_results *results, const uint16_t nbits = kTrotecBits,
+  bool decodeTrotec(decode_results *results, uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kTrotecBits,
                     const bool strict = true);
 #endif  // DECODE_TROTEC
 #if DECODE_MIDEA
-  bool decodeMidea(decode_results *results, uint16_t nbits = kMideaBits,
-                   bool strict = true);
+  bool decodeMidea(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kMideaBits,
+                   const bool strict = true);
 #endif
 #if DECODE_FUJITSU_AC
-  bool decodeFujitsuAC(decode_results *results, uint16_t nbits = kFujitsuAcBits,
-                       bool strict = false);
+  bool decodeFujitsuAC(decode_results *results, uint16_t offset = kStartOffset,
+                       const uint16_t nbits = kFujitsuAcBits,
+                       const bool strict = false);
 #endif
 #if DECODE_LASERTAG
-  bool decodeLasertag(decode_results *results, uint16_t nbits = kLasertagBits,
-                      bool strict = true);
+  bool decodeLasertag(decode_results *results, uint16_t offset = kStartOffset,
+                      const uint16_t nbits = kLasertagBits,
+                      const bool strict = true);
 #endif
 #if DECODE_CARRIER_AC
-  bool decodeCarrierAC(decode_results *results, uint16_t nbits = kCarrierAcBits,
-                       bool strict = true);
+  bool decodeCarrierAC(decode_results *results, uint16_t offset = kStartOffset,
+                       const uint16_t nbits = kCarrierAcBits,
+                       const bool strict = true);
 #endif
 #if DECODE_GOODWEATHER
   bool decodeGoodweather(decode_results *results,
+                         uint16_t offset = kStartOffset,
                          const uint16_t nbits = kGoodweatherBits,
                          const bool strict = true);
 #endif  // DECODE_GOODWEATHER
 #if DECODE_GREE
-  bool decodeGree(decode_results *results, uint16_t nbits = kGreeBits,
-                  bool strict = true);
+  bool decodeGree(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kGreeBits,
+                  const bool strict = true);
 #endif
 #if (DECODE_HAIER_AC | DECODE_HAIER_AC_YRW02)
-  bool decodeHaierAC(decode_results *results, uint16_t nbits = kHaierACBits,
-                     bool strict = true);
+  bool decodeHaierAC(decode_results *results, uint16_t offset = kStartOffset,
+                     const uint16_t nbits = kHaierACBits,
+                     const bool strict = true);
 #endif
 #if DECODE_HAIER_AC_YRW02
   bool decodeHaierACYRW02(decode_results *results,
-                          uint16_t nbits = kHaierACYRW02Bits,
-                          bool strict = true);
+                          uint16_t offset = kStartOffset,
+                          const uint16_t nbits = kHaierACYRW02Bits,
+                          const bool strict = true);
 #endif
 #if (DECODE_HITACHI_AC || DECODE_HITACHI_AC2)
-  bool decodeHitachiAC(decode_results *results,
+  bool decodeHitachiAC(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kHitachiAcBits,
                        const bool strict = true);
 #endif
 #if DECODE_HITACHI_AC1
-  bool decodeHitachiAC1(decode_results *results,
+  bool decodeHitachiAC1(decode_results *results, uint16_t offset = kStartOffset,
                         const uint16_t nbits = kHitachiAc1Bits,
                         const bool strict = true);
 #endif
 #if DECODE_HITACHI_AC424
   bool decodeHitachiAc424(decode_results *results,
+                          uint16_t offset = kStartOffset,
                           const uint16_t nbits = kHitachiAc424Bits,
                           const bool strict = true);
 #endif  // DECODE_HITACHI_AC424
 #if DECODE_GICABLE
-  bool decodeGICable(decode_results *results, uint16_t nbits = kGicableBits,
-                     bool strict = true);
+  bool decodeGICable(decode_results *results, uint16_t offset = kStartOffset,
+                     const uint16_t nbits = kGicableBits,
+                     const bool strict = true);
 #endif
 #if DECODE_WHIRLPOOL_AC
   bool decodeWhirlpoolAC(decode_results *results,
+                         uint16_t offset = kStartOffset,
                          const uint16_t nbits = kWhirlpoolAcBits,
                          const bool strict = true);
 #endif
 #if DECODE_LUTRON
-  bool decodeLutron(decode_results *results, uint16_t nbits = kLutronBits,
-                    bool strict = true);
+  bool decodeLutron(decode_results *results, uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kLutronBits,
+                    const bool strict = true);
 #endif
 #if DECODE_ELECTRA_AC
-  bool decodeElectraAC(decode_results *results, uint16_t nbits = kElectraAcBits,
-                       bool strict = true);
+  bool decodeElectraAC(decode_results *results, uint16_t offset = kStartOffset,
+                       const uint16_t nbits = kElectraAcBits,
+                       const bool strict = true);
 #endif
 #if DECODE_PANASONIC_AC
   bool decodePanasonicAC(decode_results *results,
+                         uint16_t offset = kStartOffset,
                          const uint16_t nbits = kPanasonicAcBits,
                          const bool strict = true);
 #endif
 #if DECODE_PIONEER
-  bool decodePioneer(decode_results *results,
+  bool decodePioneer(decode_results *results, uint16_t offset = kStartOffset,
                      const uint16_t nbits = kPioneerBits,
                      const bool strict = true);
 #endif
 #if DECODE_MWM
-  bool decodeMWM(decode_results *results, uint16_t nbits = 24,
-                 bool strict = true);
+  bool decodeMWM(decode_results *results, uint16_t offset = kStartOffset,
+                 const uint16_t nbits = 24,
+                 const bool strict = true);
 #endif
 #if DECODE_VESTEL_AC
-  bool decodeVestelAc(decode_results *results,
+  bool decodeVestelAc(decode_results *results, uint16_t offset = kStartOffset,
                       const uint16_t nbits = kVestelAcBits,
                       const bool strict = true);
 #endif
 #if DECODE_TECO
-  bool decodeTeco(decode_results *results, const uint16_t nbits = kTecoBits,
+  bool decodeTeco(decode_results *results, uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kTecoBits,
                   const bool strict = false);
 #endif
 #if DECODE_LEGOPF
-  bool decodeLegoPf(decode_results *results, const uint16_t nbits = kLegoPfBits,
+  bool decodeLegoPf(decode_results *results, uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kLegoPfBits,
                     const bool strict = true);
 #endif
 #if DECODE_NEOCLIMA
-bool decodeNeoclima(decode_results *results,
+bool decodeNeoclima(decode_results *results, uint16_t offset = kStartOffset,
                     const uint16_t nbits = kNeoclimaBits,
                     const bool strict = true);
 #endif  // DECODE_NEOCLIMA
 #if DECODE_AMCOR
-bool decodeAmcor(decode_results *results,
+bool decodeAmcor(decode_results *results, uint16_t offset = kStartOffset,
                  const uint16_t nbits = kAmcorBits,
                  const bool strict = true);
 #endif  // DECODE_AMCOR

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -589,6 +589,22 @@
 #define ALLOW_DELAY_CALLS true
 #endif  // ALLOW_DELAY_CALLS
 
+// Enable a run-time settable high-pass filter on captured data **before**
+// trying any protocol decoding.
+// i.e. Try to remove/merge any really short pulses detected in the raw data.
+// Note: Even when this option is enabled, it is _off_ by default, and requires
+//       a user who knows what they are doing to enable it.
+//       The option to disable this feature is here if your project is _really_
+//       tight on resources. i.e. Saves a small handful of bytes and cpu time.
+// WARNING: If you use this feature at runtime, you can no longer trust the
+//          **raw** data captured. It will now have been slightly **cooked**!
+// DANGER: If you set the `noise_floor` value too high, it **WILL** break
+//         decoding of some protocols. You have been warned. Here Be Dragons!
+//
+// See: `irrecv::decode()` in IRrecv.cpp for more info.
+#ifndef ENABLE_HIGHPASS_FILTER_OPTION
+#define ENABLE_HIGHPASS_FILTER_OPTION true
+#endif  // ENABLE_HIGHPASS_FILTER_OPTION
 /*
  * Always add to the end of the list and should never remove entries
  * or change order. Projects may save the type number for later usage

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -602,9 +602,9 @@
 //         decoding of some protocols. You have been warned. Here Be Dragons!
 //
 // See: `irrecv::decode()` in IRrecv.cpp for more info.
-#ifndef ENABLE_HIGHPASS_FILTER_OPTION
-#define ENABLE_HIGHPASS_FILTER_OPTION true
-#endif  // ENABLE_HIGHPASS_FILTER_OPTION
+#ifndef ENABLE_NOISE_FILTER_OPTION
+#define ENABLE_NOISE_FILTER_OPTION true
+#endif  // ENABLE_NOISE_FILTER_OPTION
 /*
  * Always add to the end of the list and should never remove entries
  * or change order. Projects may save the type number for later usage

--- a/src/ir_Aiwa.cpp
+++ b/src/ir_Aiwa.cpp
@@ -53,6 +53,8 @@ void IRsend::sendAiwaRCT501(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kAiwaRcT501Bits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -69,8 +71,8 @@ void IRsend::sendAiwaRCT501(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/nec.php
-bool IRrecv::decodeAiwaRCT501(decode_results *results, uint16_t nbits,
-                              bool strict) {
+bool IRrecv::decodeAiwaRCT501(decode_results *results, uint16_t offset,
+                              const uint16_t nbits, const bool strict) {
   // Compliance
   if (strict && nbits != kAiwaRcT501Bits)
     return false;  // Doesn't match our protocol defn.
@@ -82,7 +84,7 @@ bool IRrecv::decodeAiwaRCT501(decode_results *results, uint16_t nbits,
     return false;  // We can't possibly match something that big.
   // Decode it as a much bigger (non-standard) NEC message, so we have to turn
   // off strict mode checking for NEC.
-  if (!decodeNEC(results, expected_nbits, false))
+  if (!decodeNEC(results, offset, expected_nbits, false))
     return false;  // The NEC decode had a problem, so we should too.
   uint16_t actual_bits = results->bits;
   new_data = results->value;

--- a/src/ir_Amcor.cpp
+++ b/src/ir_Amcor.cpp
@@ -56,6 +56,8 @@ void IRsend::sendAmcor(const unsigned char data[], const uint16_t nbytes,
 // Decode the supplied Amcor HVAC message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion.
 //            Typically kAmcorBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -64,14 +66,12 @@ void IRsend::sendAmcor(const unsigned char data[], const uint16_t nbytes,
 //
 // Status: STABLE / Reported as working.
 //
-bool IRrecv::decodeAmcor(decode_results *results, uint16_t nbits,
-                         bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader - 1)
+bool IRrecv::decodeAmcor(decode_results *results, uint16_t offset,
+                         const uint16_t nbits, const bool strict) {
+  if (results->rawlen <= 2 * nbits + kHeader - 1 + offset)
     return false;  // Can't possibly be a valid Amcor message.
   if (strict && nbits != kAmcorBits)
     return false;  // We expect Amcor to be 64 bits of message.
-
-  uint16_t offset = kStartOffset;
 
   uint16_t used;
   // Header + Data Block (64 bits) + Footer

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -378,6 +378,8 @@ String IRArgoAC::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kArgoBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -388,11 +390,10 @@ String IRArgoAC::toString(void) {
 // Note:
 //   This decoder is based soley off sendArgo(). We have no actual captures
 //   to test this against. If you have one of these units, please let us know.
-bool IRrecv::decodeArgo(decode_results *results, const uint16_t nbits,
+bool IRrecv::decodeArgo(decode_results *results, uint16_t offset,
+                        const uint16_t nbits,
                         const bool strict) {
   if (strict && nbits != kArgoBits) return false;
-
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data
   if (!matchGeneric(results->rawbuf + offset, results->state,

--- a/src/ir_Carrier.cpp
+++ b/src/ir_Carrier.cpp
@@ -53,6 +53,8 @@ void IRsend::sendCarrierAC(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // i.e. normal + inverted + normal
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion.
 //            Typically kCarrierAcBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -61,16 +63,15 @@ void IRsend::sendCarrierAC(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Status: ALPHA / Untested.
 //
-bool IRrecv::decodeCarrierAC(decode_results *results, uint16_t nbits,
-                             bool strict) {
-  if (results->rawlen < ((2 * nbits + kHeader + kFooter) * 3) - 1)
+bool IRrecv::decodeCarrierAC(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < ((2 * nbits + kHeader + kFooter) * 3) - 1 + offset)
     return false;  // Can't possibly be a valid Carrier message.
   if (strict && nbits != kCarrierAcBits)
     return false;  // We expect Carrier to be 32 bits of message.
 
   uint64_t data = 0;
   uint64_t prev_data = 0;
-  uint16_t offset = kStartOffset;
 
   for (uint8_t i = 0; i < 3; i++) {
     prev_data = data;

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -579,17 +579,19 @@ String IRCoolixAC::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kCoolixBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: BETA / Probably working.
-bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
-                          bool strict) {
+bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t offset,
+                          const uint16_t nbits, const bool strict) {
   // The protocol sends the data normal + inverted, alternating on
   // each byte. Hence twice the number of expected data bits.
-  if (results->rawlen < 2 * 2 * nbits + kHeader + kFooter - 1)
+  if (results->rawlen <= 2 * 2 * nbits + kHeader + kFooter - 1 + offset)
     return false;  // Can't possibly be a valid COOLIX message.
   if (strict && nbits != kCoolixBits)
     return false;      // Not strictly a COOLIX message.
@@ -598,7 +600,6 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t nbits,
 
   uint64_t data = 0;
   uint64_t inverted = 0;
-  uint16_t offset = kStartOffset;
 
   if (nbits > sizeof(data) * 8)
     return false;  // We can't possibly capture a Coolix packet that big.

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -513,6 +513,8 @@ String IRDaikinESP::toString(void) {
 // Decode the supplied Daikin A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikinBits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -522,17 +524,17 @@ String IRDaikinESP::toString(void) {
 //
 // Ref:
 //   https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
-bool IRrecv::decodeDaikin(decode_results *results, const uint16_t nbits,
-                          const bool strict) {
+bool IRrecv::decodeDaikin(decode_results *results, uint16_t offset,
+                          const uint16_t nbits, const bool strict) {
   // Is there enough data to match successfully?
   if (results->rawlen < (2 * (nbits + kDaikinHeaderLength) +
-                         kDaikinSections * (kHeader + kFooter) + kFooter - 1))
+                         kDaikinSections * (kHeader + kFooter) + kFooter - 1) +
+                         offset)
     return false;
 
   // Compliance
   if (strict && nbits != kDaikinBits) return false;
 
-  uint16_t offset = kStartOffset;
   match_result_t data_result;
 
   // Header #1 - Doesn't count as data.
@@ -1206,6 +1208,8 @@ String IRDaikin2::toString(void) {
 // Decode the supplied Daikin2 A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin2Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -1219,15 +1223,14 @@ String IRDaikin2::toString(void) {
 //
 // Ref:
 //   https://github.com/mharizanov/Daikin-AC-remote-control-over-the-Internet/tree/master/IRremote
-bool IRrecv::decodeDaikin2(decode_results *results, uint16_t nbits,
-                           bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader + kFooter) + kHeader - 1)
+bool IRrecv::decodeDaikin2(decode_results *results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) + kHeader - 1 + offset)
     return false;
 
   // Compliance
   if (strict && nbits != kDaikin2Bits) return false;
 
-  uint16_t offset = kStartOffset;
   const uint8_t ksectionSize[kDaikin2Sections] = {kDaikin2Section1Length,
                                                   kDaikin2Section2Length};
 
@@ -1552,6 +1555,8 @@ String IRDaikin216::toString(void) {
 // Decode the supplied Daikin 216 bit A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin216Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -1565,15 +1570,14 @@ String IRDaikin216::toString(void) {
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/689
 //   https://github.com/danny-source/Arduino_DY_IRDaikin
-bool IRrecv::decodeDaikin216(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1)
+bool IRrecv::decodeDaikin216(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1 + offset)
     return false;
 
   // Compliance
   if (strict && nbits != kDaikin216Bits) return false;
 
-  uint16_t offset = kStartOffset;
   const uint8_t ksectionSize[kDaikin216Sections] = {kDaikin216Section1Length,
                                                     kDaikin216Section2Length};
   // Sections
@@ -1905,6 +1909,8 @@ String IRDaikin160::toString(void) {
 // Decode the supplied Daikin 160 bit A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin160Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -1917,15 +1923,14 @@ String IRDaikin160::toString(void) {
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/731
-bool IRrecv::decodeDaikin160(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1)
+bool IRrecv::decodeDaikin160(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1 + offset)
     return false;
 
   // Compliance
   if (strict && nbits != kDaikin160Bits) return false;
 
-  uint16_t offset = kStartOffset;
   const uint8_t ksectionSize[kDaikin160Sections] = {kDaikin160Section1Length,
                                                     kDaikin160Section2Length};
 
@@ -2268,6 +2273,8 @@ String IRDaikin176::toString(void) {
 // Decode the supplied Daikin 176 bit A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin176Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -2279,15 +2286,15 @@ String IRDaikin176::toString(void) {
 // Status: BETA / Probably works.
 //
 
-bool IRrecv::decodeDaikin176(decode_results *results, const uint16_t nbits,
+bool IRrecv::decodeDaikin176(decode_results *results, uint16_t offset,
+                             const uint16_t nbits,
                              const bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1)
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1 + offset)
     return false;
 
   // Compliance
   if (strict && nbits != kDaikin176Bits) return false;
 
-  uint16_t offset = kStartOffset;
   const uint8_t ksectionSize[kDaikin176Sections] = {kDaikin176Section1Length,
                                                     kDaikin176Section2Length};
 
@@ -2762,6 +2769,8 @@ stdAc::state_t IRDaikin128::toCommon(const stdAc::state_t *prev) {
 // Decode the supplied Daikin 128 bit A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin128Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -2773,16 +2782,14 @@ stdAc::state_t IRDaikin128::toCommon(const stdAc::state_t *prev) {
 // Status: STABLE / Known Working.
 //
 // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/827
-bool IRrecv::decodeDaikin128(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader) + kFooter - 1)
+bool IRrecv::decodeDaikin128(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader) + kFooter - 1 + offset)
     return false;
   if (nbits / 8 <= kDaikin128SectionLength) return false;
 
   // Compliance
   if (strict && nbits != kDaikin128Bits) return false;
-
-  uint16_t offset = kStartOffset;
 
   // Leader
   for (uint8_t i = 0; i < 2; i++) {
@@ -2862,6 +2869,8 @@ void IRsend::sendDaikin152(const unsigned char data[], const uint16_t nbytes,
 // Decode the supplied Daikin 152 bit A/C message.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. (kDaikin152Bits)
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -2873,16 +2882,15 @@ void IRsend::sendDaikin152(const unsigned char data[], const uint16_t nbytes,
 // Status: STABLE / Known working.
 //
 // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/873
-bool IRrecv::decodeDaikin152(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * (5 + nbits + kFooter) + kHeader - 1)
+bool IRrecv::decodeDaikin152(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (5 + nbits + kFooter) + kHeader - 1 + offset)
     return false;
   if (nbits / 8 < kDaikin152StateLength) return false;
 
   // Compliance
   if (strict && nbits != kDaikin152Bits) return false;
 
-  uint16_t offset = kStartOffset;
   uint16_t used;
 
   // Leader

--- a/src/ir_Denon.cpp
+++ b/src/ir_Denon.cpp
@@ -64,7 +64,10 @@ void IRsend::sendDenon(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Expected nr. of data bits. (Typically kDenonBits)
+//   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
@@ -72,7 +75,8 @@ void IRsend::sendDenon(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //   https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Denon.cpp
-bool IRrecv::decodeDenon(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeDenon(decode_results *results, uint16_t offset,
+                         const uint16_t nbits, const bool strict) {
   // Compliance
   if (strict) {
     switch (nbits) {
@@ -92,15 +96,14 @@ bool IRrecv::decodeDenon(decode_results *results, uint16_t nbits, bool strict) {
   // Ditto for Panasonic, it's the same except for a different
   // manufacturer code.
 
-  if (!decodeSharp(results, nbits, true, false) &&
-      !decodePanasonic(results, nbits, true, kDenonManufacturer)) {
+  if (!decodeSharp(results, offset, nbits, true, false) &&
+      !decodePanasonic(results, offset, nbits, true, kDenonManufacturer)) {
     // We couldn't decode it as expected, so try the old legacy method.
     // NOTE: I don't think this following protocol actually exists.
     //       Looks like a partial version of the Sharp protocol.
     if (strict && nbits != kDenonLegacyBits) return false;
 
     uint64_t data = 0;
-    uint16_t offset = kStartOffset;
 
     // Match Header + Data + Footer
     if (!matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_Dish.cpp
+++ b/src/ir_Dish.cpp
@@ -69,6 +69,8 @@ void IRsend::sendDISH(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. Typically kDishBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -84,13 +86,11 @@ void IRsend::sendDISH(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   http://www.hifi-remote.com/wiki/index.php?title=Dish
 //   http://lirc.sourceforge.net/remotes/echostar/301_501_3100_5100_58xx_59xx
 //   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Dish.cpp
-bool IRrecv::decodeDISH(decode_results *results, uint16_t nbits, bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
-    return false;  // Not enough entries to be valid.
+bool IRrecv::decodeDISH(decode_results *results, uint16_t offset,
+                        const uint16_t nbits, const bool strict) {
   if (strict && nbits != kDishBits) return false;  // Not strictly compliant.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -281,6 +281,8 @@ String IRElectraAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kElectraAcBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -288,14 +290,14 @@ String IRElectraAc::toString(void) {
 //
 // Status: STABLE / Known working.
 //
-bool IRrecv::decodeElectraAC(decode_results *results, uint16_t nbits,
-                             bool strict) {
+bool IRrecv::decodeElectraAC(decode_results *results, uint16_t offset,
+                             const uint16_t nbits,
+                             const bool strict) {
   if (strict) {
     if (nbits != kElectraAcBits)
       return false;  // Not strictly a ELECTRA_AC message.
   }
 
-  uint16_t offset = kStartOffset;
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, results->state,
                     results->rawlen - offset, nbits,

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -684,22 +684,25 @@ String IRFujitsuAC::toString(void) {
 // Places successful decode information in the results pointer.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kFujitsuAcBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status:  ALPHA / Untested.
+// Status:  STABLE / Working.
 //
 // Ref:
 //
-bool IRrecv::decodeFujitsuAC(decode_results* results, uint16_t nbits,
-                             bool strict) {
-  uint16_t offset = kStartOffset;
+bool IRrecv::decodeFujitsuAC(decode_results* results, uint16_t offset,
+                             const uint16_t nbits,
+                             const bool strict) {
   uint16_t dataBitsSoFar = 0;
 
   // Have we got enough data to successfully decode?
-  if (results->rawlen < (2 * kFujitsuAcMinBits) + kHeader + kFooter - 1)
+  if (results->rawlen < (2 * kFujitsuAcMinBits) + kHeader + kFooter - 1 +
+      offset)
     return false;  // Can't possibly be a valid message.
 
   // Compliance

--- a/src/ir_GICable.cpp
+++ b/src/ir_GICable.cpp
@@ -58,19 +58,20 @@ void IRsend::sendGICable(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kGicableBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: Alpha / Not tested against a real device.
-bool IRrecv::decodeGICable(decode_results *results, uint16_t nbits,
-                           bool strict) {
+bool IRrecv::decodeGICable(decode_results *results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
   if (strict && nbits != kGicableBits)
     return false;  // Not strictly an GICABLE message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
   // Match Header + Data + Footer
   uint16_t used;
   used = matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -370,23 +370,24 @@ String IRGoodweatherAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kGoodweatherBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: ALPHA / Untested.
-bool IRrecv::decodeGoodweather(decode_results* results,
+bool IRrecv::decodeGoodweather(decode_results* results, uint16_t offset,
                                const uint16_t nbits,
                                const bool strict) {
-  if (results->rawlen < 2 * (2 * nbits) + kHeader + 2 * kFooter - 1)
+  if (results->rawlen < 2 * (2 * nbits) + kHeader + 2 * kFooter - 1 + offset)
     return false;  // Can't possibly be a valid Goodweather message.
   if (strict && nbits != kGoodweatherBits)
     return false;  // Not strictly a Goodweather message.
 
   uint64_t dataSoFar = 0;
   uint16_t dataBitsSoFar = 0;
-  uint16_t offset = kStartOffset;
   match_result_t data_result;
 
   // Header

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -513,20 +513,21 @@ String IRGreeAC::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kGreeBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: ALPHA / Untested.
-bool IRrecv::decodeGree(decode_results* results, uint16_t nbits, bool strict) {
-  if (results->rawlen <
-      2 * (nbits + kGreeBlockFooterBits) + (kHeader + kFooter + 1))
+// Status: STABLE / Working.
+bool IRrecv::decodeGree(decode_results* results, uint16_t offset,
+                        const uint16_t nbits, bool const strict) {
+  if (results->rawlen <=
+      2 * (nbits + kGreeBlockFooterBits) + (kHeader + kFooter + 1) - 1 + offset)
     return false;  // Can't possibly be a valid Gree message.
   if (strict && nbits != kGreeBits)
     return false;  // Not strictly a Gree message.
-
-  uint16_t offset = kStartOffset;
 
   // There are two blocks back-to-back in a full Gree IR message
   // sequence.

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -853,6 +853,8 @@ String IRHaierACYRW02::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kHaierACBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -860,17 +862,15 @@ String IRHaierACYRW02::toString(void) {
 //
 // Status: STABLE / Known to be working.
 //
-bool IRrecv::decodeHaierAC(decode_results* results, uint16_t nbits,
-                           bool strict) {
+bool IRrecv::decodeHaierAC(decode_results* results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
   if (strict) {
     if (nbits != kHaierACBits)
       return false;  // Not strictly a HAIER_AC message.
   }
 
-  if (results->rawlen < (2 * nbits + kHeader) + kFooter - 1)
+  if (results->rawlen <= (2 * nbits + kHeader) + kFooter - 1 + offset)
     return false;  // Can't possibly be a valid HAIER_AC message.
-
-  uint16_t offset = kStartOffset;
 
   // Pre-Header
   if (!matchMark(results->rawbuf[offset++], kHaierAcHdr)) return false;
@@ -903,6 +903,8 @@ bool IRrecv::decodeHaierAC(decode_results* results, uint16_t nbits,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kHaierACYRW02Bits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -910,15 +912,15 @@ bool IRrecv::decodeHaierAC(decode_results* results, uint16_t nbits,
 //
 // Status: BETA / Appears to be working.
 //
-bool IRrecv::decodeHaierACYRW02(decode_results* results, uint16_t nbits,
-                                bool strict) {
+bool IRrecv::decodeHaierACYRW02(decode_results* results, uint16_t offset,
+                                const uint16_t nbits, const bool strict) {
   if (strict) {
     if (nbits != kHaierACYRW02Bits)
       return false;  // Not strictly a HAIER_AC_YRW02 message.
   }
 
   // The protocol is almost exactly the same as HAIER_AC
-  if (!decodeHaierAC(results, nbits, false)) return false;
+  if (!decodeHaierAC(results, offset, nbits, false)) return false;
 
   // Compliance
   if (strict) {

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -359,13 +359,15 @@ String IRHitachiAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect.
 //            Typically kHitachiAcBits, kHitachiAc1Bits, kHitachiAc2Bits
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: ALPHA / Untested.
+// Status: BETA / Probably works.
 //
 // Supported devices:
 //  Hitachi A/C Series VI (Circa 2007) / Remote: LT0541-HTA
@@ -373,11 +375,10 @@ String IRHitachiAc::toString(void) {
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/417
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/453
-bool IRrecv::decodeHitachiAC(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
+bool IRrecv::decodeHitachiAC(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
   const uint8_t k_tolerance = _tolerance + 5;
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
-    return false;  // Can't possibly be a valid HitachiAC message.
+
   if (strict) {
     switch (nbits) {
       case kHitachiAcBits:
@@ -388,7 +389,6 @@ bool IRrecv::decodeHitachiAC(decode_results *results, const uint16_t nbits,
         return false;  // Not strictly a Hitachi message.
     }
   }
-  uint16_t offset = kStartOffset;
   uint16_t hmark;
   uint32_t hspace;
   if (nbits == kHitachiAc1Bits) {
@@ -475,6 +475,8 @@ void IRsend::sendHitachiAc424(const uint8_t data[], const uint16_t nbytes,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kHitachiAc424Bits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -489,14 +491,14 @@ void IRsend::sendHitachiAc424(const uint8_t data[], const uint16_t nbytes,
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/973
-bool IRrecv::decodeHitachiAc424(decode_results *results, const uint16_t nbits,
+bool IRrecv::decodeHitachiAc424(decode_results *results, uint16_t offset,
+                                const uint16_t nbits,
                                 const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kHeader + kFooter - 1)
+  if (results->rawlen < 2 * nbits + kHeader + kHeader + kFooter - 1 + offset)
     return false;  // Too short a message to match.
   if (strict && nbits != kHitachiAc424Bits)
     return false;
 
-  uint16_t offset = kStartOffset;
   uint16_t used;
 
   // Leader

--- a/src/ir_Inax.cpp
+++ b/src/ir_Inax.cpp
@@ -49,6 +49,8 @@ void IRsend::sendInax(const uint64_t data, const uint16_t nbits,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion.
 //            Typically kInaxBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -57,13 +59,12 @@ void IRsend::sendInax(const uint64_t data, const uint16_t nbits,
 //
 // Status: Stable / Known working.
 //
-bool IRrecv::decodeInax(decode_results *results, const uint16_t nbits,
-                        const bool strict) {
+bool IRrecv::decodeInax(decode_results *results, uint16_t offset,
+                        const uint16_t nbits, const bool strict) {
   if (strict && nbits != kInaxBits)
     return false;  // We expect Inax to be a certain sized message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -92,6 +92,8 @@ uint16_t IRsend::encodeJVC(uint8_t address, uint8_t command) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits of data to expect. Typically kJvcBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -103,14 +105,14 @@ uint16_t IRsend::encodeJVC(uint8_t address, uint8_t command) {
 //   JVC repeat codes don't have a header.
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/jvc.php
-bool IRrecv::decodeJVC(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeJVC(decode_results *results, uint16_t offset,
+                       const uint16_t nbits, const bool strict) {
   if (strict && nbits != kJvcBits)
     return false;  // Must be called with the correct nr. of bits.
-  if (results->rawlen < 2 * nbits + kFooter - 1)
+  if (results->rawlen <= 2 * nbits + kFooter - 1 + offset)
     return false;  // Can't possibly be a valid JVC message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
   bool isRepeat = true;
 
   // Header

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -414,21 +414,22 @@ String IRKelvinatorAC::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kKelvinatorBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: STABLE / Known working.
-bool IRrecv::decodeKelvinator(decode_results *results, uint16_t nbits,
-                              bool strict) {
-  if (results->rawlen <
-      2 * (nbits + kKelvinatorCmdFooterBits) + (kHeader + kFooter + 1) * 2 - 1)
+bool IRrecv::decodeKelvinator(decode_results *results, uint16_t offset,
+                              const uint16_t nbits, const bool strict) {
+  if (results->rawlen <=
+      2 * (nbits + kKelvinatorCmdFooterBits) + (kHeader + kFooter + 1) * 2 - 1 +
+      offset)
     return false;  // Can't possibly be a valid Kelvinator message.
   if (strict && nbits != kKelvinatorBits)
     return false;  // Not strictly a Kelvinator message.
-
-  uint16_t offset = kStartOffset;
 
   // There are two messages back-to-back in a full Kelvinator IR message
   // sequence.

--- a/src/ir_Lasertag.cpp
+++ b/src/ir_Lasertag.cpp
@@ -56,6 +56,8 @@ void IRsend::sendLasertag(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -67,14 +69,13 @@ void IRsend::sendLasertag(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   http://www.sbprojects.com/knowledge/ir/rc5.php
 //   https://en.wikipedia.org/wiki/RC-5
 //   https://en.wikipedia.org/wiki/Manchester_code
-bool IRrecv::decodeLasertag(decode_results *results, uint16_t nbits,
-                            bool strict) {
-  if (results->rawlen < kLasertagMinSamples) return false;
+bool IRrecv::decodeLasertag(decode_results *results, uint16_t offset,
+                            const uint16_t nbits, const bool strict) {
+  if (results->rawlen <= kLasertagMinSamples + offset) return false;
 
   // Compliance
   if (strict && nbits != kLasertagBits) return false;
 
-  uint16_t offset = kStartOffset;
   uint16_t used = 0;
   uint64_t data = 0;
   uint16_t actual_bits = 0;

--- a/src/ir_Lego.cpp
+++ b/src/ir_Lego.cpp
@@ -67,20 +67,20 @@ void IRsend::sendLegoPf(const uint64_t data, const uint16_t nbits,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kLegoPfBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
-// Status: Alpha / Untested.
-bool IRrecv::decodeLegoPf(decode_results* results,
+// Status: BETA / Appears to work.
+bool IRrecv::decodeLegoPf(decode_results* results, uint16_t offset,
                           const uint16_t nbits, const bool strict) {
   // Check if can possibly be a valid LEGO message.
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1) return false;
   if (strict && nbits != kLegoPfBits) return false;  // Not what is expected
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_Lutron.cpp
+++ b/src/ir_Lutron.cpp
@@ -58,6 +58,8 @@ void IRsend::sendLutron(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kLutronBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -69,8 +71,8 @@ void IRsend::sendLutron(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/515
-bool IRrecv::decodeLutron(decode_results *results, uint16_t nbits,
-                          bool strict) {
+bool IRrecv::decodeLutron(decode_results *results, uint16_t offset,
+                          const uint16_t nbits, const bool strict) {
   // Technically the smallest number of entries for the smallest message is '1'.
   // i.e. All the bits set to 1, would produce a single huge mark signal.
   // So no minimum length check is required.
@@ -81,8 +83,7 @@ bool IRrecv::decodeLutron(decode_results *results, uint16_t nbits,
   int16_t bitsSoFar = -1;
 
   if (nbits > sizeof(data) * 8) return false;  // To large to store the data.
-  for (uint16_t offset = kStartOffset;
-       bitsSoFar < nbits && offset < results->rawlen; offset++) {
+  for (; bitsSoFar < nbits && offset < results->rawlen; offset++) {
     uint16_t entry = results->rawbuf[offset];
     // It has to be large enough to qualify as a bit.
     if (!matchAtLeast(entry, kLutronTick, 0, kLutronDelta)) {

--- a/src/ir_MWM.cpp
+++ b/src/ir_MWM.cpp
@@ -74,6 +74,8 @@ void IRsend::sendMWM(const uint8_t data[], const uint16_t nbytes,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -81,16 +83,16 @@ void IRsend::sendMWM(const uint8_t data[], const uint16_t nbytes,
 //
 // Status: Implemented.
 //
-bool IRrecv::decodeMWM(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeMWM(decode_results *results, uint16_t offset,
+                       const uint16_t nbits, const bool strict) {
   DPRINTLN("DEBUG: decodeMWM");
 
   // Compliance
-  if (results->rawlen < kMWMMinSamples) {
+  if (results->rawlen <= kMWMMinSamples + offset) {
     DPRINTLN("DEBUG: decodeMWM: too few samples");
     return false;
   }
 
-  uint16_t offset = kStartOffset;
   uint16_t used = 0;
   uint64_t data = 0;
   uint16_t frame_bits = 0;

--- a/src/ir_Magiquest.cpp
+++ b/src/ir_Magiquest.cpp
@@ -67,6 +67,8 @@ uint64_t IRsend::encodeMagiQuest(uint32_t wand_id, uint16_t magnitude) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion, inc. the 8 bit header.
 //            Typically kMagiquestBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -77,17 +79,16 @@ uint64_t IRsend::encodeMagiQuest(uint32_t wand_id, uint16_t magnitude) {
 //
 // Ref:
 //   https://github.com/kitlaan/Arduino-IRremote/blob/master/ir_Magiquest.cpp
-bool IRrecv::decodeMagiQuest(decode_results *results, uint16_t nbits,
-                             bool strict) {
+bool IRrecv::decodeMagiQuest(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
   uint16_t bits = 0;
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
-  if (results->rawlen < (2 * kMagiquestBits)) {
+  if (results->rawlen < (2 * kMagiquestBits) + offset - 1) {
     DPRINT("Not enough bits to be Magiquest - Rawlen: ");
     DPRINT(results->rawlen);
     DPRINT(" Expected: ");
-    DPRINTLN((2 * kMagiquestBits));
+    DPRINTLN(2 * kMagiquestBits + offset - 1);
     return false;
   }
 

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -397,6 +397,8 @@ String IRMideaAC::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kMideaBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -404,7 +406,8 @@ String IRMideaAC::toString(void) {
 //
 // Status: Alpha / Needs testing against a real device.
 //
-bool IRrecv::decodeMidea(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeMidea(decode_results *results, uint16_t offset,
+                         const uint16_t nbits, const bool strict) {
   uint8_t min_nr_of_messages = 1;
   if (strict) {
     if (nbits != kMideaBits) return false;  // Not strictly a MIDEA message.
@@ -414,12 +417,11 @@ bool IRrecv::decodeMidea(decode_results *results, uint16_t nbits, bool strict) {
   // The protocol sends the data normal + inverted, alternating on
   // each byte. Hence twice the number of expected data bits.
   if (results->rawlen <
-      min_nr_of_messages * (2 * nbits + kHeader + kFooter) - 1)
+      min_nr_of_messages * (2 * nbits + kHeader + kFooter) - 1 + offset)
     return false;  // Can't possibly be a valid MIDEA message.
 
   uint64_t data = 0;
   uint64_t inverted = 0;
-  uint16_t offset = kStartOffset;
 
   if (nbits > sizeof(data) * 8)
     return false;  // We can't possibly capture a Midea packet that big.

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -959,17 +959,17 @@ String IRMitsubishiHeavy88Ac::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect.
-//            Typically kMitsubishiHeavy88Bits or kMitsubishiHeavy152Bits.
+//            Typically kMitsubishiHeavy88Bits or kMitsubishiHeavy152Bits (def).
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: BETA / Appears to be working. Needs testing against a real device.
-bool IRrecv::decodeMitsubishiHeavy(decode_results* results,
+bool IRrecv::decodeMitsubishiHeavy(decode_results* results, uint16_t offset,
                                    const uint16_t nbits, const bool strict) {
-  // Check if can possibly be a valid MitsubishiHeavy message.
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1) return false;
   if (strict) {
     switch (nbits) {
       case kMitsubishiHeavy88Bits:
@@ -980,7 +980,6 @@ bool IRrecv::decodeMitsubishiHeavy(decode_results* results,
     }
   }
 
-  uint16_t offset = kStartOffset;
   uint16_t used;
   used = matchGeneric(results->rawbuf + offset, results->state,
                       results->rawlen - offset, nbits,

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -100,7 +100,9 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t offset,
   if (!matchMark(results->rawbuf[offset++], kNecHdrMark)) return false;
   // Check if it is a repeat code.
   if (matchSpace(results->rawbuf[offset], kNecRptSpace) &&
-      matchMark(results->rawbuf[offset + 1], kNecBitMark)) {
+      matchMark(results->rawbuf[offset + 1], kNecBitMark) &&
+      (offset + 2 <= results->rawlen ||
+       matchAtLeast(results->rawbuf[offset + 2], kNecMinGap))) {
     results->value = kRepeat;
     results->decode_type = NEC;
     results->bits = 0;

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -68,6 +68,8 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kNECBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -85,15 +87,15 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
 //
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/nec.php
-bool IRrecv::decodeNEC(decode_results *results, uint16_t nbits, bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1 &&
-      results->rawlen != kNecRptLength)
+bool IRrecv::decodeNEC(decode_results *results, uint16_t offset,
+                       const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1 + offset &&
+      results->rawlen != kNecRptLength + offset - 1)
     return false;  // Can't possibly be a valid NEC message.
   if (strict && nbits != kNECBits)
     return false;  // Not strictly an NEC message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Header
   if (!matchMark(results->rawbuf[offset++], kNecHdrMark)) return false;

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -89,19 +89,17 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
 //   http://www.sbprojects.com/knowledge/ir/nec.php
 bool IRrecv::decodeNEC(decode_results *results, uint16_t offset,
                        const uint16_t nbits, const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1 + offset &&
-      results->rawlen != kNecRptLength + offset - 1)
+  if (results->rawlen < kNecRptLength + offset - 1)
     return false;  // Can't possibly be a valid NEC message.
   if (strict && nbits != kNECBits)
     return false;  // Not strictly an NEC message.
 
   uint64_t data = 0;
 
-  // Header
+  // Header - All NEC messages have this Header Mark.
   if (!matchMark(results->rawbuf[offset++], kNecHdrMark)) return false;
   // Check if it is a repeat code.
-  if (results->rawlen == kNecRptLength &&
-      matchSpace(results->rawbuf[offset], kNecRptSpace) &&
+  if (matchSpace(results->rawbuf[offset], kNecRptSpace) &&
       matchMark(results->rawbuf[offset + 1], kNecBitMark)) {
     results->value = kRepeat;
     results->decode_type = NEC;

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -463,6 +463,8 @@ String IRNeoclimaAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of data bits to expect. Typically kNeoclimaBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -472,13 +474,12 @@ String IRNeoclimaAc::toString(void) {
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/764
-bool IRrecv::decodeNeoclima(decode_results *results, const uint16_t nbits,
-                            const bool strict) {
+bool IRrecv::decodeNeoclima(decode_results *results, uint16_t offset,
+                            const uint16_t nbits, const bool strict) {
   // Compliance
   if (strict && nbits != kNeoclimaBits)
     return false;  // Incorrect nr. of bits per spec.
 
-  uint16_t offset = kStartOffset;
   // Match Main Header + Data + Footer
   uint16_t used;
   used = matchGeneric(results->rawbuf + offset, results->state,

--- a/src/ir_Nikai.cpp
+++ b/src/ir_Nikai.cpp
@@ -48,6 +48,8 @@ void IRsend::sendNikai(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion.
 //            Typically kNikaiBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -56,12 +58,12 @@ void IRsend::sendNikai(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Status: STABLE / Working.
 //
-bool IRrecv::decodeNikai(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeNikai(decode_results *results, uint16_t offset,
+                         const uint16_t nbits, const bool strict) {
   if (strict && nbits != kNikaiBits)
     return false;  // We expect Nikai to be a certain sized message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -142,6 +142,8 @@ uint64_t IRsend::encodePanasonic(const uint16_t manufacturer,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -153,13 +155,13 @@ uint64_t IRsend::encodePanasonic(const uint16_t manufacturer,
 // Ref:
 //   http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152
 //   http://www.hifi-remote.com/wiki/index.php?title=Panasonic
-bool IRrecv::decodePanasonic(decode_results *results, const uint16_t nbits,
-                             const bool strict, const uint32_t manufacturer) {
+bool IRrecv::decodePanasonic(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict,
+                             const uint32_t manufacturer) {
   if (strict && nbits != kPanasonicBits)
     return false;  // Request is out of spec.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,
@@ -810,6 +812,8 @@ String IRPanasonicAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kPanasonicAcBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -825,19 +829,17 @@ String IRPanasonicAc::toString(void) {
 //   A/C Remotes:
 //     A75C3747 (Confirmed)
 //     A75C3704
-bool IRrecv::decodePanasonicAC(decode_results *results, const uint16_t nbits,
-                               const bool strict) {
+bool IRrecv::decodePanasonicAC(decode_results *results, uint16_t offset,
+                               const uint16_t nbits, const bool strict) {
   uint8_t min_nr_of_messages = 1;
   if (strict) {
     if (nbits != kPanasonicAcBits && nbits != kPanasonicAcShortBits)
       return false;  // Not strictly a PANASONIC_AC message.
   }
 
-  if (results->rawlen <
-      min_nr_of_messages * (2 * nbits + kHeader + kFooter) - 1)
+  if (results->rawlen <=
+      min_nr_of_messages * (2 * nbits + kHeader + kFooter) - 1 + offset)
     return false;  // Can't possibly be a valid PANASONIC_AC message.
-
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data #1 + Footer
   uint16_t used;

--- a/src/ir_Pioneer.cpp
+++ b/src/ir_Pioneer.cpp
@@ -96,6 +96,8 @@ uint64_t IRsend::encodePioneer(const uint16_t address, const uint16_t command) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kPioneerBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -103,15 +105,14 @@ uint64_t IRsend::encodePioneer(const uint16_t address, const uint16_t command) {
 //
 // Status: BETA / Should be working. (Self decodes & real examples)
 //
-bool IRrecv::decodePioneer(decode_results *results, const uint16_t nbits,
-                           const bool strict) {
-  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1)
+bool IRrecv::decodePioneer(decode_results *results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * (nbits + kHeader + kFooter) - 1 + offset)
     return false;  // Can't possibly be a valid Pioneer message.
   if (strict && nbits != kPioneerBits)
     return false;  // Not strictly an Pioneer message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
   results->value = 0;
   for (uint16_t section = 0; section < 2; section++) {
     // Match Header + Data + Footer

--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -95,6 +95,8 @@ void IRsend::sendRCMM(uint64_t data, uint16_t nbits, uint16_t repeat) {
 // Places successful decode information in the results pointer.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. Typically kRCMMBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -104,11 +106,11 @@ void IRsend::sendRCMM(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //   http://www.sbprojects.com/knowledge/ir/rcmm.php
-bool IRrecv::decodeRCMM(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeRCMM(decode_results *results, uint16_t offset,
+                        const uint16_t nbits, const bool strict) {
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
-  if (results->rawlen <= 4)
+  if (results->rawlen <= 4 + offset - 1)
     return false;  // Not enough entries to ever be RCMM.
 
   // Calc the maximum size in bits, the message can be, or that we can accept.

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -109,6 +109,8 @@ uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion. Typically kSamsungBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -121,15 +123,12 @@ uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
 //   They differ on their compliance criteria and how they repeat.
 // Ref:
 //  http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
-bool IRrecv::decodeSAMSUNG(decode_results *results, const uint16_t nbits,
-                           const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kFooter - 1)
-    return false;  // Can't possibly be a valid Samsung message.
+bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
   if (strict && nbits != kSamsungBits)
     return false;  // We expect Samsung to be 32 bits of message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,
@@ -201,6 +200,8 @@ void IRsend::sendSamsung36(const uint64_t data, const uint16_t nbits,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of bits to expect in the data portion.
 //            Typically kSamsung36Bits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
@@ -214,9 +215,9 @@ void IRsend::sendSamsung36(const uint64_t data, const uint16_t nbits,
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/621
-bool IRrecv::decodeSamsung36(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + kFooter * 2 - 1)
+bool IRrecv::decodeSamsung36(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * nbits + kHeader + kFooter * 2 - 1 + offset)
     return false;  // Can't possibly be a valid Samsung message.
   // We need to be looking for > 16 bits to make sense.
   if (nbits <= 16) return false;
@@ -224,7 +225,6 @@ bool IRrecv::decodeSamsung36(decode_results *results, const uint16_t nbits,
     return false;  // We expect nbits to be 36 bits of message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   // Match Header + Data + Footer
   uint16_t used;
@@ -687,6 +687,8 @@ String IRSamsungAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kSamsungAcBits
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -696,13 +698,11 @@ String IRSamsungAc::toString(void) {
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
-bool IRrecv::decodeSamsungAC(decode_results *results, const uint16_t nbits,
-                             const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader * 3 + kFooter * 2 - 1)
+bool IRrecv::decodeSamsungAC(decode_results *results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * nbits + kHeader * 3 + kFooter * 2 - 1 + offset)
     return false;  // Can't possibly be a valid Samsung A/C message.
   if (nbits != kSamsungAcBits && nbits != kSamsungAcExtendedBits) return false;
-
-  uint16_t offset = kStartOffset;
 
   // Message Header
   if (!matchMark(results->rawbuf[offset++], kSamsungAcBitMark)) return false;

--- a/src/ir_Sanyo.cpp
+++ b/src/ir_Sanyo.cpp
@@ -106,6 +106,8 @@ void IRsend::sendSanyoLC7461(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -123,12 +125,12 @@ void IRsend::sendSanyoLC7461(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //   http://slydiman.narod.ru/scr/kb/sanyo.htm
 //   https://github.com/marcosamarinho/IRremoteESP8266/blob/master/ir_Sanyo.cpp
 //   http://pdf.datasheetcatalog.com/datasheet/sanyo/LC7461.pdf
-bool IRrecv::decodeSanyoLC7461(decode_results *results, uint16_t nbits,
-                               bool strict) {
+bool IRrecv::decodeSanyoLC7461(decode_results *results, uint16_t offset,
+                               const uint16_t nbits, const bool strict) {
   if (strict && nbits != kSanyoLC7461Bits)
     return false;  // Not strictly in spec.
   // This protocol is basically a 42-bit variant of the NEC protocol.
-  if (!decodeNEC(results, nbits, false))
+  if (!decodeNEC(results, offset, nbits, false))
     return false;  // Didn't match a NEC format (without strict)
 
   // Bits 30 to 42+.

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -134,6 +134,8 @@ uint32_t IRsend::encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -145,8 +147,9 @@ uint32_t IRsend::encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
 //   SONY protocol, SIRC (Serial Infra-Red Control) can be 12,15,20 bits long.
 // Ref:
 // http://www.sbprojects.com/knowledge/ir/sirc.php
-bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader - 1)
+bool IRrecv::decodeSony(decode_results *results, uint16_t offset,
+                        const uint16_t nbits, const bool strict) {
+  if (results->rawlen <= 2 * nbits + kHeader - 1 + offset)
     return false;  // Message is smaller than we expected.
 
   // Compliance
@@ -162,7 +165,6 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t nbits, bool strict) {
   }
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
   uint16_t actualBits;
 
   // Header

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -298,18 +298,19 @@ String IRTecoAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kTecoBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
 //   boolean: True if it can decode it, false if it can't.
 //
 // Status: STABLE / Tested.
-bool IRrecv::decodeTeco(decode_results* results,
+bool IRrecv::decodeTeco(decode_results* results, uint16_t offset,
                         const uint16_t nbits, const bool strict) {
   if (strict && nbits != kTecoBits) return false;  // Not what is expected
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
   // Match Header + Data + Footer
   if (!matchGeneric(results->rawbuf + offset, &data,
                     results->rawlen - offset, nbits,

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -316,6 +316,8 @@ String IRToshibaAC::toString(void) {
 // Places successful decode information in the results pointer.
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kToshibaACBits.
 //   strict:  Flag to indicate if we strictly adhere to the specification.
 // Returns:
@@ -325,10 +327,8 @@ String IRToshibaAC::toString(void) {
 //
 // Ref:
 //
-bool IRrecv::decodeToshibaAC(decode_results* results, const uint16_t nbits,
-                             const bool strict) {
-  uint16_t offset = kStartOffset;
-
+bool IRrecv::decodeToshibaAC(decode_results* results, uint16_t offset,
+                             const uint16_t nbits, const bool strict) {
   // Compliance
   if (strict && nbits != kToshibaACBits)
     return false;  // Must be called with the correct nr. of bytes.

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -238,6 +238,8 @@ String IRTrotecESP::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kTrotecBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -246,13 +248,12 @@ String IRTrotecESP::toString(void) {
 // Status: BETA / Probably works. Untested on real devices.
 //
 // Ref:
-bool IRrecv::decodeTrotec(decode_results *results, const uint16_t nbits,
-                          const bool strict) {
-  if (results->rawlen < 2 * nbits + kHeader + 2 * kFooter - 1)
+bool IRrecv::decodeTrotec(decode_results *results, uint16_t offset,
+                          const uint16_t nbits, const bool strict) {
+  if (results->rawlen <= 2 * nbits + kHeader + 2 * kFooter - 1 + offset)
     return false;  // Can't possibly be a valid Samsung A/C message.
   if (strict && nbits != kTrotecBits) return false;
 
-  uint16_t offset = kStartOffset;
   uint16_t used;
   // Header + Data + Footer #1
   used = matchGeneric(results->rawbuf + offset, results->state,

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -512,6 +512,8 @@ String IRVestelAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kVestelBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -519,8 +521,8 @@ String IRVestelAc::toString(void) {
 //
 // Status: Alpha / Needs testing against a real device.
 //
-bool IRrecv::decodeVestelAc(decode_results* results, const uint16_t nbits,
-                            const bool strict) {
+bool IRrecv::decodeVestelAc(decode_results* results, uint16_t offset,
+                            const uint16_t nbits, const bool strict) {
   if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.
     return false;
 
@@ -529,7 +531,6 @@ bool IRrecv::decodeVestelAc(decode_results* results, const uint16_t nbits,
       return false;  // Not strictly a Vestel AC message.
 
   uint64_t data = 0;
-  uint16_t offset = kStartOffset;
 
   if (nbits > sizeof(data) * 8)
     return false;  // We can't possibly capture a Vestel packet that big.

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -542,6 +542,8 @@ String IRWhirlpoolAc::toString(void) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kWhirlpoolAcBits
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -552,16 +554,15 @@ String IRWhirlpoolAc::toString(void) {
 //
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/509
-bool IRrecv::decodeWhirlpoolAC(decode_results *results, const uint16_t nbits,
-                               const bool strict) {
-  if (results->rawlen < 2 * nbits + 4 + kHeader + kFooter - 1)
+bool IRrecv::decodeWhirlpoolAC(decode_results *results, uint16_t offset,
+                               const uint16_t nbits, const bool strict) {
+  if (results->rawlen < 2 * nbits + 4 + kHeader + kFooter - 1 + offset)
     return false;  // Can't possibly be a valid Whirlpool A/C message.
   if (strict) {
     if (nbits != kWhirlpoolAcBits) return false;
   }
 
-  uint16_t offset = kStartOffset;
-  uint8_t sectionSize[kWhirlpoolAcSections] = {6, 8, 7};
+  const uint8_t sectionSize[kWhirlpoolAcSections] = {6, 8, 7};
 
   // Header
   if (!matchMark(results->rawbuf[offset++], kWhirlpoolAcHdrMark)) return false;

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -69,6 +69,8 @@ void IRsend::sendWhynter(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   Nr. of data bits to expect.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -78,16 +80,15 @@ void IRsend::sendWhynter(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //   https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Whynter.cpp
-bool IRrecv::decodeWhynter(decode_results *results, uint16_t nbits,
-                           bool strict) {
-  if (results->rawlen < 2 * nbits + 2 * kHeader + kFooter - 1)
+bool IRrecv::decodeWhynter(decode_results *results, uint16_t offset,
+                           const uint16_t nbits, const bool strict) {
+  if (results->rawlen <= 2 * nbits + 2 * kHeader + kFooter - 1 + offset)
     return false;  // We don't have enough entries to possibly match.
 
   // Compliance
   if (strict && nbits != kWhynterBits)
     return false;  // Incorrect nr. of bits per spec.
 
-  uint16_t offset = kStartOffset;
   uint64_t data = 0;
   // Pre-Header
   // Sequence begins with a bit mark and a zero space.

--- a/test/IRrecv_test.cpp
+++ b/test/IRrecv_test.cpp
@@ -1358,7 +1358,7 @@ TEST(TestDecode, SkippingInDecode) {
   EXPECT_EQ(0x4BB640BF, irsend.capture.value);
 }
 
-TEST(TestDecode, CrudeHighPassFilter) {
+TEST(TestDecode, CrudeNoiseFilter) {
   IRsendTest irsend(0);
   IRrecv irrecv(1);
   irsend.begin();

--- a/test/IRsend_test.cpp
+++ b/test/IRsend_test.cpp
@@ -193,7 +193,7 @@ TEST(TestSendRaw, GeneralUse) {
   irsend.reset();
   irsend.sendRaw(rawData, 67, 38);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, kNECBits, false));
+  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, kNECBits, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0xC3E0E0E8, irsend.capture.value);

--- a/test/ir_Aiwa_test.cpp
+++ b/test/ir_Aiwa_test.cpp
@@ -130,7 +130,8 @@ TEST(TestDecodeAiwa, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendAiwaRCT501(0x7F);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                      kAiwaRcT501Bits, true));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(kAiwaRcT501Bits, irsend.capture.bits);
   EXPECT_EQ(0x7F, irsend.capture.value);
@@ -142,7 +143,8 @@ TEST(TestDecodeAiwa, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendAiwaRCT501(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                      kAiwaRcT501Bits, true));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(kAiwaRcT501Bits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -154,7 +156,8 @@ TEST(TestDecodeAiwa, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendAiwaRCT501(0x7FFF);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                      kAiwaRcT501Bits, true));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(kAiwaRcT501Bits, irsend.capture.bits);
   EXPECT_EQ(0x7FFF, irsend.capture.value);
@@ -173,7 +176,8 @@ TEST(TestDecodeAiwa, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendAiwaRCT501(0x7F, kAiwaRcT501Bits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                      kAiwaRcT501Bits, true));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(kAiwaRcT501Bits, irsend.capture.bits);
   EXPECT_EQ(0x7F, irsend.capture.value);
@@ -193,7 +197,8 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictValues) {
   irsend.sendNEC(0x1D8113F00FF, 42, kAiwaRcT501MinRepeats);
   irsend.makeDecodeResult();
   // MUST pass with strict on.
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                      kAiwaRcT501Bits, true));
   ASSERT_EQ(0x7F, irsend.capture.value);
 
   irsend.reset();
@@ -202,10 +207,12 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictValues) {
   irsend.sendNEC(0x1234567890A, 42, kAiwaRcT501MinRepeats);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                       kAiwaRcT501Bits, true));
   // Should fail if strict off too.
   ASSERT_FALSE(
-      irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, false));
+      irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, kAiwaRcT501Bits,
+                              false));
 
   irsend.reset();
   // Use sendNEC(data, 42) to make/send an illegal value Aiwa message.
@@ -213,7 +220,8 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictValues) {
   irsend.sendNEC(0x1D8113F00FE, 42, kAiwaRcT501MinRepeats);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                       kAiwaRcT501Bits, true));
   // Should fail if strict off too.
   ASSERT_FALSE(
       irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, false));
@@ -224,10 +232,12 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictValues) {
   irsend.sendNEC(0x0D8113F00FF, 42, kAiwaRcT501MinRepeats);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                       kAiwaRcT501Bits, true));
   // Should fail if strict off too.
   ASSERT_FALSE(
-      irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, false));
+      irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, kAiwaRcT501Bits,
+                              false));
 }
 
 // Decode unsupported Aiwa messages.
@@ -240,9 +250,10 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictSizes) {
   irsend.sendAiwaRCT501(0x0, 8);  // Illegal size Aiwa 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                       kAiwaRcT501Bits, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -251,12 +262,15 @@ TEST(TestDecodeAiwa, DecodeWithNonStrictSizes) {
   irsend.sendAiwaRCT501(0x12345678, 32);  // Illegal size Aiwa 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset,
+                                       kAiwaRcT501Bits, true));
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, 32,
+                                       true));
 
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, 32,
+                                      false));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -273,7 +287,8 @@ TEST(TestDecodeAiwa, Decode64BitMessages) {
   irsend.sendAiwaRCT501(0x1FFFFFFFFF, 37);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 37, false));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, 37,
+                                      false));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(37, irsend.capture.bits);
   EXPECT_EQ(0x1FFFFFFFFF, irsend.capture.value);
@@ -283,7 +298,8 @@ TEST(TestDecodeAiwa, Decode64BitMessages) {
   irsend.sendNEC(0x76044FFFFFFFFFFF, 64, kAiwaRcT501MinRepeats);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, 37, false));
+  ASSERT_TRUE(irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, 37,
+                                      false));
   EXPECT_EQ(AIWA_RC_T501, irsend.capture.decode_type);
   EXPECT_EQ(37, irsend.capture.bits);
   EXPECT_EQ(0x1FFFFFFFFF, irsend.capture.value);
@@ -316,7 +332,7 @@ TEST(TestDecodeAiwa, DecodeGlobalCacheExample) {
   EXPECT_FALSE(irsend.capture.repeat);
 
   // Confirm what the 42-bit NEC decode is.
-  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, 42, false));
+  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 42, false));
   EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
 }
 
@@ -336,5 +352,6 @@ TEST(TestDecodeAiwa, FailToDecodeNonAiwaExample) {
 
   ASSERT_FALSE(irrecv.decodeAiwaRCT501(&irsend.capture));
   ASSERT_FALSE(
-      irrecv.decodeAiwaRCT501(&irsend.capture, kAiwaRcT501Bits, false));
+      irrecv.decodeAiwaRCT501(&irsend.capture, kStartOffset, kAiwaRcT501Bits,
+                              false));
 }

--- a/test/ir_Carrier_test.cpp
+++ b/test/ir_Carrier_test.cpp
@@ -161,7 +161,8 @@ TEST(TestDecodeCarrierAC, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendCarrierAC(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCarrierAC(&irsend.capture, kCarrierAcBits, true));
+  ASSERT_TRUE(irrecv.decodeCarrierAC(&irsend.capture, kStartOffset,
+                                     kCarrierAcBits, true));
   EXPECT_EQ(CARRIER_AC, irsend.capture.decode_type);
   EXPECT_EQ(kCarrierAcBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -172,7 +173,8 @@ TEST(TestDecodeCarrierAC, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendCarrierAC(0xB335ABE2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCarrierAC(&irsend.capture, kCarrierAcBits, true));
+  ASSERT_TRUE(irrecv.decodeCarrierAC(&irsend.capture, kStartOffset,
+                                     kCarrierAcBits, true));
   EXPECT_EQ(CARRIER_AC, irsend.capture.decode_type);
   EXPECT_EQ(kCarrierAcBits, irsend.capture.bits);
   EXPECT_EQ(0xB335ABE2, irsend.capture.value);

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -215,7 +215,8 @@ TEST(TestDecodeCoolix, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendCOOLIX(0x123456);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+              true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0x123456, irsend.capture.value);
@@ -227,7 +228,8 @@ TEST(TestDecodeCoolix, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendCOOLIX(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                  true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -239,7 +241,8 @@ TEST(TestDecodeCoolix, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendCOOLIX(0xFFFFFF);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                  true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFF, irsend.capture.value);
@@ -258,20 +261,23 @@ TEST(TestDecodeCoolix, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendCOOLIX(0x123456, kCoolixBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                  true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0x123456, irsend.capture.value);
   EXPECT_FALSE(irsend.capture.repeat);
 
   irsend.makeDecodeResult(4 * kCoolixBits + 4);
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                  true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0x123456, irsend.capture.value);
 
   irsend.makeDecodeResult(2 * (4 * kCoolixBits + 4));
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                  true));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
   EXPECT_EQ(0x123456, irsend.capture.value);
@@ -287,9 +293,10 @@ TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
   irsend.sendCOOLIX(0x12, 8);  // Illegal value Coolix 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                   true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x12, irsend.capture.value);
@@ -298,13 +305,14 @@ TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
   irsend.sendCOOLIX(0x12345678, 32);  // Illegal value Coolix 32-bit message.
   irsend.makeDecodeResult();
   // Shouldn't pass with strict when we ask for less bits than we got.
-  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, true));
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                   true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -313,7 +321,7 @@ TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
   irsend.reset();
   irsend.sendCOOLIX(0x123456, kCoolixBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, 9, false));
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, 9, false));
 }
 
 // Decode (non-standard) 64-bit messages.
@@ -327,7 +335,7 @@ TEST(TestDecodeCoolix, Decode64BitMessages) {
   irsend.sendCOOLIX(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -349,7 +357,8 @@ TEST(TestDecodeCoolix, FailToDecodeNonCoolixExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kCoolixBits, false));
+  ASSERT_FALSE(irrecv.decodeCOOLIX(&irsend.capture, kStartOffset, kCoolixBits,
+                                   false));
 }
 
 // Tests for the IRCoolixAC class.

--- a/test/ir_Denon_test.cpp
+++ b/test/ir_Denon_test.cpp
@@ -185,7 +185,8 @@ TEST(TestDecodeDenon, NormalDecodeWithStrict) {
   irsend.sendDenon(0x2278);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenonBits, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kStartOffset, kDenonBits,
+                                 true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
   EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x2278, irsend.capture.value);
@@ -198,7 +199,8 @@ TEST(TestDecodeDenon, NormalDecodeWithStrict) {
   irsend.sendDenon(0x1278, kDenonLegacyBits);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenonLegacyBits, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kStartOffset,
+                                 kDenonLegacyBits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
   EXPECT_EQ(kDenonLegacyBits, irsend.capture.bits);
   EXPECT_EQ(0x1278, irsend.capture.value);
@@ -210,7 +212,8 @@ TEST(TestDecodeDenon, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendDenon(0x2A4C028D6CE3, kDenon48Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kStartOffset,
+                                 kDenon48Bits, true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
   EXPECT_EQ(kDenon48Bits, irsend.capture.bits);
   EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
@@ -235,7 +238,8 @@ TEST(TestDecodeDenon, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test_power, 67);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenonBits, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kStartOffset, kDenonBits,
+                                 true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
   EXPECT_EQ(kDenonBits, irsend.capture.bits);
   EXPECT_EQ(0x2278, irsend.capture.value);
@@ -256,7 +260,8 @@ TEST(TestDecodeDenon, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test_eco, 103);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, true));
+  ASSERT_TRUE(irrecv.decodeDenon(&irsend.capture, kStartOffset, kDenon48Bits,
+                                 true));
   EXPECT_EQ(DENON, irsend.capture.decode_type);
   EXPECT_EQ(kDenon48Bits, irsend.capture.bits);
   EXPECT_EQ(0x2A4C028D6CE3, irsend.capture.value);
@@ -280,7 +285,10 @@ TEST(TestDecodeDenon, FailToDecodeNonDenonExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenonLegacyBits, false));
-  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenonBits, false));
-  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kDenon48Bits, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kStartOffset,
+                                  kDenonLegacyBits, false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kStartOffset, kDenonBits,
+                                  false));
+  ASSERT_FALSE(irrecv.decodeDenon(&irsend.capture, kStartOffset, kDenon48Bits,
+                                  false));
 }

--- a/test/ir_Dish_test.cpp
+++ b/test/ir_Dish_test.cpp
@@ -189,7 +189,8 @@ TEST(TestDecodeDish, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendDISH(0x9C00);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kDishBits, true));
+  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kStartOffset, kDishBits,
+                                true));
   EXPECT_EQ(DISH, irsend.capture.decode_type);
   EXPECT_EQ(kDishBits, irsend.capture.bits);
   EXPECT_EQ(0x9C00, irsend.capture.value);
@@ -208,13 +209,14 @@ TEST(TestDecodeDish, DecodeWithNonStrictSize) {
   irsend.sendDISH(0x12, 8);  // Illegal size Dish message. (smaller)
   irsend.makeDecodeResult();
 
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kDishBits, true));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, kDishBits,
+                                 true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, 8, true));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 8, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(DISH, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x12, irsend.capture.value);
@@ -225,13 +227,14 @@ TEST(TestDecodeDish, DecodeWithNonStrictSize) {
   irsend.sendDISH(0x12345678, 32);  // Illegal size Dish message. (larger)
   irsend.makeDecodeResult();
 
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kDishBits, true));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, kDishBits,
+                                 true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(DISH, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -249,9 +252,9 @@ TEST(TestDecodeDish, Decode64BitMessages) {
   // Illegal value & size Dish 64-bit message.
   irsend.sendDISH(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 64, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(DISH, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -299,7 +302,8 @@ TEST(TestDecodeDish, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test_hopper, 73);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kDishBits, true));
+  ASSERT_TRUE(irrecv.decodeDISH(&irsend.capture, kStartOffset, kDishBits,
+                                true));
   EXPECT_EQ(DISH, irsend.capture.decode_type);
   EXPECT_EQ(kDishBits, irsend.capture.bits);
   EXPECT_EQ(0x9C00, irsend.capture.value);
@@ -332,5 +336,6 @@ TEST(TestDecodeDish, FailToDecodeNonDishExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kDishBits, false));
+  ASSERT_FALSE(irrecv.decodeDISH(&irsend.capture, kStartOffset, kDishBits,
+                                 false));
 }

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -768,7 +768,8 @@ TEST(TestDecodeHaierAC, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendHaierAC(expectedState);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeHaierAC(&irsend.capture, kHaierACBits, true));
+  ASSERT_TRUE(irrecv.decodeHaierAC(&irsend.capture, kStartOffset, kHaierACBits,
+                                   true));
   EXPECT_EQ(HAIER_AC, irsend.capture.decode_type);
   EXPECT_EQ(kHaierACBits, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -151,7 +151,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(0x4B4AE51, kLgBits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x4B4AE51, irsend.capture.value);
@@ -163,7 +163,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(0xB4B4AE51, kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLg32Bits, false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0xB4B4AE51, irsend.capture.value);
@@ -175,7 +175,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -187,7 +187,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x800, 0x8000), kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0x80080008, irsend.capture.value);
@@ -206,7 +206,7 @@ TEST(TestDecodeLG, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99), kLgBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -218,7 +218,7 @@ TEST(TestDecodeLG, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99), kLg32Bits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -238,19 +238,20 @@ TEST(TestDecodeLG, DecodeWithNonStrictValues) {
   irsend.reset();
   irsend.sendLG(0x1);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, false));
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLgBits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits,
+                               false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, false));
 
   // Illegal LG 32-bit message value.
   irsend.reset();
   irsend.sendLG(0x1111111, kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
 
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLg32Bits, false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0x1111111, irsend.capture.value);
@@ -261,7 +262,7 @@ TEST(TestDecodeLG, DecodeWithNonStrictValues) {
   irsend.reset();
   irsend.sendLG(0x1111111, kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, false));
 }
 
 // Decode unsupported LG message sizes.
@@ -276,13 +277,14 @@ TEST(TestDecodeLG, DecodeWithNonStrictSizes) {
   irsend.sendLG(irsend.encodeLG(0x07, 0x99), 16);
   irsend.makeDecodeResult();
   // Should fail when unexpected against different bit sizes.
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, false));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits,
+                               false));
 
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, 16, false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, 16, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(16, irsend.capture.bits);
   EXPECT_EQ(0x992, irsend.capture.value);
@@ -294,12 +296,13 @@ TEST(TestDecodeLG, DecodeWithNonStrictSizes) {
   irsend.sendLG(0x123456789, 36);  // Illegal value LG 36-bit message.
   irsend.makeDecodeResult();
   // Should fail when unexpected against different bit sizes.
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, false));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLg32Bits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits,
+                               false));
 
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, 36, false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, 36, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(36, irsend.capture.bits);
   EXPECT_EQ(0x123456789, irsend.capture.value);
@@ -318,9 +321,9 @@ TEST(TestDecodeLG, Decode64BitMessages) {
   // Illegal value & size LG 64-bit message.
   irsend.sendLG(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, 64, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -346,7 +349,7 @@ TEST(TestDecodeLG, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test, 75);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kLg32Bits, true));
+  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0xB4B4AE51, irsend.capture.value);
@@ -371,7 +374,7 @@ TEST(TestDecodeLG, FailToDecodeNonLGExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeLG(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kLgBits, false));
+  ASSERT_FALSE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, false));
 }
 
 // Tests for sendLG2().
@@ -451,6 +454,7 @@ TEST(TestDecodeLG, Issue620) {
       532, 512,  530, 484, 556, 1536, 532};  // LG 8808721
   irsend.sendRaw(rawData, 59, 38000);
   irsend.makeDecodeResult();
+
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(28, irsend.capture.bits);

--- a/test/ir_Magiquest_test.cpp
+++ b/test/ir_Magiquest_test.cpp
@@ -93,7 +93,8 @@ TEST(TestDecodeMagiQuest, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMagiQuest(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kMagiquestBits, true));
+  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kStartOffset,
+                                     kMagiquestBits, true));
   EXPECT_EQ(MAGIQUEST, irsend.capture.decode_type);
   EXPECT_EQ(kMagiquestBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -104,7 +105,8 @@ TEST(TestDecodeMagiQuest, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMagiQuest(irsend.encodeMagiQuest(0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kMagiquestBits, true));
+  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kStartOffset,
+                                     kMagiquestBits, true));
   EXPECT_EQ(MAGIQUEST, irsend.capture.decode_type);
   EXPECT_EQ(kMagiquestBits, irsend.capture.bits);
   EXPECT_EQ(0x10001, irsend.capture.value);
@@ -115,7 +117,8 @@ TEST(TestDecodeMagiQuest, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMagiQuest(irsend.encodeMagiQuest(0x12345678, 0xABCD));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kMagiquestBits, true));
+  ASSERT_TRUE(irrecv.decodeMagiQuest(&irsend.capture, kStartOffset,
+                                     kMagiquestBits, true));
   EXPECT_EQ(MAGIQUEST, irsend.capture.decode_type);
   EXPECT_EQ(kMagiquestBits, irsend.capture.bits);
   EXPECT_EQ(0x12345678ABCD, irsend.capture.value);

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -478,7 +478,8 @@ TEST(TestDecodeMidea, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMidea(0x1234567890DF);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0x1234567890DF, irsend.capture.value);
@@ -490,7 +491,8 @@ TEST(TestDecodeMidea, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMidea(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -502,7 +504,8 @@ TEST(TestDecodeMidea, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMidea(0xFFFFFFFFFFA0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFA0, irsend.capture.value);
@@ -534,20 +537,23 @@ TEST(TestDecodeMidea, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendMidea(0xA18263FFFF6E, kMideaBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
   EXPECT_FALSE(irsend.capture.repeat);
 
   irsend.makeDecodeResult(2 * (2 * kMideaBits + 4));
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
 
   irsend.makeDecodeResult(4 * (2 * kMideaBits + 4));
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 true));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
@@ -563,9 +569,10 @@ TEST(TestDecodeMidea, DecodeWithNonStrictSizes) {
   irsend.sendMidea(0x12, 8);  // Illegal value Midea 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                  true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x12, irsend.capture.value);
@@ -574,13 +581,14 @@ TEST(TestDecodeMidea, DecodeWithNonStrictSizes) {
   irsend.sendMidea(0x12345678, 32);  // Illegal value Midea 32-bit message.
   irsend.makeDecodeResult();
   // Shouldn't pass with strict when we ask for less bits than we got.
-  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kMideaBits, true));
+  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                  true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -589,7 +597,7 @@ TEST(TestDecodeMidea, DecodeWithNonStrictSizes) {
   irsend.reset();
   irsend.sendMidea(0x123456, kMideaBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, 9, false));
+  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kStartOffset, 9, false));
 }
 
 // Decode (non-standard) 64-bit messages.
@@ -603,7 +611,7 @@ TEST(TestDecodeMidea, Decode64BitMessages) {
   irsend.sendMidea(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -625,7 +633,8 @@ TEST(TestDecodeMidea, FailToDecodeNonMideaExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kMideaBits, false));
+  ASSERT_FALSE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                  false));
 }
 
 // Decode against a real capture reported by a user. See issue #354
@@ -768,7 +777,8 @@ TEST(TestDecodeMidea, Issue887) {
   irsend.reset();
   irsend.sendMidea(hwaddr);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeMidea(&irsend.capture, kMideaBits, false));
+  EXPECT_TRUE(irrecv.decodeMidea(&irsend.capture, kStartOffset, kMideaBits,
+                                 false));
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(hwaddr, irsend.capture.value);

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -143,7 +143,8 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMitsubishi(0xC2B8);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                      kMitsubishiBits, true));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
   EXPECT_EQ(0xC2B8, irsend.capture.value);
@@ -154,7 +155,8 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMitsubishi(0x0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                      kMitsubishiBits, true));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -165,7 +167,8 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendMitsubishi(0xFFFF);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                      kMitsubishiBits, true));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
   EXPECT_EQ(0xFFFF, irsend.capture.value);
@@ -178,17 +181,24 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithStrict) {
   // 12 bits.
   irsend.sendMitsubishi(0xFFF, 12);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 12, true));
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                       kMitsubishiBits, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 12,
+                                       true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 64,
+                                       true));
 
   // 32 bits.
   irsend.sendMitsubishi(0xFFF, 32);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 12, true));
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 32, true));
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                       kMitsubishiBits, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 12,
+                                       true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 32,
+                                       true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 64,
+                                       true));
 }
 
 // Decode normal repeated Mitsubishi messages.
@@ -201,7 +211,8 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendMitsubishi(0xC2B8, kMitsubishiBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                      kMitsubishiBits, true));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
   EXPECT_EQ(0xC2B8, irsend.capture.value);
@@ -213,7 +224,8 @@ TEST(TestDecodeMitsubishi, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendMitsubishi(0xC2B8, kMitsubishiBits, 0);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                      kMitsubishiBits, true));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(kMitsubishiBits, irsend.capture.bits);
   EXPECT_EQ(0xC2B8, irsend.capture.value);
@@ -232,31 +244,36 @@ TEST(TestDecodeMitsubishi, DecodeWithNonStrictValues) {
   irsend.sendMitsubishi(0x0, 8);  // Illegal sized Mitsubishi 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                        kMitsubishiBits, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 64, false));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 64,
+                                       false));
 
   irsend.reset();
   // Illegal sized Mitsubishi 64-bit message.
   irsend.sendMitsubishi(0xFEDCBA9876543210, 64);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, true));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset,
+                                       kMitsubishiBits, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 64,
+                                      false));
   EXPECT_EQ(MITSUBISHI, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFEDCBA9876543210, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
   // Should fail when we are after a shorter message than we got.
-  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, 8, false));
+  ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, 8,
+                                       false));
 }
 
 // Decode a 'real' example via GlobalCache
@@ -299,7 +316,8 @@ TEST(TestDecodeMitsubishi, FailToDecodeNonMitsubishiExample) {
 
   ASSERT_FALSE(irrecv.decodeMitsubishi(&irsend.capture));
   ASSERT_FALSE(
-      irrecv.decodeMitsubishi(&irsend.capture, kMitsubishiBits, false));
+      irrecv.decodeMitsubishi(&irsend.capture, kStartOffset, kMitsubishiBits,
+                              false));
 }
 
 // Tests for Mitsubishi A/C methods.

--- a/test/ir_NEC_test.cpp
+++ b/test/ir_NEC_test.cpp
@@ -162,7 +162,7 @@ TEST(TestDecodeNEC, NormalNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x0);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, 32, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(kNECBits, irsend.capture.bits);
   EXPECT_EQ(0, irsend.capture.value);
@@ -172,7 +172,7 @@ TEST(TestDecodeNEC, NormalNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x12345678);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, 32, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(kNECBits, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -189,7 +189,7 @@ TEST(TestDecodeNEC, ShortNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x0, 16);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, 16, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 16, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(16, irsend.capture.bits);
   EXPECT_EQ(0, irsend.capture.value);
@@ -200,13 +200,13 @@ TEST(TestDecodeNEC, ShortNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x0, 32);
   irsend.makeDecodeResult();
-  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, 16, false));
+  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 16, false));
 
   // Send 16 bits of data, but fail because we are expecting 17.
   irsend.reset();
   irsend.sendNEC(0x0, 16);
   irsend.makeDecodeResult();
-  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, 17, false));
+  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 17, false));
 }
 
 // Longer NEC-like messages (without strict naturally)
@@ -218,7 +218,7 @@ TEST(TestDecodeNEC, LongerNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x1234567890ABCDEF, 64);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, 64, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0x1234567890ABCDEF, irsend.capture.value);
@@ -229,7 +229,7 @@ TEST(TestDecodeNEC, LongerNECDecodeWithoutStrict) {
   irsend.reset();
   irsend.sendNEC(0x0, 63);
   irsend.makeDecodeResult();
-  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, 64, false));
+  EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 64, false));
 }
 
 // Incorrect decoding reported in Issue #243
@@ -299,7 +299,7 @@ TEST(TestDecodeNEC, NonStrictNECDecode_Issue264) {
   irsend.sendRaw(rawData, 67, 38);
   irsend.makeDecodeResult();
   EXPECT_FALSE(irrecv.decodeNEC(&irsend.capture));  // Not strictly NEC
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kNECBits, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, kNECBits, false));
   EXPECT_EQ(0x77E1A040, irsend.capture.value);
 
   // Do it all again, but with a normal decode.
@@ -331,7 +331,7 @@ TEST(TestDecodeNEC, AutoReceiveCalibration) {
 
   irsend.sendRaw(rawData, 67, 38);
   irsend.makeDecodeResult();
-  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kNECBits, false));
+  EXPECT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, kNECBits, false));
   EXPECT_EQ(NEC, irsend.capture.decode_type);
   EXPECT_EQ(kNECBits, irsend.capture.bits);
   EXPECT_EQ(0x77E1A040, irsend.capture.value);

--- a/test/ir_Nikai_test.cpp
+++ b/test/ir_Nikai_test.cpp
@@ -77,7 +77,8 @@ TEST(TestDecodeNikai, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendNikai(0x123456);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, true));
+  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                 true));
   EXPECT_EQ(NIKAI, irsend.capture.decode_type);
   EXPECT_EQ(kNikaiBits, irsend.capture.bits);
   EXPECT_EQ(0x123456, irsend.capture.value);
@@ -85,7 +86,8 @@ TEST(TestDecodeNikai, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendNikai(0x101);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, true));
+  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                 true));
   EXPECT_EQ(NIKAI, irsend.capture.decode_type);
   EXPECT_EQ(kNikaiBits, irsend.capture.bits);
   EXPECT_EQ(0x101, irsend.capture.value);
@@ -101,7 +103,8 @@ TEST(TestDecodeNikai, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendNikai(0xD5F2A, kNikaiBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, true));
+  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                 true));
   EXPECT_EQ(NIKAI, irsend.capture.decode_type);
   EXPECT_EQ(kNikaiBits, irsend.capture.bits);
   EXPECT_EQ(0xD5F2A, irsend.capture.value);
@@ -117,18 +120,20 @@ TEST(TestDecodeNikai, NormalDecodeWithNonStrict) {
   irsend.sendNikai(0x0, 16);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, true));
+  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                  true));
   // And it should fail when we expect more bits.
-  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, false));
+  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                  false));
 
   // Should pass if strict off if we ask for correct nr. of bits sent.
-  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, 16, false));
+  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kStartOffset, 16, false));
   EXPECT_EQ(NIKAI, irsend.capture.decode_type);
   EXPECT_EQ(16, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
 
   // Should fail as we are expecting less bits than there are.
-  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, 12, false));
+  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kStartOffset, 12, false));
 }
 
 // Decode (non-standard) 64-bit messages.
@@ -142,9 +147,10 @@ TEST(TestDecodeNikai, Decode64BitMessages) {
   // Illegal size Nikai 64-bit message.
   irsend.sendNikai(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, true));
+  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                  true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeNikai(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(NIKAI, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -211,5 +217,6 @@ TEST(TestDecodeNikai, FailToDecodeNonNikaiExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kNikaiBits, false));
+  ASSERT_FALSE(irrecv.decodeNikai(&irsend.capture, kStartOffset, kNikaiBits,
+                                  false));
 }

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -219,7 +219,8 @@ TEST(TestDecodePanasonic, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendPanasonic64(0x40040190ED7C);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
@@ -231,7 +232,8 @@ TEST(TestDecodePanasonic, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendPanasonic64(irsend.encodePanasonic(0x4004, 0x12, 0x34, 0x56));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x400412345670, irsend.capture.value);
@@ -243,7 +245,8 @@ TEST(TestDecodePanasonic, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendPanasonic64(irsend.encodePanasonic(0x4004, 0x1, 0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x400401010101, irsend.capture.value);
@@ -262,7 +265,8 @@ TEST(TestDecodePanasonic, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendPanasonic64(0x40040190ED7C, kPanasonicBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
@@ -271,13 +275,15 @@ TEST(TestDecodePanasonic, NormalDecodeWithRepeatAndStrict) {
   EXPECT_FALSE(irsend.capture.repeat);
 
   irsend.makeDecodeResult(2 * kPanasonicBits + 4);
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
 
   irsend.makeDecodeResult(2 * (2 * kPanasonicBits + 4));
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
@@ -293,9 +299,11 @@ TEST(TestDecodePanasonic, DecodeWithNonStrictValues) {
   irsend.sendPanasonic64(0x0);  // Illegal value Panasonic 48-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, false));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, false));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -307,9 +315,11 @@ TEST(TestDecodePanasonic, DecodeWithNonStrictValues) {
   irsend.sendPanasonic64(irsend.encodePanasonic(0, 1, 2, 3));
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, false));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, false));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x1020300, irsend.capture.value);
@@ -327,13 +337,14 @@ TEST(TestDecodePanasonic, DecodeWithNonStrictSize) {
   irsend.sendPanasonic64(0x12345678, 32);  // Illegal size Panasonic message.
   irsend.makeDecodeResult();
 
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -345,12 +356,14 @@ TEST(TestDecodePanasonic, DecodeWithNonStrictSize) {
   irsend.sendPanasonic64(irsend.encodePanasonic(0x4004, 1, 2, 3), 56);
   irsend.makeDecodeResult();
 
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, true));
   // Shouldn't pass if strict off and wrong bit size.
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, false));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, false));
   // Re-decode with correct bit size.
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, 56, true));
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, 56, false));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 56, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 56, false));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(56, irsend.capture.bits);
   EXPECT_EQ(0x400401020300, irsend.capture.value);
@@ -368,9 +381,9 @@ TEST(TestDecodePanasonic, Decode64BitMessages) {
   // Illegal value & size Panasonic 64-bit message.
   irsend.sendPanasonic64(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 64, true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -397,7 +410,8 @@ TEST(TestDecodePanasonic, DecodeGlobalCacheExample) {
   irsend.sendGC(gc_test, 103);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, true));
+  ASSERT_TRUE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                     kPanasonicBits, true));
   EXPECT_EQ(PANASONIC, irsend.capture.decode_type);
   EXPECT_EQ(kPanasonicBits, irsend.capture.bits);
   EXPECT_EQ(0x40040190ED7C, irsend.capture.value);
@@ -430,7 +444,8 @@ TEST(TestDecodePanasonic, FailToDecodeNonPanasonicExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kPanasonicBits, false));
+  ASSERT_FALSE(irrecv.decodePanasonic(&irsend.capture, kStartOffset,
+                                      kPanasonicBits, false));
 }
 
 // Failing to decode Panasonic in Issue #245

--- a/test/ir_RC5_RC6_test.cpp
+++ b/test/ir_RC5_RC6_test.cpp
@@ -202,7 +202,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(0x175);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -214,7 +214,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(0x175);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -227,7 +227,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(0x175, kRC5XBits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -239,7 +239,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(irsend.encodeRC5(0x00, 0x0B, true));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x80B, irsend.capture.value);
@@ -251,7 +251,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(irsend.encodeRC5X(0x02, 0x41, true), kRC5XBits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits, true));
   EXPECT_EQ(RC5X, irsend.capture.decode_type);
   EXPECT_EQ(kRC5XBits, irsend.capture.bits);
   EXPECT_EQ(0x1881, irsend.capture.value);
@@ -264,7 +264,7 @@ TEST(TestDecodeRC5, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC5(irsend.encodeRC5X(0x02, 0x41, true), kRC5XBits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
 }
 
 // Decode normal repeated RC5 messages.
@@ -277,7 +277,7 @@ TEST(TestDecodeRC5, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC5(0x174, kRC5Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x174, irsend.capture.value);
@@ -288,7 +288,7 @@ TEST(TestDecodeRC5, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC5(0x175, kRC5Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(kRC5Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -299,7 +299,7 @@ TEST(TestDecodeRC5, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC5(irsend.encodeRC5X(0x02, 0x41, true), kRC5XBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits, true));
   EXPECT_EQ(RC5X, irsend.capture.decode_type);
   EXPECT_EQ(kRC5XBits, irsend.capture.bits);
   EXPECT_EQ(0x1881, irsend.capture.value);
@@ -317,10 +317,11 @@ TEST(TestDecodeRC5, DecodeWithNonStrictValues) {
   irsend.sendRC5(0xFA, 8);  // Illegal value RC5 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits,
+                                true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0xFA, irsend.capture.value);
@@ -331,14 +332,15 @@ TEST(TestDecodeRC5, DecodeWithNonStrictValues) {
   irsend.sendRC5(0x12345678, 32);  // Illegal size RC5 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits,
+                                true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(RC5, irsend.capture.decode_type);
   EXPECT_EQ(31, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -347,14 +349,15 @@ TEST(TestDecodeRC5, DecodeWithNonStrictValues) {
   irsend.sendRC5(0x87654321, 32);  // Illegal size RC5 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5XBits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5XBits,
+                                true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(RC5X, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x87654321, irsend.capture.value);
@@ -371,7 +374,7 @@ TEST(TestDecodeRC5, Decode64BitMessages) {
   irsend.sendRC5(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeRC5(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(RC5X, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -392,7 +395,8 @@ TEST(TestDecodeRC5, FailToDecodeNonRC5Example) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kRC5Bits, false));
+  ASSERT_FALSE(irrecv.decodeRC5(&irsend.capture, kStartOffset, kRC5Bits,
+                                false));
 }
 
 //                      RRRRRR   CCCCC            666
@@ -688,7 +692,8 @@ TEST(TestDecodeRC6, NormalMode0DecodeWithStrict) {
   irsend.reset();
   irsend.sendRC6(0x175);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6Mode0Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -700,7 +705,8 @@ TEST(TestDecodeRC6, NormalMode0DecodeWithStrict) {
   irsend.reset();
   irsend.sendRC6(irsend.encodeRC6(0x1234567, 0x89, kRC6Mode0Bits));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6Mode0Bits, irsend.capture.bits);
   EXPECT_EQ(0x56789, irsend.capture.value);
@@ -712,7 +718,8 @@ TEST(TestDecodeRC6, NormalMode0DecodeWithStrict) {
   irsend.reset();
   irsend.sendRC6(0x123456789, kRC6Mode0Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6Mode0Bits, irsend.capture.bits);
   EXPECT_EQ(0x56789, irsend.capture.value);
@@ -731,7 +738,8 @@ TEST(TestDecodeRC6, Normal36BitDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC6(0x175, kRC6_36Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -743,7 +751,8 @@ TEST(TestDecodeRC6, Normal36BitDecodeWithStrict) {
   irsend.reset();
   irsend.sendRC6(irsend.encodeRC6(0x1234567, 0x89, kRC6_36Bits), kRC6_36Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
   EXPECT_EQ(0x123456789, irsend.capture.value);
@@ -762,7 +771,8 @@ TEST(TestDecodeRC6, NormalMode0DecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC6(0x174, kRC6Mode0Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6Mode0Bits, irsend.capture.bits);
   EXPECT_EQ(0x174, irsend.capture.value);
@@ -773,7 +783,8 @@ TEST(TestDecodeRC6, NormalMode0DecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC6(0x175, kRC6Mode0Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6Mode0Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -791,7 +802,8 @@ TEST(TestDecodeRC6, Normal36BitDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC6(0x175, kRC6_36Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
   EXPECT_EQ(0x175, irsend.capture.value);
@@ -802,7 +814,8 @@ TEST(TestDecodeRC6, Normal36BitDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendRC6(0x174, kRC6_36Bits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                               true));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
   EXPECT_EQ(0x174, irsend.capture.value);
@@ -881,7 +894,7 @@ TEST(TestDecodeRC6, Decode36BitGlobalCacheExample) {
   irsend.sendGC(gc_test, 65);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits));
+  ASSERT_TRUE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits));
   EXPECT_EQ(RC6, irsend.capture.decode_type);
   EXPECT_EQ(kRC6_36Bits, irsend.capture.bits);
   EXPECT_EQ(0xC800F742A, irsend.capture.value);
@@ -905,18 +918,26 @@ TEST(TestDecodeRC5, FailToDecodeNonRC6Example) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, false));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, false));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                                true));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                                false));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                                true));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, kStartOffset,
+                                false));
 
   irsend.reset();
   irsend.sendRC5(0x0);
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6Mode0Bits, false));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, true));
-  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, false));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                                true));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6Mode0Bits,
+                                false));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kStartOffset, kRC6_36Bits,
+                                true));
+  ASSERT_FALSE(irrecv.decodeRC6(&irsend.capture, kRC6_36Bits, kStartOffset,
+                                false));
 }

--- a/test/ir_RCMM_test.cpp
+++ b/test/ir_RCMM_test.cpp
@@ -91,7 +91,8 @@ TEST(TestDecodeRCMM, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRCMM(0xe0a600);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kRCMMBits, true));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, kRCMMBits,
+                                true));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(kRCMMBits, irsend.capture.bits);
   EXPECT_EQ(0xe0a600, irsend.capture.value);
@@ -103,7 +104,7 @@ TEST(TestDecodeRCMM, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRCMM(0x600, 12);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, true));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 12, true));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(12, irsend.capture.bits);
   EXPECT_EQ(0x600, irsend.capture.value);
@@ -115,7 +116,7 @@ TEST(TestDecodeRCMM, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRCMM(0x28e0a600, 32);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 32, true));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 32, true));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x28e0a600, irsend.capture.value);
@@ -134,15 +135,15 @@ TEST(TestDecodeRCMM, IllegalDecodeWithStrict) {
   irsend.reset();
   irsend.sendRCMM(0x0, 8);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 8, true));
-  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 12, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 8, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 12, true));
 
   // Illegal RCMM 36-bit message.
   irsend.reset();
   irsend.sendRCMM(0x0, 36);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 12, true));
-  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, 36, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 12, true));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 36, true));
 }
 
 // Decodes without strict mode.
@@ -155,13 +156,13 @@ TEST(TestDecodeRCMM, DecodeWithoutStrict) {
   irsend.reset();
   irsend.sendRCMM(0x55, 8);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x55, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 12, false));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x55, irsend.capture.value);
@@ -172,18 +173,18 @@ TEST(TestDecodeRCMM, DecodeWithoutStrict) {
   irsend.reset();
   irsend.sendRCMM(0x123456789, 36);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 12, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 12, false));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(36, irsend.capture.bits);
   EXPECT_EQ(0x123456789, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 24, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 24, false));
   EXPECT_EQ(36, irsend.capture.bits);
   EXPECT_EQ(0x123456789, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 36, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 36, false));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(36, irsend.capture.bits);
   EXPECT_EQ(0x123456789, irsend.capture.value);
@@ -202,7 +203,7 @@ TEST(TestDecodeRCMM, Decode64BitMessages) {
   irsend.sendRCMM(0xFEDCBA9876543210, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(RCMM, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFEDCBA9876543210, irsend.capture.value);
@@ -226,7 +227,8 @@ TEST(TestDecodeRCMM, FailToDecodeNonRCMMExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kRCMMBits, false));
+  ASSERT_FALSE(irrecv.decodeRCMM(&irsend.capture, kStartOffset, kRCMMBits,
+                                 false));
 }
 
 // Issue 281 Debugging

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -107,7 +107,8 @@ TEST(TestDecodeSamsung, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSAMSUNG(0xE0E09966);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   true));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0xE0E09966, irsend.capture.value);
@@ -118,7 +119,8 @@ TEST(TestDecodeSamsung, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSAMSUNG(irsend.encodeSAMSUNG(0x07, 0x99));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   true));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0xE0E09966, irsend.capture.value);
@@ -129,7 +131,8 @@ TEST(TestDecodeSamsung, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSAMSUNG(irsend.encodeSAMSUNG(0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   true));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0x8080807F, irsend.capture.value);
@@ -147,7 +150,8 @@ TEST(TestDecodeSamsung, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendSAMSUNG(0xE0E09966, kSamsungBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   true));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0xE0E09966, irsend.capture.value);
@@ -165,9 +169,11 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   irsend.sendSAMSUNG(0x0);  // Illegal value Samsung 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -178,9 +184,11 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   irsend.sendSAMSUNG(0x12345678);  // Illegal value Samsung 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                   false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungBits, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -192,12 +200,14 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   irsend.sendSAMSUNG(irsend.encodeSAMSUNG(0, 0), 36);
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    true));
   // Shouldn't pass if strict off and wrong expected bit size.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    false));
   // Re-decode with correct bit size.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, 36, true));
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 36, false));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, 36, true));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, 36, false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(36, irsend.capture.bits);
   EXPECT_EQ(0xFF, irsend.capture.value);  // We told it to expect 8 bits less.
@@ -214,7 +224,7 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
 
   // Should pass if strict off if we ask for correct nr. of bits sent.
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 16, false));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, 16, false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(16, irsend.capture.bits);
   EXPECT_EQ(0xFF, irsend.capture.value);  // We told it to expect 4 bits less.
@@ -222,7 +232,7 @@ TEST(TestDecodeSamsung, DecodeWithNonStrictValues) {
   EXPECT_EQ(0x00, irsend.capture.command);
 
   // Should fail as we are expecting less bits than there are.
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, 12, false));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, 12, false));
 }
 
 // Decode (non-standard) 64-bit messages.
@@ -236,9 +246,10 @@ TEST(TestDecodeSamsung, Decode64BitMessages) {
   // Illegal value & size Samsung 64-bit message.
   irsend.sendSAMSUNG(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, true));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    true));
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(SAMSUNG, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -289,7 +300,8 @@ TEST(TestDecodeSamsung, FailToDecodeNonSamsungExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kSamsungBits, false));
+  ASSERT_FALSE(irrecv.decodeSAMSUNG(&irsend.capture, kStartOffset, kSamsungBits,
+                                    false));
 }
 
 // General housekeeping

--- a/test/ir_Sanyo_test.cpp
+++ b/test/ir_Sanyo_test.cpp
@@ -71,7 +71,8 @@ TEST(TestDecodeSanyoLC7461, NormalDecodeWithStrict) {
   irsend.sendSanyoLC7461(0x1D8113F00FF);
   irsend.makeDecodeResult();
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
@@ -84,7 +85,8 @@ TEST(TestDecodeSanyoLC7461, NormalDecodeWithStrict) {
   irsend.sendSanyoLC7461(irsend.encodeSanyoLC7461(0x1234, 0x56));
   irsend.makeDecodeResult();
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x2468DCB56A9, irsend.capture.value);
@@ -97,7 +99,8 @@ TEST(TestDecodeSanyoLC7461, NormalDecodeWithStrict) {
   irsend.sendSanyoLC7461(irsend.encodeSanyoLC7461(0x1, 0x1));
   irsend.makeDecodeResult();
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x3FFE01FE, irsend.capture.value);
@@ -117,7 +120,8 @@ TEST(TestDecodeSanyoLC7461, NormalDecodeWithRepeatAndStrict) {
   irsend.sendSanyoLC7461(0x3FFE01FE, kSanyoLC7461Bits, 1);
   irsend.makeDecodeResult();
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x3FFE01FE, irsend.capture.value);
@@ -137,10 +141,12 @@ TEST(TestDecodeSanyoLC7461, DecodeWithNonStrictValues) {
   irsend.makeDecodeResult();
   // Should fail with strict on.
   ASSERT_FALSE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   // Should pass if strict off.
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, false));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               false));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -152,17 +158,22 @@ TEST(TestDecodeSanyoLC7461, DecodeWithNonStrictValues) {
   irsend.sendSanyoLC7461(0x1234567890A);
   irsend.makeDecodeResult();
   ASSERT_FALSE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
 
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 32, true));
-  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 64, true));
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, 32,
+                                        true));
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, 64,
+                                        true));
   // And should fail for a bad value.
   ASSERT_FALSE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   // Should pass if strict off.
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, false));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               false));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x1234567890A, irsend.capture.value);
@@ -170,7 +181,8 @@ TEST(TestDecodeSanyoLC7461, DecodeWithNonStrictValues) {
   EXPECT_EQ(0x89, irsend.capture.command);
 
   // Shouldn't pass if strict off and looking for a smaller size.
-  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, 34, false));
+  ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, 34,
+                                        false));
 }
 
 // Decode (non-standard) 64-bit messages.
@@ -184,7 +196,8 @@ TEST(TestDecodeSanyoLC7461, Decode64BitMessages) {
   irsend.sendSanyoLC7461(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, 64,
+                                       false));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -210,7 +223,8 @@ TEST(TestDecodeSanyoLC7461, DecodeGlobalCacheExample) {
   irsend.makeDecodeResult();
 
   ASSERT_TRUE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, true));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               true));
   EXPECT_EQ(SANYO_LC7461, irsend.capture.decode_type);
   EXPECT_EQ(kSanyoLC7461Bits, irsend.capture.bits);
   EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
@@ -219,7 +233,7 @@ TEST(TestDecodeSanyoLC7461, DecodeGlobalCacheExample) {
   EXPECT_FALSE(irsend.capture.repeat);
 
   // Confirm what the 42-bit NEC decode is.
-  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, 42, false));
+  ASSERT_TRUE(irrecv.decodeNEC(&irsend.capture, kStartOffset, 42, false));
   EXPECT_EQ(0x1D8113F00FF, irsend.capture.value);
 }
 
@@ -240,5 +254,6 @@ TEST(TestDecodeSanyoLC7461, FailToDecodeNonSanyoLC7461Example) {
 
   ASSERT_FALSE(irrecv.decodeSanyoLC7461(&irsend.capture));
   ASSERT_FALSE(
-      irrecv.decodeSanyoLC7461(&irsend.capture, kSanyoLC7461Bits, false));
+      irrecv.decodeSanyoLC7461(&irsend.capture, kStartOffset, kSanyoLC7461Bits,
+                               false));
 }

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -196,7 +196,8 @@ TEST(TestDecodeSharp, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSharpRaw(0x454A);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  EXPECT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                 true));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(kSharpBits, irsend.capture.bits);
   EXPECT_EQ(0x454A, irsend.capture.value);
@@ -208,7 +209,8 @@ TEST(TestDecodeSharp, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSharpRaw(irsend.encodeSharp(0x07, 0x99));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                 true));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(kSharpBits, irsend.capture.bits);
   EXPECT_EQ(0x7266, irsend.capture.value);
@@ -220,7 +222,8 @@ TEST(TestDecodeSharp, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendSharpRaw(irsend.encodeSharp(0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                 true));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(kSharpBits, irsend.capture.bits);
   EXPECT_EQ(0x4202, irsend.capture.value);
@@ -239,7 +242,8 @@ TEST(TestDecodeSharp, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendSharpRaw(0x7266, kSharpBits, 1);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                 true));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(kSharpBits, irsend.capture.bits);
   EXPECT_EQ(0x7266, irsend.capture.value);
@@ -247,7 +251,8 @@ TEST(TestDecodeSharp, NormalDecodeWithRepeatAndStrict) {
   EXPECT_EQ(0x99, irsend.capture.command);
 
   irsend.makeDecodeResult(2 * (2 * kSharpBits + kFooter));
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                 true));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(kSharpBits, irsend.capture.bits);
   EXPECT_EQ(0x7266, irsend.capture.value);
@@ -263,9 +268,10 @@ TEST(TestDecodeSharp, DecodeWithNonStrict) {
   irsend.sendSharpRaw(0x0, 8);  // Illegal length Sharp 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                  true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x0, irsend.capture.value);
@@ -276,12 +282,13 @@ TEST(TestDecodeSharp, DecodeWithNonStrict) {
   irsend.sendSharpRaw(0x12345678, 32);  // Illegal length Sharp 32-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kSharpBits, true));
+  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                  true));
 
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, 32, true));
+  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kStartOffset, 32, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, 32, false));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, 32, false));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(32, irsend.capture.bits);
   EXPECT_EQ(0x12345678, irsend.capture.value);
@@ -300,7 +307,7 @@ TEST(TestDecodeSharp, Decode64BitMessages) {
   irsend.sendSharpRaw(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeSharp(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(SHARP, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -350,7 +357,8 @@ TEST(TestDecodeSharp, FailToDecodeNonSharpExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kSharpBits, false));
+  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                  false));
 
   // Test only half of a good message, as it is sent (sort of) twice.
   uint16_t gc_half[35] = {38000, 1,  1,  10, 70, 10, 30, 10, 30, 10, 30,  10,
@@ -361,7 +369,8 @@ TEST(TestDecodeSharp, FailToDecodeNonSharpExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kSharpBits, false));
+  ASSERT_FALSE(irrecv.decodeSharp(&irsend.capture, kStartOffset, kSharpBits,
+                                  false));
 }
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/638#issue-421064165

--- a/test/ir_Sony_test.cpp
+++ b/test/ir_Sony_test.cpp
@@ -193,7 +193,7 @@ TEST(TestDecodeSony, SonyDecodeWithUnexpectedLegalSize) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony20Bits, 0x1, 0x1, 0x1));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSonyMinBits));
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSonyMinBits));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(kSony20Bits, irsend.capture.bits);
   EXPECT_EQ(0x81080, irsend.capture.value);
@@ -204,7 +204,7 @@ TEST(TestDecodeSony, SonyDecodeWithUnexpectedLegalSize) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony12Bits, 21, 1), kSony12Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSony20Bits));
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
   EXPECT_EQ(kSony12Bits, irsend.capture.bits);
   EXPECT_EQ(0xA90, irsend.capture.value);
@@ -215,22 +215,28 @@ TEST(TestDecodeSony, SonyDecodeWithUnexpectedLegalSize) {
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony12Bits, 21, 1), kSony12Bits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
 
   // 15-bit message should be regected when using strict and a different size.
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony15Bits, 21, 1), kSony15Bits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
 
   // 20-bit message should be regected when using strict and a different size.
   irsend.reset();
   irsend.sendSony(irsend.encodeSony(kSony20Bits, 1, 1, 1), kSony20Bits);
   irsend.makeDecodeResult();
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  ASSERT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
 }
 
 // Decode unsupported Sony messages. i.e non-standard sizes.
@@ -243,10 +249,14 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   irsend.sendSony(0xFF, 8);  // Illegal 8-bit Sony-like message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSonyMinBits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSonyMinBits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
   // Should work with a 'normal' match (not strict)
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
@@ -259,10 +269,14 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   irsend.sendSony(0x1FFF, 13);  // Illegal 13-bit Sony-like message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSonyMinBits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSonyMinBits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
   // Should work with a 'normal' match (not strict)
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
@@ -275,10 +289,14 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   irsend.sendSony(0x1FFFF, 17);  // Illegal 17-bit Sony-like message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSonyMinBits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSonyMinBits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
   // Should work with a 'normal' match (not strict)
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
@@ -291,10 +309,14 @@ TEST(TestDecodeSony, SonyDecodeWithIllegalSize) {
   irsend.sendSony(0x1FFFFF, 21);  // Illegal 21-bit Sony-like message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSonyMinBits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony15Bits, true));
-  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kSony20Bits, true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSonyMinBits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony15Bits,
+                                 true));
+  EXPECT_FALSE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony20Bits,
+                                 true));
   // Should work with a 'normal' match (not strict)
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(SONY, irsend.capture.decode_type);
@@ -336,7 +358,8 @@ TEST(TestDecodeSony, DecodeGlobalCacheExample) {
   EXPECT_EQ(0x1, irsend.capture.address);
   EXPECT_EQ(0x2E, irsend.capture.command);
   // With strict and correct size.
-  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kSony12Bits, true));
+  ASSERT_TRUE(irrecv.decodeSony(&irsend.capture, kStartOffset, kSony12Bits,
+                                true));
 }
 
 // Encoding & Decode 20 bit Sony messages. Issue #476

--- a/test/ir_Teco_test.cpp
+++ b/test/ir_Teco_test.cpp
@@ -353,7 +353,8 @@ TEST(TestDecodeTeco, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendTeco(expectedState);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeTeco(&irsend.capture, kTecoBits, true));
+  ASSERT_TRUE(irrecv.decodeTeco(&irsend.capture, kStartOffset, kTecoBits,
+                                true));
   EXPECT_EQ(TECO, irsend.capture.decode_type);
   EXPECT_EQ(kTecoBits, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);

--- a/test/ir_Vestel_test.cpp
+++ b/test/ir_Vestel_test.cpp
@@ -407,7 +407,8 @@ TEST(TestDecodeVestelAc, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendVestelAc(expectedState);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeVestelAc(&irsend.capture, kVestelAcBits, true));
+  ASSERT_TRUE(irrecv.decodeVestelAc(&irsend.capture, kStartOffset,
+                                    kVestelAcBits, true));
   EXPECT_EQ(VESTEL_AC, irsend.capture.decode_type);
   EXPECT_EQ(kVestelAcBits, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);

--- a/test/ir_Whynter_test.cpp
+++ b/test/ir_Whynter_test.cpp
@@ -199,10 +199,11 @@ TEST(TestDecodeWhynter, DecodeWithNonStrictSizes) {
   irsend.sendWhynter(0x12, 8);  // Illegal sized Whynter 8-bit message.
   irsend.makeDecodeResult();
   // Should fail with strict on.
-  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kWhynterBits, true));
-  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, 8, true));
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, kWhynterBits,
+                                    true));
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, 8, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, 8, false));
+  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, 8, false));
   EXPECT_EQ(WHYNTER, irsend.capture.decode_type);
   EXPECT_EQ(8, irsend.capture.bits);
   EXPECT_EQ(0x12, irsend.capture.value);
@@ -213,13 +214,14 @@ TEST(TestDecodeWhynter, DecodeWithNonStrictSizes) {
   irsend.sendWhynter(0x1234567890, 40);  // Illegal size Whynter 40-bit message.
   irsend.makeDecodeResult();
   // Shouldn't pass with strict when we ask for less bits than we got.
-  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kWhynterBits, true));
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, kWhynterBits,
+                                    true));
 
   irsend.makeDecodeResult();
   // Should fail with strict when we ask for the wrong bit size.
-  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, 40, true));
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, 40, true));
   // Should pass if strict off.
-  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, 40, false));
+  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, 40, false));
   EXPECT_EQ(WHYNTER, irsend.capture.decode_type);
   EXPECT_EQ(40, irsend.capture.bits);
   EXPECT_EQ(0x1234567890, irsend.capture.value);
@@ -238,7 +240,7 @@ TEST(TestDecodeWhynter, Decode64BitMessages) {
   irsend.sendWhynter(0xFFFFFFFFFFFFFFFF, 64);
   irsend.makeDecodeResult();
   // Should work with a 'normal' match (not strict)
-  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, 64, false));
+  ASSERT_TRUE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, 64, false));
   EXPECT_EQ(WHYNTER, irsend.capture.decode_type);
   EXPECT_EQ(64, irsend.capture.bits);
   EXPECT_EQ(0xFFFFFFFFFFFFFFFF, irsend.capture.value);
@@ -262,5 +264,6 @@ TEST(TestDecodeWhynter, FailToDecodeNonWhynterExample) {
   irsend.makeDecodeResult();
 
   ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture));
-  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kWhynterBits, false));
+  ASSERT_FALSE(irrecv.decodeWhynter(&irsend.capture, kStartOffset, kWhynterBits,
+                                    false));
 }


### PR DESCRIPTION
* All decoding protocols updated to use a starting offset when decoding.
* `irrecv::decode()` now has two additional optional arguments.
  - `max_skip`: Skip over entries at the start of a capture to aggressively look for protocols to decode.
     Warning: Very CPU expensive!
  - `noise_filter`: Try to remove entries from the raw data that are smaller than this value.
     Danger: This will cook the raw data and potentially break some protocol decoders.

* Unit tests updated to use starting offset.
* New unit tests to confirm the new options work as expected.

Fixes #1042