### PR TITLE
Add experimental support for Midea's NEC-like protocol.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -846,6 +846,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
     DPRINTLN("Attempting CoronaAc decode");
     if (decodeCoronaAc(results, offset)) return true;
 #endif  // DECODE_CORONA_AC
+#if DECODE_MIDEA_NEC
+    DPRINTLN("Attempting Midea-Nec decode");
+    if (decodeMideaNec(results, offset)) return true;
+#endif  // DECODE_MIDEA_NEC
   // Typically new protocols are added above this line.
   }
 #if DECODE_HASH

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -846,10 +846,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
     DPRINTLN("Attempting CoronaAc decode");
     if (decodeCoronaAc(results, offset)) return true;
 #endif  // DECODE_CORONA_AC
-#if DECODE_MIDEA_NEC
+#if DECODE_MIDEA24
     DPRINTLN("Attempting Midea-Nec decode");
-    if (decodeMideaNec(results, offset)) return true;
-#endif  // DECODE_MIDEA_NEC
+    if (decodeMidea24(results, offset)) return true;
+#endif  // DECODE_MIDEA24
   // Typically new protocols are added above this line.
   }
 #if DECODE_HASH

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -472,11 +472,11 @@ class IRrecv {
                    const uint16_t nbits = kMideaBits,
                    const bool strict = true);
 #endif  // DECODE_MIDEA
-#if DECODE_MIDEA_NEC
-  bool decodeMideaNec(decode_results *results, uint16_t offset = kStartOffset,
-                      const uint16_t nbits = kMideaNecBits,
-                      const bool strict = true);
-#endif  // DECODE_MIDEA_NEC
+#if DECODE_MIDEA24
+  bool decodeMidea24(decode_results *results, uint16_t offset = kStartOffset,
+                     const uint16_t nbits = kMidea24Bits,
+                     const bool strict = true);
+#endif  // DECODE_MIDEA24
 #if DECODE_FUJITSU_AC
   bool decodeFujitsuAC(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kFujitsuAcBits,

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -252,7 +252,8 @@ class IRrecv {
                            const bool GEThomas = true);
   void crudeNoiseFilter(decode_results *results, const uint16_t floor = 0);
   bool decodeHash(decode_results *results);
-#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || SEND_SANYO)
+#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
+     SEND_MIDEA_NEC)
   bool decodeNEC(decode_results *results, uint16_t offset = kStartOffset,
                  const uint16_t nbits = kNECBits, const bool strict = true);
 #endif

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -252,8 +252,7 @@ class IRrecv {
                            const bool GEThomas = true);
   void crudeNoiseFilter(decode_results *results, const uint16_t floor = 0);
   bool decodeHash(decode_results *results);
-#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
-     SEND_MIDEA_NEC)
+#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO)
   bool decodeNEC(decode_results *results, uint16_t offset = kStartOffset,
                  const uint16_t nbits = kNECBits, const bool strict = true);
 #endif

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -471,7 +471,12 @@ class IRrecv {
   bool decodeMidea(decode_results *results, uint16_t offset = kStartOffset,
                    const uint16_t nbits = kMideaBits,
                    const bool strict = true);
-#endif
+#endif  // DECODE_MIDEA
+#if DECODE_MIDEA_NEC
+  bool decodeMideaNec(decode_results *results, uint16_t offset = kStartOffset,
+                      const uint16_t nbits = kMideaNecBits,
+                      const bool strict = true);
+#endif  // DECODE_MIDEA_NEC
 #if DECODE_FUJITSU_AC
   bool decodeFujitsuAC(decode_results *results, uint16_t offset = kStartOffset,
                        const uint16_t nbits = kFujitsuAcBits,

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -369,6 +369,13 @@
 #define SEND_MIDEA             _IR_ENABLE_DEFAULT_
 #endif  // SEND_MIDEA
 
+#ifndef DECODE_MIDEA_NEC
+#define DECODE_MIDEA_NEC       _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MIDEA_NEC
+#ifndef SEND_MIDEA_NEC
+#define SEND_MIDEA_NEC         _IR_ENABLE_DEFAULT_
+#endif  // SEND_MIDEA_NEC
+
 #ifndef DECODE_LASERTAG
 #define DECODE_LASERTAG        _IR_ENABLE_DEFAULT_
 #endif  // DECODE_LASERTAG
@@ -786,8 +793,9 @@ enum decode_type_t {
   CARRIER_AC64,
   HITACHI_AC344,  // 85
   CORONA_AC,
+  MIDEA_NEC,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = CORONA_AC,
+  kLastDecodeType = MIDEA_NEC,
 };
 
 // Message lengths & required repeat values
@@ -905,6 +913,8 @@ const uint16_t kLutronBits = 35;
 const uint16_t kMagiquestBits = 56;
 const uint16_t kMideaBits = 48;
 const uint16_t kMideaMinRepeat = kNoRepeat;
+const uint16_t kMideaNecBits = 48;
+const uint16_t kMideaNecMinRepeat = kSingleRepeat;
 const uint16_t kMitsubishiBits = 16;
 // TODO(anyone): Verify that the Mitsubishi repeat is really needed.
 //               Based on marcosamarinho's code.

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -369,12 +369,12 @@
 #define SEND_MIDEA             _IR_ENABLE_DEFAULT_
 #endif  // SEND_MIDEA
 
-#ifndef DECODE_MIDEA_NEC
-#define DECODE_MIDEA_NEC       _IR_ENABLE_DEFAULT_
-#endif  // DECODE_MIDEA_NEC
-#ifndef SEND_MIDEA_NEC
-#define SEND_MIDEA_NEC         _IR_ENABLE_DEFAULT_
-#endif  // SEND_MIDEA_NEC
+#ifndef DECODE_MIDEA24
+#define DECODE_MIDEA24         _IR_ENABLE_DEFAULT_
+#endif  // DECODE_MIDEA24
+#ifndef SEND_MIDEA24
+#define SEND_MIDEA24           _IR_ENABLE_DEFAULT_
+#endif  // SEND_MIDEA24
 
 #ifndef DECODE_LASERTAG
 #define DECODE_LASERTAG        _IR_ENABLE_DEFAULT_
@@ -793,9 +793,9 @@ enum decode_type_t {
   CARRIER_AC64,
   HITACHI_AC344,  // 85
   CORONA_AC,
-  MIDEA_NEC,
+  MIDEA24,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = MIDEA_NEC,
+  kLastDecodeType = MIDEA24,
 };
 
 // Message lengths & required repeat values
@@ -913,8 +913,8 @@ const uint16_t kLutronBits = 35;
 const uint16_t kMagiquestBits = 56;
 const uint16_t kMideaBits = 48;
 const uint16_t kMideaMinRepeat = kNoRepeat;
-const uint16_t kMideaNecBits = 48;
-const uint16_t kMideaNecMinRepeat = kSingleRepeat;
+const uint16_t kMidea24Bits = 24;
+const uint16_t kMidea24MinRepeat = kSingleRepeat;
 const uint16_t kMitsubishiBits = 16;
 // TODO(anyone): Verify that the Mitsubishi repeat is really needed.
 //               Based on marcosamarinho's code.

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -52,7 +52,7 @@
 #endif  // UNIT_TEST
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.7.7"
+#define _IRREMOTEESP8266_VERSION_ "2.7.7-DEBUG-Issue1170"
 
 // Set the language & locale for the library. See the `locale` dir for options.
 #ifndef _IR_LOCALE_
@@ -78,7 +78,7 @@
 //      Kelvinator protocol, you would use:
 //        `-DDECODE_KELVINATOR=false`
 #ifndef _IR_ENABLE_DEFAULT_
-#define _IR_ENABLE_DEFAULT_ true  // Unless set externally, the default is on.
+#define _IR_ENABLE_DEFAULT_ false  // Unless set externally, the default is on.
 #endif  // _IR_ENABLE_DEFAULT_
 
 // Supported IR protocols
@@ -370,10 +370,10 @@
 #endif  // SEND_MIDEA
 
 #ifndef DECODE_MIDEA_NEC
-#define DECODE_MIDEA_NEC       _IR_ENABLE_DEFAULT_
+#define DECODE_MIDEA_NEC       true
 #endif  // DECODE_MIDEA_NEC
 #ifndef SEND_MIDEA_NEC
-#define SEND_MIDEA_NEC         _IR_ENABLE_DEFAULT_
+#define SEND_MIDEA_NEC         true
 #endif  // SEND_MIDEA_NEC
 
 #ifndef DECODE_LASERTAG
@@ -1056,7 +1056,7 @@ const uint8_t  kVestelAcBits = 56;
 #define WHYNTER_BITS                  kWhynterBits
 
 // Turn on Debugging information by uncommenting the following line.
-// #define DEBUG 1
+#define DEBUG 1
 
 #ifdef DEBUG
 #ifdef UNIT_TEST

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -52,7 +52,7 @@
 #endif  // UNIT_TEST
 
 // Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.7.7-DEBUG-Issue1170"
+#define _IRREMOTEESP8266_VERSION_ "2.7.7"
 
 // Set the language & locale for the library. See the `locale` dir for options.
 #ifndef _IR_LOCALE_
@@ -78,7 +78,7 @@
 //      Kelvinator protocol, you would use:
 //        `-DDECODE_KELVINATOR=false`
 #ifndef _IR_ENABLE_DEFAULT_
-#define _IR_ENABLE_DEFAULT_ false  // Unless set externally, the default is on.
+#define _IR_ENABLE_DEFAULT_ true  // Unless set externally, the default is on.
 #endif  // _IR_ENABLE_DEFAULT_
 
 // Supported IR protocols
@@ -370,10 +370,10 @@
 #endif  // SEND_MIDEA
 
 #ifndef DECODE_MIDEA_NEC
-#define DECODE_MIDEA_NEC       true
+#define DECODE_MIDEA_NEC       _IR_ENABLE_DEFAULT_
 #endif  // DECODE_MIDEA_NEC
 #ifndef SEND_MIDEA_NEC
-#define SEND_MIDEA_NEC         true
+#define SEND_MIDEA_NEC         _IR_ENABLE_DEFAULT_
 #endif  // SEND_MIDEA_NEC
 
 #ifndef DECODE_LASERTAG
@@ -1056,7 +1056,7 @@ const uint8_t  kVestelAcBits = 56;
 #define WHYNTER_BITS                  kWhynterBits
 
 // Turn on Debugging information by uncommenting the following line.
-#define DEBUG 1
+// #define DEBUG 1
 
 #ifdef DEBUG
 #ifdef UNIT_TEST

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -566,6 +566,7 @@ uint16_t IRsend::minRepeats(const decode_type_t protocol) {
     case COOLIX:
     case GICABLE:
     case INAX:
+    case MIDEA_NEC:
     case MITSUBISHI:
     case MITSUBISHI2:
     case MITSUBISHI_AC:
@@ -651,6 +652,7 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
       return kSanyoLC7461Bits;  // 42
     case GOODWEATHER:
     case MIDEA:
+    case MIDEA_NEC:
     case PANASONIC:
       return 48;
     case MAGIQUEST:
@@ -865,7 +867,12 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
     case MIDEA:
       sendMidea(data, nbits, min_repeat);
       break;
-#endif
+#endif  // SEND_MIDEA
+#if SEND_MIDEA_NEC
+    case MIDEA_NEC:
+      sendMideaNec(data, nbits, min_repeat);
+      break;
+#endif  // SEND_MIDEA_NEC
 #if SEND_MITSUBISHI
     case MITSUBISHI:
       sendMitsubishi(data, nbits, min_repeat);

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -566,7 +566,7 @@ uint16_t IRsend::minRepeats(const decode_type_t protocol) {
     case COOLIX:
     case GICABLE:
     case INAX:
-    case MIDEA_NEC:
+    case MIDEA24:
     case MITSUBISHI:
     case MITSUBISHI2:
     case MITSUBISHI_AC:
@@ -624,6 +624,7 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
       return 20;
     case COOLIX:
     case INAX:
+    case MIDEA24:
     case NIKAI:
     case RCMM:
       return 24;
@@ -652,7 +653,6 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
       return kSanyoLC7461Bits;  // 42
     case GOODWEATHER:
     case MIDEA:
-    case MIDEA_NEC:
     case PANASONIC:
       return 48;
     case MAGIQUEST:
@@ -868,11 +868,11 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
       sendMidea(data, nbits, min_repeat);
       break;
 #endif  // SEND_MIDEA
-#if SEND_MIDEA_NEC
-    case MIDEA_NEC:
-      sendMideaNec(data, nbits, min_repeat);
+#if SEND_MIDEA24
+    case MIDEA24:
+      sendMidea24(data, nbits, min_repeat);
       break;
-#endif  // SEND_MIDEA_NEC
+#endif  // SEND_MIDEA24
 #if SEND_MITSUBISHI
     case MITSUBISHI:
       sendMitsubishi(data, nbits, min_repeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -220,7 +220,8 @@ class IRsend {
             const uint16_t nbits, const uint16_t repeat = kNoRepeat);
   bool send(const decode_type_t type, const uint8_t *state,
             const uint16_t nbytes);
-#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
+#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
+     SEND_MIDEA_NEC)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,
                uint16_t repeat = kNoRepeat);
   uint32_t encodeNEC(uint16_t address, uint16_t command);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -470,7 +470,7 @@ class IRsend {
 #endif  // SEND_MIDEA
 #if SEND_MIDEA24
   void sendMidea24(const uint64_t data, const uint16_t nbits = kMidea24Bits,
-                    const uint16_t repeat = kMidea24MinRepeat);
+                   const uint16_t repeat = kMidea24MinRepeat);
 #endif  // SEND_MIDEA24
 #if SEND_MAGIQUEST
   void sendMagiQuest(uint64_t data, uint16_t nbits = kMagiquestBits,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -466,7 +466,11 @@ class IRsend {
 #if SEND_MIDEA
   void sendMidea(uint64_t data, uint16_t nbits = kMideaBits,
                  uint16_t repeat = kMideaMinRepeat);
-#endif
+#endif  // SEND_MIDEA
+#if SEND_MIDEA_NEC
+  void sendMideaNec(const uint64_t data, const uint16_t nbits = kMideaNecBits,
+                    const uint16_t repeat = kMideaNecMinRepeat);
+#endif  // SEND_MIDEA_NEC
 #if SEND_MAGIQUEST
   void sendMagiQuest(uint64_t data, uint16_t nbits = kMagiquestBits,
                      uint16_t repeat = kNoRepeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -221,7 +221,7 @@ class IRsend {
   bool send(const decode_type_t type, const uint8_t *state,
             const uint16_t nbytes);
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
-     SEND_MIDEA_NEC)
+     SEND_MIDEA24)
   void sendNEC(uint64_t data, uint16_t nbits = kNECBits,
                uint16_t repeat = kNoRepeat);
   uint32_t encodeNEC(uint16_t address, uint16_t command);
@@ -468,10 +468,10 @@ class IRsend {
   void sendMidea(uint64_t data, uint16_t nbits = kMideaBits,
                  uint16_t repeat = kMideaMinRepeat);
 #endif  // SEND_MIDEA
-#if SEND_MIDEA_NEC
-  void sendMideaNec(const uint64_t data, const uint16_t nbits = kMideaNecBits,
-                    const uint16_t repeat = kMideaNecMinRepeat);
-#endif  // SEND_MIDEA_NEC
+#if SEND_MIDEA24
+  void sendMidea24(const uint64_t data, const uint16_t nbits = kMidea24Bits,
+                    const uint16_t repeat = kMidea24MinRepeat);
+#endif  // SEND_MIDEA24
 #if SEND_MAGIQUEST
   void sendMagiQuest(uint64_t data, uint16_t nbits = kMagiquestBits,
                      uint16_t repeat = kNoRepeat);

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -261,6 +261,6 @@ const PROGMEM char *kAllProtocolNamesStr =
     D_STR_CARRIER_AC64 "\x0"
     D_STR_HITACHI_AC344 "\x0"
     D_STR_CORONA_AC "\x0"
-    D_STR_MIDEA_NEC "\x0"
+    D_STR_MIDEA24 "\x0"
     // New protocol strings should be added just above this line.
     "\x0";  // This string requires double null termination.

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -261,5 +261,6 @@ const PROGMEM char *kAllProtocolNamesStr =
     D_STR_CARRIER_AC64 "\x0"
     D_STR_HITACHI_AC344 "\x0"
     D_STR_CORONA_AC "\x0"
+    D_STR_MIDEA_NEC "\x0"
     // New protocol strings should be added just above this line.
     "\x0";  // This string requires double null termination.

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -83,7 +83,7 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
     }
   }
 }
-#endif
+#endif  // SEND_MIDEA
 
 // Code to emulate Midea A/C IR remote control unit.
 // Warning: Consider this very alpha code.
@@ -451,3 +451,46 @@ bool IRrecv::decodeMidea(decode_results *results, uint16_t offset,
   return true;
 }
 #endif  // DECODE_MIDEA
+
+#if SEND_MIDEA_NEC
+/// Send a Midea NEC-like formatted message.
+/// Status: Alpha / Untested on a real device.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1170
+/// @note This protocol is basically a 48-bit version of the NEC protocol with
+///   at least a single repeat.
+void IRsend::sendMideaNec(const uint64_t data, const uint16_t nbits,
+                          const uint16_t repeat) {
+  sendNEC(data, nbits, repeat);
+}
+#endif  // SEND_MIDEA_NEC
+
+#if DECODE_MIDEA_NEC
+/// Decode the supplied Midea NEC-like message.
+/// Status: Alpha / Needs testing against a real device.
+/// @param[in,out] results Ptr to the data to decode & where to store the decode
+///   result.
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return A boolean. True if it can decode it, false if it can't.
+/// @note This protocol is basically a 48-bit version of the NEC protocol.
+bool IRrecv::decodeMideaNec(decode_results *results, uint16_t offset,
+                            const uint16_t nbits, const bool strict) {
+  if (strict) {
+    if (nbits != kMideaNecBits) return false;  // Not strictly a MIDEA message.
+  }
+
+  if (!decodeNEC(results, offset, nbits, false)) return false;
+
+  // Success
+  results->decode_type = decode_type_t::MIDEA_NEC;
+  results->bits = nbits;
+  results->address = 0;
+  results->command = 0;
+  return true;
+}
+#endif  // DECODE_MIDEA_NEC

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -2,6 +2,7 @@
 // Midea A/C added by (send) bwze/crankyoldgit & (decode) crankyoldgit
 
 #include "ir_Midea.h"
+#include "ir_NEC.h"
 #include <algorithm>
 #ifndef ARDUINO
 #include <string>
@@ -30,6 +31,7 @@ const uint16_t kMideaMinGapTicks =
     kMideaHdrMarkTicks + kMideaZeroSpaceTicks + kMideaBitMarkTicks;
 const uint16_t kMideaMinGap = kMideaMinGapTicks * kMideaTick;
 const uint8_t kMideaTolerance = 30;  // Percent
+const uint16_t kMideaNecMinGap = 13000;  ///< uSecs
 
 using irutils::addBoolToString;
 using irutils::addFanToString;
@@ -484,7 +486,12 @@ bool IRrecv::decodeMideaNec(decode_results *results, uint16_t offset,
     if (nbits != kMideaNecBits) return false;  // Not strictly a MIDEA message.
   }
 
-  if (!decodeNEC(results, offset, nbits, false)) return false;
+  if (!matchGeneric(results->rawbuf + offset, &(results->value),
+                    results->rawlen - offset, nbits,
+                    kNecHdrMark, kNecHdrSpace,
+                    kNecBitMark, kNecOneSpace,
+                    kNecBitMark, kNecZeroSpace,
+                    kNecBitMark, kMideaNecMinGap, true)) return false;
 
   // Success
   results->decode_type = decode_type_t::MIDEA_NEC;

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -6,7 +6,7 @@
 //   Brand: Pioneer System,  Model: RUBO18GMFILCAD A/C (18K BTU) (MIDEA)
 //   Brand: Comfee, Model: MPD1-12CRN7 A/C (MIDEA)
 //   Brand: Keystone, Model: RG57H4(B)BGEF remote (MIDEA)
-//   Brand: Midea,  Model: FS40-7AR Stand Fan (MIDEA_NEC)
+//   Brand: Midea,  Model: FS40-7AR Stand Fan (MIDEA24)
 
 #ifndef IR_MIDEA_H_
 #define IR_MIDEA_H_

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -2,10 +2,11 @@
 // Midea
 
 // Supports:
-//   Brand: Pioneer System,  Model: RYBO12GMFILCAD A/C (12K BTU)
-//   Brand: Pioneer System,  Model: RUBO18GMFILCAD A/C (18K BTU)
-//   Brand: Comfee, Model: MPD1-12CRN7 A/C
-//   Brand: Keystone, Model: RG57H4(B)BGEF remote
+//   Brand: Pioneer System,  Model: RYBO12GMFILCAD A/C (12K BTU) (MIDEA)
+//   Brand: Pioneer System,  Model: RUBO18GMFILCAD A/C (18K BTU) (MIDEA)
+//   Brand: Comfee, Model: MPD1-12CRN7 A/C (MIDEA)
+//   Brand: Keystone, Model: RG57H4(B)BGEF remote (MIDEA)
+//   Brand: Midea,  Model: FS40-7AR Stand Fan (MIDEA_NEC)
 
 #ifndef IR_MIDEA_H_
 #define IR_MIDEA_H_

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -65,8 +65,7 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
 #endif  // (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO ||
         //  SEND_MIDEA_NEC)
 
-#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO || \
-     DECODE_MIDEA_NEC)
+#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO)
 // Decode the supplied NEC message.
 //
 // Args:
@@ -149,4 +148,4 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t offset,
   return true;
 }
 #endif  // (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 ||
-        // DECODE_SANYO || DECODE_MIDEA_NEC)
+        // DECODE_SANYO)

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -11,7 +11,8 @@
 #include "IRsend.h"
 #include "IRutils.h"
 
-#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO)
+#if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
+     SEND_MIDEA_NEC)
 // Send a raw NEC(Renesas) formatted message.
 //
 // Args:
@@ -61,9 +62,11 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
     return (address << 24) + ((address ^ 0xFF) << 16) + command;  // Normal.
   }
 }
-#endif  // (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO )
+#endif  // (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO ||
+        //  SEND_MIDEA_NEC)
 
-#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO)
+#if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO || \
+     DECODE_MIDEA_NEC)
 // Decode the supplied NEC message.
 //
 // Args:
@@ -145,4 +148,5 @@ bool IRrecv::decodeNEC(decode_results *results, uint16_t offset,
     results->address = reverseBits((data >> 16) & UINT16_MAX, 16);
   return true;
 }
-#endif  // DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO
+#endif  // (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 ||
+        // DECODE_SANYO || DECODE_MIDEA_NEC)

--- a/src/ir_NEC.cpp
+++ b/src/ir_NEC.cpp
@@ -12,7 +12,7 @@
 #include "IRutils.h"
 
 #if (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO || \
-     SEND_MIDEA_NEC)
+     SEND_MIDEA24)
 // Send a raw NEC(Renesas) formatted message.
 //
 // Args:
@@ -63,7 +63,7 @@ uint32_t IRsend::encodeNEC(uint16_t address, uint16_t command) {
   }
 }
 #endif  // (SEND_NEC || SEND_SHERWOOD || SEND_AIWA_RC_T501 || SEND_SANYO ||
-        //  SEND_MIDEA_NEC)
+        //  SEND_MIDEA24)
 
 #if (DECODE_NEC || DECODE_SHERWOOD || DECODE_AIWA_RC_T501 || DECODE_SANYO)
 // Decode the supplied NEC message.

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -601,9 +601,9 @@
 #ifndef D_STR_MIDEA
 #define D_STR_MIDEA "MIDEA"
 #endif  // D_STR_MIDEA
-#ifndef D_STR_MIDEA_NEC
-#define D_STR_MIDEA_NEC "MIDEA_NEC"
-#endif  // D_STR_MIDEA_NEC
+#ifndef D_STR_MIDEA24
+#define D_STR_MIDEA24 "MIDEA24"
+#endif  // D_STR_MIDEA24
 #ifndef D_STR_MITSUBISHI
 #define D_STR_MITSUBISHI "MITSUBISHI"
 #endif  // D_STR_MITSUBISHI

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -601,6 +601,9 @@
 #ifndef D_STR_MIDEA
 #define D_STR_MIDEA "MIDEA"
 #endif  // D_STR_MIDEA
+#ifndef D_STR_MIDEA_NEC
+#define D_STR_MIDEA_NEC "MIDEA_NEC"
+#endif  // D_STR_MIDEA_NEC
 #ifndef D_STR_MITSUBISHI
 #define D_STR_MITSUBISHI "MITSUBISHI"
 #endif  // D_STR_MITSUBISHI

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -887,4 +887,40 @@ TEST(TestDecodeMideaNec, RealExample2) {
   EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
+
+  // ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639349316
+  const uint16_t rawData639349316[105] = {
+      8924, 4410, 596, 1628, 590, 538, 538, 568, 588, 520, 592, 516, 588, 518,
+      588, 516, 558, 568, 594, 538, 566, 1652, 568, 1650, 540, 1680, 590, 1628,
+      592, 1628, 590, 1628, 590, 1650, 540, 1680, 592, 1630, 590, 518, 586, 538,
+      538, 568, 590, 514, 616, 494, 588, 516, 588, 516, 560, 566, 590, 1630,
+      586, 1634, 564, 1652, 538, 1704, 566, 948, 254, 450, 564, 1654, 566,
+      1652, 540, 1682, 610, 518, 588, 516, 590, 514, 590, 514, 582, 526, 614,
+      436, 670, 512, 592, 514, 538, 1578, 718, 1602, 614, 1542, 676, 1626, 538,
+      1678, 586, 1634, 616, 13308, 8920, 2158, 626};  // UNKNOWN CBEC0079
+  irsend.reset();
+  irsend.sendRaw(rawData639349316, 105, 38);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_NE(MIDEA_NEC, irsend.capture.decode_type);
+
+  // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639358566
+  const uint16_t rawData639358566[103] = {
+      8920, 4412, 620, 1606, 614, 512, 592, 512, 536, 568, 618, 512, 590, 492,
+      614, 514, 514, 590, 594, 510, 620, 1624, 592, 1604, 590, 1632, 608, 1626,
+      606, 1616, 618, 1602, 618, 1602, 560, 1682, 622, 1602, 618, 512, 592, 510,
+      538, 568, 590, 512, 622, 488, 616, 490, 614, 488, 560, 568, 620, 1624,
+      594, 1604, 616, 1602, 536, 1684, 640, 1600, 618, 1598, 618, 1602, 590,
+      1630, 612, 512, 622, 510, 594, 514, 592, 512, 534, 568, 620, 512, 594,
+      488, 616, 488, 536, 1702, 594, 1622, 622, 1604, 614, 1624, 594, 1602, 610,
+      1630, 620, 13294, 8914, 2184, 596};  // UNKNOWN 774B249A
+  irsend.reset();
+  irsend.sendRaw(rawData639358566, 103, 38);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
+  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
+  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(0, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
 }

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -792,7 +792,7 @@ TEST(TestDecodeMidea, Issue887) {
 }
 
 // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1170
-TEST(TestDecodeMideaNec, RealExample) {
+TEST(TestDecodeMidea24, RealExample) {
   IRsendTest irsend(kGpioUnused);
   IRrecv irrecv(kGpioUnused);
   irsend.begin();
@@ -811,25 +811,25 @@ TEST(TestDecodeMideaNec, RealExample) {
   irsend.sendRaw(rawData, 103, 38);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
-  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
-  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(MIDEA24, irsend.capture.decode_type);
+  EXPECT_EQ(kMidea24Bits, irsend.capture.bits);
+  EXPECT_EQ(0x80C0C0, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 }
 
-TEST(TestDecodeMideaNec, SyntheticExample) {
+TEST(TestDecodeMidea24, SyntheticExample) {
   IRsendTest irsend(kGpioUnused);
   IRrecv irrecv(kGpioUnused);
   irsend.begin();
   irsend.reset();
 
-  irsend.sendMideaNec(0x807FC03FC03F);
+  irsend.sendMidea24(0x80C0C0);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
-  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
-  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(MIDEA24, irsend.capture.decode_type);
+  EXPECT_EQ(kMidea24Bits, irsend.capture.bits);
+  EXPECT_EQ(0x80C0C0, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
   EXPECT_EQ(
@@ -854,15 +854,15 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::MIDEA));
   ASSERT_EQ(kMideaBits, IRsend::defaultBits(decode_type_t::MIDEA));
 
-  ASSERT_EQ("MIDEA_NEC", typeToString(decode_type_t::MIDEA_NEC));
-  ASSERT_EQ(decode_type_t::MIDEA_NEC, strToDecodeType("MIDEA_NEC"));
-  ASSERT_FALSE(hasACState(decode_type_t::MIDEA_NEC));
-  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::MIDEA_NEC));
-  ASSERT_EQ(kSingleRepeat, IRsend::minRepeats(decode_type_t::MIDEA_NEC));
-  ASSERT_EQ(kMideaBits, IRsend::defaultBits(decode_type_t::MIDEA_NEC));
+  ASSERT_EQ("MIDEA24", typeToString(decode_type_t::MIDEA24));
+  ASSERT_EQ(decode_type_t::MIDEA24, strToDecodeType("MIDEA24"));
+  ASSERT_FALSE(hasACState(decode_type_t::MIDEA24));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::MIDEA24));
+  ASSERT_EQ(kSingleRepeat, IRsend::minRepeats(decode_type_t::MIDEA24));
+  ASSERT_EQ(kMidea24Bits, IRsend::defaultBits(decode_type_t::MIDEA24));
 }
 
-TEST(TestDecodeMideaNec, RealExample2) {
+TEST(TestDecodeMidea24, RealExample2) {
   IRsendTest irsend(kGpioUnused);
   IRrecv irrecv(kGpioUnused);
   irsend.begin();
@@ -882,9 +882,9 @@ TEST(TestDecodeMideaNec, RealExample2) {
   irsend.sendRaw(rawData, 103, 38);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
-  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
-  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(MIDEA24, irsend.capture.decode_type);
+  EXPECT_EQ(kMidea24Bits, irsend.capture.bits);
+  EXPECT_EQ(0x80C0C0, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 
@@ -902,7 +902,7 @@ TEST(TestDecodeMideaNec, RealExample2) {
   irsend.sendRaw(rawData639349316, 105, 38);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_NE(MIDEA_NEC, irsend.capture.decode_type);
+  EXPECT_NE(MIDEA24, irsend.capture.decode_type);
 
   // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639358566
   const uint16_t rawData639358566[103] = {
@@ -918,16 +918,16 @@ TEST(TestDecodeMideaNec, RealExample2) {
   irsend.sendRaw(rawData639358566, 103, 38);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
-  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
-  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(MIDEA24, irsend.capture.decode_type);
+  EXPECT_EQ(kMidea24Bits, irsend.capture.bits);
+  EXPECT_EQ(0x80C0C0, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 }
 
 // See https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639468620
 // for why this test exists.
-TEST(TestDecodeMideaNec, LargeTimeout) {
+TEST(TestDecodeMidea24, LargeTimeout) {
   IRsendTest irsend(kGpioUnused);
   IRrecv irrecv(kGpioUnused, 1000, 90);  // Test with a large timeout value
   irsend.begin();
@@ -946,9 +946,9 @@ TEST(TestDecodeMideaNec, LargeTimeout) {
   irsend.sendRaw(rawData639358566, 103, 38);
   irsend.makeDecodeResult();
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
-  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
-  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
-  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(MIDEA24, irsend.capture.decode_type);
+  EXPECT_EQ(kMidea24Bits, irsend.capture.bits);
+  EXPECT_EQ(0x80C0C0, irsend.capture.value);
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 }

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -861,3 +861,30 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ(kSingleRepeat, IRsend::minRepeats(decode_type_t::MIDEA_NEC));
   ASSERT_EQ(kMideaBits, IRsend::defaultBits(decode_type_t::MIDEA_NEC));
 }
+
+TEST(TestDecodeMideaNec, RealExample2) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  irsend.begin();
+  irsend.reset();
+
+  // https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639271003
+  const uint16_t rawData[103] = {
+      8926, 4412, 590, 1630, 536, 570, 608, 518, 594, 516, 588, 518, 588, 538,
+      538, 568, 592, 514, 590, 518, 588, 1630, 536, 1684, 610, 1628, 594, 1630,
+      588, 1630, 590, 1630, 560, 1680, 592, 1630, 588, 1650, 568, 538, 538, 568,
+      590, 514, 594, 538, 566, 518, 536, 594, 584, 516, 594, 518, 586, 1630,
+      588, 1650, 538, 1682, 592, 1630, 588, 1628, 588, 1630, 560, 1680, 590,
+      1626, 594, 538, 566, 538, 568, 536, 538, 570, 590, 538, 566, 538, 568,
+      538, 538, 568, 590, 1626, 594, 1650, 568, 1628, 558, 1662, 558, 1680, 592,
+      1650, 568, 13312, 8924, 2186, 588};  // UNKNOWN 774B249A
+
+  irsend.sendRaw(rawData, 103, 38);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
+  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
+  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(0, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
+}

--- a/test/ir_Midea_test.cpp
+++ b/test/ir_Midea_test.cpp
@@ -924,3 +924,31 @@ TEST(TestDecodeMideaNec, RealExample2) {
   EXPECT_EQ(0, irsend.capture.address);
   EXPECT_EQ(0, irsend.capture.command);
 }
+
+// See https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639468620
+// for why this test exists.
+TEST(TestDecodeMideaNec, LargeTimeout) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused, 1000, 90);  // Test with a large timeout value
+  irsend.begin();
+  irsend.reset();
+  // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1170#issuecomment-639358566
+  const uint16_t rawData639358566[103] = {
+      8920, 4412, 620, 1606, 614, 512, 592, 512, 536, 568, 618, 512, 590, 492,
+      614, 514, 514, 590, 594, 510, 620, 1624, 592, 1604, 590, 1632, 608, 1626,
+      606, 1616, 618, 1602, 618, 1602, 560, 1682, 622, 1602, 618, 512, 592, 510,
+      538, 568, 590, 512, 622, 488, 616, 490, 614, 488, 560, 568, 620, 1624,
+      594, 1604, 616, 1602, 536, 1684, 640, 1600, 618, 1598, 618, 1602, 590,
+      1630, 612, 512, 622, 510, 594, 514, 592, 512, 534, 568, 620, 512, 594,
+      488, 616, 488, 536, 1702, 594, 1622, 622, 1604, 614, 1624, 594, 1602, 610,
+      1630, 620, 13294, 8914, 2184, 596};  // UNKNOWN 774B249A
+  irsend.reset();
+  irsend.sendRaw(rawData639358566, 103, 38);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(MIDEA_NEC, irsend.capture.decode_type);
+  EXPECT_EQ(kMideaNecBits, irsend.capture.bits);
+  EXPECT_EQ(0x807FC03FC03F, irsend.capture.value);
+  EXPECT_EQ(0, irsend.capture.address);
+  EXPECT_EQ(0, irsend.capture.command);
+}


### PR DESCRIPTION
This protocol is basically NEC but extended to 48 bits with a single repeat.

Fixes #1170