### PR TITLE
Load balance travis tasks to reduce wall clock time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ addons:
     - pylint3
     - python3-setuptools
 env:
-  - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"
-  - COMPLEX_EXAMPLES_RE=".*IR(MQTTServer|recvDumpV).*"
+  - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"; COMPLEX_EXAMPLES_RE=".*IR(MQTTServer|recvDumpV).*"
 cache:
   directories:
     - "~/.platformio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"
     IRRECVDUMP_RE=".*IRrecvDumpV.*"
     IRMQTTSERVER_RE=".*IRMQTTServer.*"
+    MAKEFLAGS="-j 2"
 cache:
   directories:
     - "~/.platformio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       # Check that IRrecvDumpV2+ compiles.
       # i.e. We are splitting the work load in to parallel tasks.
       - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
-    - name: "Unit tests, Linter, & Documentation checks and Compile IRMQTTServer"
+    - name: "Unit tests, Linter, Doc checks, & Compile IRMQTTServer"
       script:
       # Run all the Tests & check the code linters have no issues, and that
       # IRMQTTServer compiles.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
     - pylint3
     - python3-setuptools
 env:
-  - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"; COMPLEX_EXAMPLES_RE=".*IR(MQTTServer|recvDumpV).*"
+  - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"
+    IRRECVDUMP_RE=".*IRrecvDumpV.*"
+    IRMQTTSERVER_RE=".*IRMQTTServer.*"
 cache:
   directories:
     - "~/.platformio"
@@ -29,17 +31,18 @@ jobs:
   include:
     - name: "Compile the trivial examples"
       script:
-      # Check that everything compiles but some heavy tasks e.g. IRMQTTServer & IRrecvDumpV2
+      # Check that everything compiles but some heavy tasks e.g. IRMQTTServer & IRrecvDumpV2+
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f \! -regex "${COMPLEX_EXAMPLES_RE}" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
-    - name: "Compile the complex examples"
+      - find . -regextype egrep -name platformio.ini -type f \! -regex "${IRRECVDUMP_RE}|${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+    - name: "Compile the IRrecvDumpV2+ examples"
       script:
-      # Check that everything else compiles.
+      # Check that IRrecvDumpV2+ compiles.
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${COMPLEX_EXAMPLES_RE}" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
-    - name: "Unit tests, Linter, & Documentation checks"
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+    - name: "Unit tests, Linter, & Documentation checks and Compile IRMQTTServer"
       script:
-      # Run all the Tests & check the code linters have no issues.
+      # Run all the Tests & check the code linters have no issues, and that
+      # IRMQTTServer compiles.
       # i.e. We are splitting the work load in to parallel tasks.
       # Check the version numbers match.
       - LIB_VERSION=$(egrep "^#define\s+_IRREMOTEESP8266_VERSION_\s+" src/IRremoteESP8266.h  | cut -d\" -f2)
@@ -61,3 +64,5 @@ jobs:
       - (DOXYGEN_OUTPUT=$(doxygen 2>&1); if [[ $? -ne 0 || -n "${DOXYGEN_OUTPUT}" ]]; then echo "${DOXYGEN_OUTPUT}"; exit 1; fi)
       # Check that all files has supported sections.
       - (SUPPORTED_OUTPUT=$(python3 tools/scrape_supported_devices.py --noout --alert 2>&1); if [[ $? -ne 0 || -n "${SUPPORTED_OUTPUT}" ]]; then echo "${SUPPORTED_OUTPUT}"; exit 1; fi)
+      # Check that IRMQTTServer compiles.
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ jobs:
       # Check that all files has supported sections.
       - (SUPPORTED_OUTPUT=$(python3 tools/scrape_supported_devices.py --noout --alert 2>&1); if [[ $? -ne 0 || -n "${SUPPORTED_OUTPUT}" ]]; then echo "${SUPPORTED_OUTPUT}"; exit 1; fi)
       # Check that IRMQTTServer compiles.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ jobs:
       script:
       # Check that everything compiles but some heavy tasks e.g. IRMQTTServer & IRrecvDumpV2+
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f \! -regex "${IRRECVDUMP_RE}|${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f \! -regex "${IRRECVDUMP_RE}|${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2
     - name: "Compile the IRrecvDumpV2+ examples"
       script:
       # Check that IRrecvDumpV2+ compiles.
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2
     - name: "Unit tests, Linter, Doc checks, & Compile IRMQTTServer"
       script:
       # Run all the Tests & check the code linters have no issues, and that
@@ -66,4 +66,4 @@ jobs:
       # Check that all files has supported sections.
       - (SUPPORTED_OUTPUT=$(python3 tools/scrape_supported_devices.py --noout --alert 2>&1); if [[ $? -ne 0 || -n "${SUPPORTED_OUTPUT}" ]]; then echo "${SUPPORTED_OUTPUT}"; exit 1; fi)
       # Check that IRMQTTServer compiles.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ jobs:
       script:
       # Check that everything compiles but some heavy tasks e.g. IRMQTTServer & IRrecvDumpV2+
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f \! -regex "${IRRECVDUMP_RE}|${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2
+      - find . -regextype egrep -name platformio.ini -type f \! -regex "${IRRECVDUMP_RE}|${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --jobs 2 --project-dir
     - name: "Compile the IRrecvDumpV2+ examples"
       script:
       # Check that IRrecvDumpV2+ compiles.
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRRECVDUMP_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run  --jobs 2 --project-dir
     - name: "Unit tests, Linter, Doc checks, & Compile IRMQTTServer"
       script:
       # Run all the Tests & check the code linters have no issues, and that
@@ -66,4 +66,4 @@ jobs:
       # Check that all files has supported sections.
       - (SUPPORTED_OUTPUT=$(python3 tools/scrape_supported_devices.py --noout --alert 2>&1); if [[ $? -ne 0 || -n "${SUPPORTED_OUTPUT}" ]]; then echo "${SUPPORTED_OUTPUT}"; exit 1; fi)
       # Check that IRMQTTServer compiles.
-      - find . -regextype egrep -name platformio.ini -type f -regex "${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --project-dir --jobs 2
+      - find . -regextype egrep -name platformio.ini -type f -regex "${IRMQTTSERVER_RE}" | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run  --jobs 2 --project-dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - python3-setuptools
 env:
   - PLATFORMIO_BUILD_CACHE_DIR="../../.pio/buildcache"
+  - COMPLEX_EXAMPLES_RE=".*IR(MQTTServer|recvDumpV).*"
 cache:
   directories:
     - "~/.platformio"
@@ -31,12 +32,12 @@ jobs:
       script:
       # Check that everything compiles but some heavy tasks e.g. IRMQTTServer & IRrecvDumpV2
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f \! -regex ".*IR(MQTTServer|recvDumpV2).*" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f \! -regex "${COMPLEX_EXAMPLES_RE}" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
     - name: "Compile the complex examples"
       script:
       # Check that everything else compiles.
       # i.e. We are splitting the work load in to parallel tasks.
-      - find . -regextype egrep -name platformio.ini -type f -regex ".*IR(MQTTServer|recvDumpV2).*" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
+      - find . -regextype egrep -name platformio.ini -type f -regex "${COMPLEX_EXAMPLES_RE}" | sed 's,/platformio.ini$,,' | xargs -n 1 pio run --project-dir
     - name: "Unit tests, Linter, & Documentation checks"
       script:
       # Run all the Tests & check the code linters have no issues.


### PR DESCRIPTION
## Existing run times:
```
Compile the trivial examples
 16 min 6 sec

 Compile the complex examples
 11 min 39 sec

 Unit tests, Linter, & Documentation checks
 4 min 5 sec
```
Longest task: 16+ mins.

## Proposed:
```
 Compile the trivial examples
 9 min 51 sec

 Compile the IRrecvDumpV2+ examples
 10 min 8 sec

 Unit tests, Linter, Doc checks, & Compile IRMQTTServer
 7 min 21 sec
```
Longest task: 10+ mins