### PR TITLE
IRMQTTServer: Use more i18n text.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -239,7 +239,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.4.8"
+#define _MY_VERSION_ "v1.4.9"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -627,7 +627,7 @@ bool loadConfigFile(void) {
 
 String timeElapsed(uint32_t const msec) {
   String result = msToString(msec);
-  if (result.equalsIgnoreCase("Now"))
+  if (result.equalsIgnoreCase(D_STR_NOW))
     return result;
   else
     return result + F(" ago");
@@ -647,7 +647,7 @@ String timeSince(uint32_t const start) {
 
 String gpioToString(const int16_t gpio) {
   if (gpio == kGpioUnused)
-    return F("Unused");
+    return F(D_STR_UNUSED);
   else
     return String(gpio);
 }
@@ -720,13 +720,13 @@ void handleRoot(void) {
   html += F(
     "<h3>Send a simple IR message</h3><p>"
     "<form method='POST' action='/ir' enctype='multipart/form-data'>"
-      "Type: ");
+      D_STR_PROTOCOL ": ");
   html += htmlSelectAcStateProtocol(KEY_TYPE, decode_type_t::NEC, true);
   html += F(
-      " Code: 0x<input type='text' name='code' min='0' value='0' size='16'"
-        " maxlength='16'>"
-      " Bit size: "
-      "<select name='bits'>"
+      " " D_STR_CODE ": 0x<input type='text' name='" KEY_CODE "' min='0' "
+        "value='0' size='16' maxlength='16'> "
+      D_STR_BITS ": "
+      "<select name='" KEY_BITS "'>"
         "<option selected='selected' value='0'>Default</option>");  // Default
   for (uint8_t i = 0; i < sizeof(kCommonBitSizes); i++) {
     String num = String(kCommonBitSizes[i]);
@@ -738,18 +738,18 @@ void handleRoot(void) {
   }
   html += F(
       "</select>"
-      " Repeats: <input type='number' name='repeats' min='0' max='99' value='0'"
-        "size='2' maxlength='2'>"
-      " <input type='submit' value='Send IR'>"
+      " " D_STR_REPEAT ": <input type='number' name='" KEY_REPEAT "' min='0' "
+        "max='99' value='0' size='2' maxlength='2'>"
+      " <input type='submit' value='Send " D_STR_CODE "'>"
     "</form>"
     "<br><hr>"
     "<h3>Send a complex (Air Conditioner) IR message</h3><p>"
     "<form method='POST' action='/ir' enctype='multipart/form-data'>"
-      "Type: ");
+      D_STR_PROTOCOL ": ");
   html += htmlSelectAcStateProtocol(KEY_TYPE, decode_type_t::KELVINATOR, false);
   html += F(
-      " State code: 0x"
-      "<input type='text' name='code' size='");
+      " State " D_STR_CODE ": 0x"
+      "<input type='text' name='" KEY_CODE "' size='");
   html += String(kStateSizeMax * 2);
   html += F("' maxlength='");
   html += String(kStateSizeMax * 2);
@@ -759,14 +759,14 @@ void handleRoot(void) {
                 "190B8050000000E0190B8070000010F0"
 #endif   // EXAMPLES_ENABLE
                 "'>"
-      " <input type='submit' value='Send A/C State'>"
+      " <input type='submit' value='Send A/C " D_STR_CODE "'>"
     "</form>"
     "<br><hr>"
     "<h3>Send an IRremote Raw IR message</h3><p>"
     "<form method='POST' action='/ir' enctype='multipart/form-data'>"
-      "<input type='hidden' name='type' value='30'>"
-      "String: (freq,array data) <input type='text' name='code' size='132'"
-      " value='"
+      "<input type='hidden' name='" KEY_TYPE "' value='30'>"
+      "String: (freq,array data) <input type='text' name='" KEY_CODE "'"
+      " size='132' value='"
 #if EXAMPLES_ENABLE
           "38000,4420,4420,520,1638,520,1638,520,1638,520,520,520,520,520,"
           "520,520,520,520,520,520,1638,520,1638,520,1638,520,520,520,"
@@ -781,8 +781,8 @@ void handleRoot(void) {
     "<h3>Send a <a href='https://irdb.globalcache.com/'>GlobalCache</a>"
         " IR message</h3><p>"
     "<form method='POST' action='/ir' enctype='multipart/form-data'>"
-      "<input type='hidden' name='type' value='31'>"
-      "String: 1:1,1,<input type='text' name='code' size='132'"
+      "<input type='hidden' name='" KEY_TYPE "' value='31'>"
+      "String: 1:1,1,<input type='text' name='" KEY_CODE "' size='132'"
       " value='"
 #if EXAMPLES_ENABLE
           "38000,1,1,170,170,20,63,20,63,20,63,20,20,20,20,20,20,20,20,20,"
@@ -797,9 +797,9 @@ void handleRoot(void) {
     "<h3>Send a <a href='http://www.remotecentral.com/cgi-bin/files/rcfiles.cgi"
       "?area=pronto&db=discrete'>Pronto code</a> IR message</h3><p>"
     "<form method='POST' action='/ir' enctype='multipart/form-data'>"
-      "<input type='hidden' name='type' value='25'>"
-      "String (comma separated): <input type='text' name='code' size='132'"
-      " value='"
+      "<input type='hidden' name='" KEY_TYPE "' value='25'>"
+      "String (comma separated): <input type='text' name='" KEY_CODE "'"
+      " size='132' value='"
 #if EXAMPLES_ENABLE
           "0000,0067,0000,0015,0060,0018,0018,0018,0030,0018,0030,0018,"
           "0030,0018,0018,0018,0030,0018,0018,0018,0018,0018,0030,0018,0018,"
@@ -807,8 +807,8 @@ void handleRoot(void) {
           "0018,0018,0018,0018,0030,0018,0018,03f6"
 #endif   // EXAMPLES_ENABLE
           "'>"
-      " Repeats: <input type='number' name='repeats' min='0' max='99' value='0'"
-          "size='2' maxlength='2'>"
+      " " D_STR_REPEAT ": <input type='number' name='" KEY_REPEAT "' min='0' "
+          "max='99' value='0' size='2' maxlength='2'>"
       " <input type='submit' value='Send Pronto'>"
     "</form>"
     "<br>");
@@ -830,7 +830,7 @@ String addJsReloadUrl(const String url, const uint16_t timeout_s,
   if (notify && timeout_s) {
     html += F("  document.write(\"You will be redirected to the main page in ");
     html += String(timeout_s);
-    html += F(" seconds.\");\n");
+    html += F(" " D_STR_SECONDS ".\");\n");
   }
   html += F("  setTimeout('Redirect()', ");
   html += String(timeout_s * 1000);  // Convert to mSecs
@@ -853,35 +853,44 @@ void handleExamples(void) {
   html += htmlMenu();
   html += F(
     "<h3>Hardcoded examples</h3>"
-    "<p><a href=\"ir?code=38000,1,69,341,171,21,64,21,64,21,21,21,21,21,21,21,"
-        "21,21,21,21,64,21,64,21,21,21,64,21,21,21,21,21,21,21,64,21,21,21,64,"
-        "21,21,21,21,21,21,21,64,21,21,21,21,21,21,21,21,21,64,21,64,21,64,21,"
-        "21,21,64,21,64,21,64,21,1600,341,85,21,3647&type=31\">"
-        "Sherwood Amp On (GlobalCache)</a></p>"
-    "<p><a href=\"ir?code=38000,8840,4446,546,1664,546,1664,546,546,546,546,"
-        "546,546,546,546,546,546,546,1664,546,1664,546,546,546,1664,546,546,"
-        "546,546,546,546,546,1664,546,546,546,1664,546,546,546,1664,546,1664,"
-        "546,1664,546,546,546,546,546,546,546,546,546,1664,546,546,546,546,546,"
-        "546,546,1664,546,1664,546,1664,546,41600,8840,2210,546&type=30\">"
-        "Sherwood Amp Off (Raw)</a></p>"
-    "<p><a href=\"ir?code=0000,006E,0022,0002,0155,00AA,0015,0040,0015,0040"
-        ",0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0040,0015,0040"
-        ",0015,0015,0015,0040,0015,0015,0015,0015,0015,0015,0015,0040,0015,0015"
-        ",0015,0015,0015,0040,0015,0040,0015,0015,0015,0015,0015,0015,0015,0015"
-        ",0015,0015,0015,0040,0015,0015,0015,0015,0015,0040,0015,0040,0015,0040"
-        ",0015,0040,0015,0040,0015,0640,0155,0055,0015,0E40"
-        "&type=25&repeats=1\">"
+    "<p><a href=\"ir?" KEY_CODE "=38000,1,69,341,171,21,64,21,64,21,21,21,21,"
+        "21,21,21,21,21,21,21,64,21,64,21,21,21,64,21,21,21,21,21,21,21,64,21,"
+        "21,21,64,21,21,21,21,21,21,21,64,21,21,21,21,21,21,21,21,21,64,21,64,"
+        "21,64,21,21,21,64,21,64,21,64,21,1600,341,85,21,3647"
+        "&" KEY_TYPE "=31\">Sherwood Amp " D_STR_ON " (GlobalCache)</a></p>"
+    "<p><a href=\"ir?" KEY_CODE "=38000,8840,4446,546,1664,546,1664,546,546,"
+        "546,546,546,546,546,546,546,546,546,1664,546,1664,546,546,546,1664,"
+        "546,546,546,546,546,546,546,1664,546,546,546,1664,546,546,546,1664,"
+        "546,1664,546,1664,546,546,546,546,546,546,546,546,546,1664,546,546,"
+        "546,546,546,546,546,1664,546,1664,546,1664,546,41600,8840,2210,546"
+        "&" KEY_TYPE "=30\">Sherwood Amp " D_STR_OFF " (Raw)</a></p>"
+    "<p><a href=\"ir?" KEY_CODE "=0000,006E,0022,0002,0155,00AA,0015,0040,0015,"
+        "0040,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0015,0040,0015,"
+        "0040,0015,0015,0015,0040,0015,0015,0015,0015,0015,0015,0015,0040,0015,"
+        "0015,0015,0015,0015,0040,0015,0040,0015,0015,0015,0015,0015,0015,0015,"
+        "0015,0015,0015,0015,0040,0015,0015,0015,0015,0015,0040,0015,0040,0015,"
+        "0040,0015,0040,0015,0040,0015,0640,0155,0055,0015,0E40"
+        "&" KEY_TYPE "=25&" KEY_REPEAT "=1\">"
         "Sherwood Amp Input TAPE (Pronto)</a></p>"
-    "<p><a href=\"ir?type=7&code=E0E09966\">TV on (Samsung)</a></p>"
-    "<p><a href=\"ir?type=4&code=0xf50&bits=12\">Power Off (Sony 12bit)</a></p>"
-    "<p><a href=\"aircon/set?protocol=PANASONIC_AC&model=LKE&power=on&"
-      "mode=auto&fanspeed=min&temp=23\">"
-      "Panasonic A/C LKE model, On, Auto mode, Min fan, 23C"
+    "<p><a href=\"ir?" KEY_TYPE "=7&" KEY_CODE "=E0E09966\">TV " D_STR_ON
+        " (Samsung)</a></p>"
+    "<p><a href=\"ir?" KEY_TYPE "=4&" KEY_CODE "=0xf50&bits=12\">" D_STR_POWER
+        " " D_STR_OFF " (Sony 12 " D_STR_BITS ")</a></p>"
+    "<p><a href=\"aircon/set?protocol=PANASONIC_AC&"
+      KEY_MODEL "=LKE&"
+      KEY_POWER "=on&"
+      KEY_MODE "=auto&"
+      KEY_FANSPEED "=min&"
+      KEY_TEMP "=23\">"
+      "Panasonic A/C " D_STR_MODEL " LKE, " D_STR_ON ", " D_STR_AUTO " "
+      D_STR_MODE ", " D_STR_MIN " " D_STR_FAN ", 23C"
       " <i>(via HTTP aircon interface)</i></a></p>"
-    "<p><a href=\"aircon/set?temp=27\">"
-      "Change just the temp to 27C <i>(via HTTP aircon interface)</i></a></p>"
-    "<p><a href=\"aircon/set?power=off&mode=off\">"
-      "Turn OFF the current A/C <i>(via HTTP aircon interface)</i></a></p>"
+    "<p><a href=\"aircon/set?" KEY_TEMP "=27\">"
+      "Change just the " D_STR_TEMP " to 27C <i>"
+      "(via HTTP aircon interface)</i></a></p>"
+    "<p><a href=\"aircon/set?" KEY_POWER "=off&" KEY_MODE "=off\">"
+      "Turn " D_STR_OFF " the current A/C <i>("
+      "via HTTP aircon interface)</i></a></p>"
     "<br><hr>");
   html += htmlEnd();
   server.send(200, "text/html", html);
@@ -1049,20 +1058,20 @@ void handleAirCon(void) {
         "<input type='hidden' name='" KEY_CHANNEL "' value='" + String(chan) +
             "'>" +
         "<table style='width:33%'>"
-        "<tr><td>Protocol</td><td>" +
+        "<tr><td>" D_STR_PROTOCOL "</td><td>" +
             htmlSelectClimateProtocol(KEY_PROTOCOL,
                                       climate[chan]->next.protocol) +
             "</td></tr>"
-        "<tr><td>Model</td><td>" +
+        "<tr><td>" D_STR_MODEL "</td><td>" +
             htmlSelectModel(KEY_MODEL, climate[chan]->next.model) +
             "</td></tr>"
-        "<tr><td>Power</td><td>" +
+        "<tr><td>" D_STR_POWER "</td><td>" +
             htmlSelectBool(KEY_POWER, climate[chan]->next.power) +
             "</td></tr>"
-        "<tr><td>Mode</td><td>" +
+        "<tr><td>" D_STR_MODE "</td><td>" +
             htmlSelectMode(KEY_MODE, climate[chan]->next.mode) +
             "</td></tr>"
-        "<tr><td>Temp</td><td>"
+        "<tr><td>" D_STR_TEMP "</td><td>"
             "<input type='number' name='" KEY_TEMP "' min='16' max='90' "
             "step='0.5' value='" + String(climate[chan]->next.degrees, 1) + "'>"
             "<select name='" KEY_CELSIUS "'>"
@@ -1073,34 +1082,34 @@ void handleAirCon(void) {
                 (!climate[chan]->next.celsius ? " selected='selected'" : "") +
                 ">F</option>"
             "</select></td></tr>"
-        "<tr><td>Fan Speed</td><td>" +
+        "<tr><td>" D_STR_FAN "</td><td>" +
             htmlSelectFanspeed(KEY_FANSPEED, climate[chan]->next.fanspeed) +
             "</td></tr>"
-        "<tr><td>Swing (V)</td><td>" +
+        "<tr><td>" D_STR_SWINGV "</td><td>" +
             htmlSelectSwingv(KEY_SWINGV, climate[chan]->next.swingv) +
             "</td></tr>"
-        "<tr><td>Swing (H)</td><td>" +
+        "<tr><td>" D_STR_SWINGH "</td><td>" +
             htmlSelectSwingh(KEY_SWINGH, climate[chan]->next.swingh) +
             "</td></tr>"
-        "<tr><td>Quiet</td><td>" +
+        "<tr><td>" D_STR_QUIET "</td><td>" +
             htmlSelectBool(KEY_QUIET, climate[chan]->next.quiet) +
             "</td></tr>"
-        "<tr><td>Turbo</td><td>" +
+        "<tr><td>" D_STR_TURBO "</td><td>" +
             htmlSelectBool(KEY_TURBO, climate[chan]->next.turbo) +
             "</td></tr>"
-        "<tr><td>Econo</td><td>" +
+        "<tr><td>" D_STR_ECONO "</td><td>" +
             htmlSelectBool(KEY_ECONO, climate[chan]->next.econo) +
             "</td></tr>"
-        "<tr><td>Light</td><td>" +
+        "<tr><td>" D_STR_LIGHT "</td><td>" +
             htmlSelectBool(KEY_LIGHT, climate[chan]->next.light) +
             "</td></tr>"
-        "<tr><td>Filter</td><td>" +
+        "<tr><td>" D_STR_FILTER "</td><td>" +
             htmlSelectBool(KEY_FILTER, climate[chan]->next.filter) +
             "</td></tr>"
-        "<tr><td>Clean</td><td>" +
+        "<tr><td>" D_STR_CLEAN "</td><td>" +
             htmlSelectBool(KEY_CLEAN, climate[chan]->next.clean) +
             "</td></tr>"
-        "<tr><td>Beep</td><td>" +
+        "<tr><td>" D_STR_BEEP "</td><td>" +
             htmlSelectBool(KEY_BEEP, climate[chan]->next.beep) +
             "</td></tr>"
         "<tr><td>Force resend</td><td>" +
@@ -1267,9 +1276,9 @@ void handleInfo(void) {
     "Last IR Received: " + lastIrReceived +
     " <i>(" + timeSince(lastIrReceivedTime) + ")</i><br>"
 #endif  // IR_RX
-    "Duplicate Wifi networks: " +
+    "Duplicate " D_STR_WIFI " networks: " +
         String(HIDE_DUPLICATE_NETWORKS ? "Hide" : "Show") + "<br>"
-    "Min Wifi signal required: "
+    "Min " D_STR_WIFI " signal required: "
 #ifdef MIN_SIGNAL_STRENGTH
         + String(static_cast<int>(MIN_SIGNAL_STRENGTH)) +
 #else  // MIN_SIGNAL_STRENGTH
@@ -1278,9 +1287,9 @@ void handleInfo(void) {
         "%<br>"
     "Serial debugging: "
 #if DEBUG
-        + String(isSerialGpioUsedByIr() ? "Off" : "On") +
+        + String(isSerialGpioUsedByIr() ? D_STR_OFF : D_STR_ON) +
 #else  // DEBUG
-        "Off"
+        D_STR_OFF
 #endif  // DEBUG
         "<br>"
 #if REPORT_VCC
@@ -1296,7 +1305,7 @@ void handleInfo(void) {
                              : "Disconnected " + timeSince(lastConnectedTime)) +
     ")</i><br>"
     "Disconnections: " + String(mqttDisconnectCounter - 1) + "<br>"
-    "Max Packet Size: " + MQTT_MAX_PACKET_SIZE + "<br>"
+    "Max Packet Size: " + MQTT_MAX_PACKET_SIZE + " bytes<br>"
     "Client id: " + MqttClientId + "<br>"
     "Command topic(s): " + listOfCommandTopics() + "<br>"
     "Acknowledgements topic: " + MqttAck + "<br>"
@@ -1348,7 +1357,7 @@ void handleInfo(void) {
     "</p>"
     // Page footer
     "<hr><p><small><center>"
-      "<i>(Note: Page will refresh every 60 seconds.)</i>"
+      "<i>(Note: Page will refresh every 60 " D_STR_SECONDS ".)</i>"
     "<centre></small></p>";
   html += addJsReloadUrl(kUrlInfo, 60, false);
   html += htmlEnd();
@@ -1410,7 +1419,7 @@ void handleClearMqtt(void) {
     htmlHeader(F("Clearing saved info from MQTT"),
                F("Removing all saved settings for this device from "
                  "MQTT.")) +
-    "<p>Device restarting. Try connecting in a few seconds.</p>" +
+    "<p>Device restarting. Try connecting in a few " D_STR_SECONDS ".</p>" +
     addJsReloadUrl(kUrlRoot, 10, true) +
     htmlEnd());
   // Do the clearing.
@@ -1432,7 +1441,7 @@ void handleReset(void) {
   server.send(200, "text/html",
     htmlHeader(F("Reset WiFi Config"),
                F("Resetting the WiFiManager config back to defaults.")) +
-    "<p>Device restarting. Try connecting in a few seconds.</p>" +
+    "<p>Device restarting. Try connecting in a few " D_STR_SECONDS ".</p>" +
     addJsReloadUrl(kUrlRoot, 10, true) +
     htmlEnd());
   // Do the reset.
@@ -1465,7 +1474,7 @@ void handleReboot() {
 #endif
   server.send(200, "text/html",
     htmlHeader(F("Device restarting.")) +
-    "<p>Try connecting in a few seconds.</p>" +
+    "<p>Try connecting in a few " D_STR_SECONDS ".</p>" +
     addJsReloadUrl(kUrlRoot, kRebootTime, true) +
     htmlEnd());
   doRestart("Reboot requested");
@@ -2021,7 +2030,8 @@ void setup_wifi(void) {
 
   if (!wifiManager.autoConnect())
     // Reboot. A.k.a. "Have you tried turning it Off and On again?"
-    doRestart("Wifi failed to connect and hit timeout. Rebooting...", true);
+    doRestart(D_STR_WIFI " failed to connect and hit timeout. Rebooting...",
+              true);
 
 #if MQTT_ENABLE
   strncpy(MqttServer, custom_mqtt_server.getValue(), kHostnameLength);
@@ -2193,7 +2203,8 @@ void setup(void) {
         server.send(200, "text/html",
             htmlHeader(F("Updating firmware")) +
             "<hr>"
-            "<h3>Warning! Don't power off the device for 60 seconds!</h3>"
+            "<h3>Warning! Don't " D_STR_POWER " " D_STR_OFF " the device for "
+            "60 " D_STR_SECONDS "!</h3>"
             "<p>The firmware is uploading and will try to flash itself. "
             "It is important to not interrupt the process.</p>"
             "<p>The firmware upload seems to have " +
@@ -2777,12 +2788,12 @@ bool sendIRCode(IRsend *irsend, decode_type_t const ir_type,
   } else {
     debug("Failed to send IR Message:");
   }
-  debug("Type:");
+  debug(D_STR_PROTOCOL ": ");
   debug(String(ir_type).c_str());
   // For "long" codes we basically repeat what we got.
   if (hasACState(ir_type) || ir_type == PRONTO || ir_type == RAW ||
       ir_type == GLOBALCACHE) {
-    debug("Code: ");
+    debug(D_STR_CODE ": ");
     debug(code_str);
     // Confirm what we were asked to send was sent.
 #if MQTT_ENABLE
@@ -2801,9 +2812,9 @@ bool sendIRCode(IRsend *irsend, decode_type_t const ir_type,
     }
 #endif  // MQTT_ENABLE
   } else {  // For "short" codes, we break it down a bit more before we report.
-    debug(("Code: 0x" + uint64ToString(code, 16)).c_str());
-    debug(("Bits: " + String(bits)).c_str());
-    debug(("Repeats: " + String(repeat)).c_str());
+    debug((D_STR_CODE ": 0x" + uint64ToString(code, 16)).c_str());
+    debug((D_STR_BITS ": " + String(bits)).c_str());
+    debug((D_STR_REPEAT ": " + String(repeat)).c_str());
 #if MQTT_ENABLE
     if (success) {
       mqtt_client.publish(MqttAck.c_str(), (String(ir_type) +


### PR DESCRIPTION
* Use existing `IRtext` strings where possible to better handle Internationalisation(i18n).
* Use the `KEY_*` defines in the examples/forms in case the user changes them.
* Update some misc text to be better from an i18n perspective.
* NOTE: Nowhere near a complete i18n conversion.
* Bump IRMQTTServer version number.

* Tested with en-AU & zh-CN. Appears to work as expected.

FYI @Caffreyfans