### PR TITLE
Update D_STR_IRRECVDUMP_STARTUP text.

### DIFF
--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -2,7 +2,7 @@
  * IRremoteESP8266: IRrecvDemo - demonstrates receiving IR codes with IRrecv
  * This is very simple teaching code to show you how to use the library.
  * If you are trying to decode your Infra-Red remote(s) for later replay,
- * use the IRrecvDumpV2.ino example code instead of this.
+ * use the IRrecvDumpV2.ino (or later) example code instead of this.
  * An IR detector/demodulator must be connected to the input kRecvPin.
  * Copyright 2009 Ken Shirriff, http://arcfn.com
  * Example circuit diagram:

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -575,7 +575,7 @@ void IRsend::sendManchester(const uint16_t headermark,
 //   Even elements are Mark times (On), Odd elements are Space times (Off).
 //
 // Ref:
-//   examples/IRrecvDumpV2/IRrecvDumpV2.ino
+//   examples/IRrecvDumpV2/IRrecvDumpV2.ino (or later)
 void IRsend::sendRaw(const uint16_t buf[], const uint16_t len,
                      const uint16_t hz) {
   // Set IR carrier frequency

--- a/src/locale/de-CH.h
+++ b/src/locale/de-CH.h
@@ -148,7 +148,7 @@
 #define D_STR_TIMESTAMP "Ziitstämpfel"
 #undef D_STR_IRRECVDUMP_STARTUP
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 lauft und wartet uf IR Iigab ufem Pin %d"
+    "IRrecvDump lauft und wartet uf IR Iigab ufem Pin %d"
 #undef D_WARN_BUFFERFULL
 #define D_WARN_BUFFERFULL \
     "WARNUNG: IR Code isch zgross für de Buffer (>= %d). " \

--- a/src/locale/de-CH.h
+++ b/src/locale/de-CH.h
@@ -143,7 +143,7 @@
 #undef D_STR_REPEAT
 #define D_STR_REPEAT "Wiederhole"
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #undef D_STR_TIMESTAMP
 #define D_STR_TIMESTAMP "Ziitstämpfel"
 #undef D_STR_IRRECVDUMP_STARTUP

--- a/src/locale/de-DE.h
+++ b/src/locale/de-DE.h
@@ -112,7 +112,7 @@
 
 #define D_STR_REPEAT "Wiederholen"
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #define D_STR_TIMESTAMP "Zeitstempel"
 #define D_STR_LIBRARY "Bibliothek"
 #define D_STR_MESGDESC "Nachr. Beschr."

--- a/src/locale/de-DE.h
+++ b/src/locale/de-DE.h
@@ -117,7 +117,7 @@
 #define D_STR_LIBRARY "Bibliothek"
 #define D_STR_MESGDESC "Nachr. Beschr."
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 läuft und wartet auf IR Eingabe auf Pin %d"
+    "IRrecvDump läuft und wartet auf IR Eingabe auf Pin %d"
 #define D_WARN_BUFFERFULL \
     "WARNUNG: IR Code ist zu gross für Buffer (>= %d). " \
     "Dem Resultat sollte nicht vertraut werden bevor das behoben ist. " \

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -734,7 +734,7 @@
 #endif  // D_STR_MESGDESC
 #ifndef D_STR_IRRECVDUMP_STARTUP
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 is now running and waiting for IR input on Pin %d"
+    "IRrecvDump is now running and waiting for IR input on Pin %d"
 #endif  // D_STR_IRRECVDUMP_STARTUP
 #ifndef D_WARN_BUFFERFULL
 #define D_WARN_BUFFERFULL \

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -722,7 +722,7 @@
 #define D_STR_WHYNTER "WHYNTER"
 #endif  // D_STR_WHYNTER
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #ifndef D_STR_TIMESTAMP
 #define D_STR_TIMESTAMP "Timestamp"
 #endif  // D_STR_TIMESTAMP

--- a/src/locale/es-ES.h
+++ b/src/locale/es-ES.h
@@ -125,7 +125,7 @@
 #define D_STR_TIMESTAMP "marca de tiempo"
 #define D_STR_LIBRARY "Libreria"
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 esta ahora corriendo y esperando por comando IR en Pin %d"
+    "IRrecvDump esta ahora corriendo y esperando por comando IR en Pin %d"
 #ifndef D_WARN_BUFFERFULL
 #define D_WARN_BUFFERFULL \
     "WARNING: Codigo IR es muy grande para el buffer (>= %d). "\

--- a/src/locale/es-ES.h
+++ b/src/locale/es-ES.h
@@ -121,7 +121,7 @@
 #define D_STR_REPEAT "Repetir"
 #define D_STR_CODE "Codigo"
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #define D_STR_TIMESTAMP "marca de tiempo"
 #define D_STR_LIBRARY "Libreria"
 #define D_STR_IRRECVDUMP_STARTUP \

--- a/src/locale/fr-FR.h
+++ b/src/locale/fr-FR.h
@@ -108,7 +108,7 @@
 #define D_STR_LIBRARY "Bibliothèque"
 #define D_STR_MESGDESC "Rèférence"
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 fonctionne et attend l’entrée IR sur la broche %d"
+    "IRrecvDump fonctionne et attend l’entrée IR sur la broche %d"
 #define D_WARN_BUFFERFULL \
     "ATTENTION: IR Code est trop gros pour le buffer (>= %d). " \
     "Le résultat ne doit pas être approuvé avant que cela soit résolu. " \

--- a/src/locale/fr-FR.h
+++ b/src/locale/fr-FR.h
@@ -103,7 +103,7 @@
 
 #define D_STR_REPEAT "Répetition"
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #define D_STR_TIMESTAMP "Horodatage"
 #define D_STR_LIBRARY "Bibliothèque"
 #define D_STR_MESGDESC "Rèférence"

--- a/src/locale/it-IT.h
+++ b/src/locale/it-IT.h
@@ -141,8 +141,8 @@
 #define D_STR_REPEAT "Ripeti"
 #define D_STR_CODE "Codice"
 #define D_STR_BITS "Bit"
-// IRrecvDumpV2
 
+// IRrecvDumpV2+
 #define D_STR_LIBRARY "Libreria"
 #define D_STR_MESGDESC "Desc. Mess."
 #define D_STR_IRRECVDUMP_STARTUP \

--- a/src/locale/it-IT.h
+++ b/src/locale/it-IT.h
@@ -146,7 +146,7 @@
 #define D_STR_LIBRARY "Libreria"
 #define D_STR_MESGDESC "Desc. Mess."
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 è ora attivo e in attesa di segnali IR dal pin %d"
+    "IRrecvDump è ora attivo e in attesa di segnali IR dal pin %d"
 
 #ifndef D_WARN_BUFFERFULL
 #define D_WARN_BUFFERFULL \

--- a/src/locale/zh-CN.h
+++ b/src/locale/zh-CN.h
@@ -441,7 +441,7 @@
 #define D_STR_BITS "位"
 #endif  // D_STR_BITS
 
-// IRrecvDumpV2
+// IRrecvDumpV2+
 #ifndef D_STR_TIMESTAMP
 #define D_STR_TIMESTAMP "时间戳记"
 #endif  // D_STR_TIMESTAMP

--- a/src/locale/zh-CN.h
+++ b/src/locale/zh-CN.h
@@ -416,7 +416,7 @@
 #ifndef D_STR_THREELETTERDAYS
 #define D_STR_THREELETTERDAYS "周一至周末"
 #endif  // D_STR_THREELETTERDAYS
-*/ 
+*/
 
 #ifndef D_STR_YES
 #define D_STR_YES "是"
@@ -453,7 +453,7 @@
 #endif  // D_STR_MESGDESC
 #ifndef D_STR_IRRECVDUMP_STARTUP
 #define D_STR_IRRECVDUMP_STARTUP \
-    "IRrecvDumpV2 运行当中，等待红外信息输入位于引脚 %d"
+    "IRrecvDump 运行当中，等待红外信息输入位于引脚 %d"
 #endif  // D_STR_IRRECVDUMP_STARTUP
 #ifndef D_WARN_BUFFERFULL
 #define D_WARN_BUFFERFULL \

--- a/tools/auto_analyse_raw_data.py
+++ b/tools/auto_analyse_raw_data.py
@@ -711,7 +711,7 @@ def add_rawdata_args(parser):
   arg_group = parser.add_mutually_exclusive_group(required=True)
   arg_group.add_argument(
       "rawdata",
-      help="A rawData line from IRrecvDumpV2. e.g. 'uint16_t rawbuf[37] = {"
+      help="A rawData line from IRrecvDumpV2+. e.g. 'uint16_t rawbuf[37] = {"
       "7930, 3952, 494, 1482, 520, 1482, 494, 1508, 494, 520, 494, 1482, 494, "
       "520, 494, 1482, 494, 1482, 494, 3978, 494, 520, 494, 520, 494, 520, "
       "494, 520, 520, 520, 494, 520, 494, 520, 494, 520, 494};'",


### PR DESCRIPTION
* D_STR_IRRECVDUMP_STARTUP is used in V2 & V3. Remove version to make it correct/shared.

Ref: #1142