### PR TITLE
v2.7.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 This library enables you to **send _and_ receive** infra-red signals on an [ESP8266](https://github.com/esp8266/Arduino) or an
 [ESP32](https://github.com/espressif/arduino-esp32) using the [Arduino framework](https://www.arduino.cc/) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* demodulators etc.
 
-## v2.7.5 Now Available
-Version 2.7.5 of the library is now [available](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
+## v2.7.6 Now Available
+Version 2.7.6 of the library is now [available](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
 
 #### Upgrading from pre-v2.0
 Usage of the library has been slightly changed in v2.0. You will need to change your usage to work with v2.0 and beyond. You can read more about the changes required on our [Upgrade to v2.0](https://github.com/crankyoldgit/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/README_fr.md
+++ b/README_fr.md
@@ -9,8 +9,8 @@
 Cette librairie vous permetra de **recevoir et d'envoyer des signaux** infrarouge sur le protocole [ESP8266](https://github.com/esp8266/Arduino) ou sur le protocole
 [ESP32](https://github.com/espressif/arduino-esp32) en utilisant le [Arduino framework](https://www.arduino.cc/) qui utilise la norme 940nm IR LEDs et le module basique de reception d'onde IR. Exemple : TSOP{17,22,24,36,38,44,48}* modules etc.
 
-## v2.7.5 disponible
-Version 2.7.5 de la libraire est maintenant [disponible](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Vous pouvez voir le [Release Notes](ReleaseNotes.md) pour tous les changements importants.
+## v2.7.6 disponible
+Version 2.7.6 de la libraire est maintenant [disponible](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Vous pouvez voir le [Release Notes](ReleaseNotes.md) pour tous les changements importants.
 
 #### mise à jour depuis pre-v2.0
 L'utilisation de la librairie à un peu changer depuis la version in v2.0. Si vous voulez l'utiliser vous devrez changer votre utilisation aussi. Vous pouvez vous renseigner sur les précondition d'utilisation ici : [Upgrade to v2.0](https://github.com/crankyoldgit/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## _v2.7.6 (20200425)_
+
+**[Features]**
+- IRMQTTServer: Use more i18n text. (#1086)
+- Convert Protocol names to shared text. Saves ~3k of flash. (#1078)
+- Add Chinese translation (zh-CN) & add utf-8 support. (#1080, #1085)
+
+**[Misc]**
+- IRMQTTServer: Ensure MQTT_MAX_PACKET_SIZE is correctly set. (#1084)
+- Add Italian locale to IRrecvDumpV2 platformio file.
+
+
 ## _v2.7.5 (20200409)_
 
 **[Features]**

--- a/keywords.txt
+++ b/keywords.txt
@@ -629,6 +629,7 @@ xorBytes	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
+*kAllProtocolNamesStr	LITERAL1
 //	LITERAL1
 AIRWELL	LITERAL1
 AIWA_RC_T501	LITERAL1

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "IRremoteESP8266",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "keywords": "infrared, ir, remote, esp8266, esp32",
   "description": "Send and receive infrared signals with multiple protocols (ESP8266/ESP32)",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.7.5
+version=2.7.6
 author=David Conran, Sebastien Warin, Mark Szabo, Ken Shirriff
 maintainer=David Conran, Mark Szabo, Sebastien Warin, Roi Dayan, Massimiliano Pinto
 sentence=Send and receive infrared signals with multiple protocols (ESP8266/ESP32)

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -52,7 +52,7 @@
 #endif  // UNIT_TEST
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.7.5"
+#define _IRREMOTEESP8266_VERSION_ "2.7.6"
 
 // Set the language & locale for the library. See the `locale` dir for options.
 #ifndef _IR_LOCALE_


### PR DESCRIPTION
_v2.7.6 (20200425)_

**[Features]**
- IRMQTTServer: Use more i18n text. (#1086)
- Convert Protocol names to shared text. Saves ~3k of flash. (#1078)
- Add Chinese translation (zh-CN) & add utf-8 support. (#1080, #1085)

**[Misc]**
- IRMQTTServer: Ensure MQTT_MAX_PACKET_SIZE is correctly set. (#1084)
- Add Italian locale to IRrecvDumpV2 platformio file.