### PR TITLE
Add support for Epson protocol.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -473,7 +473,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
   // similar in timings & structure, but the Epson one is much longer than the
   // NEC protocol (3x32 identical bits vs 1x32 bits) so this one should be tried
   // first to try to reduce false detection as a NEC packet.
-  if (decodeEpson(results)) return true;
+  if (decodeEpson(results, offset)) return true;
 #endif
 #if DECODE_NEC
     DPRINTLN("Attempting NEC decode");

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -467,6 +467,14 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
     // first to try to reduce false detection as a NEC packet.
     if (decodePioneer(results, offset)) return true;
 #endif
+#if DECODE_EPSON
+  DPRINTLN("Attempting Epson decode");
+  // Try decodeEpson() before decodeNEC() because the protocols are
+  // similar in timings & structure, but the Epson one is much longer than the
+  // NEC protocol (3x32 identical bits vs 1x32 bits) so this one should be tried
+  // first to try to reduce false detection as a NEC packet.
+  if (decodeEpson(results)) return true;
+#endif
 #if DECODE_NEC
     DPRINTLN("Attempting NEC decode");
     if (decodeNEC(results, offset)) return true;

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -553,6 +553,11 @@ bool decodeAmcor(decode_results *results, uint16_t offset = kStartOffset,
                  const uint16_t nbits = kAmcorBits,
                  const bool strict = true);
 #endif  // DECODE_AMCOR
+#if DECODE_EPSON
+bool decodeEpson(decode_results *results,
+                 const uint16_t nbits = kEpsonBits,
+                 const bool strict = true);
+#endif  // DECODE_EPSON
 };
 
 #endif  // IRRECV_H_

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -544,19 +544,19 @@ class IRrecv {
                     const bool strict = true);
 #endif
 #if DECODE_NEOCLIMA
-bool decodeNeoclima(decode_results *results, uint16_t offset = kStartOffset,
-                    const uint16_t nbits = kNeoclimaBits,
-                    const bool strict = true);
+  bool decodeNeoclima(decode_results *results, uint16_t offset = kStartOffset,
+                      const uint16_t nbits = kNeoclimaBits,
+                      const bool strict = true);
 #endif  // DECODE_NEOCLIMA
 #if DECODE_AMCOR
-bool decodeAmcor(decode_results *results, uint16_t offset = kStartOffset,
-                 const uint16_t nbits = kAmcorBits,
-                 const bool strict = true);
+  bool decodeAmcor(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kAmcorBits,
+                   const bool strict = true);
 #endif  // DECODE_AMCOR
 #if DECODE_EPSON
-bool decodeEpson(decode_results *results,
-                 const uint16_t nbits = kEpsonBits,
-                 const bool strict = true);
+  bool decodeEpson(decode_results *results, uint16_t offset = kStartOffset,
+                   const uint16_t nbits = kEpsonBits,
+                   const bool strict = true);
 #endif  // DECODE_EPSON
 };
 

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -565,6 +565,13 @@
 #define SEND_HITACHI_AC424     _IR_ENABLE_DEFAULT_
 #endif  // SEND_HITACHI_AC424
 
+#ifndef DECODE_EPSON
+#define DECODE_EPSON   _IR_ENABLE_DEFAULT_
+#endif  // DECODE_EPSON
+#ifndef SEND_EPSON
+#define SEND_EPSON     _IR_ENABLE_DEFAULT_
+#endif  // SEND_EPSON
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
@@ -687,8 +694,9 @@ enum decode_type_t {
   MITSUBISHI112,
   HITACHI_AC424,
   SONY_38K,
+  EPSON,  // 75
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = SONY_38K,
+  kLastDecodeType = EPSON,
 };
 
 // Message lengths & required repeat values
@@ -736,6 +744,8 @@ const uint16_t kDenon48Bits = 48;
 const uint16_t kDenonLegacyBits = 14;
 const uint16_t kDishBits = 16;
 const uint16_t kDishMinRepeat = 3;
+const uint16_t kEpsonBits = 32;
+const uint16_t kEpsonMinRepeat = 2;
 const uint16_t kElectraAcStateLength = 13;
 const uint16_t kElectraAcBits = kElectraAcStateLength * 8;
 const uint16_t kElectraAcMinRepeat = kNoRepeat;

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -477,7 +477,8 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
 //
 // Ref:
 //   examples/IRrecvDumpV2/IRrecvDumpV2.ino
-void IRsend::sendRaw(uint16_t buf[], uint16_t len, uint16_t hz) {
+void IRsend::sendRaw(const uint16_t buf[], const uint16_t len,
+                     const uint16_t hz) {
   // Set IR carrier frequency
   enableIROut(hz);
   for (uint16_t i = 0; i < len; i++) {
@@ -517,6 +518,8 @@ uint16_t IRsend::minRepeats(const decode_type_t protocol) {
       return kSonyMinRepeat;
     case SONY_38K:
       return kSonyMinRepeat + 1;
+    case EPSON:
+      return kEpsonMinRepeat;
     default:
       return kNoRepeat;
   }
@@ -558,6 +561,7 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
     case LG2:
       return 28;
     case CARRIER_AC:
+    case EPSON:
     case NEC:
     case NEC_LIKE:
     case SAMSUNG:
@@ -685,6 +689,11 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
 #if SEND_DISH
     case DISH:
       sendDISH(data, nbits, min_repeat);
+      break;
+#endif
+#if SEND_EPSON
+    case EPSON:
+      sendEpson(data, nbits, min_repeat);
       break;
 #endif
 #if SEND_GICABLE

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -158,7 +158,7 @@ class IRsend {
   VIRTUAL uint16_t mark(uint16_t usec);
   VIRTUAL void space(uint32_t usec);
   int8_t calibrate(uint16_t hz = 38000U);
-  void sendRaw(uint16_t buf[], uint16_t len, uint16_t hz);
+  void sendRaw(const uint16_t buf[], const uint16_t len, const uint16_t hz);
   void sendData(uint16_t onemark, uint32_t onespace, uint16_t zeromark,
                 uint32_t zerospace, uint64_t data, uint16_t nbits,
                 bool MSBfirst = true);
@@ -535,7 +535,10 @@ class IRsend {
                  const uint16_t nbytes = kAmcorStateLength,
                  const uint16_t repeat = kAmcorDefaultRepeat);
 #endif  // SEND_AMCOR
-
+#if SEND_EPSON
+  void sendEpson(uint64_t data, uint16_t nbits = kEpsonBits,
+                 uint16_t repeat = kEpsonMinRepeat);
+#endif
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -125,6 +125,8 @@ decode_type_t strToDecodeType(const char * const str) {
     return decode_type_t::DISH;
   else if (!strcasecmp(str, "ELECTRA_AC"))
     return decode_type_t::ELECTRA_AC;
+  else if (!strcasecmp(str, "EPSON"))
+    return decode_type_t::EPSON;
   else if (!strcasecmp(str, "FUJITSU_AC"))
     return decode_type_t::FUJITSU_AC;
   else if (!strcasecmp(str, "GICABLE"))
@@ -309,6 +311,9 @@ String typeToString(const decode_type_t protocol, const bool isRepeat) {
       break;
     case ELECTRA_AC:
       result = F("ELECTRA_AC");
+      break;
+    case EPSON:
+      result = F("EPSON");
       break;
     case FUJITSU_AC:
       result = F("FUJITSU_AC");

--- a/src/ir_Epson.cpp
+++ b/src/ir_Epson.cpp
@@ -35,6 +35,8 @@ void IRsend::sendEpson(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Args:
 //   results: Ptr to the data to decode and where to store the decode result.
+//   offset:  The starting index to use when attempting to decode the raw data.
+//            Typically/Defaults to kStartOffset.
 //   nbits:   The number of data bits to expect. Typically kNECBits.
 //   strict:  Flag indicating if we should perform strict matching.
 // Returns:
@@ -50,11 +52,12 @@ void IRsend::sendEpson(uint64_t data, uint16_t nbits, uint16_t repeat) {
 //
 // Ref:
 //  https://github.com/crankyoldgit/IRremoteESP8266/issues/1034
-bool IRrecv::decodeEpson(decode_results *results, uint16_t nbits, bool strict) {
+bool IRrecv::decodeEpson(decode_results *results, uint16_t offset,
+                         const uint16_t nbits, const bool strict) {
   const uint8_t kEpsonMinMesgsForDecode = 2;
 
   if (results->rawlen < kEpsonMinMesgsForDecode * (2 * nbits + kHeader +
-                                                   kFooter) - 1)
+                                                   kFooter) + offset - 1)
     return false;  // Can't possibly be a valid Epson message.
   if (strict && nbits != kEpsonBits)
     return false;  // Not strictly an Epson message.
@@ -62,7 +65,6 @@ bool IRrecv::decodeEpson(decode_results *results, uint16_t nbits, bool strict) {
   uint64_t data = 0;
   uint64_t first_data = 0;
   bool first = true;
-  uint16_t offset = kStartOffset;
 
   for (uint8_t i = 0; i < kEpsonMinMesgsForDecode; i++) {
     // Match Header + Data + Footer

--- a/src/ir_Epson.cpp
+++ b/src/ir_Epson.cpp
@@ -1,0 +1,112 @@
+// Copyright 2020 David Conran
+
+// Epson is an NEC-like protocol, except it doesn't use the NEC style repeat.
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#include <algorithm>
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRutils.h"
+#include "ir_NEC.h"
+
+#if SEND_EPSON
+// Send an Epson formatted message.
+//
+// Args:
+//   data:   The message to be sent.
+//   nbits:  The number of bits of the message to be sent. Typically kEpsonBits.
+//   repeat: The number of times the command is to be repeated.
+//
+// Status: Beta / Probably works.
+//
+// Ref:
+//  https://github.com/crankyoldgit/IRremoteESP8266/issues/1034
+void IRsend::sendEpson(uint64_t data, uint16_t nbits, uint16_t repeat) {
+  sendGeneric(kNecHdrMark, kNecHdrSpace, kNecBitMark, kNecOneSpace, kNecBitMark,
+              kNecZeroSpace, kNecBitMark, kNecMinGap, kNecMinCommandLength,
+              data, nbits, 38, true, repeat, 33);
+}
+
+#endif  // SEND_EPSON
+
+#if DECODE_EPSON
+// Decode the supplied Epson message.
+//
+// Args:
+//   results: Ptr to the data to decode and where to store the decode result.
+//   nbits:   The number of data bits to expect. Typically kNECBits.
+//   strict:  Flag indicating if we should perform strict matching.
+// Returns:
+//   boolean: True if it can decode it, false if it can't.
+//
+// Status: Beta / Probably works.
+//
+// Notes:
+//   Experimental data indicates there are at least three
+//   messages (first + 2 repeats). We only require the first + a single repeat
+//   to match. This helps us distinguish it from NEC messages which are near
+//   identical.
+//
+// Ref:
+//  https://github.com/crankyoldgit/IRremoteESP8266/issues/1034
+bool IRrecv::decodeEpson(decode_results *results, uint16_t nbits, bool strict) {
+  const uint8_t kEpsonMinMesgsForDecode = 2;
+
+  if (results->rawlen < kEpsonMinMesgsForDecode * (2 * nbits + kHeader +
+                                                   kFooter) - 1)
+    return false;  // Can't possibly be a valid Epson message.
+  if (strict && nbits != kEpsonBits)
+    return false;  // Not strictly an Epson message.
+
+  uint64_t data = 0;
+  uint64_t first_data = 0;
+  bool first = true;
+  uint16_t offset = kStartOffset;
+
+  for (uint8_t i = 0; i < kEpsonMinMesgsForDecode; i++) {
+    // Match Header + Data + Footer
+    uint16_t delta = matchGeneric(results->rawbuf + offset, &data,
+                                  results->rawlen - offset, nbits,
+                                  kNecHdrMark, kNecHdrSpace,
+                                  kNecBitMark, kNecOneSpace,
+                                  kNecBitMark, kNecZeroSpace,
+                                  kNecBitMark, kNecMinGap, true);
+    if (!delta) return false;
+    offset += delta;
+    if (first)
+      first_data = data;
+    else if (data != first_data) return false;
+    first = false;  // No longer the first message.
+  }
+  // Compliance
+  // Calculate command and optionally enforce integrity checking.
+  uint8_t command = (data & 0xFF00) >> 8;
+  // Command is sent twice, once as plain and then inverted.
+  if ((command ^ 0xFF) != (data & 0xFF)) {
+    if (strict) return false;  // Command integrity failed.
+    command = 0;  // The command value isn't valid, so default to zero.
+  }
+
+  // Success
+  results->bits = nbits;
+  results->value = data;
+  results->decode_type = EPSON;
+  // Epson command and address are technically in LSB first order so the
+  // final versions have to be reversed.
+  results->command = reverseBits(command, 8);
+  // Normal Epson (NEC) protocol has an 8 bit address sent,
+  // followed by it inverted.
+  uint8_t address = (data & 0xFF000000) >> 24;
+  uint8_t address_inverted = (data & 0x00FF0000) >> 16;
+  if (address == (address_inverted ^ 0xFF))
+    // Inverted, so it is normal Epson (NEC) protocol.
+    results->address = reverseBits(address, 8);
+  else
+    // Not inverted, so must be Extended Epson (NEC) protocol,
+    // thus 16 bit address.
+    results->address = reverseBits((data >> 16) & UINT16_MAX, 16);
+  results->repeat = !first;
+  return true;
+}
+#endif  // DECODE_EPSON

--- a/test/Makefile
+++ b/test/Makefile
@@ -39,7 +39,7 @@ TESTS = IRutils_test IRsend_test ir_NEC_test ir_GlobalCache_test \
 	ir_Whirlpool_test ir_Lutron_test ir_Electra_test ir_Pioneer_test \
   ir_MWM_test ir_Vestel_test ir_Teco_test ir_Tcl_test ir_Lego_test IRac_test \
 	ir_MitsubishiHeavy_test ir_Trotec_test ir_Argo_test ir_Goodweather_test \
-	ir_Inax_test ir_Neoclima_test ir_Amcor_test
+	ir_Inax_test ir_Neoclima_test ir_Amcor_test ir_Epson_test
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -85,7 +85,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
 	ir_Hitachi.o ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o \
 	ir_Pioneer.o ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o ir_Argo.o \
 	ir_Trotec.o ir_MitsubishiHeavy.o ir_Goodweather.o ir_Inax.o ir_Neoclima.o \
-  ir_Amcor.o
+  ir_Amcor.o ir_Epson.o
 
 # All the IR Protocol header files.
 PROTOCOLS_H = $(USER_DIR)/ir_Amcor.h \
@@ -622,4 +622,13 @@ ir_Amcor_test.o : ir_Amcor_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Amcor_test.cpp
 
 ir_Amcor_test : $(COMMON_OBJ) ir_Amcor_test.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+ir_Epson.o : $(USER_DIR)/ir_Epson.cpp $(COMMON_DEPS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Epson.cpp
+
+ir_Epson_test.o : ir_Epson_test.cpp $(COMMON_TEST_DEPS) $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c ir_Epson_test.cpp
+
+ir_Epson_test : $(COMMON_OBJ) ir_Epson_test.o
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/ir_Epson_test.cpp
+++ b/test/ir_Epson_test.cpp
@@ -1,0 +1,159 @@
+// Copyright 2020 David Conran
+
+#include "IRac.h"
+#include "IRrecv.h"
+#include "IRrecv_test.h"
+#include "IRsend.h"
+#include "IRsend_test.h"
+#include "gtest/gtest.h"
+
+// Tests for sendEpson().
+
+// Test sending typical data only.
+TEST(TestSendEpson, SendDataOnly) {
+  IRsendTest irsend(kGpioUnused);
+  irsend.begin();
+  irsend.sendEpson(0xC1AA09F6);
+  EXPECT_EQ(
+      "f38000d33"
+      "m8960s4480"
+      "m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560m560s1680"
+      "m560s1680m560s560m560s1680m560s560m560s1680m560s560m560s1680m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s560m560s560m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680m560s560m560s1680m560s1680m560s560"
+      "m560s41440"
+      "m8960s4480"
+      "m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560m560s1680"
+      "m560s1680m560s560m560s1680m560s560m560s1680m560s560m560s1680m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s560m560s560m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680m560s560m560s1680m560s1680m560s560"
+      "m560s41440"
+      "m8960s4480"
+      "m560s1680m560s1680m560s560m560s560m560s560m560s560m560s560m560s1680"
+      "m560s1680m560s560m560s1680m560s560m560s1680m560s560m560s1680m560s560"
+      "m560s560m560s560m560s560m560s560m560s1680m560s560m560s560m560s1680"
+      "m560s1680m560s1680m560s1680m560s1680m560s560m560s1680m560s1680m560s560"
+      "m560s41440",
+      irsend.outputStr());
+}
+
+// Tests for decodeEpson().
+
+// Decode normal Epson messages.
+TEST(TestDecodeEpson, SyntheticSelfDecode) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  irsend.begin();
+
+  // Real-life Epson code from an actual capture/decode.
+  irsend.reset();
+  irsend.sendEpson(0xC1AA09F6);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(EPSON, irsend.capture.decode_type);
+  EXPECT_EQ(kEpsonBits, irsend.capture.bits);
+  EXPECT_EQ(0xC1AA09F6, irsend.capture.value);
+  EXPECT_EQ(0x5583, irsend.capture.address);
+  EXPECT_EQ(0x90, irsend.capture.command);
+  EXPECT_TRUE(irsend.capture.repeat);
+}
+
+// Decode a real Epson message.
+TEST(TestDecodeEpson, RealMessageDecode) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  irsend.begin();
+
+  // Real-life Epson code from an actual capture/decode.
+  irsend.reset();
+  const uint16_t rawData_0[203] = {
+      8976, 4496, 542, 1690, 542, 1688, 542, 588, 518, 612, 542, 586, 518, 610,
+      518, 610, 542, 1688, 516, 1714, 542, 614, 516, 1688, 542, 612, 516, 1690,
+      540, 614, 514, 1690, 520, 638, 516, 584, 518, 612, 542, 586, 540, 588,
+      542, 1688, 520, 610, 540, 586, 520, 1712, 540, 1692, 542, 1688, 542, 1690,
+      520, 1710, 518, 610, 518, 1712, 518, 1716, 544, 584, 544, 40870,
+      8978, 4496, 542, 1690, 542, 1688, 520, 610, 542, 584, 516, 638, 514, 588,
+      540, 588, 540, 1690, 516, 1716, 516, 614, 542, 1688, 518, 612, 542, 1688,
+      540, 614, 514, 1692, 542, 588, 538, 590, 542, 586, 542, 612, 516, 612,
+      514, 1692, 516, 612, 540, 586, 520, 1712, 518, 1714, 542, 1688, 518, 1716,
+      542, 1688, 516, 614, 542, 1686, 518, 1714, 516, 612, 532, 40882,
+      8976, 4498, 516, 1716, 542, 1690, 540, 614, 516, 614, 516, 614, 514, 588,
+      540, 588, 544, 1688, 522, 1710, 518, 638, 516, 1688, 520, 636, 492, 1714,
+      542, 586, 542, 1690, 542, 588, 542, 584, 542, 612, 516, 612, 514, 614,
+      516, 1690, 542, 586, 542, 586, 540, 1690, 518, 1712, 518, 1716, 518, 1714,
+      542, 1690, 542, 586, 540, 1690, 542, 1690, 542, 588, 540};
+  irsend.sendRaw(rawData_0, 203, 38000);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(EPSON, irsend.capture.decode_type);
+  EXPECT_EQ(kEpsonBits, irsend.capture.bits);
+  EXPECT_EQ(0xC1AA09F6, irsend.capture.value);
+  EXPECT_EQ(0x5583, irsend.capture.address);
+  EXPECT_EQ(0x90, irsend.capture.command);
+  EXPECT_TRUE(irsend.capture.repeat);
+}
+
+TEST(TestDecodeEpson, RequiresARepeat) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  irsend.begin();
+
+  // Simulate sending only two messages (mesg + repeat)
+  irsend.reset();
+  irsend.sendEpson(0xC1AA09F6, kEpsonBits, 1);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(EPSON, irsend.capture.decode_type);
+  EXPECT_EQ(kEpsonBits, irsend.capture.bits);
+  EXPECT_EQ(0xC1AA09F6, irsend.capture.value);
+  EXPECT_EQ(0x5583, irsend.capture.address);
+  EXPECT_EQ(0x90, irsend.capture.command);
+  EXPECT_TRUE(irsend.capture.repeat);
+
+  // Simulate sending no repeats (just 1 message) which should fail to be
+  // detected as Epson.
+  irsend.reset();
+  irsend.sendEpson(0xC1AA09F6, kEpsonBits, 0);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_NE(EPSON, irsend.capture.decode_type);
+}
+
+TEST(TestDecodeEpson, DecodeOnlyIfRepeatIsTheSame) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  irsend.begin();
+
+  // Simulate sending only two identical messages.
+  // This should succeed.
+  irsend.reset();
+  irsend.sendEpson(0xC1AA09F6, kEpsonBits, 0);
+  irsend.sendEpson(0xC1AA09F6, kEpsonBits, 0);
+
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(EPSON, irsend.capture.decode_type);
+  EXPECT_EQ(kEpsonBits, irsend.capture.bits);
+  EXPECT_EQ(0xC1AA09F6, irsend.capture.value);
+  EXPECT_EQ(0x5583, irsend.capture.address);
+  EXPECT_EQ(0x90, irsend.capture.command);
+  EXPECT_TRUE(irsend.capture.repeat);
+
+  // Simulate sending a repeat but with a different code.
+  // This should fail.
+  irsend.reset();
+  irsend.sendEpson(0xC1AA09F6, kEpsonBits, 0);  // Valid code.
+  irsend.sendEpson(0x4BB640BF, kEpsonBits, 0);  // Valid code but different.
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_NE(EPSON, irsend.capture.decode_type);
+}
+
+TEST(TestUtils, Housekeeping) {
+  ASSERT_EQ("EPSON", typeToString(decode_type_t::EPSON));
+  ASSERT_EQ(decode_type_t::EPSON, strToDecodeType("EPSON"));
+  ASSERT_FALSE(hasACState(decode_type_t::EPSON));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::EPSON));
+  ASSERT_EQ(kEpsonBits, IRsendTest::defaultBits(decode_type_t::EPSON));
+  ASSERT_EQ(kEpsonMinRepeat, IRsendTest::minRepeats(decode_type_t::EPSON));
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -51,7 +51,7 @@ PROTOCOLS = ir_NEC.o ir_Sony.o ir_Samsung.o ir_JVC.o ir_RCMM.o ir_RC5_RC6.o \
             ir_GICable.o ir_Whirlpool.o ir_Lutron.o ir_Electra.o ir_Pioneer.o \
             ir_MWM.o ir_Vestel.o ir_Teco.o ir_Tcl.o ir_Lego.o \
             ir_MitsubishiHeavy.o ir_Goodweather.o ir_Inax.o ir_Argo.o \
-						ir_Trotec.o ir_Neoclima.o ir_Amcor.o
+						ir_Trotec.o ir_Neoclima.o ir_Amcor.o ir_Epson.o
 
 # Common object files
 COMMON_OBJ = IRutils.o IRtimer.o IRsend.o IRrecv.o IRtext.o IRac.o $(PROTOCOLS)
@@ -233,6 +233,9 @@ ir_Neoclima.o : $(USER_DIR)/ir_Neoclima.cpp $(USER_DIR)/ir_Neoclima.h $(COMMON_D
 
 ir_Amcor.o : $(USER_DIR)/ir_Amcor.cpp $(USER_DIR)/ir_Amcor.h $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Amcor.cpp
+
+ir_Epson.o : $(USER_DIR)/ir_Epson.cpp $(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/ir_Epson.cpp
 
 IRac.o : $(USER_DIR)/IRac.cpp $(USER_DIR)/IRac.h $(COMMON_DEPS) $(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES)  -c $(USER_DIR)/IRac.cpp


### PR DESCRIPTION
Epson's protocol is a modified NEC protocol.
It requires 3 messages (1 mesg + 2 repeats), however it doesn't use the
NEC-style repeat. It's just a full duplicate.

The decoder only requires two messages to be the same to reduce failed
detection due to corruption.

For #1034