### PR TITLE
IRMQTTServer: Better handle power & mode operations for Home Assistant.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -102,11 +102,23 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 #define MQTT_CLIMATE_STAT "stat"  // Sub-topic for the climate stat topics.
 // Enable sending/receiving climate via JSON. `true` cost ~5k of program space.
 #define MQTT_CLIMATE_JSON false
+
 // Use Home Assistant-style operation modes.
-// i.e. Change the climate mode to "off" when turning the power "off".
+// TL;DR: Power and Mode are linked together. One changes the other.
+// i.e.
+//  - When power is set to "off", the mode is set to "off".
+//  - When the mode changes from "off" to something else, power is set to "on".
 // See: https://www.home-assistant.io/components/climate.mqtt/#modes
-// Change to false, if your home automation system doesn't like this.
+// *** WARNING ***
+// This setting will cause IRMQTTServer to forget what the previous operation
+// mode was. e.g. a power "on" -> "off" -> "on" will cause it to use the
+// default mode for your A/C, not the previous mode.
+// Typically this is "Auto" or "Cool" mode.
+// Change to false, if your home automation system doesn't like this, or if
+// you want IRMQTTServer to be the authoritative source for controling your
+// A/C.
 #define MQTT_CLIMATE_HA_MODE true
+
 // Do we send an IR message when we reboot and recover the existing A/C state?
 // If set to `false` you may miss requested state changes while the ESP was
 // down. If set to `true`, it will resend the previous desired state sent to the
@@ -239,7 +251,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.4.9"
+#define _MY_VERSION_ "v1.5.0-alpha"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -251,7 +251,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.5.0-alpha"
+#define _MY_VERSION_ "v1.5.0"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2964,40 +2964,47 @@ void updateClimate(stdAc::state_t *state, const String str,
     *state = jsonToState(*state, payload.c_str());
   else
 #endif  // MQTT_CLIMATE_JSON
-  if (str.equals(prefix + KEY_PROTOCOL))
+  if (str.equals(prefix + KEY_PROTOCOL)) {
     state->protocol = strToDecodeType(payload.c_str());
-  else if (str.equals(prefix + KEY_MODEL))
+  } else if (str.equals(prefix + KEY_MODEL)) {
     state->model = IRac::strToModel(payload.c_str());
-  else if (str.equals(prefix + KEY_POWER))
+  } else if (str.equals(prefix + KEY_POWER)) {
     state->power = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_MODE))
+#if MQTT_CLIMATE_HA_MODE
+    if (!state->power) state->mode = stdAc::opmode_t::kOff;
+#endif  // MQTT_CLIMATE_HA_MODE
+  } else if (str.equals(prefix + KEY_MODE)) {
     state->mode = IRac::strToOpmode(payload.c_str());
-  else if (str.equals(prefix + KEY_TEMP))
+#if MQTT_CLIMATE_HA_MODE
+    state->power = (state->mode != stdAc::opmode_t::kOff);
+#endif  // MQTT_CLIMATE_HA_MODE
+  } else if (str.equals(prefix + KEY_TEMP)) {
     state->degrees = payload.toFloat();
-  else if (str.equals(prefix + KEY_FANSPEED))
+  } else if (str.equals(prefix + KEY_FANSPEED)) {
     state->fanspeed = IRac::strToFanspeed(payload.c_str());
-  else if (str.equals(prefix + KEY_SWINGV))
+  } else if (str.equals(prefix + KEY_SWINGV)) {
     state->swingv = IRac::strToSwingV(payload.c_str());
-  else if (str.equals(prefix + KEY_SWINGH))
+  } else if (str.equals(prefix + KEY_SWINGH)) {
     state->swingh = IRac::strToSwingH(payload.c_str());
-  else if (str.equals(prefix + KEY_QUIET))
+  } else if (str.equals(prefix + KEY_QUIET)) {
     state->quiet = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_TURBO))
+  } else if (str.equals(prefix + KEY_TURBO)) {
     state->turbo = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_ECONO))
+  } else if (str.equals(prefix + KEY_ECONO)) {
     state->econo = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_LIGHT))
+  } else if (str.equals(prefix + KEY_LIGHT)) {
     state->light = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_BEEP))
+  } else if (str.equals(prefix + KEY_BEEP)) {
     state->beep = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_FILTER))
+  } else if (str.equals(prefix + KEY_FILTER)) {
     state->filter = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_CLEAN))
+  } else if (str.equals(prefix + KEY_CLEAN)) {
     state->clean = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_CELSIUS))
+  } else if (str.equals(prefix + KEY_CELSIUS)) {
     state->celsius = IRac::strToBool(payload.c_str());
-  else if (str.equals(prefix + KEY_SLEEP))
+  } else if (str.equals(prefix + KEY_SLEEP)) {
     state->sleep = payload.toInt();
+  }
 }
 
 bool sendClimate(const String topic_prefix, const bool retain,

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -3261,7 +3261,8 @@ bool IRrecv::decodeDaikin64(decode_results *results, uint16_t offset,
                                kDaikin64BitMark, kDaikin64OneSpace,
                                kDaikin64BitMark, kDaikin64ZeroSpace,
                                kDaikin64BitMark, kDaikin64Gap,
-                               false, _tolerance, kMarkExcess, false);
+                               false, _tolerance + kDaikin64ToleranceDelta,
+                               kMarkExcess, false);
   if (used == 0) return false;
   offset += used;
   // Footer #2

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -441,7 +441,8 @@ const uint16_t kDaikin64LdrMark = kDaikin128LeaderMark;
 const uint16_t kDaikin64Gap = kDaikin128Gap;
 const uint16_t kDaikin64LdrSpace = kDaikin128LeaderSpace;
 const uint16_t kDaikin64Freq = kDaikin128Freq;  // Hz.
-const uint16_t kDaikin64Overhead = 9;
+const uint8_t kDaikin64Overhead = 9;
+const int8_t  kDaikin64ToleranceDelta = 5;  // +5%
 
 const uint64_t kDaikin64KnownGoodState = 0x7C16161607204216;
 const uint8_t kDaikin64ModeOffset = 8;

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -3692,10 +3692,10 @@ TEST(TestDaikin64Class, HumanReadable) {
 }
 
 TEST(TestDecodeDaikin64, Issue1092) {
-   IRsendTest irsend(kGpioUnused);
-   IRrecv irrecv(kGpioUnused);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
 
-   uint16_t rawData[137] = {
+  uint16_t rawData[137] = {
       9792, 9786, 9818, 9860, 4600, 2532, 338, 422, 332, 950, 362, 950, 360,
       378, 354, 954, 386, 378, 334, 376, 356, 382, 360, 380, 364, 946, 354, 410,
       334, 380, 364, 972, 328, 386, 358, 380, 364, 374, 358, 380, 362, 376, 356,
@@ -3707,19 +3707,19 @@ TEST(TestDecodeDaikin64, Issue1092) {
       358, 380, 364, 374, 358, 952, 360, 380, 362, 376, 356, 382, 382, 928, 362,
       376, 356, 20348, 4628};  // UNKNOWN C508A32A
 
-   irsend.begin();
-   irsend.reset();
-   irsend.sendRaw(rawData, 137, kDaikin64Freq);
-   irsend.makeDecodeResult();
-   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-   ASSERT_EQ(decode_type_t::DAIKIN64, irsend.capture.decode_type);
-   ASSERT_EQ(kDaikin64Bits, irsend.capture.bits);
-   EXPECT_EQ(0x4426161600001216, irsend.capture.value);
-   EXPECT_EQ(
-       "Power Toggle: Off, Mode: 2 (Cool), Temp: 26C, Fan: 1 (Auto), "
-       "Turbo: Off, Quiet: Off, Swing(V): Off, Sleep: Off, "
-       "Clock: 00:00, On Timer: Off, Off Timer: Off",
-       IRAcUtils::resultAcToString(&irsend.capture));
-   stdAc::state_t result, prev;
-   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
- }
+  irsend.begin();
+  irsend.reset();
+  irsend.sendRaw(rawData, 137, kDaikin64Freq);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  ASSERT_EQ(decode_type_t::DAIKIN64, irsend.capture.decode_type);
+  ASSERT_EQ(kDaikin64Bits, irsend.capture.bits);
+  EXPECT_EQ(0x4426161600001216, irsend.capture.value);
+  EXPECT_EQ(
+      "Power Toggle: Off, Mode: 2 (Cool), Temp: 26C, Fan: 1 (Auto), "
+      "Turbo: Off, Quiet: Off, Swing(V): Off, Sleep: Off, "
+      "Clock: 00:00, On Timer: Off, Off Timer: Off",
+      IRAcUtils::resultAcToString(&irsend.capture));
+  stdAc::state_t result, prev;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
+}

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -3690,3 +3690,36 @@ TEST(TestDaikin64Class, HumanReadable) {
       "Clock: 12:31, On Timer: 08:30, Off Timer: Off",
       ac.toString());
 }
+
+TEST(TestDecodeDaikin64, Issue1092) {
+   IRsendTest irsend(kGpioUnused);
+   IRrecv irrecv(kGpioUnused);
+
+   uint16_t rawData[137] = {
+      9792, 9786, 9818, 9860, 4600, 2532, 338, 422, 332, 950, 362, 950, 360,
+      378, 354, 954, 386, 378, 334, 376, 356, 382, 360, 380, 364, 946, 354, 410,
+      334, 380, 364, 972, 328, 386, 358, 380, 364, 374, 358, 380, 362, 376, 356,
+      382, 360, 378, 354, 410, 334, 404, 326, 412, 332, 408, 336, 376, 356, 382,
+      362, 378, 354, 384, 360, 378, 354, 384, 358, 380, 354, 384, 358, 382, 362,
+      976, 336, 974, 338, 374, 358, 980, 332, 380, 362, 376, 356, 382, 362, 376,
+      356, 956, 356, 980, 330, 382, 360, 976, 334, 376, 356, 382, 360, 378, 354,
+      384, 358, 952, 360, 950, 360, 378, 354, 384, 360, 952, 360, 378, 354, 384,
+      358, 380, 364, 374, 358, 952, 360, 380, 362, 376, 356, 382, 382, 928, 362,
+      376, 356, 20348, 4628};  // UNKNOWN C508A32A
+
+   irsend.begin();
+   irsend.reset();
+   irsend.sendRaw(rawData, 137, kDaikin64Freq);
+   irsend.makeDecodeResult();
+   ASSERT_TRUE(irrecv.decode(&irsend.capture));
+   ASSERT_EQ(decode_type_t::DAIKIN64, irsend.capture.decode_type);
+   ASSERT_EQ(kDaikin64Bits, irsend.capture.bits);
+   EXPECT_EQ(0x4426161600001216, irsend.capture.value);
+   EXPECT_EQ(
+       "Power Toggle: Off, Mode: 2 (Cool), Temp: 26C, Fan: 1 (Auto), "
+       "Turbo: Off, Quiet: Off, Swing(V): Off, Sleep: Off, "
+       "Clock: 00:00, On Timer: Off, Off Timer: Off",
+       IRAcUtils::resultAcToString(&irsend.capture));
+   stdAc::state_t result, prev;
+   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
+ }


### PR DESCRIPTION
WARNING: Breaking Change!
When `MQTT_CLIMATE_HA_MODE` is enabled (default) this will break previous operation mode resumption when power is changed.

* Increase decoding tolerance for DAIKIN64
* Version bump to v1.5.0

Fixes #1092