### PR TITLE
Treat compiler warnings as errors.

### DIFF
--- a/examples/CommonAcControl/platformio.ini
+++ b/examples/CommonAcControl/platformio.ini
@@ -15,3 +15,11 @@ board = nodemcuv2
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
+
+; Build the program forcing the compiler to treat all warnings as errors.
+[env:shakedown]
+platform = espressif8266
+board = nodemcuv2
+build_flags =
+  ${env.build_flags}
+  -Werror

--- a/examples/CommonAcControl/platformio.ini
+++ b/examples/CommonAcControl/platformio.ini
@@ -17,7 +17,7 @@ platform = espressif32
 board = esp32dev
 
 ; Build the program forcing the compiler to treat all warnings as errors.
-[env:shakedown]
+[env:shakedown_all_protocols]
 platform = espressif8266
 board = nodemcuv2
 build_flags =

--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -50,3 +50,8 @@ build_flags = -D_IR_LOCALE_=it-IT  ;  Italian
 
 [env:zh-CN]
 build_flags = -D_IR_LOCALE_=zh-CN  ;  Chinese (Simplified)
+
+; Build the library with all protocols disabled to flush out #if/#ifdef issues &
+; any compiler warnings, by turning them into errors.
+[env:no-protocols]
+build_flags = -D_IR_ENABLE_DEFAULT_=false -Werror

--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -53,5 +53,5 @@ build_flags = -D_IR_LOCALE_=zh-CN  ;  Chinese (Simplified)
 
 ; Build the library with all protocols disabled to flush out #if/#ifdef issues &
 ; any compiler warnings, by turning them into errors.
-[env:no-protocols]
+[env:shakedown_no_protocols]
 build_flags = -D_IR_ENABLE_DEFAULT_=false -Werror

--- a/examples/SmartIRRepeater/SmartIRRepeater.ino
+++ b/examples/SmartIRRepeater/SmartIRRepeater.ino
@@ -121,8 +121,10 @@ void loop() {
       uint16_t *raw_array = resultToRawArray(&results);
       // Find out how many elements are in the array.
       size = getCorrectedRawLength(&results);
+#if SEND_RAW
       // Send it out via the IR LED circuit.
       irsend.sendRaw(raw_array, size, kFrequency);
+#endif  // SEND_RAW
       // Deallocate the memory allocated by resultToRawArray().
       delete [] raw_array;
     } else if (hasACState(protocol)) {  // Does the message require a state[]?

--- a/examples/SmartIRRepeater/platformio.ini
+++ b/examples/SmartIRRepeater/platformio.ini
@@ -15,3 +15,21 @@ board = nodemcuv2
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
+
+; Build the program forcing the compiler to treat all warnings as errors.
+[env:shakedown_all_protocols]
+platform = espressif8266
+board = nodemcuv2
+build_flags =
+  ${env.build_flags}
+  -Werror
+
+; Disable all protocols to see if we can force any errors.
+; Build the program forcing the compiler to treat all warnings as errors.
+[env:shakedown_no_protocols]
+platform = espressif8266
+board = nodemcuv2
+build_flags =
+  ${env.build_flags}
+  -Werror
+  -D_IR_ENABLE_DEFAULT_=false

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1948,8 +1948,8 @@ bool IRac::sendAc(const decode_type_t vendor, const int16_t model,
 /// @return True, if accepted/converted/attempted etc. False, if unsupported.
 bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
   // Convert the temp from Fahrenheit to Celsius if we are not in Celsius mode.
-  float degC = desired.celsius ? desired.degrees
-                               : fahrenheitToCelsius(desired.degrees);
+  float degC __attribute__((unused)) =
+      desired.celsius ? desired.degrees : fahrenheitToCelsius(desired.degrees);
   // special `state_t` that is required to be sent based on that.
   stdAc::state_t send = this->handleToggles(this->cleanState(desired), prev);
   // Per vendor settings & setup.

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -748,7 +748,8 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
 /// @return True if it is a type we can attempt to send, false if not.
 bool IRsend::send(const decode_type_t type, const uint64_t data,
                   const uint16_t nbits, const uint16_t repeat) {
-  uint16_t min_repeat = std::max(IRsend::minRepeats(type), repeat);
+  uint16_t min_repeat __attribute__((unused)) =
+      std::max(IRsend::minRepeats(type), repeat);
   switch (type) {
 #if SEND_AIRWELL
     case AIRWELL:

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ INCLUDES = -I$(USER_DIR) -I.
 CPPFLAGS += -isystem $(GTEST_DIR)/include -DUNIT_TEST -D_IR_LOCALE_=en-AU
 
 # Flags passed to the C++ compiler.
-CXXFLAGS += -g -Wall -Wextra -pthread -std=gnu++11
+CXXFLAGS += -g -Wall -Wextra -Werror -pthread -std=gnu++11
 
 # All tests produced by this Makefile. generated from all *_test.cpp files
 TESTS = $(patsubst %.cpp,%,$(wildcard *_test.cpp))


### PR DESCRIPTION
* Add `-Werror` to various places to catch compiler warnings in various environments.
  - test/Makefile (Unit test env)
  - various example/*/platformio.ini
    o IRrecvDumpV2 - full range of protocol decoding covered.
    o SmartIRRepeater - full range of protocol sending covered.
    o CommonAcControl - Common A/C api coveraged.
* Add compile tests for when all the protocols are disabled.
  - IRrecvDumpV2: should provide 100% of decode coverage cases
  - SmartIRRepeater: should provide 100% of send coverage cases
* Above measures will be checked/tested on every Travis/CI build.
* Fix a few `-Wunused-variables` warnings.
  - Note: `#pragma GCC diagnostic ignored "-Wunused-variable"` approach did not work. Known compiler issue it seems
* Protect SmartIRRepeater from `SEND_RAW` being `false`

For #1172