### PR TITLE
SamsungAc: Add full support for light & ion.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -968,7 +968,8 @@ void IRac::samsung(IRSamsungAc *ac,
                    const bool on, const stdAc::opmode_t mode,
                    const float degrees,
                    const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
-                   const bool quiet, const bool turbo, const bool clean,
+                   const bool quiet, const bool turbo, const bool light,
+                   const bool filter, const bool clean,
                    const bool beep, const bool prevpower,
                    const bool forcepower) {
   ac->begin();
@@ -981,9 +982,9 @@ void IRac::samsung(IRSamsungAc *ac,
   // No Horizontal swing setting available.
   ac->setQuiet(quiet);
   ac->setPowerful(turbo);
-  // No Light setting available.
+  ac->setDisplay(light);
   // No Econo setting available.
-  // No Filter setting available.
+  ac->setIon(filter);
   ac->setClean(clean);
   ac->setBeep(beep);
   // No Sleep setting available.
@@ -1557,7 +1558,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRSamsungAc ac(_pin, _inverted, _modulation);
       samsung(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
-              send.quiet, send.turbo, send.clean, send.beep, prev->power);
+              send.quiet, send.turbo, send.light, send.filter, send.clean,
+              send.beep, prev->power);
       break;
     }
 #endif  // SEND_SAMSUNG_AC

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -300,7 +300,8 @@ void electra(IRElectraAc *ac,
   void samsung(IRSamsungAc *ac,
                const bool on, const stdAc::opmode_t mode, const float degrees,
                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
-               const bool quiet, const bool turbo, const bool clean,
+               const bool quiet, const bool turbo, const bool light,
+               const bool filter, const bool clean,
                const bool beep, const bool prevpower = true,
                const bool forcepower = true);
 #endif  // SEND_SAMSUNG_AC

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -647,11 +647,11 @@ stdAc::state_t IRSamsungAc::toCommon(void) {
   result.turbo = this->getPowerful();
   result.clean = this->getClean();
   result.beep = this->getBeep();
+  result.light = this->getDisplay();
+  result.filter = this->getIon();
   // Not supported.
   result.swingh = stdAc::swingh_t::kOff;
   result.econo = false;
-  result.filter = false;
-  result.light = false;
   result.sleep = -1;
   result.clock = -1;
   return result;
@@ -660,7 +660,7 @@ stdAc::state_t IRSamsungAc::toCommon(void) {
 // Convert the internal state into a human readable string.
 String IRSamsungAc::toString(void) {
   String result = "";
-  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
+  result.reserve(115);  // Reserve some heap for the string to reduce fragging.
   result += addBoolToString(getPower(), kPowerStr, false);
   result += addModeToString(getMode(), kSamsungAcAuto, kSamsungAcCool,
                             kSamsungAcHeat, kSamsungAcDry,
@@ -695,6 +695,8 @@ String IRSamsungAc::toString(void) {
   result += addBoolToString(getClean(), kCleanStr);
   result += addBoolToString(getQuiet(), kQuietStr);
   result += addBoolToString(getPowerful(), kPowerfulStr);
+  result += addBoolToString(getDisplay(), kLightStr);
+  result += addBoolToString(getIon(), kIonStr);
   return result;
 }
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -892,7 +892,7 @@ TEST(TestIRac, Samsung) {
   IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 0 (Auto), Temp: 28C, Fan: 6 (Auto), Swing: On, "
-      "Beep: On, Clean: On, Quiet: On, Powerful: Off";
+      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Light: On, Ion: Off";
 
   ac.begin();
   irac.samsung(&ac,
@@ -903,6 +903,8 @@ TEST(TestIRac, Samsung) {
                stdAc::swingv_t::kAuto,      // Veritcal swing
                true,                        // Quiet
                false,                       // Turbo
+               true,                        // Light (Display)
+               false,                       // Filter (Ion)
                true,                        // Clean
                true,                        // Beep
                true,                        // Previous power state
@@ -923,6 +925,8 @@ TEST(TestIRac, Samsung) {
                stdAc::swingv_t::kAuto,      // Veritcal swing
                true,                        // Quiet
                false,                       // Turbo
+               true,                        // Light (Display)
+               false,                       // Filter (Ion)
                true,                        // Clean
                true,                        // Beep
                true,                        // Previous power state
@@ -936,7 +940,7 @@ TEST(TestIRac, Samsung) {
   // desired state.
   char expected_on[] =
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off";
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off";
   ASSERT_EQ(expected_on, IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -451,6 +451,26 @@ TEST(TestIRSamsungAcClass, SetAndGetBeep) {
   EXPECT_TRUE(samsung.getBeep());
 }
 
+TEST(TestIRSamsungAcClass, SetAndGetDisplay) {
+  IRSamsungAc ac(0);
+  ac.setDisplay(true);
+  EXPECT_TRUE(ac.getDisplay());
+  ac.setDisplay(false);
+  EXPECT_FALSE(ac.getDisplay());
+  ac.setDisplay(true);
+  EXPECT_TRUE(ac.getDisplay());
+}
+
+TEST(TestIRSamsungAcClass, SetAndGetIon) {
+  IRSamsungAc ac(0);
+  ac.setIon(true);
+  EXPECT_TRUE(ac.getIon());
+  ac.setIon(false);
+  EXPECT_FALSE(ac.getIon());
+  ac.setIon(true);
+  EXPECT_TRUE(ac.getIon());
+}
+
 TEST(TestIRSamsungAcClass, SetAndGetTemp) {
   IRSamsungAc samsung(0);
   samsung.setTemp(25);
@@ -549,7 +569,8 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_EQ(kSamsungAcFanTurbo, ac.getFan());
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 7 (Turbo), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: On", ac.toString());
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: On, Light: On, Ion: Off",
+      ac.toString());
 
   uint8_t off[kSamsungAcStateLength] = {
       0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0,
@@ -559,7 +580,8 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_NE(kSamsungAcFanTurbo, ac.getFan());
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off", ac.toString());
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      ac.toString());
 }
 
 TEST(TestIRSamsungAcClass, QuietAndPowerfulAreMutuallyExclusive) {
@@ -624,7 +646,7 @@ TEST(TestIRSamsungAcClass, HumanReadable) {
   IRSamsungAc samsung(0);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 2 (Low), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
   samsung.setTemp(kSamsungAcMaxTemp);
   samsung.setMode(kSamsungAcHeat);
@@ -635,18 +657,24 @@ TEST(TestIRSamsungAcClass, HumanReadable) {
   samsung.setClean(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 5 (High), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: Off, Powerful: Off",
+      "Beep: On, Clean: On, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
   samsung.setQuiet(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: On, Powerful: Off",
+      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
   samsung.setQuiet(false);
   samsung.setPowerful(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 7 (Turbo), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: Off, Powerful: On",
+      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Light: On, Ion: Off",
+      samsung.toString());
+  samsung.setIon(true);
+  samsung.setDisplay(false);
+  EXPECT_EQ(
+      "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 7 (Turbo), Swing: Off, "
+      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Light: Off, Ion: On",
       samsung.toString());
 }
 
@@ -750,7 +778,7 @@ TEST(TestDecodeSamsungAC, DecodeRealExample) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 2 (Low), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -799,7 +827,7 @@ TEST(TestDecodeSamsungAC, DecodeRealExample2) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -858,7 +886,7 @@ TEST(TestDecodeSamsungAC, DecodePowerOnSample) {
   samsung.setRaw(irsend.capture.state, kSamsungAcExtendedStateLength);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -918,7 +946,7 @@ TEST(TestDecodeSamsungAC, DecodePowerOffSample) {
   samsung.setRaw(irsend.capture.state, kSamsungAcExtendedStateLength);
   EXPECT_EQ(
       "Power: Off, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -965,7 +993,7 @@ TEST(TestDecodeSamsungAC, DecodeHeatSample) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 4 (Heat), Temp: 17C, Fan: 0 (Auto), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1012,7 +1040,7 @@ TEST(TestDecodeSamsungAC, DecodeCoolSample) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1070,7 +1098,7 @@ TEST(TestDecodeSamsungAC, Issue604DecodeExtended) {
   samsung.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1267,7 +1295,7 @@ TEST(TestIRSamsungAcClass, Issue604SendPowerHack) {
       "m586s100000";
   std::string text = "Power: On, Mode: 1 (Cool), Temp: 23C, Fan: 4 (Med), "
                      "Swing: On, Beep: Off, Clean: Off, Quiet: Off, "
-                     "Powerful: Off";
+                     "Powerful: Off, Light: On, Ion: Off";
   // Don't do a setPower()/on()/off() as that will trigger the special message.
   // So it should only be the normal "settings" message.
   ac.setTemp(23);
@@ -1328,6 +1356,8 @@ TEST(TestIRSamsungAcClass, toCommon) {
   ac.setBeep(true);
   ac.setClean(true);
   ac.setQuiet(true);
+  ac.setDisplay(true);
+  ac.setIon(true);
   // Now test it.
   ASSERT_EQ(decode_type_t::SAMSUNG_AC, ac.toCommon().protocol);
   ASSERT_EQ(-1, ac.toCommon().model);
@@ -1339,13 +1369,13 @@ TEST(TestIRSamsungAcClass, toCommon) {
   ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
   ASSERT_FALSE(ac.toCommon().turbo);
   ASSERT_TRUE(ac.toCommon().quiet);
+  ASSERT_TRUE(ac.toCommon().light);
+  ASSERT_TRUE(ac.toCommon().filter);
   ASSERT_TRUE(ac.toCommon().clean);
   ASSERT_TRUE(ac.toCommon().beep);
   // Unsupported.
   ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
   ASSERT_FALSE(ac.toCommon().econo);
-  ASSERT_FALSE(ac.toCommon().light);
-  ASSERT_FALSE(ac.toCommon().filter);
   ASSERT_EQ(-1, ac.toCommon().sleep);
   ASSERT_EQ(-1, ac.toCommon().clock);
 }
@@ -1392,7 +1422,7 @@ TEST(TestDecodeSamsungAC, Issue734QuietSetting) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Light: On, Ion: Off",
       ac.toString());
 
   // Make sure the ac class state is in something wildly different first.
@@ -1414,7 +1444,7 @@ TEST(TestDecodeSamsungAC, Issue734QuietSetting) {
   ac.setQuiet(true);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Light: On, Ion: Off",
       ac.toString());
   // Check it matches the known good/expected state.
   EXPECT_STATE_EQ(expectedState, ac.getRaw(), kSamsungAcBits);
@@ -1464,6 +1494,6 @@ TEST(TestDecodeSamsungAC, Issue734PowerfulOff) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
       ac.toString());
 }


### PR DESCRIPTION
* Add full support for Light (Display) & Ion (VirusDoctor) for Samsung 
A/Cs
* Adjust unit tests accordingly.
* Add unit tests for Light & Ion respectively.
* Update common A/C api

Fixes #1045
Ref: #1048

FYI @rg2k