### PR TITLE
Introduce IRrecvDumpV3 with basic OTA update support

### DIFF
--- a/examples/IRrecvDumpV3/BaseOTA.h
+++ b/examples/IRrecvDumpV3/BaseOTA.h
@@ -1,0 +1,71 @@
+// Copyright 2020 Christian Nilsson (@nikize)
+// Based on public Arduino BasicOTA example
+
+#ifndef EXAMPLES_IRRECVDUMPV3_BASEOTA_H_
+#define EXAMPLES_IRRECVDUMPV3_BASEOTA_H_
+
+#ifndef OTA_ENABLE
+#define OTA_ENABLE false
+#endif  // OTA_ENABLE
+
+#if OTA_ENABLE
+
+#include <WiFi.h>
+#include <ESPmDNS.h>
+#include <WiFiUdp.h>
+#include <ArduinoOTA.h>
+
+void OTAwifi() {
+  // start default wifi (previously saved on the ESP) for OTA
+  WiFi.mode(WIFI_STA);
+  WiFi.begin();
+}
+
+void OTAinit() {
+  // See BasicOTA ESP example for source and settings
+
+  ArduinoOTA
+    .onStart([]() {
+      String type;
+      if (ArduinoOTA.getCommand() == U_FLASH)
+        type = "sketch";
+      else
+        type = "filesystem";
+
+      Serial.println("Start updating " + type);
+    })
+    .onEnd([]() {
+      Serial.println("\nEnd");
+    })
+    .onProgress([](unsigned int progress, unsigned int total) {
+      Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
+    })
+    .onError([](ota_error_t error) {
+      Serial.printf("Error[%u]: ", error);
+      if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
+      else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
+      else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
+      else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
+      else if (error == OTA_END_ERROR) Serial.println("End Failed");
+    });
+
+  ArduinoOTA.begin();
+  Serial.println();
+  if (WiFi.waitForConnectResult() == WL_CONNECTED) {
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+  } else {
+    Serial.println("Wifi Connection Failed.");
+  }
+}
+
+void OTAloopHandler() {
+  ArduinoOTA.handle();
+}
+
+#else   // OTA_ENABLE
+void OTAwifi() {}
+void OTAinit() {}
+void OTAloopHandler() {}
+#endif  // OTA_ENABLE
+#endif  // EXAMPLES_IRRECVDUMPV3_BASEOTA_H_

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -1,0 +1,156 @@
+/*
+ * IRremoteESP8266: IRrecvDumpV2 - dump details of IR codes with IRrecv
+ * An IR detector/demodulator must be connected to the input kRecvPin.
+ *
+ * Copyright 2009 Ken Shirriff, http://arcfn.com
+ * Copyright 2017-2019 David Conran
+ *
+ * Example circuit diagram:
+ *  https://github.com/crankyoldgit/IRremoteESP8266/wiki#ir-receiving
+ *
+ * Changes:
+ *   Version 1.0 October, 2019
+ *     - Internationalisation (i18n) support.
+ *     - Stop displaying the legacy raw timing info.
+ *   Version 0.5 June, 2019
+ *     - Move A/C description to IRac.cpp.
+ *   Version 0.4 July, 2018
+ *     - Minor improvements and more A/C unit support.
+ *   Version 0.3 November, 2017
+ *     - Support for A/C decoding for some protocols.
+ *   Version 0.2 April, 2017
+ *     - Decode from a copy of the data so we can start capturing faster thus
+ *       reduce the likelihood of miscaptures.
+ * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
+ */
+
+#include <Arduino.h>
+#include <IRrecv.h>
+#include <IRremoteESP8266.h>
+#include <IRac.h>
+#include <IRtext.h>
+#include <IRutils.h>
+
+// ==================== start of TUNEABLE PARAMETERS ====================
+// An IR detector/demodulator is connected to GPIO pin 14
+// e.g. D5 on a NodeMCU board.
+// Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+const uint16_t kRecvPin = 14;
+
+// The Serial connection baud rate.
+// i.e. Status message will be sent to the PC at this baud rate.
+// Try to avoid slow speeds like 9600, as you will miss messages and
+// cause other problems. 115200 (or faster) is recommended.
+// NOTE: Make sure you set your Serial Monitor to the same speed.
+const uint32_t kBaudRate = 115200;
+
+// As this program is a special purpose capture/decoder, let us use a larger
+// than normal buffer so we can handle Air Conditioner remote codes.
+const uint16_t kCaptureBufferSize = 1024;
+
+// kTimeout is the Nr. of milli-Seconds of no-more-data before we consider a
+// message ended.
+// This parameter is an interesting trade-off. The longer the timeout, the more
+// complex a message it can capture. e.g. Some device protocols will send
+// multiple message packets in quick succession, like Air Conditioner remotes.
+// Air Coniditioner protocols often have a considerable gap (20-40+ms) between
+// packets.
+// The downside of a large timeout value is a lot of less complex protocols
+// send multiple messages when the remote's button is held down. The gap between
+// them is often also around 20+ms. This can result in the raw data be 2-3+
+// times larger than needed as it has captured 2-3+ messages in a single
+// capture. Setting a low timeout value can resolve this.
+// So, choosing the best kTimeout value for your use particular case is
+// quite nuanced. Good luck and happy hunting.
+// NOTE: Don't exceed kMaxTimeoutMs. Typically 130ms.
+#if DECODE_AC
+// Some A/C units have gaps in their protocols of ~40ms. e.g. Kelvinator
+// A value this large may swallow repeats of some protocols
+const uint8_t kTimeout = 50;
+#else   // DECODE_AC
+// Suits most messages, while not swallowing many repeats.
+const uint8_t kTimeout = 15;
+#endif  // DECODE_AC
+// Alternatives:
+// const uint8_t kTimeout = 90;
+// Suits messages with big gaps like XMP-1 & some aircon units, but can
+// accidentally swallow repeated messages in the rawData[] output.
+//
+// const uint8_t kTimeout = kMaxTimeoutMs;
+// This will set it to our currently allowed maximum.
+// Values this high are problematic because it is roughly the typical boundary
+// where most messages repeat.
+// e.g. It will stop decoding a message and start sending it to serial at
+//      precisely the time when the next message is likely to be transmitted,
+//      and may miss it.
+
+// Set the smallest sized "UNKNOWN" message packets we actually care about.
+// This value helps reduce the false-positive detection rate of IR background
+// noise as real messages. The chances of background IR noise getting detected
+// as a message increases with the length of the kTimeout value. (See above)
+// The downside of setting this message too large is you can miss some valid
+// short messages for protocols that this library doesn't yet decode.
+//
+// Set higher if you get lots of random short UNKNOWN messages when nothing
+// should be sending a message.
+// Set lower if you are sure your setup is working, but it doesn't see messages
+// from your device. (e.g. Other IR remotes work.)
+// NOTE: Set this value very high to effectively turn off UNKNOWN detection.
+const uint16_t kMinUnknownSize = 12;
+
+// Legacy (No longer supported!)
+//
+// Change to `true` if you miss/need the old "Raw Timing[]" display.
+#define LEGACY_TIMING_INFO false
+// ==================== end of TUNEABLE PARAMETERS ====================
+
+// Use turn on the save buffer feature for more complete capture coverage.
+IRrecv irrecv(kRecvPin, kCaptureBufferSize, kTimeout, true);
+decode_results results;  // Somewhere to store the results
+
+// This section of code runs only once at start-up.
+void setup() {
+#if defined(ESP8266)
+  Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
+#else  // ESP8266
+  Serial.begin(kBaudRate, SERIAL_8N1);
+#endif  // ESP8266
+  while (!Serial)  // Wait for the serial connection to be establised.
+    delay(50);
+  Serial.printf("\n" D_STR_IRRECVDUMP_STARTUP "\n", kRecvPin);
+#if DECODE_HASH
+  // Ignore messages with less than minimum on or off pulses.
+  irrecv.setUnknownThreshold(kMinUnknownSize);
+#endif  // DECODE_HASH
+  irrecv.enableIRIn();  // Start the receiver
+}
+
+// The repeating section of the code
+void loop() {
+  // Check if the IR code has been received.
+  if (irrecv.decode(&results)) {
+    // Display a crude timestamp.
+    uint32_t now = millis();
+    Serial.printf(D_STR_TIMESTAMP " : %06u.%03u\n", now / 1000, now % 1000);
+    // Check if we got an IR message that was to big for our capture buffer.
+    if (results.overflow)
+      Serial.printf(D_WARN_BUFFERFULL "\n", kCaptureBufferSize);
+    // Display the library version the message was captured with.
+    Serial.println(D_STR_LIBRARY "   : v" _IRREMOTEESP8266_VERSION_ "\n");
+    // Display the basic output of what we found.
+    Serial.print(resultToHumanReadableBasic(&results));
+    // Display any extra A/C info if we have it.
+    String description = IRAcUtils::resultAcToString(&results);
+    if (description.length()) Serial.println(D_STR_MESGDESC ": " + description);
+    yield();  // Feed the WDT as the text output can take a while to print.
+#if LEGACY_TIMING_INFO
+    // Output legacy RAW timing info of the result.
+    Serial.println(resultToTimingInfo(&results));
+    yield();  // Feed the WDT (again)
+#endif  // LEGACY_TIMING_INFO
+    // Output the results as source code
+    Serial.println(resultToSourceCode(&results));
+    Serial.println();    // Blank line between entries
+    yield();             // Feed the WDT (again)
+  }
+}

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -1,5 +1,5 @@
 /*
- * IRremoteESP8266: IRrecvDumpV2 - dump details of IR codes with IRrecv
+ * IRremoteESP8266: IRrecvDumpV3 - dump details of IR codes with IRrecv
  * An IR detector/demodulator must be connected to the input kRecvPin.
  *
  * Copyright 2009 Ken Shirriff, http://arcfn.com
@@ -9,6 +9,9 @@
  *  https://github.com/crankyoldgit/IRremoteESP8266/wiki#ir-receiving
  *
  * Changes:
+ *   Version 1.1 May, 2020
+ *     - Create DumpV3 from DumpV2
+ *     - Add OTA Base
  *   Version 1.0 October, 2019
  *     - Internationalisation (i18n) support.
  *     - Stop displaying the legacy raw timing info.
@@ -23,6 +26,10 @@
  *       reduce the likelihood of miscaptures.
  * Based on Ken Shirriff's IrsendDemo Version 0.1 July, 2009,
  */
+
+// Allow over air update
+// #define OTA_ENABLE true
+#include "BaseOTA.h"
 
 #include <Arduino.h>
 #include <IRrecv.h>
@@ -110,6 +117,7 @@ decode_results results;  // Somewhere to store the results
 
 // This section of code runs only once at start-up.
 void setup() {
+  OTAwifi();  // start default wifi (previously saved on the ESP) for OTA
 #if defined(ESP8266)
   Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
 #else  // ESP8266
@@ -118,6 +126,7 @@ void setup() {
   while (!Serial)  // Wait for the serial connection to be establised.
     delay(50);
   Serial.printf("\n" D_STR_IRRECVDUMP_STARTUP "\n", kRecvPin);
+  OTAinit();  // setup OTA handlers and show IP
 #if DECODE_HASH
   // Ignore messages with less than minimum on or off pulses.
   irrecv.setUnknownThreshold(kMinUnknownSize);
@@ -153,4 +162,5 @@ void loop() {
     Serial.println();    // Blank line between entries
     yield();             // Feed the WDT (again)
   }
+  OTAloopHandler();
 }

--- a/examples/IRrecvDumpV3/platformio.ini
+++ b/examples/IRrecvDumpV3/platformio.ini
@@ -1,0 +1,52 @@
+[platformio]
+src_dir = .
+
+[env]
+; Default platform
+platform = espressif8266
+; Default board
+board = nodemcuv2
+framework = arduino
+lib_extra_dirs = ../../
+lib_ldf_mode = deep+
+lib_ignore = examples
+build_flags = ; -D_IR_LOCALE_=en-AU
+
+[env:nodemcuv2]
+board = nodemcuv2
+; build_flags = -D_IR_LOCALE_=en-AU
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+; build_flags = -D_IR_LOCALE_=en-AU
+
+[env:de-CH]
+build_flags = -D_IR_LOCALE_=de-CH  ;  German (Swiss)
+
+[env:de-DE]
+build_flags = -D_IR_LOCALE_=de-DE  ;  German
+
+[env:en-AU]
+build_flags = -D_IR_LOCALE_=en-AU  ;  English (Australian) (Default)
+
+[env:en-IE]
+build_flags = -D_IR_LOCALE_=en-IE  ;  English (Irish)
+
+[env:en-UK]
+build_flags = -D_IR_LOCALE_=en-UK  ;  English (UK)
+
+[env:en-US]
+build_flags = -D_IR_LOCALE_=en-US  ;  English (Simplified) (USA)
+
+[env:es-ES]
+build_flags = -D_IR_LOCALE_=es-ES  ;  Spanish
+
+[env:fr-FR]
+build_flags = -D_IR_LOCALE_=fr-FR  ;  French
+
+[env:it-IT]
+build_flags = -D_IR_LOCALE_=it-IT  ;  Italian
+
+[env:zh-CN]
+build_flags = -D_IR_LOCALE_=zh-CN  ;  Chinese (Simplified)


### PR DESCRIPTION
OTA part is only enabled if the OTA_ENABLED define is included
* Copy IRrecvDumpV2
* Introduce helper based on BasicOTA example with a few helper functions
  - Don't define wifi SSID or PWD, which reuses last known values of ESP
* Add calls to helper from main setup() and loop()