### PR TITLE
Minor code cleanups

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -187,15 +187,15 @@ IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
 
 // Class destructor
 IRrecv::~IRrecv(void) {
+  disableIRIn();
+#if defined(ESP32)
+  if (timer != NULL) timerEnd(timer);  // Cleanup the ESP32 timeout timer.
+#endif  // ESP32
   delete[] irparams.rawbuf;
   if (irparams_save != NULL) {
     delete[] irparams_save->rawbuf;
     delete irparams_save;
   }
-  disableIRIn();
-#if defined(ESP32)
-  if (timer != NULL) timerEnd(timer);  // Cleanup the ESP32 timeout timer.
-#endif  // ESP32
 }
 
 // Set up and (re)start the IR capture mechanism.

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -1025,7 +1025,7 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
 //   nbytes: How many bytes are in the state.
 // Returns:
 //   bool: True if it is a type we can attempt to send, false if not.
-bool IRsend::send(const decode_type_t type, const unsigned char *state,
+bool IRsend::send(const decode_type_t type, const uint8_t *state,
                   const uint16_t nbytes) {
   switch (type) {
 #if SEND_AMCOR

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -204,7 +204,7 @@ class IRsend {
   static uint16_t defaultBits(const decode_type_t protocol);
   bool send(const decode_type_t type, const uint64_t data,
             const uint16_t nbits, const uint16_t repeat = kNoRepeat);
-  bool send(const decode_type_t type, const uint8_t state[],
+  bool send(const decode_type_t type, const unsigned char *state,
             const uint16_t nbytes);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -204,7 +204,7 @@ class IRsend {
   static uint16_t defaultBits(const decode_type_t protocol);
   bool send(const decode_type_t type, const uint64_t data,
             const uint16_t nbits, const uint16_t repeat = kNoRepeat);
-  bool send(const decode_type_t type, const unsigned char *state,
+  bool send(const decode_type_t type, const uint8_t *state,
             const uint16_t nbytes);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -1,6 +1,7 @@
 // Copyright 2019-2020 - David Conran (@crankyoldgit)
 
-/// @warn If you add or remove an entry in this file, you should run:
+/// @file IRtext.cpp
+/// @warning If you add or remove an entry in this file, you should run:
 ///   '../tools/generate_irtext_h.sh' to rebuild the `IRtext.h` file.
 
 #ifndef UNIT_TEST

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -599,50 +599,21 @@ namespace irutils {
       char c = unescaped[i];
       switch (c) {
         // ';!-"<>=&#{}() are all unsafe.
-        case '\'':
-          result += F("&apos;");
-          break;
-        case ';':
-          result += F("&semi;");
-          break;
-        case '!':
-          result += F("&excl;");
-          break;
-        case '-':
-          result += F("&dash;");
-          break;
-        case '\"':
-          result += F("&quot;");
-          break;
-        case '<':
-          result += F("&lt;");
-          break;
-        case '>':
-          result += F("&gt;");
-          break;
-        case '=':
-          result += F("&#equals;");
-          break;
-        case '&':
-          result += F("&amp;");
-          break;
-        case '#':
-          result += F("&num;");
-          break;
-        case '{':
-          result += F("&lcub;");
-          break;
-        case '}':
-          result += F("&rcub;");
-          break;
-        case '(':
-          result += F("&lpar;");
-          break;
-        case ')':
-          result += F("&rpar;");
-          break;
-        default:
-          result += c;
+        case '\'': result += F("&apos;"); break;
+        case ';':  result += F("&semi;"); break;
+        case '!':  result += F("&excl;"); break;
+        case '-':  result += F("&dash;"); break;
+        case '\"': result += F("&quot;"); break;
+        case '<':  result += F("&lt;"); break;
+        case '>':  result += F("&gt;"); break;
+        case '=':  result += F("&#equals;"); break;
+        case '&':  result += F("&amp;"); break;
+        case '#':  result += F("&num;"); break;
+        case '{':  result += F("&lcub;"); break;
+        case '}':  result += F("&rcub;"); break;
+        case '(':  result += F("&lpar;"); break;
+        case ')':  result += F("&rpar;"); break;
+        default:   result += c;
       }
     }
     return result;

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -54,7 +54,7 @@ using irutils::setBits;
 //
 // Ref:
 //   https://github.com/ToniA/arduino-heatpumpir/blob/master/GreeHeatpumpIR.cpp
-void IRsend::sendGree(const unsigned char data[], const uint16_t nbytes,
+void IRsend::sendGree(const uint8_t data[], const uint16_t nbytes,
                       const uint16_t repeat) {
   if (nbytes < kGreeStateLength)
     return;  // Not enough bytes to send a proper message.

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -249,13 +249,14 @@ void IRPanasonicAc::begin(void) { _irsend.begin(); }
 //   length: The size of the state.
 // Returns:
 //   A boolean.
-bool IRPanasonicAc::validChecksum(uint8_t state[], const uint16_t length) {
+bool IRPanasonicAc::validChecksum(const uint8_t *state, const uint16_t length) {
   if (length < 2) return false;  // 1 byte of data can't have a checksum.
   return (state[length - 1] ==
           sumBytes(state, length - 1, kPanasonicAcChecksumInit));
 }
 
-uint8_t IRPanasonicAc::calcChecksum(uint8_t state[], const uint16_t length) {
+uint8_t IRPanasonicAc::calcChecksum(const uint8_t *state,
+                                    const uint16_t length) {
   return sumBytes(state, length - 1, kPanasonicAcChecksumInit);
 }
 

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -117,9 +117,9 @@ class IRPanasonicAc {
   uint8_t getMode(void);
   void setRaw(const uint8_t state[]);
   uint8_t *getRaw(void);
-  static bool validChecksum(uint8_t *state,
+  static bool validChecksum(const uint8_t *state,
                             const uint16_t length = kPanasonicAcStateLength);
-  static uint8_t calcChecksum(uint8_t *state,
+  static uint8_t calcChecksum(const uint8_t *state,
                               const uint16_t length = kPanasonicAcStateLength);
   void setQuiet(const bool on);
   bool getQuiet(void);
@@ -166,8 +166,6 @@ class IRPanasonicAc {
   uint8_t _swingh;
   uint8_t _temp;
   void fixChecksum(const uint16_t length = kPanasonicAcStateLength);
-  static uint8_t calcChecksum(const uint8_t *state,
-                              const uint16_t length = kPanasonicAcStateLength);
   static uint16_t _getTime(const uint8_t ptr[]);
   static void _setTime(uint8_t * const ptr, const uint16_t mins_since_midnight,
                        const bool round_down);


### PR DESCRIPTION
* Change `IRrecv`'s destructor to clean up in a safer way.
* Use consistent parameter declarations between .h & .cpp files.
* Make code more readable in `htmlEscape()`
* Remove duplicate `calcChecksum()` declaration.
* Fix a doxygen warning message.

Note: Changes result from a code audit preping for Doxygen doc generation.