### PR TITLE
Improve `raw_to_pronto_code.py`

### DIFF
--- a/test/ir_Pronto_test.cpp
+++ b/test/ir_Pronto_test.cpp
@@ -423,4 +423,15 @@ TEST(TestSendPronto, Issue1103) {
       "f38028d50m20066s20435m15069s30665",
       irsend.outputStr());
   // Which pretty much matches the `rawData` above.
+
+  // Ref:
+  //  https://github.com/crankyoldgit/IRremoteESP8266/issues/1103#issuecomment-628946514
+  uint16_t pronto_test_using_repeat[12] = {
+      0x0000, 0x006D, 0x0000, 0x0004, 0x02fb, 0x0309, 0x023d, 0x048e, 0x02fb,
+      0x0309, 0x023d, 0x0474};
+  irsend.reset();
+  irsend.sendPronto(pronto_test_using_repeat, 12);
+  EXPECT_EQ(
+      "f38028d50m20066s20435m15069s30665m20066s20435m15069s29982",
+      irsend.outputStr());
 }

--- a/tools/raw_to_pronto_code.py
+++ b/tools/raw_to_pronto_code.py
@@ -7,7 +7,9 @@ import sys
 from auto_analyse_raw_data import convert_rawdata, add_rawdata_args, get_rawdata
 
 
-def parse_and_report(rawdata_str, hertz, end_usecs, verbose, output=sys.stdout):
+# pylint: disable=too-many-arguments
+def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, verbose,
+                     output=sys.stdout):
   """Analyse the rawdata c++ definition of a IR message."""
 
   # Parse the input.
@@ -29,15 +31,20 @@ def parse_and_report(rawdata_str, hertz, end_usecs, verbose, output=sys.stdout):
   if verbose:
     output.write("Pronto period is %f uSecs.\n" % period)
   # Add the lengths to the code.
-  result.append("%04X" % int(len(rawdata) / 2))  # Initial burst
-  result.append("%04X" % 0)  # Repeat (not used by this program)
+  if use_repeat:
+    result.append("%04x" % 0)  # No Initial burst
+    result.append("%04x" % int(len(rawdata) / 2))  # Repeat code length
+  else:
+    result.append("%04x" % int(len(rawdata) / 2))  # Initial burst code length
+    result.append("%04x" % 0)  # No Repeat
 
   # Add the data.
   if verbose:
     output.write("Raw data: %s " % rawdata)
   for i in rawdata:
-    result.append("%04X" % int(i / period))
+    result.append("%04x" % int(i / period))
   output.write("Pronto code = '%s'\n" % " ".join(result))
+# pylint: enable=too-many-arguments
 
 
 def main():
@@ -54,6 +61,7 @@ def main():
       dest="hertz",
       required=True)
   arg_parser.add_argument(
+      "-g",
       "--gap",
       "--endgap",
       type=int,
@@ -67,10 +75,17 @@ def main():
       action="store_true",
       dest="verbose",
       default=False)
+  arg_parser.add_argument(
+      "-r",
+      "--repeat_code",
+      action='store_true',
+      help="Send using the 'repeat' section of the pronto code.",
+      dest="use_repeat")
   add_rawdata_args(arg_parser)
   arg_options = arg_parser.parse_args()
   parse_and_report(get_rawdata(arg_options), arg_options.hertz,
-                   arg_options.usecs, arg_options.verbose)
+                   arg_options.usecs, arg_options.use_repeat,
+                   arg_options.verbose)
 
 
 if __name__ == '__main__':

--- a/tools/raw_to_pronto_code.py
+++ b/tools/raw_to_pronto_code.py
@@ -8,8 +8,8 @@ from auto_analyse_raw_data import convert_rawdata, add_rawdata_args, get_rawdata
 
 
 # pylint: disable=too-many-arguments
-def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, verbose,
-                     output=sys.stdout):
+def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, generate_code,
+                     verbose, output=sys.stdout):
   """Analyse the rawdata c++ definition of a IR message."""
 
   # Parse the input.
@@ -43,7 +43,11 @@ def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, verbose,
     output.write("Raw data: %s " % rawdata)
   for i in rawdata:
     result.append("%04x" % int(i / period))
-  output.write("Pronto code = '%s'\n" % " ".join(result))
+  if generate_code:
+    output.write("uint16_t pronto[%d] = {0x%s};\n" % (len(result),
+                                                      ", 0x".join(result)))
+  else:
+    output.write("Pronto code = '%s'\n" % " ".join(result))
 # pylint: enable=too-many-arguments
 
 
@@ -61,6 +65,12 @@ def main():
       dest="hertz",
       required=True)
   arg_parser.add_argument(
+      "-c",
+      "--code",
+      action='store_true',
+      help="Output C/C++ code instead of human-readable.",
+      dest="generate_code")
+  arg_parser.add_argument(
       "-g",
       "--gap",
       "--endgap",
@@ -69,23 +79,23 @@ def main():
       dest="usecs",
       default=100000)
   arg_parser.add_argument(
+      "-r",
+      "--repeat_code",
+      action='store_true',
+      help="Send using the 'repeat' section of the pronto code.",
+      dest="use_repeat")
+  arg_parser.add_argument(
       "-v",
       "--verbose",
       help="Increase output verbosity",
       action="store_true",
       dest="verbose",
       default=False)
-  arg_parser.add_argument(
-      "-r",
-      "--repeat_code",
-      action='store_true',
-      help="Send using the 'repeat' section of the pronto code.",
-      dest="use_repeat")
   add_rawdata_args(arg_parser)
   arg_options = arg_parser.parse_args()
   parse_and_report(get_rawdata(arg_options), arg_options.hertz,
                    arg_options.usecs, arg_options.use_repeat,
-                   arg_options.verbose)
+                   arg_options.generate_code, arg_options.verbose)
 
 
 if __name__ == '__main__':

--- a/tools/raw_to_pronto_code.py
+++ b/tools/raw_to_pronto_code.py
@@ -8,8 +8,9 @@ from auto_analyse_raw_data import convert_rawdata, add_rawdata_args, get_rawdata
 
 
 # pylint: disable=too-many-arguments
-def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, generate_code,
-                     verbose, output=sys.stdout):
+def parse_and_report(rawdata_str, hertz=38000, end_usecs=100000,
+                     use_initial=False, generate_code=False, verbose=False,
+                     output=sys.stdout):
   """Analyse the rawdata c++ definition of a IR message."""
 
   # Parse the input.
@@ -31,12 +32,12 @@ def parse_and_report(rawdata_str, hertz, end_usecs, use_repeat, generate_code,
   if verbose:
     output.write("Pronto period is %f uSecs.\n" % period)
   # Add the lengths to the code.
-  if use_repeat:
-    result.append("%04x" % 0)  # No Initial burst
-    result.append("%04x" % int(len(rawdata) / 2))  # Repeat code length
-  else:
+  if use_initial:
     result.append("%04x" % int(len(rawdata) / 2))  # Initial burst code length
-    result.append("%04x" % 0)  # No Repeat
+    result.append("%04x" % 0)  # No Repeat code length
+  else:
+    result.append("%04x" % 0)  # No Initial burst code length
+    result.append("%04x" % int(len(rawdata) / 2))  # Repeat code length
 
   # Add the data.
   if verbose:
@@ -79,11 +80,11 @@ def main():
       dest="usecs",
       default=100000)
   arg_parser.add_argument(
-      "-r",
-      "--repeat_code",
+      "-i",
+      "--initial_burst",
       action='store_true',
-      help="Send using the 'repeat' section of the pronto code.",
-      dest="use_repeat")
+      help="Send using only the 'inital burst' section of the pronto code.",
+      dest="use_initial")
   arg_parser.add_argument(
       "-v",
       "--verbose",
@@ -94,7 +95,7 @@ def main():
   add_rawdata_args(arg_parser)
   arg_options = arg_parser.parse_args()
   parse_and_report(get_rawdata(arg_options), arg_options.hertz,
-                   arg_options.usecs, arg_options.use_repeat,
+                   arg_options.usecs, arg_options.use_initial,
                    arg_options.generate_code, arg_options.verbose)
 
 

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -49,7 +49,7 @@ class TestRawToPronto(unittest.TestCase):
         "Pronto code = "
         "'0000 0047 0004 0000 0485 049b 0365 06e8 0485 049b 0364 1680'\n")
 
-  def test_parse_and_report_using_repeat(self):
+  def test_using_repeat(self):
     """Tests for the parse_and_report() function @38kHz using repeat section."""
 
     output = StringIO()

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -14,11 +14,11 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 100000, False, output)
+    pronto.parse_and_report(input_str, 38000, 100000, False, False, output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
-        "'0000 006D 0004 0000 02FB 0309 023D 048E 02FB 0309 023D 0ED8'\n")
+        "'0000 006D 0004 0000 02fb 0309 023d 048e 02fb 0309 023d 0ed8'\n")
 
   def test_parse_and_report_at_36000(self):
     """Tests for the parse_and_report() function @ 36kHz."""
@@ -27,11 +27,11 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 36000, 100000, False, output)
+    pronto.parse_and_report(input_str, 36000, 100000, False, False, output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
-        "'0000 0073 0004 0000 02D3 02E0 021F 0451 02D3 02E0 021F 0E10'\n")
+        "'0000 0073 0004 0000 02d3 02e0 021f 0451 02d3 02e0 021f 0e10'\n")
 
   def test_parse_and_report_at_57600(self):
     """Tests for the parse_and_report() function @ 57.6kHz."""
@@ -40,11 +40,24 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
       uint16_t rawData[7] = {
           20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 57600, 100000, False, output)
+    pronto.parse_and_report(input_str, 57600, 100000, False, False, output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
-        "'0000 0047 0004 0000 0485 049B 0365 06E8 0485 049B 0364 1680'\n")
+        "'0000 0047 0004 0000 0485 049b 0365 06e8 0485 049b 0364 1680'\n")
+
+  def test_parse_and_report_at_38000_using_repeat_section(self):
+    """Tests for the parse_and_report() function @38kHz using repeat section."""
+
+    output = StringIO()
+    input_str = """
+        uint16_t rawData[7] = {
+            20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
+    pronto.parse_and_report(input_str, 38000, 30000, True, False, output)
+    self.assertEqual(
+        output.getvalue(),
+        "Pronto code = "
+        "'0000 006D 0000 0004 02fb 0309 023d 048e 02fb 0309 023d 0474'\n")
 
 
 if __name__ == '__main__':

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -46,7 +46,7 @@ class TestRawToPronto(unittest.TestCase):
         "Pronto code = "
         "'0000 0047 0004 0000 0485 049b 0365 06e8 0485 049b 0364 1680'\n")
 
-  def test_parse_and_report_at_38000_using_repeat_section(self):
+  def test_parse_and_report_using_repeat(self):
     """Tests for the parse_and_report() function @38kHz using repeat section."""
 
     output = StringIO()

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -14,7 +14,7 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 100000, False, False, False,
+    pronto.parse_and_report(input_str, 38000, 100000, True, False, False,
                             output)
     self.assertEqual(
         output.getvalue(),
@@ -28,7 +28,7 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 36000, 100000, False, False, False,
+    pronto.parse_and_report(input_str, 36000, 100000, True, False, False,
                             output)
     self.assertEqual(
         output.getvalue(),
@@ -42,7 +42,7 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
       uint16_t rawData[7] = {
           20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 57600, 100000, False, False, False,
+    pronto.parse_and_report(input_str, 57600, 100000, True, False, False,
                             output)
     self.assertEqual(
         output.getvalue(),
@@ -56,7 +56,8 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 30000, True, False, False, output)
+    pronto.parse_and_report(input_str, 38000, 30000, False, False, False,
+                            output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -69,7 +70,7 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 30000, False, True, False, output)
+    pronto.parse_and_report(input_str, 38000, 30000, True, True, False, output)
     self.assertEqual(
         output.getvalue(),
         "uint16_t pronto[12] = {0x0000, 0x006D, 0x0004, 0x0000, 0x02fb, "

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -14,7 +14,8 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 100000, False, False, output)
+    pronto.parse_and_report(input_str, 38000, 100000, False, False, False,
+                            output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -27,7 +28,8 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 36000, 100000, False, False, output)
+    pronto.parse_and_report(input_str, 36000, 100000, False, False, False,
+                            output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -40,7 +42,8 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
       uint16_t rawData[7] = {
           20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 57600, 100000, False, False, output)
+    pronto.parse_and_report(input_str, 57600, 100000, False, False, False,
+                            output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -53,11 +56,24 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 30000, True, False, output)
+    pronto.parse_and_report(input_str, 38000, 30000, True, False, False, output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
         "'0000 006D 0000 0004 02fb 0309 023d 048e 02fb 0309 023d 0474'\n")
+
+  def test_generate_code_output(self):
+    """Tests for the parse_and_report() function geneating code output."""
+
+    output = StringIO()
+    input_str = """
+        uint16_t rawData[7] = {
+            20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
+    pronto.parse_and_report(input_str, 38000, 30000, False, True, False, output)
+    self.assertEqual(
+        output.getvalue(),
+        "uint16_t pronto[12] = {0x0000, 0x006D, 0x0004, 0x0000, 0x02fb, "
+        "0x0309, 0x023d, 0x048e, 0x02fb, 0x0309, 0x023d, 0x0474};\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Use lower-case hex code output for pronto codes.
* Add option to send the raw code via the repeat section of the Pronto code, rather than the inital section.
* Add synonym of `-g` for the gap arg.

Fixes #1103