### PR TITLE
Hitachi344: Add Swing(H) and improve Swing(V)

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -785,15 +785,15 @@ void IRac::hitachi1(IRHitachiAc1 *ac, const hitachi_ac1_remote_model_t model,
 void IRac::hitachi344(IRHitachiAc344 *ac,
                       const bool on, const stdAc::opmode_t mode,
                       const float degrees, const stdAc::fanspeed_t fan,
-                      const stdAc::swingv_t swingv) {
+                      const stdAc::swingv_t swingv,
+                      const stdAc::swingh_t swingh) {
   ac->begin();
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
+  ac->setSwingV(swingv != stdAc::swingv_t::kOff);
+  ac->setSwingH(ac->convertSwingH(swingh));
   ac->setPower(on);
-  // SwingVToggle is special. Needs to be last method called.
-  ac->setSwingVToggle(swingv != stdAc::swingv_t::kOff);
-  // No Swing(H) setting available.
   // No Quiet setting available.
   // No Turbo setting available.
   // No Light setting available.
@@ -1371,7 +1371,6 @@ stdAc::state_t IRac::handleToggles(const stdAc::state_t desired,
       case decode_type_t::ELECTRA_AC:
         result.light = desired.light ^ prev->light;
         break;
-      case decode_type_t::HITACHI_AC344:
       case decode_type_t::HITACHI_AC424:
       case decode_type_t::MIDEA:
       case decode_type_t::SHARP_AC:
@@ -1654,7 +1653,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case HITACHI_AC344:
     {
       IRHitachiAc344 ac(_pin, _inverted, _modulation);
-      hitachi344(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv);
+      hitachi344(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
+                 send.swingh);
       break;
     }
 #endif  // SEND_HITACHI_AC344

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -786,13 +786,11 @@ void IRac::hitachi344(IRHitachiAc344 *ac,
                       const bool on, const stdAc::opmode_t mode,
                       const float degrees, const stdAc::fanspeed_t fan,
                       const stdAc::swingv_t swingv,
-                      const stdAc::swingv_t prev_swingv,
                       const stdAc::swingh_t swingh) {
   ac->begin();
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
-  ac->setSwingV(swingv != stdAc::swingv_t::kOff);
   ac->setSwingH(ac->convertSwingH(swingh));
   ac->setPower(on);
   // No Quiet setting available.
@@ -804,13 +802,8 @@ void IRac::hitachi344(IRHitachiAc344 *ac,
   // No Sleep setting available.
   // No Clock setting available.
 
-  // Needs to be done last.
-  // Toggle when swingv & prev_swingv are changing.
-  // i.e from "any on" to off, or from off to "any on".
-  ac->setSwingVToggle((swingv != stdAc::swingv_t::kOff &&
-                       prev_swingv == stdAc::swingv_t::kOff) ||
-                      (swingv == stdAc::swingv_t::kOff &&
-                       prev_swingv != stdAc::swingv_t::kOff));
+  // SwingVToggle is special. Needs to be last method called.
+  ac->setSwingVToggle(swingv != stdAc::swingv_t::kOff);
   ac->send();
 }
 #endif  // SEND_HITACHI_AC344
@@ -1380,6 +1373,7 @@ stdAc::state_t IRac::handleToggles(const stdAc::state_t desired,
       case decode_type_t::ELECTRA_AC:
         result.light = desired.light ^ prev->light;
         break;
+      case decode_type_t::HITACHI_AC344:
       case decode_type_t::HITACHI_AC424:
       case decode_type_t::MIDEA:
       case decode_type_t::SHARP_AC:
@@ -1663,7 +1657,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRHitachiAc344 ac(_pin, _inverted, _modulation);
       hitachi344(&ac, send.power, send.mode, degC, send.fanspeed,
-                 send.swingv, prev->swingv, send.swingh);
+                 send.swingv, send.swingh);
       break;
     }
 #endif  // SEND_HITACHI_AC344

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -791,7 +791,6 @@ void IRac::hitachi344(IRHitachiAc344 *ac,
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
-  ac->setSwingV(swingv != stdAc::swingv_t::kOff);
   ac->setSwingH(ac->convertSwingH(swingh));
   ac->setPower(on);
   // No Quiet setting available.
@@ -802,6 +801,10 @@ void IRac::hitachi344(IRHitachiAc344 *ac,
   // No Beep setting available.
   // No Sleep setting available.
   // No Clock setting available.
+
+  // Do Swing(V) last as it appears that it's the only way to make it respond
+  // to the SwingV command. i.e. It reliese on the `setButton()` value.
+  ac->setSwingV(swingv != stdAc::swingv_t::kOff);
   ac->send();
 }
 #endif  // SEND_HITACHI_AC344

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -254,7 +254,6 @@ void electra(IRElectraAc *ac,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
                   const stdAc::swingv_t swingv,
-                  const stdAc::swingv_t prev_swingv,
                   const stdAc::swingh_t swingh);
 #endif  // SEND_HITACHI_AC344
 #if SEND_HITACHI_AC424

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -253,7 +253,9 @@ void electra(IRElectraAc *ac,
   void hitachi344(IRHitachiAc344 *ac,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
-                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh);
+                  const stdAc::swingv_t swingv,
+                  const stdAc::swingv_t prev_swingv,
+                  const stdAc::swingh_t swingh);
 #endif  // SEND_HITACHI_AC344
 #if SEND_HITACHI_AC424
   void hitachi424(IRHitachiAc424 *ac,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -253,7 +253,7 @@ void electra(IRElectraAc *ac,
   void hitachi344(IRHitachiAc344 *ac,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
-                  const stdAc::swingv_t swingv);
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh);
 #endif  // SEND_HITACHI_AC344
 #if SEND_HITACHI_AC424
   void hitachi424(IRHitachiAc424 *ac,

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -1394,7 +1394,7 @@ void IRHitachiAc344::setSwingH(const uint8_t position) {
   if (position > kHitachiAc344SwingHLeftMax)
     return setSwingH(kHitachiAc344SwingHMiddle);
   setBits(&remote_state[kHitachiAc344SwingHByte], kHitachiAc344SwingHOffset,
-         kHitachiAc344SwingHSize, position);
+          kHitachiAc344SwingHSize, position);
   setButton(kHitachiAc344ButtonSwingH);
 }
 
@@ -1402,7 +1402,7 @@ void IRHitachiAc344::setSwingH(const uint8_t position) {
 /// @return The current position horizontal swing is set to.
 uint8_t IRHitachiAc344::getSwingH(void) {
   return GETBITS8(remote_state[kHitachiAc344SwingHByte],
-                 kHitachiAc344SwingHOffset, kHitachiAc344SwingHSize);
+                  kHitachiAc344SwingHOffset, kHitachiAc344SwingHSize);
 }
 
 /// Convert a standard A/C horizontal swing into its native setting.

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -1375,7 +1375,7 @@ void IRHitachiAc344::setRaw(const uint8_t new_code[], const uint16_t length) {
 }
 
 /// Control the vertical swing setting.
-/// @param on True, turns on the feature. False, turns off the feature.
+/// @param[in] on True, turns on the feature. False, turns off the feature.
 void IRHitachiAc344::setSwingV(const bool on) {
   setSwingVToggle(on);  // Set the button value.
   setBit(&remote_state[kHitachiAc344SwingVByte], kHitachiAc344SwingVOffset, on);
@@ -1389,7 +1389,7 @@ bool IRHitachiAc344::getSwingV(void) {
 }
 
 /// Control the horizontal swing setting.
-/// @param position The position to set the horizontal swing to.
+/// @param[in] position The position to set the horizontal swing to.
 void IRHitachiAc344::setSwingH(const uint8_t position) {
   if (position > kHitachiAc344SwingHLeftMax)
     return setSwingH(kHitachiAc344SwingHMiddle);
@@ -1406,6 +1406,7 @@ uint8_t IRHitachiAc344::getSwingH(void) {
 }
 
 /// Convert a standard A/C horizontal swing into its native setting.
+/// @param[in] position A stdAc::swingh_t position to convert.
 /// @return The equivilent native horizontal swing position.
 uint8_t IRHitachiAc344::convertSwingH(const stdAc::swingh_t position) {
   switch (position) {
@@ -1419,6 +1420,7 @@ uint8_t IRHitachiAc344::convertSwingH(const stdAc::swingh_t position) {
 }
 
 /// Convert a native horizontal swing postion to it's common equivalent.
+/// @param[in] pos A native position to convert.
 /// @return The common horizontal swing position.
 stdAc::swingh_t IRHitachiAc344::toCommonSwingH(const uint8_t pos) {
   switch (pos) {

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -52,11 +52,13 @@ const uint8_t kHitachiAc424ButtonFan = 0x42;
 const uint8_t kHitachiAc424ButtonTempDown = 0x43;
 const uint8_t kHitachiAc424ButtonTempUp = 0x44;
 const uint8_t kHitachiAc424ButtonSwingV = 0x81;
+const uint8_t kHitachiAc424ButtonSwingH = 0x8C;
 const uint8_t kHitachiAc344ButtonPowerMode = kHitachiAc424ButtonPowerMode;
 const uint8_t kHitachiAc344ButtonFan = kHitachiAc424ButtonFan;
 const uint8_t kHitachiAc344ButtonTempDown = kHitachiAc424ButtonTempDown;
 const uint8_t kHitachiAc344ButtonTempUp = kHitachiAc424ButtonTempUp;
 const uint8_t kHitachiAc344ButtonSwingV = kHitachiAc424ButtonSwingV;
+const uint8_t kHitachiAc344ButtonSwingH = kHitachiAc424ButtonSwingH;
 
 // Byte[13]
 const uint8_t kHitachiAc424TempByte = 13;
@@ -98,6 +100,21 @@ const uint8_t kHitachiAc344FanMax = kHitachiAc424FanMax;
 const uint8_t kHitachiAc424PowerByte = 27;
 const uint8_t kHitachiAc424PowerOn = 0xF1;
 const uint8_t kHitachiAc424PowerOff = 0xE1;
+
+// Byte[35]
+const uint8_t kHitachiAc344SwingHByte = 35;
+const uint8_t kHitachiAc344SwingHOffset = 0;  // Mask 0b00000xxx
+const uint8_t kHitachiAc344SwingHSize = 3;    // Mask 0b00000xxx
+const uint8_t kHitachiAc344SwingHAuto = 0;              // 0b000
+const uint8_t kHitachiAc344SwingHRightMax = 1;          // 0b001
+const uint8_t kHitachiAc344SwingHRight = 2;             // 0b010
+const uint8_t kHitachiAc344SwingHMiddle = 3;            // 0b011
+const uint8_t kHitachiAc344SwingHLeft = 4;              // 0b100
+const uint8_t kHitachiAc344SwingHLeftMax = 5;           // 0b101
+
+// Byte[37]
+const uint8_t kHitachiAc344SwingVByte = 37;
+const uint8_t kHitachiAc344SwingVOffset = 5;  // Mask 0b00x00000
 
 // HitachiAc1
 // Byte[3] (Model)
@@ -317,6 +334,7 @@ class IRHitachiAc424 {
   // The state of the IR remote in IR code form.
   uint8_t remote_state[kHitachiAc424StateLength];
   void setInvertedStates(void);
+  String _toString(void);
   uint8_t _previoustemp;
 };
 
@@ -359,6 +377,13 @@ class IRHitachiAc344: public IRHitachiAc424 {
 #if SEND_HITACHI_AC344
   void send(const uint16_t repeat = kHitachiAcDefaultRepeat);
 #endif  // SEND_HITACHI_AC344
+  void setSwingV(const bool on);
+  bool getSwingV(void);
+  void setSwingH(const uint8_t position);
+  uint8_t getSwingH(void);
+  static uint8_t convertSwingH(const stdAc::swingh_t position);
+  static stdAc::swingh_t toCommonSwingH(const uint8_t pos);
+  String toString(void);
 };
 
 #endif  // IR_HITACHI_H_

--- a/src/ir_Hitachi.h
+++ b/src/ir_Hitachi.h
@@ -11,7 +11,8 @@
 //   Brand: Hitachi,  Model: PC-LH3B (HITACHI_AC3)
 //   Brand: Hitachi,  Model: KAZE-312KSDP A/C (HITACHI_AC1)
 //   Brand: Hitachi,  Model: R-LT0541-HTA/Y.K.1.1-1 V2.3 remote (HITACHI_AC1)
-//   Brand: Hitachi,  Model: RAS-22NK remote (HITACHI_AC344)
+//   Brand: Hitachi,  Model: RAS-22NK A/C (HITACHI_AC344)
+//   Brand: Hitachi,  Model: RF11T1 remote (HITACHI_AC344)
 
 #ifndef IR_HITACHI_H_
 #define IR_HITACHI_H_

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -363,7 +363,7 @@ stdAc::fanspeed_t IRMitsubishiHeavy152Ac::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert a native vertical swing to it's common equivalent.
+// Convert a native horizontal swing to it's common equivalent.
 stdAc::swingh_t IRMitsubishiHeavy152Ac::toCommonSwingH(const uint8_t pos) {
   switch (pos) {
     case kMitsubishiHeavy152SwingHLeftMax:  return stdAc::swingh_t::kLeftMax;

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -730,7 +730,7 @@ TEST(TestIRac, Hitachi344) {
   IRHitachiAc344 ac(kGpioUnused);
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
-  char expected[] =
+  char expected_swingon[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
       "Button: 129 (Swing(V)), Swing(V): On, Swing(H): 2 (Right)";
 
@@ -741,20 +741,42 @@ TEST(TestIRac, Hitachi344) {
                   25,                           // Celsius
                   stdAc::fanspeed_t::kMax,      // Fan speed
                   stdAc::swingv_t::kAuto,       // Swing(V)
+                  stdAc::swingv_t::kOff,        // Previous Swing(V)
                   stdAc::swingh_t::kRight);     // Swing(H)
 
-  ASSERT_EQ(expected, ac.toString());
+  ASSERT_EQ(expected_swingon, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(HITACHI_AC344, ac._irsend.capture.decode_type);
   ASSERT_EQ(kHitachiAc344Bits, ac._irsend.capture.bits);
-  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_EQ(expected_swingon, IRAcUtils::resultAcToString(&ac._irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
   EXPECT_EQ(decode_type_t::HITACHI_AC344, r.protocol);
   EXPECT_TRUE(r.power);
   EXPECT_EQ(stdAc::opmode_t::kHeat, r.mode);
   EXPECT_EQ(25, r.degrees);
+
+  char expected_swingoff[] =
+      "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
+      "Button: 129 (Swing(V)), Swing(V): Off, Swing(H): 2 (Right)";
+
+  ac._irsend.reset();
+  irac.hitachi344(&ac,
+                  true,                         // Power
+                  stdAc::opmode_t::kHeat,       // Mode
+                  25,                           // Celsius
+                  stdAc::fanspeed_t::kMax,      // Fan speed
+                  stdAc::swingv_t::kOff,        // Swing(V)
+                  stdAc::swingv_t::kAuto,       // Previous Swing(V)
+                  stdAc::swingh_t::kRight);     // Swing(H)
+  ASSERT_EQ(expected_swingoff, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HITACHI_AC344, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHitachiAc344Bits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected_swingoff,
+            IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 
 TEST(TestIRac, Hitachi424) {

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -732,10 +732,7 @@ TEST(TestIRac, Hitachi344) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)";
-  char expected_swingv[] =
-      "Power: On, Mode: 3 (Cool), Temp: 26C, Fan: 1 (Min), "
-      "Swing(V) Toggle: On, Button: 129 (Swing(V))";
+      "Button: 19 (Power/Mode), Swing(V): On, Swing(H): 2 (Right)";
 
   ac.begin();
   irac.hitachi344(&ac,
@@ -743,7 +740,8 @@ TEST(TestIRac, Hitachi344) {
                   stdAc::opmode_t::kHeat,       // Mode
                   25,                           // Celsius
                   stdAc::fanspeed_t::kMax,      // Fan speed
-                  stdAc::swingv_t::kOff);       // Swing(V)
+                  stdAc::swingv_t::kAuto,       // Swing(V)
+                  stdAc::swingh_t::kRight);     // Swing(H)
 
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
@@ -757,22 +755,6 @@ TEST(TestIRac, Hitachi344) {
   EXPECT_TRUE(r.power);
   EXPECT_EQ(stdAc::opmode_t::kHeat, r.mode);
   EXPECT_EQ(25, r.degrees);
-
-  ac._irsend.reset();
-  irac.hitachi344(&ac,
-                  true,                         // Power
-                  stdAc::opmode_t::kCool,       // Mode
-                  26,                           // Celsius
-                  stdAc::fanspeed_t::kMin,      // Fan speed
-                  stdAc::swingv_t::kAuto);      // Swing(V)
-
-  ASSERT_EQ(expected_swingv, ac.toString());
-  ac._irsend.makeDecodeResult();
-  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
-  ASSERT_EQ(HITACHI_AC344, ac._irsend.capture.decode_type);
-  ASSERT_EQ(kHitachiAc344Bits, ac._irsend.capture.bits);
-  ASSERT_EQ(expected_swingv, IRAcUtils::resultAcToString(&ac._irsend.capture));
-  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
 TEST(TestIRac, Hitachi424) {
@@ -781,10 +763,10 @@ TEST(TestIRac, Hitachi424) {
   IRrecv capture(0);
   char expected[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)";
+      "Button: 19 (Power/Mode), Swing(V) Toggle: Off";
   char expected_swingv[] =
       "Power: On, Mode: 3 (Cool), Temp: 26C, Fan: 1 (Min), "
-      "Swing(V) Toggle: On, Button: 129 (Swing(V))";
+      "Button: 129 (Swing(V)), Swing(V) Toggle: On";
 
   ac.begin();
   irac.hitachi424(&ac,

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -732,7 +732,7 @@ TEST(TestIRac, Hitachi344) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Button: 19 (Power/Mode), Swing(V): On, Swing(H): 2 (Right)";
+      "Button: 129 (Swing(V)), Swing(V): On, Swing(H): 2 (Right)";
 
   ac.begin();
   irac.hitachi344(&ac,

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -732,7 +732,7 @@ TEST(TestIRac, Hitachi344) {
   IRrecv capture(kGpioUnused);
   char expected_swingon[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Button: 129 (Swing(V)), Swing(V): On, Swing(H): 2 (Right)";
+      "Button: 129 (Swing(V)), Swing(V): Off, Swing(H): 2 (Right)";
 
   ac.begin();
   irac.hitachi344(&ac,
@@ -741,7 +741,6 @@ TEST(TestIRac, Hitachi344) {
                   25,                           // Celsius
                   stdAc::fanspeed_t::kMax,      // Fan speed
                   stdAc::swingv_t::kAuto,       // Swing(V)
-                  stdAc::swingv_t::kOff,        // Previous Swing(V)
                   stdAc::swingh_t::kRight);     // Swing(H)
 
   ASSERT_EQ(expected_swingon, ac.toString());
@@ -759,7 +758,7 @@ TEST(TestIRac, Hitachi344) {
 
   char expected_swingoff[] =
       "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 6 (Max), "
-      "Button: 129 (Swing(V)), Swing(V): Off, Swing(H): 2 (Right)";
+      "Button: 19 (Power/Mode), Swing(V): Off, Swing(H): 2 (Right)";
 
   ac._irsend.reset();
   irac.hitachi344(&ac,
@@ -768,7 +767,6 @@ TEST(TestIRac, Hitachi344) {
                   25,                           // Celsius
                   stdAc::fanspeed_t::kMax,      // Fan speed
                   stdAc::swingv_t::kOff,        // Swing(V)
-                  stdAc::swingv_t::kAuto,       // Previous Swing(V)
                   stdAc::swingh_t::kRight);     // Swing(H)
   ASSERT_EQ(expected_swingoff, ac.toString());
   ac._irsend.makeDecodeResult();

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -949,7 +949,7 @@ TEST(TestDecodeHitachiAc424, RealExample) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 5 (Auto), "
-      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)",
+      "Button: 19 (Power/Mode), Swing(V) Toggle: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -1124,29 +1124,29 @@ TEST(TestIRHitachiAc424Class, HumanReadable) {
   ac.setFan(kHitachiAc424FanHigh);
   EXPECT_EQ(
       "Power: On, Mode: 6 (Heat), Temp: 32C, Fan: 4 (High), "
-      "Swing(V) Toggle: Off, Button: 66 (Fan)",
+      "Button: 66 (Fan), Swing(V) Toggle: Off",
       ac.toString());
   ac.setMode(kHitachiAc424Cool);
   ac.setFan(kHitachiAc424FanMin);
   ac.setTemp(kHitachiAc424MinTemp);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
-      "Swing(V) Toggle: Off, Button: 67 (Temp Down)",
+      "Button: 67 (Temp Down), Swing(V) Toggle: Off",
       ac.toString());
   ac.setSwingVToggle(true);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
-      "Swing(V) Toggle: On, Button: 129 (Swing(V))",
+      "Button: 129 (Swing(V)), Swing(V) Toggle: On",
       ac.toString());
   ac.setTemp(ac.getTemp() + 1);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 17C, Fan: 1 (Min), "
-      "Swing(V) Toggle: Off, Button: 68 (Temp Up)",
+      "Button: 68 (Temp Up), Swing(V) Toggle: Off",
       ac.toString());
   ac.setTemp(ac.getTemp() - 1);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 1 (Min), "
-      "Swing(V) Toggle: Off, Button: 67 (Temp Down)",
+      "Button: 67 (Temp Down), Swing(V) Toggle: Off",
       ac.toString());
 }
 
@@ -1922,7 +1922,7 @@ TEST(TestDecodeHitachiAc344, SyntheticExample) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 26C, Fan: 1 (Min), "
-      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)",
+      "Button: 19 (Power/Mode), Swing(V): On, Swing(H): 3 (Middle)",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -1940,7 +1940,7 @@ TEST(TestIRHitachiAc344, ExampleMessages) {
   ac.setRaw(state);
   EXPECT_EQ(
       "Power: On, Mode: 6 (Heat), Temp: 17C, Fan: 5 (Auto), "
-      "Swing(V) Toggle: Off, Button: 19 (Power/Mode)",
+      "Button: 19 (Power/Mode), Swing(V): Off, Swing(H): 3 (Middle)",
       ac.toString());
 }
 

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1926,7 +1926,7 @@ TEST(TestDecodeHitachiAc344, SyntheticExample) {
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
-TEST(TestIRHitachiAc344, ExampleMessages) {
+TEST(TestDecodeIRHitachiAc344, ExampleMessages) {
   IRHitachiAc344 ac(kGpioUnused);
 
   // On, 17, Hot, Auto
@@ -1944,7 +1944,7 @@ TEST(TestIRHitachiAc344, ExampleMessages) {
       ac.toString());
 }
 
-TEST(TestIRHitachiAc344, ReconstructKnownState) {
+TEST(TestIRHitachiAc344Class, ReconstructKnownState) {
   IRHitachiAc344 ac(kGpioUnused);
 
   // On, 17, Hot, Auto
@@ -1958,4 +1958,29 @@ TEST(TestIRHitachiAc344, ReconstructKnownState) {
   ac.setFan(kHitachiAc344FanAuto);
   ac.setButton(kHitachiAc344ButtonPowerMode);
   EXPECT_STATE_EQ(expected, ac.getRaw(), kHitachiAc344Bits);
+}
+
+TEST(TestIRHitachiAc344Class, SwingV) {
+  IRHitachiAc344 ac(kGpioUnused);
+  // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1134#issuecomment-635760537
+
+  // https://docs.google.com/spreadsheets/d/1LPd8K9V437oyEMZT6JDv5LlPXh61RPmgeoVcHLWWr7k/edit#gid=874235844&range=G4
+  // aka. On	17	Cool	Auto	SwingV off	SwingH off
+  const uint8_t start[43] = {
+      0x01, 0x10, 0x00, 0x40, 0xBF, 0xFF, 0x00, 0xCC, 0x33, 0x92, 0x6D, 0x44,
+      0xBB, 0x44, 0xBB, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x53, 0xAC, 0xF1, 0x0E, 0x00, 0xFF, 0x00, 0xFF, 0x80, 0x7F, 0x03,
+      0xFC, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF};
+  ac.setRaw(start);
+  EXPECT_FALSE(ac.getSwingV());
+  const uint8_t turn_on_swingv[43] = {
+      0x01, 0x10, 0x00, 0x40, 0xBF, 0xFF, 0x00, 0xCC, 0x33, 0x92, 0x6D, 0x81,
+      0x7E, 0x44, 0xBB, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,
+      0xFF, 0x53, 0xAC, 0xF1, 0x0E, 0x00, 0xFF, 0x00, 0xFF, 0x80, 0x7F, 0x03,
+      0xFC, 0x20, 0xDF, 0x00, 0xFF, 0x00, 0xFF};
+  ac.setSwingV(true);  // Turn it on.
+  EXPECT_TRUE(ac.getSwingV());
+  EXPECT_STATE_EQ(turn_on_swingv, ac.getRaw(), kHitachiAc344Bits);
+  ac.setSwingV(false);
+  EXPECT_FALSE(ac.getSwingV());
 }

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1965,7 +1965,7 @@ TEST(TestIRHitachiAc344Class, SwingV) {
   // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1134#issuecomment-635760537
 
   // https://docs.google.com/spreadsheets/d/1LPd8K9V437oyEMZT6JDv5LlPXh61RPmgeoVcHLWWr7k/edit#gid=874235844&range=G4
-  // aka. On	17	Cool	Auto	SwingV off	SwingH off
+  // aka. On 17 Cool Auto SwingV off SwingH off
   const uint8_t start[43] = {
       0x01, 0x10, 0x00, 0x40, 0xBF, 0xFF, 0x00, 0xCC, 0x33, 0x92, 0x6D, 0x44,
       0xBB, 0x44, 0xBB, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00,


### PR DESCRIPTION
* Correct Swing(V) control
* Add Swing(H) support.
* Update common A/C support.
* Reduce duplicate code between 344 & 424 classes.
* add & update supporting Unit Tests.
* Fix typo

Fixes #1134