### PR TITLE
Add `decodeToState()` unit tests to all supported protocols

### DIFF
--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -54,6 +54,8 @@ TEST(TestIRac, Amcor) {
   ASSERT_EQ(AMCOR, ac._irsend.capture.decode_type);
   ASSERT_EQ(kAmcorBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Argo) {
@@ -103,6 +105,8 @@ TEST(TestIRac, Coolix) {
   ASSERT_EQ(COOLIX, ac._irsend.capture.decode_type);
   ASSERT_EQ(kCoolixBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
   // Confirm we are sending with a repeat of 1. i.e. two messages.
   EXPECT_EQ(
       "f38000d50"  // 38kHz Frequency and 50% duty-cycle.
@@ -165,6 +169,8 @@ TEST(TestIRac, Daikin) {
   ASSERT_EQ(DAIKIN, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikinBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin128) {
@@ -196,6 +202,8 @@ TEST(TestIRac, Daikin128) {
   ASSERT_EQ(DAIKIN128, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin128Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin152) {
@@ -222,6 +230,8 @@ TEST(TestIRac, Daikin152) {
   ASSERT_EQ(DAIKIN152, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin152Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin160) {
@@ -245,6 +255,8 @@ TEST(TestIRac, Daikin160) {
   ASSERT_EQ(DAIKIN160, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin160Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin176) {
@@ -267,6 +279,8 @@ TEST(TestIRac, Daikin176) {
   ASSERT_EQ(DAIKIN176, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin176Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin2) {
@@ -303,6 +317,8 @@ TEST(TestIRac, Daikin2) {
   ASSERT_EQ(DAIKIN2, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin2Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Daikin216) {
@@ -329,6 +345,8 @@ TEST(TestIRac, Daikin216) {
   ASSERT_EQ(DAIKIN216, ac._irsend.capture.decode_type);
   ASSERT_EQ(kDaikin216Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Electra) {
@@ -392,6 +410,8 @@ TEST(TestIRac, Fujitsu) {
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits - 8, ac._irsend.capture.bits);
   ASSERT_EQ(ardb1_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
   irac.fujitsu(&ac,
@@ -413,6 +433,7 @@ TEST(TestIRac, Fujitsu) {
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(arrah2e_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
   ac._irsend.reset();
   irac.fujitsu(&ac,
                fujitsu_ac_remote_model_t::ARRY4,  // Model
@@ -433,6 +454,7 @@ TEST(TestIRac, Fujitsu) {
   ASSERT_EQ(FUJITSU_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kFujitsuAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(arry4_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Goodweather) {
@@ -459,6 +481,8 @@ TEST(TestIRac, Goodweather) {
   ASSERT_EQ(GOODWEATHER, ac._irsend.capture.decode_type);
   ASSERT_EQ(kGoodweatherBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Gree) {
@@ -489,6 +513,8 @@ TEST(TestIRac, Gree) {
   ASSERT_EQ(GREE, ac._irsend.capture.decode_type);
   ASSERT_EQ(kGreeBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Haier) {
@@ -516,6 +542,8 @@ TEST(TestIRac, Haier) {
   ASSERT_EQ(HAIER_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHaierACBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 
@@ -544,6 +572,8 @@ TEST(TestIRac, HaierYrwo2) {
   ASSERT_EQ(HAIER_AC_YRW02, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHaierACYRW02Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Hitachi) {
@@ -569,6 +599,8 @@ TEST(TestIRac, Hitachi) {
   ASSERT_EQ(HITACHI_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Hitachi424) {
@@ -596,6 +628,8 @@ TEST(TestIRac, Hitachi424) {
   ASSERT_EQ(HITACHI_AC424, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAc424Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
   irac.hitachi424(&ac,
@@ -611,6 +645,7 @@ TEST(TestIRac, Hitachi424) {
   ASSERT_EQ(HITACHI_AC424, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAc424Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected_swingv, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Kelvinator) {
@@ -642,6 +677,8 @@ TEST(TestIRac, Kelvinator) {
   ASSERT_EQ(KELVINATOR, ac._irsend.capture.decode_type);
   ASSERT_EQ(kKelvinatorBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, LG) {
@@ -666,6 +703,8 @@ TEST(TestIRac, LG) {
   ASSERT_EQ(LG, ac._irsend.capture.decode_type);
   ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Midea) {
@@ -692,6 +731,8 @@ TEST(TestIRac, Midea) {
   ASSERT_EQ(MIDEA, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMideaBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Mitsubishi) {
@@ -719,6 +760,8 @@ TEST(TestIRac, Mitsubishi) {
   ASSERT_EQ(MITSUBISHI_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishiACBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Mitsubishi136) {
@@ -743,6 +786,8 @@ TEST(TestIRac, Mitsubishi136) {
   ASSERT_EQ(MITSUBISHI136, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishi136Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, MitsubishiHeavy88) {
@@ -771,6 +816,8 @@ TEST(TestIRac, MitsubishiHeavy88) {
   ASSERT_EQ(MITSUBISHI_HEAVY_88, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishiHeavy88Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, MitsubishiHeavy152) {
@@ -802,6 +849,8 @@ TEST(TestIRac, MitsubishiHeavy152) {
   ASSERT_EQ(MITSUBISHI_HEAVY_152, ac._irsend.capture.decode_type);
   ASSERT_EQ(kMitsubishiHeavy152Bits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Neoclima) {
@@ -832,6 +881,8 @@ TEST(TestIRac, Neoclima) {
   ASSERT_EQ(decode_type_t::NEOCLIMA, ac._irsend.capture.decode_type);
   ASSERT_EQ(kNeoclimaBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Panasonic) {
@@ -862,6 +913,8 @@ TEST(TestIRac, Panasonic) {
   ASSERT_EQ(PANASONIC_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kPanasonicAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected_nke, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   char expected_dke[] =
       "Model: 3 (DKE), Power: On, Mode: 3 (Cool), Temp: 18C, Fan: 4 (High), "
@@ -887,6 +940,7 @@ TEST(TestIRac, Panasonic) {
   ASSERT_EQ(PANASONIC_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kPanasonicAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected_dke, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Samsung) {
@@ -918,6 +972,8 @@ TEST(TestIRac, Samsung) {
   ASSERT_EQ(SAMSUNG_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kSamsungAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
   irac.samsung(&ac,
@@ -945,6 +1001,7 @@ TEST(TestIRac, Samsung) {
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
       "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off";
   ASSERT_EQ(expected_on, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Sharp) {
@@ -966,6 +1023,8 @@ TEST(TestIRac, Sharp) {
   ASSERT_EQ(SHARP_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kSharpAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Tcl112) {
@@ -994,6 +1053,8 @@ TEST(TestIRac, Tcl112) {
   ASSERT_EQ(TCL112AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Teco) {
@@ -1019,6 +1080,8 @@ TEST(TestIRac, Teco) {
   ASSERT_EQ(TECO, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTecoBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Toshiba) {
@@ -1039,6 +1102,8 @@ TEST(TestIRac, Toshiba) {
   ASSERT_EQ(TOSHIBA_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Trotec) {
@@ -1066,6 +1131,8 @@ TEST(TestIRac, Trotec) {
   ASSERT_EQ(TROTEC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTrotecBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Vestel) {
@@ -1093,6 +1160,8 @@ TEST(TestIRac, Vestel) {
   ASSERT_EQ(VESTEL_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kVestelAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
   char expected_clocks[] =
@@ -1117,6 +1186,7 @@ TEST(TestIRac, Vestel) {
   ASSERT_EQ(VESTEL_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kVestelAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected_clocks, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   // Now check it sends both messages during normal operation when the
   // clock is set.
@@ -1183,6 +1253,8 @@ TEST(TestIRac, Whirlpool) {
   ASSERT_EQ(WHIRLPOOL_AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kWhirlpoolAcBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, cmpStates) {
@@ -1577,6 +1649,8 @@ TEST(TestIRac, Issue1001) {
             "On Timer: Off, Off Timer: Off, Sleep: Off, Super: Off, "
             "Command: 1 (Power)",
             IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   // Now check if the mode is set to "Off" instead of just change to power off.
   // i.e. How Home Assistant expects things to work.
@@ -1606,6 +1680,7 @@ TEST(TestIRac, Issue1001) {
             "On Timer: Off, Off Timer: Off, Sleep: Off, Super: Off, "
             "Command: 1 (Power)",
             IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 // Check power switching in Daikin2 common a/c handling when from an IR message.

--- a/test/ir_Argo_test.cpp
+++ b/test/ir_Argo_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2019 David Conran
 #include "ir_Argo.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -105,6 +106,12 @@ TEST(TestDecodeArgo, SyntheticDecode) {
   EXPECT_EQ(decode_type_t::ARGO, irsend.capture.decode_type);
   EXPECT_EQ(kArgoBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (Cool), Fan: 0 (Auto), Temp: 20C, Room Temp: 21C, "
+      "Max: On, IFeel: On, Night: On",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -773,6 +773,8 @@ TEST(TestCoolixACClass, Issue985) {
   EXPECT_EQ(kCoolixBits, ac._irsend.capture.bits);
   EXPECT_EQ(kCoolixOff, ac._irsend.capture.value);
   EXPECT_EQ("Power: Off", IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
 
@@ -793,6 +795,7 @@ TEST(TestCoolixACClass, Issue985) {
   EXPECT_EQ(
       "Power: On, Mode: 0 (Cool), Fan: 5 (Auto), Temp: 20C, Zone Follow: Off, "
       "Sensor Temp: Off", IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
   ac._irsend.reset();
 
@@ -808,6 +811,7 @@ TEST(TestCoolixACClass, Issue985) {
   EXPECT_EQ(kCoolixBits, ac._irsend.capture.bits);
   EXPECT_EQ(kCoolixOff, ac._irsend.capture.value);
   EXPECT_EQ("Power: Off", IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestCoolixACClass, PowerStateWithSetRaw) {

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -2581,6 +2581,8 @@ TEST(TestDecodeDaikin128, RealExample) {
       "On Timer: Off, On Timer: 07:30, Off Timer: Off, Off Timer: 22:00, "
       "Light Toggle: 0 (Off)",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t result, prev;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
 }
 
 // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/827
@@ -2971,6 +2973,8 @@ TEST(TestDecodeDaikin152, RealExample) {
       "Power: Off, Mode: 0 (Auto), Temp: 26C, Fan: 2 (UNKNOWN), Swing(V): Off, "
       "Powerful: Off, Quiet: On, Econo: Off, Sensor: Off, Comfort: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t result, prev;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
 }
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/873
@@ -3006,6 +3010,8 @@ TEST(TestDecodeDaikin152, SyntheticExample) {
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 1 (Low), Swing(V): On, "
       "Powerful: Off, Quiet: Off, Econo: Off, Sensor: Off, Comfort: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t result, prev;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
 }
 
 TEST(TestDaikin2ClassNew, Issue908) {

--- a/test/ir_Electra_test.cpp
+++ b/test/ir_Electra_test.cpp
@@ -103,6 +103,8 @@ TEST(TestDecodeElectraAC, RealExampleDecode) {
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 3 (Low), "
       "Swing(V): Off, Swing(H): Off, Light: -, Clean: Off, Turbo: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestIRElectraAcClass, Power) {

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -1,5 +1,5 @@
 // Copyright 2017 Jonny Graham, David Conran
-
+#include "IRac.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
 #include "IRsend_test.h"
@@ -316,6 +316,12 @@ TEST(TestDecodeFujitsuAC, SyntheticShortMessages) {
   ASSERT_EQ(kFujitsuAcMinBits + 8, irsend.capture.bits);
   uint8_t expected_arrah2e[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02, 0xFD};
   EXPECT_STATE_EQ(expected_arrah2e, irsend.capture.state, irsend.capture.bits);
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: Off, Mode: 0 (Auto), Temp: 16C, "
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 
   irsend.reset();
 

--- a/test/ir_Goodweather_test.cpp
+++ b/test/ir_Goodweather_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019 David Conran
 
 #include "ir_Goodweather.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -276,11 +277,12 @@ uint16_t rawData_FAD2BE31[197] = {
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
   EXPECT_FALSE(irsend.capture.repeat);
-  ac.setRaw(irsend.capture.value);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 22C, Fan: 3 (Low), Turbo: -, Light: -, "
       "Sleep: -, Swing: 1 (Slow), Command: 4 (Swing)",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 

--- a/test/ir_Gree_test.cpp
+++ b/test/ir_Gree_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 David Conran
 
 #include "ir_Gree.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRremoteESP8266.h"
@@ -576,7 +577,9 @@ TEST(TestDecodeGree, NormalRealExample) {
       "Model: 1 (YAW1F), Power: On, Mode: 1 (Cool), Temp: 26C, Fan: 1 (Low), "
       "Turbo: Off, IFeel: Off, WiFi: Off, XFan: Off, Light: On, Sleep: Off, "
       "Swing(V) Mode: Manual, Swing(V): 2 (UNKNOWN), Timer: Off",
-      irgree.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestGreeClass, toCommon) {

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2018 David Conran
 
 #include "ir_Haier.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -818,13 +819,13 @@ TEST(TestDecodeHaierAC, RealExample1) {
   EXPECT_FALSE(irsend.capture.repeat);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
 
-  IRHaierAC haier(0);
-  haier.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Command: 1 (On), Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), "
       "Swing: 0 (Off), Sleep: Off, Health: Off, "
       "Clock: 00:01, On Timer: Off, Off Timer: Off",
-      haier.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Decode a "real" example message.

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -915,6 +915,8 @@ TEST(TestDecodeHitachiAc424, RealExample) {
       "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 5 (Auto), "
       "Swing(V) Toggle: Off, Button: 19 (Power/Mode)",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestDecodeHitachiAc424, SyntheticExample) {

--- a/test/ir_Kelvinator_test.cpp
+++ b/test/ir_Kelvinator_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 David Conran
 
 #include "ir_Kelvinator.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRremoteESP8266.h"
@@ -519,6 +520,13 @@ TEST(TestDecodeKelvinator, NormalSynthetic) {
   EXPECT_EQ(KELVINATOR, irsend.capture.decode_type);
   ASSERT_EQ(kKelvinatorBits, irsend.capture.bits);
   EXPECT_STATE_EQ(kelv_code, irsend.capture.state, kKelvinatorBits);
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Cool), Temp: 27C, Fan: 1 (Low), Turbo: Off, "
+      "Quiet: Off, XFan: On, Ion: Off, Light: Off, "
+      "Swing(H): Off, Swing(V): Off",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestKelvinatorClass, toCommon) {

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -843,6 +843,8 @@ TEST(TestDecodeLG2, Issue1008) {
   ASSERT_EQ(LG2, ac._irsend.capture.decode_type);
   ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRLgAcClass, DifferentModels) {
@@ -864,6 +866,8 @@ TEST(TestIRLgAcClass, DifferentModels) {
   ASSERT_EQ(LG, ac._irsend.capture.decode_type);  // Not "LG2"
   ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected1, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 
 
   ac.setModel(lg_ac_remote_model_t::AKB75215403);  // aka. 2
@@ -879,4 +883,5 @@ TEST(TestIRLgAcClass, DifferentModels) {
   ASSERT_EQ(LG2, ac._irsend.capture.decode_type);  // Not "LG"
   ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected2, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 David Conran
 
 #include "ir_Midea.h"
+#include "IRac.h"
 #include "IRsend.h"
 #include "IRsend_test.h"
 #include "gtest/gtest.h"
@@ -669,6 +670,12 @@ TEST(TestDecodeMidea, DecodeRealExample) {
   EXPECT_EQ(MIDEA, irsend.capture.decode_type);
   EXPECT_EQ(kMideaBits, irsend.capture.bits);
   EXPECT_EQ(0xA18263FFFF6E, irsend.capture.value);
+  EXPECT_EQ(
+      "Power: On, Mode: 2 (Auto), Celsius: Off, Temp: 18C/65F, Fan: 0 (Auto), "
+      "Sleep: Off, Swing(V) Toggle: Off",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestMideaACClass, toCommon) {

--- a/test/ir_MitsubishiHeavy_test.cpp
+++ b/test/ir_MitsubishiHeavy_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019 David Conran
 
 #include "ir_MitsubishiHeavy.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRremoteESP8266.h"
@@ -742,7 +743,9 @@ TEST(TestDecodeMitsubishiHeavy, ZmsRealExample) {
       "Power: On, Mode: 4 (Heat), Temp: 24C, Fan: 4 (Max), "
       "Swing(V): 0 (Auto), Swing(H): 0 (Auto), Silent: Off, Turbo: Off, "
       "Econo: Off, Night: Off, Filter: Off, 3D: Off, Clean: Off",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Decode a Synthetic MitsubishiHeavy 152Bit message.
@@ -847,7 +850,9 @@ TEST(TestDecodeMitsubishiHeavy, ZjsSyntheticExample) {
       "Power: On, Mode: 2 (Dry), Temp: 25C, Fan: 0 (Auto), "
       "Swing(V): 0 (Off), Swing(H): 6 (Left Right), Turbo: Off, Econo: Off, "
       "3D: Off, Clean: Off",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestMitsubishiHeavy152AcClass, toCommon) {

--- a/test/ir_Mitsubishi_test.cpp
+++ b/test/ir_Mitsubishi_test.cpp
@@ -1230,6 +1230,8 @@ TEST(TestDecodeMitsubishi136, DecodeRealExample) {
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 3 (High), "
       "Swing(V): 3 (Highest), Quiet: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Self decode a synthetic example.
@@ -1719,6 +1721,8 @@ TEST(TestDecodeMitsubishi112, DecodeRealExample) {
       "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 2 (Quiet), "
       "Swing(V): 7 (Auto), Swing(H): 12 (Auto), Quiet: On",
       IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Self decode a synthetic example.

--- a/test/ir_Neoclima_test.cpp
+++ b/test/ir_Neoclima_test.cpp
@@ -2,6 +2,7 @@
 
 #include "ir_Neoclima.h"
 #include <algorithm>
+#include "IRac.h"
 #include "IRsend.h"
 #include "IRsend_test.h"
 #include "IRrecv.h"
@@ -12,6 +13,7 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("NEOCLIMA", typeToString(decode_type_t::NEOCLIMA));
   ASSERT_EQ(decode_type_t::NEOCLIMA, strToDecodeType("NEOCLIMA"));
   ASSERT_TRUE(hasACState(decode_type_t::NEOCLIMA));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::NEOCLIMA));
 }
 
 // Test sending typical data only.
@@ -83,7 +85,9 @@ TEST(TestDecodeNeoclima, RealExample) {
       "Swing(V): Off, Swing(H): On, Sleep: Off, Turbo: Off, Hold: Off, "
       "Ion: Off, Eye: Off, Light: Off, Follow: Off, 8C Heat: Off, Fresh: Off, "
       "Button: 0 (Power)",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Self decode.

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017, 2018 David Conran
 
 #include "ir_Panasonic.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -889,14 +890,13 @@ TEST(TestDecodePanasonicAC, SyntheticExample) {
   EXPECT_EQ(kPanasonicAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);
-
-  IRPanasonicAc pana(0);
-  pana.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Model: 4 (JKE), Power: Off, Mode: 3 (Cool), Temp: 25C, "
       "Fan: 7 (Auto), Swing(V): 15 (Auto), Quiet: Off, "
       "Powerful: Off, Clock: 00:00, On Timer: Off, Off Timer: Off",
-      pana.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Tests for general utility functions.

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "ir_Samsung.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -1047,13 +1048,12 @@ TEST(TestDecodeSamsungAC, DecodeCoolSample) {
   ASSERT_EQ(SAMSUNG_AC, irsend.capture.decode_type);
   EXPECT_EQ(kSamsungAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-
-  IRSamsungAc samsung(0);
-  samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 0 (Auto), Swing: Off, "
       "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
-      samsung.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestDecodeSamsungAC, Issue604DecodeExtended) {

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 David Conran
 
 #include "ir_Sharp.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -407,12 +408,10 @@ TEST(TestDecodeSharpAc, RealExample) {
   ASSERT_EQ(SHARP_AC, irsend.capture.decode_type);
   ASSERT_EQ(kSharpAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-
-  IRSharpAc ac(0);
-  ac.begin();
-  ac.setRaw(irsend.capture.state);
   EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 2 (Auto)",
-            ac.toString());
+            IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/638#issue-421064165

--- a/test/ir_Teco_test.cpp
+++ b/test/ir_Teco_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019 David Conran
 
 #include "ir_Teco.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -387,7 +388,6 @@ TEST(TestDecodeTeco, NormalDecodeWithStrict) {
 TEST(TestDecodeTeco, RealNormalExample) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
-  IRTecoAc ac(0);
   irsend.begin();
 
   uint16_t rawData1[73] = {
@@ -408,12 +408,12 @@ TEST(TestDecodeTeco, RealNormalExample) {
   EXPECT_EQ(expected1, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
-  ac.begin();
-  ac.setRaw(irsend.capture.value);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 27C, Fan: 0 (Auto), Sleep: On, "
       "Swing: On, Light: Off, Humid: Off, Save: Off, Timer: Off",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 
   uint16_t rawData2[73] = {
     9048, 4472, 636, 548, 636, 1654, 638, 546, 642, 1650, 642, 546, 638,
@@ -433,12 +433,11 @@ TEST(TestDecodeTeco, RealNormalExample) {
   EXPECT_EQ(expected2, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
-  ac.begin();
-  ac.setRaw(irsend.capture.value);
   EXPECT_EQ(
       "Power: On, Mode: 2 (Dry), Temp: 21C, Fan: 2 (Medium), Sleep: Off, "
       "Swing: On, Light: Off, Humid: Off, Save: Off, Timer: Off",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 

--- a/test/ir_Toshiba_test.cpp
+++ b/test/ir_Toshiba_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 David Conran
 #include "ir_Toshiba.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -499,6 +500,11 @@ TEST(TestDecodeToshibaAC, SyntheticExample) {
   ASSERT_EQ(TOSHIBA_AC, irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
+  EXPECT_EQ(
+      "Power: On, Mode: 0 (Auto), Temp: 17C, Fan: 0 (Auto)",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Test decoding against captures from a real Toshiba A/C remote.

--- a/test/ir_Trotec_test.cpp
+++ b/test/ir_Trotec_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2019 David Conran
 #include "ir_Trotec.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -97,11 +98,11 @@ TEST(TestDecodeTrotec, SyntheticDecode) {
   EXPECT_EQ(decode_type_t::TROTEC, irsend.capture.decode_type);
   EXPECT_EQ(kTrotecBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-  IRTrotecESP ac(0);
-  ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 2 (Medium), Sleep: On",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 
@@ -176,4 +177,5 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("TROTEC", typeToString(decode_type_t::TROTEC));
   ASSERT_EQ(decode_type_t::TROTEC, strToDecodeType("TROTEC"));
   ASSERT_TRUE(hasACState(decode_type_t::TROTEC));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::TROTEC));
 }

--- a/test/ir_Vestel_test.cpp
+++ b/test/ir_Vestel_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019 David Conran
 
 #include "ir_Vestel.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -441,7 +442,6 @@ TEST(TestDecodeVestelAc, NormalDecodeWithStrict) {
 TEST(TestDecodeVestelAc, RealNormalExample) {
   IRsendTest irsend(0);
   IRrecv irrecv(0);
-  IRVestelAc ac(0);
   irsend.begin();
 
   uint16_t rawData[115] = {
@@ -465,12 +465,12 @@ TEST(TestDecodeVestelAc, RealNormalExample) {
   EXPECT_EQ(0xF4410001FF1201ULL, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
-  ac.begin();
-  ac.setRaw(irsend.capture.value);
   EXPECT_EQ(
       "Power: On, Mode: 4 (Heat), Temp: 16C, Fan: 1 (Auto), Sleep: Off, "
       "Turbo: Off, Ion: On, Swing: Off",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestDecodeVestelAc, RealTimerExample) {

--- a/test/ir_Whirlpool_test.cpp
+++ b/test/ir_Whirlpool_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2018 David Conran
 
 #include "ir_Whirlpool.h"
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRrecv_test.h"
 #include "IRsend.h"
@@ -66,13 +67,13 @@ TEST(TestDecodeWhirlpoolAC, SyntheticDecode) {
   EXPECT_EQ(WHIRLPOOL_AC, irsend.capture.decode_type);
   EXPECT_EQ(kWhirlpoolAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-  IRWhirlpoolAc ac(0);
-  ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Model: 1 (DG11J13A), Power Toggle: Off, Mode: 1 (Auto), Temp: 25C, "
       "Fan: 0 (Auto), Swing: Off, Light: On, Clock: 17:31, On Timer: Off, "
       "Off Timer: Off, Sleep: Off, Super: Off, Command: 2 (Temp)",
-      ac.toString());
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 TEST(TestDecodeWhirlpoolAC, Real26CFanAutoCoolingSwingOnClock1918) {


### PR DESCRIPTION
Add Unit tests (coverage) where possible to all protocols. Some in multiple places.

Fixes #1067