### PR TITLE
Remove `calcLGChecksum()` and use new generic `sumNibbles()`

### DIFF
--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -749,6 +749,21 @@ namespace irutils {
     return sum;
   }
 
+  /// Sum all the nibbles together in an integer.
+  /// @param[in] data The integer to be summed.
+  /// @param[in] count The number of nibbles to sum. Starts from LSB. Max of 16.
+  /// @param[in] init Starting value of the calculation to use. (Default is 0)
+  /// @param[in] nibbleonly true, the result is 4 bits. false, it's 8 bits.
+  /// @return The 8-bit calculated result of all the nibbles and init value.
+  uint8_t sumNibbles(const uint64_t data, const uint8_t count,
+                     const uint8_t init, const bool nibbleonly) {
+    uint8_t sum = init;
+    uint64_t copy = data;
+    const uint8_t nrofnibbles = (count < 16) ? count : (64 / 4);
+    for (uint8_t i = 0; i < nrofnibbles; i++, copy >>= 4) sum += copy & 0xF;
+    return nibbleonly ? sum & 0xF : sum;
+  }
+
   /// Convert a byte of Binary Coded Decimal(BCD) into an Integer.
   /// @param[in] bcd The BCD value.
   /// @return A normal Integer value.

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -754,7 +754,7 @@ namespace irutils {
   /// @param[in] count The number of nibbles to sum. Starts from LSB. Max of 16.
   /// @param[in] init Starting value of the calculation to use. (Default is 0)
   /// @param[in] nibbleonly true, the result is 4 bits. false, it's 8 bits.
-  /// @return The 8-bit calculated result of all the nibbles and init value.
+  /// @return The 4/8-bit calculated result of all the nibbles and init value.
   uint8_t sumNibbles(const uint64_t data, const uint8_t count,
                      const uint8_t init, const bool nibbleonly) {
     uint8_t sum = init;

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -69,6 +69,8 @@ namespace irutils {
   String minsToString(const uint16_t mins);
   uint8_t sumNibbles(const uint8_t * const start, const uint16_t length,
                      const uint8_t init = 0);
+  uint8_t sumNibbles(const uint64_t data, const uint8_t count = 16,
+                     const uint8_t init = 0, const bool nibbleonly = true);
   uint8_t bcdToUint8(const uint8_t bcd);
   uint8_t uint8ToBcd(const uint8_t integer);
   bool getBit(const uint64_t data, const uint8_t position,

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -518,6 +518,7 @@ TEST(TestUtils, MinsToString) {
 }
 
 TEST(TestUtils, sumNibbles) {
+  // PTR/Array variant.
   uint8_t testdata[] = {0x01, 0x23, 0x45};
   EXPECT_EQ(0, irutils::sumNibbles(testdata, 0));
   EXPECT_EQ(1, irutils::sumNibbles(testdata, 0, 1));
@@ -525,6 +526,30 @@ TEST(TestUtils, sumNibbles) {
   EXPECT_EQ(2, irutils::sumNibbles(testdata, 1, 1));
   EXPECT_EQ(15, irutils::sumNibbles(testdata, 3));
   EXPECT_EQ(115, irutils::sumNibbles(testdata, 3, 100));
+
+  // Integer variant.
+  EXPECT_EQ(0x0, irutils::sumNibbles(0x0));
+  EXPECT_EQ(0x1, irutils::sumNibbles(0x1));
+  EXPECT_EQ(0xF, irutils::sumNibbles(0xF));
+  EXPECT_EQ(0x4, irutils::sumNibbles(0x1111));
+  EXPECT_EQ(0x8, irutils::sumNibbles(0x2222));
+  EXPECT_EQ(0x0, irutils::sumNibbles(0x4444));
+  EXPECT_EQ(0xA, irutils::sumNibbles(0x1234));
+  EXPECT_EQ(0xA, irutils::sumNibbles(0x4321));
+  EXPECT_EQ(0xE, irutils::sumNibbles(0xABCD));
+  EXPECT_EQ(0x1, irutils::sumNibbles(0x4AE5));
+  EXPECT_EQ(0xC, irutils::sumNibbles(0xFFFF));
+  EXPECT_EQ(0x1, irutils::sumNibbles(0xC005));
+  EXPECT_EQ(0x4, irutils::sumNibbles(0xC035));
+  EXPECT_EQ(0x2, irutils::sumNibbles(0x88C0051));
+  EXPECT_EQ(0x1, irutils::sumNibbles(0x88C0051, 1));
+  EXPECT_EQ(0x2, irutils::sumNibbles(0x88C0051, 1, 1));
+  EXPECT_EQ(0x6, irutils::sumNibbles(0x88C0051, 2));
+  EXPECT_EQ(0x6, irutils::sumNibbles(0x88C0051, 4));
+  EXPECT_EQ(0x2, irutils::sumNibbles(0x88C0051, 5));
+  EXPECT_EQ(0x22, irutils::sumNibbles(0x88C0051, 16, 0, false));
+  EXPECT_EQ(0x12, irutils::sumNibbles(0x88C0051, 5, 0, false));
+  EXPECT_EQ(0x22, irutils::sumNibbles(0x88C0051, 255, 0, false));
 }
 
 TEST(TestUtils, BCD) {

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -6,24 +6,6 @@
 #include "IRsend_test.h"
 #include "gtest/gtest.h"
 
-// Tests for calcLGChecksum()
-TEST(TestCalcLGChecksum, General) {
-  EXPECT_EQ(0x0, calcLGChecksum(0x0));
-  EXPECT_EQ(0x1, calcLGChecksum(0x1));
-  EXPECT_EQ(0xF, calcLGChecksum(0xF));
-  EXPECT_EQ(0x4, calcLGChecksum(0x1111));
-  EXPECT_EQ(0x8, calcLGChecksum(0x2222));
-  EXPECT_EQ(0x0, calcLGChecksum(0x4444));
-  EXPECT_EQ(0xA, calcLGChecksum(0x1234));
-  EXPECT_EQ(0xA, calcLGChecksum(0x4321));
-  EXPECT_EQ(0xE, calcLGChecksum(0xABCD));
-  EXPECT_EQ(0x1, calcLGChecksum(0x4AE5));
-  EXPECT_EQ(0xC, calcLGChecksum(0xFFFF));
-  EXPECT_EQ(0x1, calcLGChecksum(0xC005));
-  EXPECT_EQ(0x1, IRLgAc::calcChecksum(0x88C0051));
-  EXPECT_EQ(0x4, calcLGChecksum(0xC035));
-  EXPECT_EQ(0x4, IRLgAc::calcChecksum(0x88C0354));
-}
 
 // Tests for sendLG().
 
@@ -668,6 +650,11 @@ TEST(TestIRLgAcClass, isValidLgAc) {
   // Use a wrong signature.
   ac.setRaw(0x8000A4E);
   ASSERT_FALSE(ac.isValidLgAc());
+}
+
+TEST(TestIRLgAcClass, calcChecksum) {
+  EXPECT_EQ(0x1, IRLgAc::calcChecksum(0x88C0051));
+  EXPECT_EQ(0x4, IRLgAc::calcChecksum(0x88C0354));
 }
 
 TEST(TestUtils, Housekeeping) {


### PR DESCRIPTION
* Allow (future) code consolidate/de-duplification.
* Fixes compile error when LG protocol is disabled but IRLgAc class is still used.
* Adjust unit test accordingly

For #1172 & #1129

Ref https://github.com/crankyoldgit/IRremoteESP8266/issues/1172#issuecomment-640141683