### PR TITLE
SamsungAc: Add Breeze (Aka WindFree) control

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2770,7 +2770,7 @@ kRightMaxStr	LITERAL1
 kRightStr	LITERAL1
 kRoomStr	LITERAL1
 kSamsung36Bits	LITERAL1
-kSamsungACSectionLength	LITERAL1
+kSamsungAcSectionLength	LITERAL1
 kSamsungAcAuto	LITERAL1
 kSamsungAcAutoTemp	LITERAL1
 kSamsungAcBeepOffset	LITERAL1

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -271,7 +271,7 @@ bool IRrecv::decodeSamsung36(decode_results *results, uint16_t offset,
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
 void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
                            const uint16_t repeat) {
-  if (nbytes < kSamsungAcStateLength && nbytes % kSamsungACSectionLength)
+  if (nbytes < kSamsungAcStateLength && nbytes % kSamsungAcSectionLength)
     return;  // Not an appropriate number of bytes to send a proper message.
 
   enableIROut(38);
@@ -281,11 +281,11 @@ void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
     space(kSamsungAcHdrSpace);
     // Send in 7 byte sections.
     for (uint16_t offset = 0; offset < nbytes;
-         offset += kSamsungACSectionLength) {
+         offset += kSamsungAcSectionLength) {
       sendGeneric(kSamsungAcSectionMark, kSamsungAcSectionSpace,
                   kSamsungAcBitMark, kSamsungAcOneSpace, kSamsungAcBitMark,
                   kSamsungAcZeroSpace, kSamsungAcBitMark, kSamsungAcSectionGap,
-                  data + offset, kSamsungACSectionLength,  // 7 bytes == 56 bits
+                  data + offset, kSamsungAcSectionLength,  // 7 bytes == 56 bits
                   38000, false, 0, 50);                    // Send in LSBF order
     }
     // Complete made up guess at inter-message gap.
@@ -379,10 +379,10 @@ void IRSamsungAc::sendExtended(const uint16_t repeat, const bool calcchecksum) {
       0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   // Copy/convert the internal state to an extended state.
-  for (uint16_t i = 0; i < kSamsungACSectionLength; i++)
+  for (uint16_t i = 0; i < kSamsungAcSectionLength; i++)
     extended_state[i] = remote_state[i];
-  for (uint16_t i = kSamsungACSectionLength; i < kSamsungAcStateLength; i++)
-    extended_state[i + kSamsungACSectionLength] = remote_state[i];
+  for (uint16_t i = kSamsungAcSectionLength; i < kSamsungAcStateLength; i++)
+    extended_state[i + kSamsungAcSectionLength] = remote_state[i];
   // extended_state[8] seems special. This is a guess on how to calculate it.
   extended_state[8] = (extended_state[1] & 0x9F) | 0x40;
   // Send it.
@@ -425,7 +425,7 @@ void IRSamsungAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   // Shrink the extended state into a normal state.
   if (length > kSamsungAcStateLength) {
     for (uint8_t i = kSamsungAcStateLength; i < length; i++)
-      remote_state[i - kSamsungACSectionLength] = remote_state[i];
+      remote_state[i - kSamsungAcSectionLength] = remote_state[i];
   }
 }
 
@@ -550,14 +550,15 @@ void IRSamsungAc::setQuiet(const bool on) {
 
 bool IRSamsungAc::getPowerful(void) {
   return !(remote_state[8] & kSamsungAcPowerfulMask8) &&
-         GETBITS8(remote_state[10], kSamsungAcPowerful10Offset,
-                  kSamsungAcPowerful10Offset) &&
+         (GETBITS8(remote_state[10], kSamsungAcPowerful10Offset,
+                   kSamsungAcPowerful10Size) == kSamsungAcPowerful10On) &&
          (this->getFan() == kSamsungAcFanTurbo);
 }
 
 void IRSamsungAc::setPowerful(const bool on) {
+  uint8_t off_value = this->getBreeze() ? kSamsungAcBreezeOn : 0b000;
   setBits(&remote_state[10], kSamsungAcPowerful10Offset,
-          kSamsungAcPowerful10Offset, on ? 0b11: 0b00);
+          kSamsungAcPowerful10Size, on ? kSamsungAcPowerful10On : off_value);
   if (on) {
     remote_state[8] &= ~kSamsungAcPowerfulMask8;  // Bit needs to be cleared.
     // Powerful mode sets fan speed to Turbo.
@@ -567,6 +568,26 @@ void IRSamsungAc::setPowerful(const bool on) {
     remote_state[8] |= kSamsungAcPowerfulMask8;  // Bit needs to be set.
     // Turning off Powerful mode sets fan speed to Auto if we were in Turbo mode
     if (this->getFan() == kSamsungAcFanTurbo) this->setFan(kSamsungAcFanAuto);
+  }
+}
+
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
+// Are the vanes closed over the fan outlet, to stop direct wind? Aka. WindFree
+bool IRSamsungAc::getBreeze(void) {
+  return (GETBITS8(remote_state[10], kSamsungAcBreezeOffset,
+                   kSamsungAcBreezeSize) == kSamsungAcBreezeOn) &&
+         (this->getFan() == kSamsungAcFanAuto && !getSwing());
+}
+
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
+// Closes the vanes over the fan outlet, to stop direct wind. Aka. WindFree
+void IRSamsungAc::setBreeze(const bool on) {
+  uint8_t off_value = this->getPowerful() ? kSamsungAcPowerful10On : 0b000;
+  setBits(&remote_state[10], kSamsungAcBreezeOffset,
+          kSamsungAcBreezeSize, on ? kSamsungAcBreezeOn : off_value);
+  if (on) {
+    this->setFan(kSamsungAcFanAuto);
+    this->setSwing(false);
   }
 }
 
@@ -695,6 +716,7 @@ String IRSamsungAc::toString(void) {
   result += addBoolToString(getClean(), kCleanStr);
   result += addBoolToString(getQuiet(), kQuietStr);
   result += addBoolToString(getPowerful(), kPowerfulStr);
+  result += addBoolToString(getBreeze(), kBreezeStr);
   result += addBoolToString(getDisplay(), kLightStr);
   result += addBoolToString(getIon(), kIonStr);
   return result;
@@ -726,17 +748,17 @@ bool IRrecv::decodeSamsungAC(decode_results *results, uint16_t offset,
   if (!matchMark(results->rawbuf[offset++], kSamsungAcBitMark)) return false;
   if (!matchSpace(results->rawbuf[offset++], kSamsungAcHdrSpace)) return false;
   // Section(s)
-  for (uint16_t pos = 0; pos <= (nbits / 8) - kSamsungACSectionLength;
-       pos += kSamsungACSectionLength) {
+  for (uint16_t pos = 0; pos <= (nbits / 8) - kSamsungAcSectionLength;
+       pos += kSamsungAcSectionLength) {
     uint16_t used;
     // Section Header + Section Data (7 bytes) + Section Footer
     used = matchGeneric(results->rawbuf + offset, results->state + pos,
-                        results->rawlen - offset, kSamsungACSectionLength * 8,
+                        results->rawlen - offset, kSamsungAcSectionLength * 8,
                         kSamsungAcSectionMark, kSamsungAcSectionSpace,
                         kSamsungAcBitMark, kSamsungAcOneSpace,
                         kSamsungAcBitMark, kSamsungAcZeroSpace,
                         kSamsungAcBitMark, kSamsungAcSectionGap,
-                        pos + kSamsungACSectionLength >= nbits / 8,
+                        pos + kSamsungAcSectionLength >= nbits / 8,
                         _tolerance, 0, false);
     if (used == 0) return false;
     offset += used;

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -19,22 +19,59 @@
 // Supports:
 //   Brand: Samsung,  Model: UA55H6300 TV
 //   Brand: Samsung,  Model: DB63-03556X003 remote
+//   Brand: Samsung,  Model: DB93-16761C remote
 //   Brand: Samsung,  Model: IEC-R03 remote
 //   Brand: Samsung,  Model: AR09FSSDAWKNFA A/C
 //   Brand: Samsung,  Model: AR12KSFPEWQNET A/C
 //   Brand: Samsung,  Model: AR12HSSDBWKNEU A/C
+//   Brand: Samsung,  Model: AR12NXCXAWKXEU A/C
 
 // Ref:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
 
 // Constants
+// Byte[1]
+// Checksum                                        0b11110000 ???
+const uint8_t kSamsungAcPower1Offset = 5;  // Mask 0b00100000
+const uint8_t kSamsungAcQuiet1Offset = 4;  // Mask 0b00010000
+// Byte[5]
+const uint8_t kSamsungAcQuiet5Offset = 5;
+// Byte[6]
+const uint8_t kSamsungAcPower6Offset = 4;  // Mask 0b00110000
+const uint8_t kSamsungAcPower6Size = 2;  // Bits
+// Byte[8]
+// Checksum                             0b11110000 ???
+const uint8_t kSamsungAcPowerfulMask8 = 0b01010000;
+// Byte[9]
+const uint8_t kSamsungAcSwingOffset = 4;  // Mask 0b01110000
+const uint8_t kSamsungAcSwingSize = 3;  // Bits
+const uint8_t kSamsungAcSwingMove =                0b010;
+const uint8_t kSamsungAcSwingStop =                0b111;
+// Byte[10]
+const uint8_t kSamsungAcPowerful10Offset = 1;  // Mask 0b00001110
+const uint8_t kSamsungAcPowerful10Size = 3;    // Mask 0b00001110
+const uint8_t kSamsungAcPowerful10On =                     0b011;
+// Breeze (aka. WindFree)
+const uint8_t kSamsungAcBreezeOffset = kSamsungAcPowerful10Offset;
+const uint8_t kSamsungAcBreezeSize = kSamsungAcPowerful10Size;
+const uint8_t kSamsungAcBreezeOn =                         0b101;
+const uint8_t kSamsungAcDisplayOffset = 4;     // Mask 0b00010000
+const uint8_t kSamsungAcClean10Offset = 7;     // Mask 0b10000000
+// Byte[11]
+const uint8_t kSamsungAcIonOffset = 0;      // Mask 0b00000001
+const uint8_t kSamsungAcClean11Offset = 1;  // Mask 0b00000010
+const uint8_t kSamsungAcMinTemp = 16;   // C   Mask 0b11110000
+const uint8_t kSamsungAcMaxTemp = 30;   // C   Mask 0b11110000
+const uint8_t kSamsungAcAutoTemp = 25;  // C   Mask 0b11110000
+// Byte[12]
+const uint8_t kSamsungAcModeOffset = 4;  // Mask 0b01110000
 const uint8_t kSamsungAcAuto = 0;
 const uint8_t kSamsungAcCool = 1;
 const uint8_t kSamsungAcDry = 2;
 const uint8_t kSamsungAcFan = 3;
 const uint8_t kSamsungAcHeat = 4;
-const uint8_t kSamsungAcModeOffset = 4;  // Mask 0b01110000
-const uint8_t kSamsungAcFanOffest = 1;  // Mask 0b00001110
+const uint8_t kSamsungAcFanOffest = 1;   // Mask 0b00001110
 const uint8_t kSamsungAcFanSize = 3;  // Bits
 const uint8_t kSamsungAcFanAuto = 0;
 const uint8_t kSamsungAcFanLow = 2;
@@ -42,28 +79,10 @@ const uint8_t kSamsungAcFanMed = 4;
 const uint8_t kSamsungAcFanHigh = 5;
 const uint8_t kSamsungAcFanAuto2 = 6;
 const uint8_t kSamsungAcFanTurbo = 7;
-const uint8_t kSamsungAcMinTemp = 16;   // 16C
-const uint8_t kSamsungAcMaxTemp = 30;   // 30C
-const uint8_t kSamsungAcAutoTemp = 25;  // 25C
-const uint8_t kSamsungAcPower1Offset = 5;
-const uint8_t kSamsungAcPower6Offset = 4;  // Mask 0b00110000
-const uint8_t kSamsungAcPower6Size = 2;  // Bits
-const uint8_t kSamsungAcSwingOffset = 4;  // Mask 0b01110000
-const uint8_t kSamsungAcSwingSize = 3;  // Bits
-const uint8_t kSamsungAcSwingMove = 0b010;
-const uint8_t kSamsungAcSwingStop = 0b111;
-const uint8_t kSamsungAcBeepOffset = 1;
-const uint8_t kSamsungAcClean10Offset = 7;
-const uint8_t kSamsungAcClean11Offset = 1;     // 0b00000010
-const uint8_t kSamsungAcQuiet1Offset = 4;
-const uint8_t kSamsungAcQuiet5Offset = 5;
-const uint8_t kSamsungAcPowerfulMask8 = 0b01010000;
-const uint8_t kSamsungAcPowerful10Offset = 1;  // Mask 0b00000110
-const uint8_t kSamsungAcPowerful10Size = 1;  // Mask 0b00000110
-const uint8_t kSamsungAcDisplayOffset = 4;  // Mask 0b00010000
-const uint8_t kSamsungAcIonOffset = 0;  // Mask 0b00000001
+// Byte[13]
+const uint8_t kSamsungAcBeepOffset = 1;  // Mask 0b00000010
 
-const uint16_t kSamsungACSectionLength = 7;
+const uint16_t kSamsungAcSectionLength = 7;
 const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 
 // Classes
@@ -103,7 +122,8 @@ class IRSamsungAc {
   bool getQuiet(void);
   void setPowerful(const bool on);
   bool getPowerful(void);
-
+  void setBreeze(const bool on);
+  bool getBreeze(void);
   void setDisplay(const bool on);
   bool getDisplay(void);
   void setIon(const bool on);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -977,7 +977,8 @@ TEST(TestIRac, Samsung) {
   IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 0 (Auto), Temp: 28C, Fan: 6 (Auto), Swing: On, "
-      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Light: On, Ion: Off";
+      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off";
 
   ac.begin();
   irac.samsung(&ac,
@@ -1027,7 +1028,8 @@ TEST(TestIRac, Samsung) {
   // desired state.
   char expected_on[] =
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off";
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off";
   ASSERT_EQ(expected_on, IRAcUtils::resultAcToString(&ac._irsend.capture));
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018, 2019 David Conran
+// Copyright 2017-2020 David Conran
 
 #include <string>
 #include "ir_Samsung.h"
@@ -572,6 +572,13 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_FALSE(ac.getPowerful());
   EXPECT_EQ(kSamsungAcFanAuto, ac.getFan());
 
+  // Breeze and Powerful/Turbo are mutually exclusive.
+  ac.setPowerful(true);
+  EXPECT_TRUE(ac.getPowerful());
+  ac.setBreeze(true);
+  EXPECT_TRUE(ac.getBreeze());
+  EXPECT_FALSE(ac.getPowerful());
+
   // Actual powerful on & off states from:
   // https://github.com/crankyoldgit/IRremoteESP8266/issues/734#issuecomment-500120270
   uint8_t on[kSamsungAcStateLength] = {
@@ -582,7 +589,8 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_EQ(kSamsungAcFanTurbo, ac.getFan());
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 7 (Turbo), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: On, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: On, Breeze: Off, "
+      "Light: On, Ion: Off",
       ac.toString());
 
   uint8_t off[kSamsungAcStateLength] = {
@@ -593,7 +601,8 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_NE(kSamsungAcFanTurbo, ac.getFan());
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       ac.toString());
 }
 
@@ -659,7 +668,8 @@ TEST(TestIRSamsungAcClass, HumanReadable) {
   IRSamsungAc samsung(0);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 2 (Low), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
   samsung.setTemp(kSamsungAcMaxTemp);
   samsung.setMode(kSamsungAcHeat);
@@ -670,24 +680,28 @@ TEST(TestIRSamsungAcClass, HumanReadable) {
   samsung.setClean(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 5 (High), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: On, Clean: On, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
   samsung.setQuiet(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Light: On, Ion: Off",
+      "Beep: On, Clean: On, Quiet: On, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
   samsung.setQuiet(false);
   samsung.setPowerful(true);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 7 (Turbo), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Light: On, Ion: Off",
+      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
   samsung.setIon(true);
   samsung.setDisplay(false);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 7 (Turbo), Swing: Off, "
-      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Light: Off, Ion: On",
+      "Beep: On, Clean: On, Quiet: Off, Powerful: On, Breeze: Off, "
+      "Light: Off, Ion: On",
       samsung.toString());
 }
 
@@ -791,7 +805,8 @@ TEST(TestDecodeSamsungAC, DecodeRealExample) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 2 (Low), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -840,7 +855,8 @@ TEST(TestDecodeSamsungAC, DecodeRealExample2) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -899,7 +915,8 @@ TEST(TestDecodeSamsungAC, DecodePowerOnSample) {
   samsung.setRaw(irsend.capture.state, kSamsungAcExtendedStateLength);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -959,7 +976,8 @@ TEST(TestDecodeSamsungAC, DecodePowerOffSample) {
   samsung.setRaw(irsend.capture.state, kSamsungAcExtendedStateLength);
   EXPECT_EQ(
       "Power: Off, Mode: 1 (Cool), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1006,7 +1024,8 @@ TEST(TestDecodeSamsungAC, DecodeHeatSample) {
   samsung.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 4 (Heat), Temp: 17C, Fan: 0 (Auto), Swing: On, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1050,7 +1069,8 @@ TEST(TestDecodeSamsungAC, DecodeCoolSample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -1110,7 +1130,8 @@ TEST(TestDecodeSamsungAC, Issue604DecodeExtended) {
   samsung.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: Off, Mode: 4 (Heat), Temp: 30C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       samsung.toString());
 }
 
@@ -1307,7 +1328,7 @@ TEST(TestIRSamsungAcClass, Issue604SendPowerHack) {
       "m586s100000";
   std::string text = "Power: On, Mode: 1 (Cool), Temp: 23C, Fan: 4 (Med), "
                      "Swing: On, Beep: Off, Clean: Off, Quiet: Off, "
-                     "Powerful: Off, Light: On, Ion: Off";
+                     "Powerful: Off, Breeze: Off, Light: On, Ion: Off";
   // Don't do a setPower()/on()/off() as that will trigger the special message.
   // So it should only be the normal "settings" message.
   ac.setTemp(23);
@@ -1434,7 +1455,8 @@ TEST(TestDecodeSamsungAC, Issue734QuietSetting) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       ac.toString());
 
   // Make sure the ac class state is in something wildly different first.
@@ -1456,7 +1478,8 @@ TEST(TestDecodeSamsungAC, Issue734QuietSetting) {
   ac.setQuiet(true);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: On, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       ac.toString());
   // Check it matches the known good/expected state.
   EXPECT_STATE_EQ(expectedState, ac.getRaw(), kSamsungAcBits);
@@ -1506,6 +1529,52 @@ TEST(TestDecodeSamsungAC, Issue734PowerfulOff) {
   ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 16C, Fan: 0 (Auto), Swing: Off, "
-      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Light: On, Ion: Off",
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
+      ac.toString());
+}
+
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
+TEST(TestIRSamsungAcClass, SetAndGetBreeze) {
+  IRSamsungAc ac(kGpioUnused);
+  ac.setFan(kSamsungAcFanMed);
+  ac.setBreeze(false);
+  EXPECT_FALSE(ac.getBreeze());
+  EXPECT_EQ(kSamsungAcFanMed, ac.getFan());
+  ac.setBreeze(true);
+  EXPECT_TRUE(ac.getBreeze());
+  EXPECT_EQ(kSamsungAcFanAuto, ac.getFan());  // Breeze sets fan to auto.
+  ac.setBreeze(false);
+  EXPECT_FALSE(ac.getBreeze());
+  EXPECT_EQ(kSamsungAcFanAuto, ac.getFan());
+
+  // Breeze and Powerful/Turbo are mutually exclusive.
+  ac.setBreeze(true);
+  EXPECT_TRUE(ac.getBreeze());
+  ac.setPowerful(true);
+  EXPECT_FALSE(ac.getBreeze());
+
+  // Check against real messages.
+  // MODE FAN, 24C WINDFREE ON
+  const uint8_t on[14] = {
+      0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0, 0x01, 0xB2, 0xFE, 0x7B, 0x80,
+      0x31, 0xF0};
+  ac.setRaw(on);
+  ASSERT_TRUE(ac.getBreeze());
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 24C, Fan: 0 (Auto), Swing: Off, "
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: On, "
+      "Light: On, Ion: Off",
+      ac.toString());
+  // MODE FAN, 24C WINDFREE OFF, FAN = LOW
+  const uint8_t off[14] = {
+      0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0, 0x01, 0xC2, 0xFE, 0x71, 0x80,
+      0x35, 0xF0};
+  ac.setRaw(off);
+  ASSERT_FALSE(ac.getBreeze());
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 24C, Fan: 2 (Low), Swing: Off, "
+      "Beep: Off, Clean: Off, Quiet: Off, Powerful: Off, Breeze: Off, "
+      "Light: On, Ion: Off",
       ac.toString());
 }


### PR DESCRIPTION
* Add `setBreeze()`/`getBreeze()`
* Adjust Powerful(Turbo) control as it overlaps.
* Unit tests.
* Clean up & organise the `ir_Samsung.h` file.

Fixes #1062