### PR TITLE
Set correct return type for `.calibrate()`

### DIFF
--- a/src/ir_Amcor.h
+++ b/src/ir_Amcor.h
@@ -86,7 +86,7 @@ class IRAmcorAc {
   void stateReset();
 #if SEND_AMCOR
   void send(const uint16_t repeat = kAmcorDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_AMCOR
   void begin();
   static uint8_t calcChecksum(const uint8_t state[],

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -131,7 +131,7 @@ class IRArgoAC {
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_ARGO
   void begin(void);
   void on(void);

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -106,7 +106,7 @@ class IRCoolixAC {
   void stateReset();
 #if SEND_COOLIX
   void send(const uint16_t repeat = kCoolixDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_COOLIX
   void begin();
   void on();

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -503,7 +503,7 @@ class IRDaikinESP {
 
 #if SEND_DAIKIN
   void send(const uint16_t repeat = kDaikinDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin(void);
   void on(void);
@@ -578,7 +578,7 @@ class IRDaikin2 {
 
 #if SEND_DAIKIN2
   void send(const uint16_t repeat = kDaikin2DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   void on();
@@ -672,7 +672,7 @@ class IRDaikin216 {
 
 #if SEND_DAIKIN216
   void send(const uint16_t repeat = kDaikin216DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   uint8_t* getRaw();
@@ -722,7 +722,7 @@ class IRDaikin160 {
 
 #if SEND_DAIKIN160
   void send(const uint16_t repeat = kDaikin160DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   uint8_t* getRaw();
@@ -768,7 +768,7 @@ class IRDaikin176 {
 
 #if SEND_DAIKIN176
   void send(const uint16_t repeat = kDaikin176DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   uint8_t* getRaw();
@@ -817,7 +817,7 @@ class IRDaikin128 {
                        const bool use_modulation = true);
 #if SEND_DAIKIN128
   void send(const uint16_t repeat = kDaikin128DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_DAIKIN128
   void begin();
   void setPowerToggle(const bool toggle);
@@ -886,7 +886,7 @@ class IRDaikin152 {
 
 #if SEND_DAIKIN152
   void send(const uint16_t repeat = kDaikin152DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif
   void begin();
   uint8_t* getRaw();
@@ -942,7 +942,7 @@ class IRDaikin64 {
 
 #if SEND_DAIKIN64
   void send(const uint16_t repeat = kDaikin64DefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_DAIKIN64
   void begin();
   uint64_t getRaw();

--- a/src/ir_Electra.h
+++ b/src/ir_Electra.h
@@ -86,7 +86,7 @@ class IRElectraAc {
   void stateReset(void);
 #if SEND_ELECTRA_AC
   void send(const uint16_t repeat = kElectraAcMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_ELECTRA_AC
   void begin(void);
   void on(void);

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -107,7 +107,7 @@ class IRFujitsuAC {
   void stateReset(void);
 #if SEND_FUJITSU_AC
   void send(const uint16_t repeat = kFujitsuAcMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_FUJITSU_AC
   void begin(void);
   void stepHoriz(void);

--- a/src/ir_Goodweather.h
+++ b/src/ir_Goodweather.h
@@ -95,7 +95,7 @@ class IRGoodweatherAc {
   void stateReset(void);
 #if SEND_GOODWEATHER
   void send(const uint16_t repeat = kGoodweatherMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_GOODWEATHER
   void begin(void);
   void on(void);

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -106,7 +106,7 @@ class IRGreeAC {
   void stateReset(void);
 #if SEND_GREE
   void send(const uint16_t repeat = kGreeDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_GREE
   void begin(void);
   void on(void);

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -217,7 +217,7 @@ class IRHaierAC {
 
 #if SEND_HAIER_AC
   void send(const uint16_t repeat = kHaierAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HAIER_AC
   void begin(void);
 

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -147,7 +147,7 @@ class IRHitachiAc {
   void stateReset(void);
 #if SEND_HITACHI_AC
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HITACHI_AC
   void begin(void);
   void on(void);
@@ -198,7 +198,7 @@ class IRHitachiAc1 {
   void stateReset(void);
 #if SEND_HITACHI_AC1
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HITACHI_AC1
   void begin(void);
   void on(void);
@@ -260,7 +260,7 @@ class IRHitachiAc424 {
   void stateReset(void);
 #if SEND_HITACHI_AC424
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HITACHI_AC424
   void begin(void);
   void on(void);
@@ -307,7 +307,7 @@ class IRHitachiAc3 {
   void stateReset(void);
 #if SEND_HITACHI_AC3
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_HITACHI_AC3
   void begin(void);
   uint8_t getMode(void);

--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -141,7 +141,7 @@ class IRKelvinatorAC {
   void stateReset(void);
 #if SEND_KELVINATOR
   void send(const uint16_t repeat = kKelvinatorDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_KELVINATOR
   void begin(void);
   void on(void);

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -67,7 +67,7 @@ class IRLgAc {
   bool isValidLgAc(void);
 #if SEND_LG
   void send(const uint16_t repeat = kLgDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_LG
   void begin(void);
   void on(void);

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -74,7 +74,7 @@ class IRMideaAC {
   void stateReset(void);
 #if SEND_MIDEA
   void send(const uint16_t repeat = kMideaMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MIDEA
   void begin(void);
   void on(void);

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -159,7 +159,7 @@ class IRMitsubishiAC {
   static bool validChecksum(const uint8_t* data);
 #if SEND_MITSUBISHI_AC
   void send(const uint16_t repeat = kMitsubishiACMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHI_AC
   void begin(void);
   void on(void);
@@ -217,7 +217,7 @@ class IRMitsubishi136 {
   void stateReset(void);
 #if SEND_MITSUBISHI136
   void send(const uint16_t repeat = kMitsubishi136MinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHI136
   void begin(void);
   static bool validChecksum(const uint8_t* data,
@@ -267,7 +267,7 @@ class IRMitsubishi112 {
   void stateReset(void);
 #if SEND_MITSUBISHI112
   void send(const uint16_t repeat = kMitsubishi112MinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHI112
   void begin(void);
   void on(void);

--- a/src/ir_MitsubishiHeavy.h
+++ b/src/ir_MitsubishiHeavy.h
@@ -133,7 +133,7 @@ class IRMitsubishiHeavy152Ac {
   void stateReset(void);
 #if SEND_MITSUBISHIHEAVY
   void send(const uint16_t repeat = kMitsubishiHeavy152MinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_MITSUBISHIHEAVY
   void begin(void);
   void on(void);

--- a/src/ir_Neoclima.h
+++ b/src/ir_Neoclima.h
@@ -92,7 +92,7 @@ class IRNeoclimaAc {
   void stateReset(void);
 #if SEND_NEOCLIMA
   void send(const uint16_t repeat = kNeoclimaMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_NEOCLIMA
   void begin(void);
   void setButton(const uint8_t button);

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -102,7 +102,7 @@ class IRPanasonicAc {
   void stateReset(void);
 #if SEND_PANASONIC
   void send(const uint16_t repeat = kPanasonicAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_PANASONIC
   void begin(void);
   void on(void);

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -99,7 +99,7 @@ class IRSamsungAc {
                     const bool calcchecksum = true);
   void sendOn(const uint16_t repeat = kSamsungAcDefaultRepeat);
   void sendOff(const uint16_t repeat = kSamsungAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SAMSUNG_AC
   void begin(void);
   void on(void);

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -60,7 +60,7 @@ class IRSharpAc {
 
 #if SEND_SHARP_AC
   void send(const uint16_t repeat = kSharpAcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SHARP_AC
   void begin(void);
   void on(void);

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -63,7 +63,7 @@ class IRTcl112Ac {
 
 #if SEND_TCL112AC
   void send(const uint16_t repeat = kTcl112AcDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TCL
   void begin(void);
   uint8_t* getRaw(void);

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -62,7 +62,7 @@ class IRToshibaAC {
   void stateReset(void);
 #if SEND_TOSHIBA_AC
   void send(const uint16_t repeat = kToshibaACMinRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TOSHIBA_AC
   void begin(void);
   void on(void);

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -69,7 +69,7 @@ class IRTrotecESP {
 
 #if SEND_TROTEC
   void send(const uint16_t repeat = kTrotecDefaultRepeat);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TROTEC
   void begin(void);
 

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -116,7 +116,7 @@ class IRVestelAc {
   void stateReset(void);
 #if SEND_VESTEL_AC
   void send(void);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_VESTEL_AC
   void begin(void);
   void on(void);

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -93,7 +93,7 @@ class IRWhirlpoolAc {
 #if SEND_WHIRLPOOL_AC
   void send(const uint16_t repeat = kWhirlpoolAcDefaultRepeat,
             const bool calcchecksum = true);
-  uint8_t calibrate(void) { return _irsend.calibrate(); }
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_WHIRLPOOL_AC
   void begin(void);
   void on(void);


### PR DESCRIPTION
Not really a library impacting bug, as all the code uses the returned value for display. Just invoking `calibrate()` sets the value correctly, but a bug/mistake none-the-less.

Ref #1093