### PR TITLE
CarrierAc64: Add detailed support.

### DIFF
--- a/src/IRac.h
+++ b/src/IRac.h
@@ -9,6 +9,7 @@
 #include "IRremoteESP8266.h"
 #include "ir_Amcor.h"
 #include "ir_Argo.h"
+#include "ir_Carrier.h"
 #include "ir_Coolix.h"
 #include "ir_Daikin.h"
 #include "ir_Delonghi.h"
@@ -106,6 +107,12 @@ class IRac {
             const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
             const bool turbo, const int16_t sleep = -1);
 #endif  // SEND_ARGO
+#if SEND_CARRIER_AC64
+void carrier64(IRCarrierAc64 *ac,
+               const bool on, const stdAc::opmode_t mode,
+               const float degrees, const stdAc::fanspeed_t fan,
+               const stdAc::swingv_t swingv, const int16_t sleep = -1);
+#endif  // SEND_CARRIER_AC64
 #if SEND_COOLIX
   void coolix(IRCoolixAC *ac,
               const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/ir_Carrier.cpp
+++ b/src/ir_Carrier.cpp
@@ -184,7 +184,7 @@ bool IRrecv::decodeCarrierAC40(decode_results *results, uint16_t offset,
 
 #if SEND_CARRIER_AC64
 /// Send a Carrier 64bit HVAC formatted message.
-/// Status: Alpha / Yet to be tested against a real device.
+/// Status: STABLE / Known to be working.
 /// @param[in] data The message to be sent.
 /// @param[in] nbits The bit size of the message being sent.
 /// @param[in] repeat The number of times the message is to be repeated.
@@ -199,7 +199,7 @@ void IRsend::sendCarrierAC64(const uint64_t data, const uint16_t nbits,
 
 #if DECODE_CARRIER_AC64
 /// Decode the supplied Carrier 64-bit HVAC message.
-/// Status: BETA / Probably works.
+/// Status: STABLE / Known to be working.
 /// @param[in,out] results Ptr to the data to decode & where to store the decode
 ///   result.
 /// @param[in] offset The starting index to use when attempting to decode the

--- a/src/ir_Carrier.cpp
+++ b/src/ir_Carrier.cpp
@@ -8,9 +8,24 @@
 //   Brand: Carrier/Surrey,  Model: 619EGX0220E0 A/C
 //   Brand: Carrier/Surrey,  Model: 53NGK009/012 Inverter
 
+#include "ir_Carrier.h"
+#include <algorithm>
+#include "IRac.h"
 #include "IRrecv.h"
 #include "IRsend.h"
+#include "IRtext.h"
 #include "IRutils.h"
+
+using irutils::addBoolToString;
+using irutils::addIntToString;
+using irutils::addLabeledString;
+using irutils::addModeToString;
+using irutils::addTempToString;
+using irutils::addFanToString;
+using irutils::minsToString;
+using irutils::setBit;
+using irutils::setBits;
+using irutils::sumNibbles;
 
 // Constants
 // Ref:
@@ -207,6 +222,9 @@ bool IRrecv::decodeCarrierAC64(decode_results *results, uint16_t offset,
                     kCarrierAc64BitMark, kCarrierAc64Gap, true,
                     kUseDefTol, kMarkExcess, false)) return false;
 
+  // Compliance
+  if (strict && !IRCarrierAc64::validChecksum(results->value)) return false;
+
   // Success
   results->bits = nbits;
   results->decode_type = CARRIER_AC64;
@@ -215,3 +233,299 @@ bool IRrecv::decodeCarrierAC64(decode_results *results, uint16_t offset,
   return true;
 }
 #endif  // DECODE_CARRIER_AC64
+
+/// Class constructor for handling detailed Carrier 64 bit A/C messages.
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRCarrierAc64 object.
+IRCarrierAc64::IRCarrierAc64(const uint16_t pin, const bool inverted,
+                            const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
+
+/// Reset the internal state to a fixed known good state.
+/// @note The state is powered off.
+void IRCarrierAc64::stateReset(void) { remote_state = 0x109000002C2A5584; }
+
+/// Calculate the checksum for a given state.
+/// @param state The value to calc the checksum of.
+/// @return The 4-bit checksum stored in a uint_8.
+uint8_t IRCarrierAc64::calcChecksum(const uint64_t state) {
+  uint64_t data = GETBITS64(state,
+      kCarrierAc64ChecksumOffset + kCarrierAc64ChecksumSize, kCarrierAc64Bits -
+      (kCarrierAc64ChecksumOffset + kCarrierAc64ChecksumSize));
+  uint8_t result = 0;
+  for (; data; data >>= 4)  // Add each nibble together.
+    result += GETBITS64(data, 0, 4);
+  return result & 0xF;
+}
+
+/// Verify the checksum is valid for a given state.
+/// @param state The array to verify the checksum of.
+/// @param length The size of the state.
+/// @return true, if the state has a valid checksum. Otherwise, false.
+bool IRCarrierAc64::validChecksum(const uint64_t state) {
+  // Validate the checksum of the given state.
+  return (GETBITS64(state, kCarrierAc64ChecksumOffset,
+                    kCarrierAc64ChecksumSize) == calcChecksum(state));
+}
+
+/// Calculate and set the checksum values for the internal state.
+void IRCarrierAc64::checksum(void) {
+  setBits(&remote_state, kCarrierAc64ChecksumOffset, kCarrierAc64ChecksumSize,
+          calcChecksum(remote_state));
+}
+
+void IRCarrierAc64::begin(void) { _irsend.begin(); }
+
+#if SEND_CARRIER_AC64
+void IRCarrierAc64::send(const uint16_t repeat) {
+  _irsend.sendCarrierAC64(getRaw(), kCarrierAc64Bits, repeat);
+}
+#endif  // SEND_CARRIER_AC64
+
+/// Get a copy of the internal state as a valid code for this protocol.
+/// @return A valid code for this protocol based on the current internal state.
+uint64_t IRCarrierAc64::getRaw(void) {
+  checksum();  // Ensure correct settings before sending.
+  return remote_state;
+}
+
+/// Set the internal state from a valid code for this protocol.
+/// @param state A valid code for this protocol.
+void IRCarrierAc64::setRaw(const uint64_t state) { remote_state = state; }
+
+/// Set the temp in deg C.
+/// @param temp The desired temperature in Celsius.
+void IRCarrierAc64::setTemp(const uint8_t temp) {
+  uint8_t degrees = std::max(temp, kCarrierAc64MinTemp);
+  degrees = std::min(degrees, kCarrierAc64MaxTemp);
+  setBits(&remote_state, kCarrierAc64TempOffset, kCarrierAc64TempSize,
+          degrees - kCarrierAc64MinTemp);
+}
+
+/// Get the current temperature from the internal state.
+/// @return The current temperatue in Celsius.
+uint8_t IRCarrierAc64::getTemp(void) {
+  return GETBITS64(remote_state, kCarrierAc64TempOffset, kCarrierAc64TempSize) +
+      kCarrierAc64MinTemp;
+}
+
+/// Change the power setting.
+/// @param on true, the setting is on. false, the setting is off.
+void IRCarrierAc64::setPower(const bool on) {
+  setBit(&remote_state, kCarrierAc64PowerOffset, on);
+}
+
+/// Gte the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
+bool IRCarrierAc64::getPower(void) {
+  return GETBIT64(remote_state, kCarrierAc64PowerOffset);
+}
+
+/// Change the power setting to On.
+void IRCarrierAc64::on(void) { setPower(true); }
+
+/// Change the power setting to Off.
+void IRCarrierAc64::off(void) { setPower(false); }
+
+/// Get the operating mode setting of the A/C.
+/// @preturn The current operating mode setting.
+uint8_t IRCarrierAc64::getMode(void) {
+  return GETBITS64(remote_state, kCarrierAc64ModeOffset, kCarrierAc64ModeSize);
+}
+
+/// Set the operating mode of the A/C.
+/// @param mode The desired operating mode.
+void IRCarrierAc64::setMode(const uint8_t mode) {
+  switch (mode) {
+    case kCarrierAc64Heat:
+    case kCarrierAc64Cool:
+    case kCarrierAc64Fan:
+      setBits(&remote_state, kCarrierAc64ModeOffset, kCarrierAc64ModeSize,
+              mode);
+      return;
+    default:
+      this->setMode(kCarrierAc64Cool);
+  }
+}
+
+/// Convert a standard A/C mode into its native mode.
+/// @param mode A stdAc::opmode_t mode to be converted to it's native equivalent
+/// @return The corresponding native mode.
+uint8_t IRCarrierAc64::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kHeat: return kCarrierAc64Heat;
+    case stdAc::opmode_t::kFan: return kCarrierAc64Fan;
+    default: return kDaikinCool;
+  }
+}
+
+/// Convert a native mode to it's common stdAc::opmode_t equivalent.
+/// @param mode A native operation mode to be converted.
+/// @return The corresponding common stdAc::opmode_t mode.
+stdAc::opmode_t IRCarrierAc64::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kCarrierAc64Heat:  return stdAc::opmode_t::kHeat;
+    case kCarrierAc64Fan:  return stdAc::opmode_t::kFan;
+    default: return stdAc::opmode_t::kCool;
+  }
+}
+
+
+uint8_t IRCarrierAc64::getFan(void) {
+  return GETBITS64(remote_state, kCarrierAc64FanOffset, kCarrierAc64FanSize);
+}
+
+void IRCarrierAc64::setFan(const uint8_t speed) {
+  if (speed > kCarrierAc64FanHigh)
+    setFan(kCarrierAc64FanAuto);
+  else
+    setBits(&remote_state, kCarrierAc64FanOffset, kCarrierAc64FanSize, speed);
+}
+
+// Convert a standard A/C Fan speed into its native fan speed.
+uint8_t IRCarrierAc64::convertFan(const stdAc::fanspeed_t speed) {
+  switch (speed) {
+    case stdAc::fanspeed_t::kMin:
+    case stdAc::fanspeed_t::kLow:    return kCarrierAc64FanLow;
+    case stdAc::fanspeed_t::kMedium: return kCarrierAc64FanMedium;
+    case stdAc::fanspeed_t::kHigh:
+    case stdAc::fanspeed_t::kMax:    return kCarrierAc64FanHigh;
+    default:                         return kCarrierAc64FanAuto;
+  }
+}
+
+// Convert a native fan speed to it's common equivalent.
+stdAc::fanspeed_t IRCarrierAc64::toCommonFanSpeed(const uint8_t speed) {
+  switch (speed) {
+    case kCarrierAc64FanHigh:    return stdAc::fanspeed_t::kHigh;
+    case kCarrierAc64FanMedium:  return stdAc::fanspeed_t::kMedium;
+    case kCarrierAc64FanLow:     return stdAc::fanspeed_t::kLow;
+    default:                     return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+/// Set the Vertical Swing mode of the A/C.
+/// @param on true, the setting is on. false, the setting is off.
+void IRCarrierAc64::setSwingV(const bool on) {
+  setBit(&remote_state, kCarrierAc64SwingVOffset, on);
+}
+
+/// Get the Vertical Swing mode of the A/C.
+/// @return true, the setting is on. false, the setting is off.
+bool IRCarrierAc64::getSwingV(void) {
+  return GETBIT64(remote_state, kCarrierAc64SwingVOffset);
+}
+
+/// Set the Sleep mode of the A/C.
+/// @param on true, the setting is on. false, the setting is off.
+void IRCarrierAc64::setSleep(const bool on) {
+  setBit(&remote_state, kCarrierAc64SleepOffset, on);
+  if (on) {
+    // Sleep sets specific values in the On & Off timer times, but has them
+    // disabled.
+    setOffTimer(2 * 60);
+    setOnTimer(3 * 60);
+    // Clear the enable bits for each timer.
+    setBit(&remote_state, kCarrierAc64OffTimerEnableOffset, false);
+    setBit(&remote_state, kCarrierAc64OnTimerEnableOffset, false);
+  }
+}
+
+/// Get the Sleep mode of the A/C.
+/// @return true, the setting is on. false, the setting is off.
+bool IRCarrierAc64::getSleep(void) {
+  return GETBIT64(remote_state, kCarrierAc64SleepOffset);
+}
+
+/// Get the current On Timer time.
+/// @return The number of minutes it is set for. 0 means it's off.
+/// @note The A/C protocol only supports one hour increments.
+uint16_t IRCarrierAc64::getOnTimer(void) {
+  if (GETBIT64(remote_state, kCarrierAc64OnTimerEnableOffset))
+    return GETBITS64(remote_state, kCarrierAc64OnTimerOffset,
+                     kCarrierAc64TimerSize) * 60;
+  else
+    return 0;
+}
+
+/// Set the On Timer time.
+/// @param nr_of_mins Number of minutes to set the timer to. (< 60 is disable).
+/// @note The A/C protocol only supports one hour increments.
+void IRCarrierAc64::setOnTimer(const uint16_t nr_of_mins) {
+  uint8_t hours = std::min((uint8_t)(nr_of_mins / 60), kCarrierAc64TimerMax);
+  setBit(&remote_state, kCarrierAc64OnTimerEnableOffset, hours);  // Enable
+  setBits(&remote_state, kCarrierAc64OnTimerOffset, kCarrierAc64TimerSize,
+          std::max(kCarrierAc64TimerMin, hours));  // Hours
+}
+
+/// Get the current Off Timer time.
+/// @return The number of minutes it is set for. 0 means it's off.
+/// @note The A/C protocol only supports one hour increments.
+uint16_t IRCarrierAc64::getOffTimer(void) {
+  if (GETBIT64(remote_state, kCarrierAc64OffTimerEnableOffset))
+    return GETBITS64(remote_state, kCarrierAc64OffTimerOffset,
+                     kCarrierAc64TimerSize) * 60;
+  else
+    return 0;
+}
+
+/// Set the Off Timer time.
+/// @param nr_of_mins Number of minutes to set the timer to. (< 60 is disable).
+/// @note The A/C protocol only supports one hour increments.
+void IRCarrierAc64::setOffTimer(const uint16_t nr_of_mins) {
+  uint8_t hours = std::min((uint8_t)(nr_of_mins / 60), kCarrierAc64TimerMax);
+  setBit(&remote_state, kCarrierAc64OffTimerEnableOffset, hours);  // Enable
+  setBits(&remote_state, kCarrierAc64OffTimerOffset, kCarrierAc64TimerSize,
+          std::max(kCarrierAc64TimerMin, hours));  // Hours
+}
+
+/// Convert the internal state into a human readable string.
+/// @return The current internal state expressed as a human readable String.
+String IRCarrierAc64::toString(void) {
+  String result = "";
+  result.reserve(120);  // Reserve some heap for the string to reduce fragging.
+  result += addBoolToString(getPower(), kPowerStr, false);
+  result += addModeToString(getMode(), 0xFF, kCarrierAc64Cool,
+                            kCarrierAc64Heat, 0xFF, kCarrierAc64Fan);
+  result += addTempToString(getTemp());
+  result += addFanToString(getFan(), kCarrierAc64FanHigh, kCarrierAc64FanLow,
+                           kCarrierAc64FanAuto, kCarrierAc64FanAuto,
+                           kCarrierAc64FanMedium);
+  result += addBoolToString(getSwingV(), kSwingVStr);
+  result += addBoolToString(getSleep(), kSleepStr);
+  result += addLabeledString(getOnTimer()
+                             ? minsToString(getOnTimer()) : kOffStr,
+                             kOnTimerStr);
+  result += addLabeledString(getOffTimer()
+                             ? minsToString(getOffTimer()) : kOffStr,
+                             kOffTimerStr);
+  return result;
+}
+
+/// Convert the A/C state to it's common stdAc::state_t equivalent.
+/// @return A stdAc::state_t state.
+stdAc::state_t IRCarrierAc64::toCommon(void) {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::CARRIER_AC64;
+  result.model = -1;  // No models used.
+  result.power = getPower();
+  result.mode = toCommonMode(getMode());
+  result.celsius = true;
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  result.swingv = getSwingV() ? stdAc::swingv_t::kAuto : stdAc::swingv_t::kOff;
+  result.sleep = getSleep() ? 0 : -1;
+  // Not supported.
+  result.swingh = stdAc::swingh_t::kOff;
+  result.turbo = false;
+  result.quiet = false;
+  result.clean = false;
+  result.filter = false;
+  result.beep = false;
+  result.econo = false;
+  result.light = false;
+  result.clock = -1;
+  return result;
+}

--- a/src/ir_Carrier.h
+++ b/src/ir_Carrier.h
@@ -1,0 +1,117 @@
+// Carrier A/C
+//
+// Copyright 2020 David Conran
+
+#ifndef IR_CARRIER_H_
+#define IR_CARRIER_H_
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
+
+// Ref:
+//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1127
+
+// Constants
+
+// CARRIER_AC64
+// Ref:
+//   https://docs.google.com/spreadsheets/d/1EZy78L0cn1KDIX1aKq2biptejFqCjD5HO3tLiRvXf48/edit#gid=0
+const uint8_t kCarrierAc64ChecksumOffset = 16;
+const uint8_t kCarrierAc64ChecksumSize = 4;
+const uint8_t kCarrierAc64ModeOffset = kCarrierAc64ChecksumOffset +
+                                       kCarrierAc64ChecksumSize;  // 20
+const uint8_t kCarrierAc64ModeSize = 2;
+const uint8_t kCarrierAc64Heat = 0b01;  // 1
+const uint8_t kCarrierAc64Cool = 0b10;  // 2
+const uint8_t kCarrierAc64Fan =  0b11;  // 3
+const uint8_t kCarrierAc64FanOffset = kCarrierAc64ModeOffset +
+                                      kCarrierAc64ModeSize;  // 22
+const uint8_t kCarrierAc64FanSize = 2;
+const uint8_t kCarrierAc64FanAuto =    0b00;  // 0
+const uint8_t kCarrierAc64FanLow =     0b01;  // 1
+const uint8_t kCarrierAc64FanMedium =  0b10;  // 2
+const uint8_t kCarrierAc64FanHigh =    0b11;  // 3
+const uint8_t kCarrierAc64TempOffset = kCarrierAc64FanOffset +
+                                       kCarrierAc64FanSize;  // 24
+const uint8_t kCarrierAc64TempSize = 4;
+const uint8_t kCarrierAc64MinTemp = 16;  // Celsius
+const uint8_t kCarrierAc64MaxTemp = 30;  // Celsius
+const uint8_t kCarrierAc64SwingVOffset = kCarrierAc64TempOffset +
+                                         kCarrierAc64TempSize + 1;  // 29
+const uint8_t kCarrierAc64PowerOffset = kCarrierAc64SwingVOffset + 6 + 1;  // 36
+const uint8_t kCarrierAc64OffTimerEnableOffset =
+    kCarrierAc64PowerOffset + 1;  // 37
+const uint8_t kCarrierAc64OnTimerEnableOffset =
+    kCarrierAc64OffTimerEnableOffset + 1;  // 38
+const uint8_t kCarrierAc64SleepOffset =
+    kCarrierAc64OnTimerEnableOffset + 1;  // 39
+const uint8_t kCarrierAc64TimerSize = 4;
+const uint8_t kCarrierAc64TimerMax = 9;  // Hours.
+const uint8_t kCarrierAc64TimerMin = 1;  // Hours.
+const uint8_t kCarrierAc64OnTimerOffset =
+    kCarrierAc64SleepOffset + 12 + 1;  // 52
+const uint8_t kCarrierAc64OffTimerOffset = kCarrierAc64OnTimerOffset +
+                                           kCarrierAc64TimerSize + 4;  // 60
+
+
+// Classes
+
+/// Class for handling detailed Carrier 64 bit A/C messages.
+class IRCarrierAc64 {
+ public:
+  explicit IRCarrierAc64(const uint16_t pin, const bool inverted = false,
+                         const bool use_modulation = true);
+
+  void stateReset();
+#if SEND_CARRIER_AC64
+  void send(const uint16_t repeat = kCarrierAc64MinRepeat);
+  int8_t calibrate(void) { return _irsend.calibrate(); }
+#endif  // SEND_CARRIER_AC64
+  void begin();
+  static uint8_t calcChecksum(const uint64_t state);
+  static bool validChecksum(const uint64_t state);
+  void setPower(const bool on);
+  bool getPower();
+  void on();
+  void off();
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp();
+  void setSwingV(const bool on);
+  bool getSwingV(void);
+  void setSleep(const bool on);
+  bool getSleep(void);
+  void setFan(const uint8_t speed);
+  uint8_t getFan();
+  void setMode(const uint8_t mode);
+  uint8_t getMode();
+  void setOnTimer(const uint16_t nr_of_mins);
+  uint16_t getOnTimer(void);
+  void setOffTimer(const uint16_t nr_of_mins);
+  uint16_t getOffTimer(void);
+  uint64_t getRaw();
+  void setRaw(const uint64_t state);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
+  String toString();
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;
+#else
+  IRsendTest _irsend;
+#endif
+  uint64_t remote_state;  // The state of the IR remote.
+  void checksum(void);
+};
+#endif  // IR_CARRIER_H_

--- a/src/ir_Carrier.h
+++ b/src/ir_Carrier.h
@@ -113,5 +113,7 @@ class IRCarrierAc64 {
 #endif
   uint64_t remote_state;  // The state of the IR remote.
   void checksum(void);
+  void _cancelOnTimer(void);
+  void _cancelOffTimer(void);
 };
 #endif  // IR_CARRIER_H_

--- a/test/ir_Carrier_test.cpp
+++ b/test/ir_Carrier_test.cpp
@@ -1,5 +1,6 @@
 // Copyright 2018, 2020 David Conran
 
+#include "ir_Carrier.h"
 #include "IRac.h"
 #include "IRrecv.h"
 #include "IRsend.h"
@@ -256,7 +257,7 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("CARRIER_AC64", typeToString(decode_type_t::CARRIER_AC64));
   ASSERT_EQ(decode_type_t::CARRIER_AC64, strToDecodeType("CARRIER_AC64"));
   ASSERT_FALSE(hasACState(decode_type_t::CARRIER_AC64));
-  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::CARRIER_AC64));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::CARRIER_AC64));
   ASSERT_EQ(kCarrierAc64Bits,
             IRsend::defaultBits(decode_type_t::CARRIER_AC64));
   ASSERT_EQ(kCarrierAc64MinRepeat,
@@ -368,6 +369,10 @@ TEST(TestDecodeCarrierAC64, RealExample) {
   EXPECT_EQ(0x404000102E5E5584, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Heat), Temp: 30C, Fan: 1 (Low), Swing(V): On, "
+      "Sleep: Off, On Timer: Off, Off Timer: Off",
+      IRAcUtils::resultAcToString(&irsend.capture));
 }
 
 /// Send & Decode a synthetic message.
@@ -402,4 +407,207 @@ TEST(TestDecodeCarrierAC64, SyntheticExample) {
       // Footer
       "m503s100000",
       irsend.outputStr());
+}
+
+// Tests for IRCarrierAc64 class.
+
+TEST(TestCarrierAc64Class, Power) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
+
+  ASSERT_EQ(36, kCarrierAc64PowerOffset);
+}
+
+TEST(TestCarrierAc64Class, Temperature) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+
+  ac.setTemp(0);
+  EXPECT_EQ(kCarrierAc64MinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kCarrierAc64MaxTemp, ac.getTemp());
+
+  ac.setTemp(kCarrierAc64MinTemp);
+  EXPECT_EQ(kCarrierAc64MinTemp, ac.getTemp());
+
+  ac.setTemp(kCarrierAc64MaxTemp);
+  EXPECT_EQ(kCarrierAc64MaxTemp, ac.getTemp());
+
+  ac.setTemp(kCarrierAc64MinTemp - 1);
+  EXPECT_EQ(kCarrierAc64MinTemp, ac.getTemp());
+
+  ac.setTemp(kCarrierAc64MaxTemp + 1);
+  EXPECT_EQ(kCarrierAc64MaxTemp, ac.getTemp());
+
+  ac.setTemp(17);
+  EXPECT_EQ(17, ac.getTemp());
+
+  ac.setTemp(21);
+  EXPECT_EQ(21, ac.getTemp());
+
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+
+  ac.setTemp(29);
+  EXPECT_EQ(29, ac.getTemp());
+}
+
+TEST(TestCarrierAc64Class, OperatingMode) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+
+  ac.setMode(kCarrierAc64Cool);
+  EXPECT_EQ(kCarrierAc64Cool, ac.getMode());
+
+  ac.setMode(kCarrierAc64Fan);
+  EXPECT_EQ(kCarrierAc64Fan, ac.getMode());
+
+  ac.setMode(kCarrierAc64Heat);
+  EXPECT_EQ(kCarrierAc64Heat, ac.getMode());
+
+  ac.setMode(kCarrierAc64Fan + 1);
+  EXPECT_EQ(kCarrierAc64Cool, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kCarrierAc64Cool, ac.getMode());
+  ac.setMode(0);
+  EXPECT_EQ(kCarrierAc64Cool, ac.getMode());
+}
+
+TEST(TestCarrierAc64Class, Sleep) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+  ac.setSleep(true);
+  EXPECT_TRUE(ac.getSleep());
+  ac.setSleep(false);
+  EXPECT_FALSE(ac.getSleep());
+  ac.setSleep(true);
+  EXPECT_TRUE(ac.getSleep());
+}
+
+TEST(TestCarrierAc64Class, SwingVertical) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+  ac.setSwingV(true);
+  EXPECT_TRUE(ac.getSwingV());
+  ac.setSwingV(false);
+  EXPECT_FALSE(ac.getSwingV());
+  ac.setSwingV(true);
+  EXPECT_TRUE(ac.getSwingV());
+}
+
+TEST(TestCarrierAc64Class, FanSpeed) {
+  IRCarrierAc64 ac(kGpioUnused);
+  ac.begin();
+
+  // Unexpected value should default to Auto.
+  ac.setFan(255);
+  EXPECT_EQ(kCarrierAc64FanAuto, ac.getFan());
+  ac.setFan(5);
+  EXPECT_EQ(kCarrierAc64FanAuto, ac.getFan());
+
+  ac.setFan(kCarrierAc64FanHigh);
+  EXPECT_EQ(kCarrierAc64FanHigh, ac.getFan());
+
+  // Beyond High should default to Auto.
+  ac.setFan(kCarrierAc64FanHigh + 1);
+  EXPECT_EQ(kCarrierAc64FanAuto, ac.getFan());
+
+  ac.setFan(kCarrierAc64FanMedium);
+  EXPECT_EQ(kCarrierAc64FanMedium, ac.getFan());
+
+  ac.setFan(kCarrierAc64FanLow);
+  EXPECT_EQ(kCarrierAc64FanLow, ac.getFan());
+
+  ac.setFan(kCarrierAc64FanAuto);
+  EXPECT_EQ(kCarrierAc64FanAuto, ac.getFan());
+}
+
+TEST(TestCarrierAc64Class, ChecksumAndSetGetRaw) {
+  IRCarrierAc64 ac(kGpioUnused);
+
+  const uint64_t valid =   0x90900030205C5584;
+  const uint64_t invalid = 0x9090003020505584;
+  ASSERT_NE(valid, invalid);
+  ASSERT_EQ(0x0C, IRCarrierAc64::calcChecksum(valid));
+  ASSERT_TRUE(IRCarrierAc64::validChecksum(valid));
+  ASSERT_FALSE(IRCarrierAc64::validChecksum(invalid));
+  ac.setRaw(valid);
+  ASSERT_EQ(valid, ac.getRaw());
+  ac.setRaw(invalid);
+  ASSERT_EQ(valid, ac.getRaw());
+
+  // Additional known states.
+  ASSERT_TRUE(IRCarrierAc64::validChecksum(0x109000002C2A5584));
+  ASSERT_TRUE(IRCarrierAc64::validChecksum(0x109000102C2B5584));
+}
+
+// Test human readable output.
+TEST(TestCarrierAc64Class, HumanReadable) {
+  IRCarrierAc64 ac(kGpioUnused);
+  EXPECT_EQ(
+      "Power: Off, Mode: 2 (Cool), Temp: 28C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: Off, On Timer: Off, Off Timer: Off",
+      ac.toString());
+  ac.setPower(true);
+  ac.setMode(kCarrierAc64Fan);
+  ac.setTemp(30);
+  ac.setFan(kCarrierAc64FanAuto);
+  ac.setSwingV(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: Off, On Timer: Off, Off Timer: Off",
+      ac.toString());
+  ac.setOffTimer(8* 60 + 37);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: Off, On Timer: Off, Off Timer: 08:00",
+      ac.toString());
+  ac.setOnTimer(5 * 60 + 59);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: Off, On Timer: 05:00, Off Timer: 08:00",
+      ac.toString());
+  ac.setOnTimer(59);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: Off, On Timer: Off, Off Timer: 08:00",
+      ac.toString());
+  ac.setSleep(true);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
+      "Sleep: On, On Timer: Off, Off Timer: Off",
+      ac.toString());
+}
+
+TEST(TestCarrierAc64Class, ReconstructKnownState) {
+  IRCarrierAc64 ac(kGpioUnused);
+  const uint64_t expected = 0x2030009020555584;
+  ac.begin();
+  ac.stateReset();
+  ASSERT_NE(expected, ac.getRaw());
+  ac.on();
+  ac.setMode(kCarrierAc64Heat);
+  ac.setTemp(16);
+  ac.setFan(kCarrierAc64FanLow);
+  ac.setSwingV(true);
+  ac.setSleep(true);
+  EXPECT_EQ(expected, ac.getRaw());
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Heat), Temp: 16C, Fan: 1 (Low), Swing(V): On, "
+      "Sleep: On, On Timer: Off, Off Timer: Off",
+      ac.toString());
 }

--- a/test/ir_Carrier_test.cpp
+++ b/test/ir_Carrier_test.cpp
@@ -579,12 +579,12 @@ TEST(TestCarrierAc64Class, HumanReadable) {
   ac.setOnTimer(5 * 60 + 59);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
-      "Sleep: Off, On Timer: 05:00, Off Timer: 08:00",
+      "Sleep: Off, On Timer: 05:00, Off Timer: Off",
       ac.toString());
   ac.setOnTimer(59);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Fan), Temp: 30C, Fan: 0 (Auto), Swing(V): On, "
-      "Sleep: Off, On Timer: Off, Off Timer: 08:00",
+      "Sleep: Off, On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setSleep(true);
   EXPECT_EQ(
@@ -604,6 +604,7 @@ TEST(TestCarrierAc64Class, ReconstructKnownState) {
   ac.setTemp(16);
   ac.setFan(kCarrierAc64FanLow);
   ac.setSwingV(true);
+  ac.setOnTimer(3 * 60);
   ac.setSleep(true);
   EXPECT_EQ(expected, ac.getRaw());
   EXPECT_EQ(


### PR DESCRIPTION
* Add support the following settings:
  - Power
  - Operating Mode
  - Temperature (Celsius)
  - Fan Speed
  - Swing (Vertical)
  - Sleep
  - On Timer
  - Off Timer
* Unit test coverage
* Common A/C API updated.

Fixes #1127