### PR TITLE
Samsung AC Display and VirusDoctor toggles

### DIFF
--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -576,11 +576,6 @@ bool IRSamsungAc::getDisplay(void) {
 
 void IRSamsungAc::setDisplay(const bool on) {
   setBit(&remote_state[10], kSamsungAcDisplayOffset, on);
-  //if (on) {
-  //  remote_state[10] = kSamsungAcDisplaykOn;
-  //  } else {
-  //   remote_state[10] = kSamsungAcDisplaykOff;
-  //}
 }
 
 bool IRSamsungAc::getIon(void) {

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -571,27 +571,24 @@ void IRSamsungAc::setPowerful(const bool on) {
 }
 
 bool IRSamsungAc::getDisplay(void) {
-  return remote_state[10];
+  return GETBIT8(remote_state[10], kSamsungAcDisplayOffset);
 }
 
-void IRSamsungAc::setDisplay(const bool state) {
-  if (state) {
-    remote_state[10] = kSamsungAcDisplaykOn;
-    } else {
-    remote_state[10] = kSamsungAcDisplaykOff;
-  }
+void IRSamsungAc::setDisplay(const bool on) {
+  setBit(&remote_state[10], kSamsungAcDisplayOffset, on);
+  //if (on) {
+  //  remote_state[10] = kSamsungAcDisplaykOn;
+  //  } else {
+  //   remote_state[10] = kSamsungAcDisplaykOff;
+  //}
 }
 
-bool IRSamsungAc::getVirusDoctor(void) {
-  return remote_state[11] & kSamsungAcVirusDoctorMask;
+bool IRSamsungAc::getIon(void) {
+  return GETBIT8(remote_state[11], kSamsungAcIonOffset);
 }
 
-void IRSamsungAc::setVirusDoctor(const bool state) {
-  if (state) {
-    remote_state[11] |= kSamsungAcVirusDoctorMask;
-    } else {
-    remote_state[11] &= ~kSamsungAcVirusDoctorMask;
-  }
+void IRSamsungAc::setIon(const bool on) {
+  setBit(&remote_state[11], kSamsungAcIonOffset, on);
 }
 
 // Convert a standard A/C mode into its native mode.

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -570,6 +570,30 @@ void IRSamsungAc::setPowerful(const bool on) {
   }
 }
 
+bool IRSamsungAc::getDisplay(void) {
+  return remote_state[10];
+}
+
+void IRSamsungAc::setDisplay(const bool state) {
+  if (state) {
+    remote_state[10] = kSamsungAcDisplaykOn;
+    } else {
+    remote_state[10] = kSamsungAcDisplaykOff;
+  }
+}
+
+bool IRSamsungAc::getVirusDoctor(void) {
+  return remote_state[11] & kSamsungAcVirusDoctorMask;
+}
+
+void IRSamsungAc::setVirusDoctor(const bool state) {
+  if (state) {
+    remote_state[11] |= kSamsungAcVirusDoctorMask;
+    } else {
+    remote_state[11] &= ~kSamsungAcVirusDoctorMask;
+  }
+}
+
 // Convert a standard A/C mode into its native mode.
 uint8_t IRSamsungAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -103,6 +103,11 @@ class IRSamsungAc {
   bool getQuiet(void);
   void setPowerful(const bool on);
   bool getPowerful(void);
+
+  void setDisplay(const bool state);
+  bool getDisplay();
+  void setVirusDoctor(const bool state);
+  bool getVirusDoctor();
   
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -105,8 +105,8 @@ class IRSamsungAc {
 
   void setDisplay(const bool on);
   bool getDisplay(void);
-  void setVIon(const bool on);
-  bool getVIon(void);
+  void setIon(const bool on);
+  bool getIon(void);
   
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -58,12 +58,11 @@ const uint8_t kSamsungAcQuiet5Offset = 5;
 const uint8_t kSamsungAcPowerfulMask8 = 0b01010000;
 const uint8_t kSamsungAcPowerful10Offset = 1;  // Mask 0b00000110
 const uint8_t kSamsungAcPowerful10Size = 1;  // Mask 0b00000110
+const uint8_t kSamsungAcDisplayOffset = 4;  // Mask 0b00010000
+const uint8_t kSamsungAcIonOffset = 0;  // Mask 0b00000001
 
 const uint16_t kSamsungACSectionLength = 7;
 const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
-
-const uint8_t kSamsungAcDisplayOffset = 4; // 0b00010000
-const uint8_t kSamsungAcIonOffset = 0; // 0b00000001
 
 // Classes
 class IRSamsungAc {
@@ -107,7 +106,7 @@ class IRSamsungAc {
   bool getDisplay(void);
   void setIon(const bool on);
   bool getIon(void);
-  
+
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kSamsungAcStateLength);

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -62,6 +62,10 @@ const uint8_t kSamsungAcPowerful10Size = 1;  // Mask 0b00000110
 const uint16_t kSamsungACSectionLength = 7;
 const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 
+const uint8_t kSamsungAcDisplaykOn = 0x71;
+const uint8_t kSamsungAcDisplaykOff = 0x61;
+const uint8_t kSamsungAcVirusDoctorMask = 0x01;
+
 // Classes
 class IRSamsungAc {
  public:
@@ -99,6 +103,7 @@ class IRSamsungAc {
   bool getQuiet(void);
   void setPowerful(const bool on);
   bool getPowerful(void);
+  
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kSamsungAcStateLength);

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -62,9 +62,8 @@ const uint8_t kSamsungAcPowerful10Size = 1;  // Mask 0b00000110
 const uint16_t kSamsungACSectionLength = 7;
 const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 
-const uint8_t kSamsungAcDisplaykOn = 0x71;
-const uint8_t kSamsungAcDisplaykOff = 0x61;
-const uint8_t kSamsungAcVirusDoctorMask = 0x01;
+const uint8_t kSamsungAcDisplayOffset = 4; // 0b00010000
+const uint8_t kSamsungAcIonOffset = 0; // 0b00000001
 
 // Classes
 class IRSamsungAc {
@@ -104,10 +103,10 @@ class IRSamsungAc {
   void setPowerful(const bool on);
   bool getPowerful(void);
 
-  void setDisplay(const bool state);
-  bool getDisplay();
-  void setVirusDoctor(const bool state);
-  bool getVirusDoctor();
+  void setDisplay(const bool on);
+  bool getDisplay(void);
+  void setVIon(const bool on);
+  bool getVIon(void);
   
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],


### PR DESCRIPTION
1) Adds the capability to turn on/off the AC display. Useful if you sleep with the AC on.
2) Adds the capability to turn on/off the VirusDoctor feature.

VirusDoctor generates active hydrogen and oxygen ion, which forms Hydroperoxy radicals (HOO–). It reacts with virus and turns into harmless water vapor (H2O) Also the active hydrogen (H) combines with OH-radical and forms water vapor, neutralizing harmful OH-radical.

Tested on Samsung AC model: AR09FSSDAWKNFA with remote: DB63-03556X003.
