### PR TITLE
SsssSufferin’ ssssuccotash! Doxygen'ed again!

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -290,8 +290,9 @@ class IRsend {
 #endif
 #if SEND_SANYO
   uint64_t encodeSanyoLC7461(uint16_t address, uint8_t command);
-  void sendSanyoLC7461(uint64_t data, uint16_t nbits = kSanyoLC7461Bits,
-                       uint16_t repeat = kNoRepeat);
+  void sendSanyoLC7461(const uint64_t data,
+                       const uint16_t nbits = kSanyoLC7461Bits,
+                       const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_DISH
   // sendDISH() should typically be called with repeat=3 as DISH devices

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -232,13 +232,13 @@ class IRsend {
   // Legacy use of this procedure was to only send a single code so call it with
   // repeat=0 for backward compatibility. As of v2.0 it defaults to sending
   // a Sony command that will be accepted be a device.
-  void sendSony(uint64_t data, uint16_t nbits = kSony20Bits,
-                uint16_t repeat = kSonyMinRepeat);
-  void sendSony38(uint64_t data, uint16_t nbits = kSony20Bits,
-                  uint16_t repeat = kSonyMinRepeat + 1);
-  uint32_t encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
-                      uint16_t extended = 0);
-#endif
+  void sendSony(const uint64_t data, const uint16_t nbits = kSony20Bits,
+                const uint16_t repeat = kSonyMinRepeat);
+  void sendSony38(const uint64_t data, const uint16_t nbits = kSony20Bits,
+                  const uint16_t repeat = kSonyMinRepeat + 1);
+  uint32_t encodeSony(const uint16_t nbits, const uint16_t command,
+                      const uint16_t address, const uint16_t extended = 0);
+#endif  // SEND_SONY
 #if SEND_SHERWOOD
   void sendSherwood(uint64_t data, uint16_t nbits = kSherwoodBits,
                     uint16_t repeat = kSherwoodMinRepeat);
@@ -658,9 +658,9 @@ class IRsend {
   bool modulation;
   uint32_t calcUSecPeriod(uint32_t hz, bool use_offset = true);
 #if SEND_SONY
-  void _sendSony(uint64_t data, uint16_t nbits,
-                 uint16_t repeat, uint16_t freq);
-#endif
+  void _sendSony(const uint64_t data, const uint16_t nbits,
+                 const uint16_t repeat, const uint16_t freq);
+#endif  // SEND_SONY
 };
 
 #endif  // IRSEND_H_

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -321,24 +321,30 @@ bool IRNeoclimaAc::getSleep(void) {
   return GETBIT8(remote_state[7],  kNeoclimaSleepOffset);
 }
 
-// A.k.a. Swing
+/// Set the vertical swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setSwingV(const bool on) {
   this->setButton(kNeoclimaButtonSwing);
   setBits(&remote_state[7], kNeoclimaSwingVOffset, kNeoclimaSwingVSize,
           on ? kNeoclimaSwingVOn : kNeoclimaSwingVOff);
 }
 
+/// Get the vertical swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRNeoclimaAc::getSwingV(void) {
   return GETBITS8(remote_state[7], kNeoclimaSwingVOffset,
                   kNeoclimaSwingVSize) == kNeoclimaSwingVOn;
 }
 
-// A.k.a. Air Flow
+/// Set the horizontal swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setSwingH(const bool on) {
   this->setButton(kNeoclimaButtonAirFlow);
   setBit(&remote_state[7], kNeoclimaSwingHOffset, !on);  // Cleared when `on`
 }
 
+/// Get the horizontal swing (Air Flow) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRNeoclimaAc::getSwingH(void) {
   return !GETBIT8(remote_state[7], kNeoclimaSwingHOffset);
 }
@@ -539,6 +545,7 @@ String IRNeoclimaAc::toString(void) {
 ///   raw data. Typically/Defaults to kStartOffset.
 /// @param[in] nbits The number of data bits to expect.
 /// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeNeoclima(decode_results *results, uint16_t offset,
                             const uint16_t nbits, const bool strict) {
   // Compliance

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -1,7 +1,12 @@
 // Copyright 2009 Ken Shirriff
 // Copyright 2017, 2018, 2019 David Conran
-
-// Samsung remote emulation
+/// @file
+/// @brief Support for Samsung protocols.
+/// Samsung originally added from https://github.com/shirriff/Arduino-IRremote/
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/621
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
+/// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
 
 #include "ir_Samsung.h"
 #include <algorithm>
@@ -14,11 +19,7 @@
 #include "IRtext.h"
 #include "IRutils.h"
 
-// Samsung originally added from https://github.com/shirriff/Arduino-IRremote/
-
 // Constants
-// Ref:
-//   http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
 const uint16_t kSamsungTick = 560;
 const uint16_t kSamsungHdrMarkTicks = 8;
 const uint16_t kSamsungHdrMark = kSamsungHdrMarkTicks * kSamsungTick;
@@ -62,19 +63,15 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_SAMSUNG
-// Send a Samsung formatted message.
-// Samsung has a separate message to indicate a repeat, like NEC does.
-// TODO(crankyoldgit): Confirm that is actually how Samsung sends a repeat.
-//                     The refdoc doesn't indicate it is true.
-//
-// Args:
-//   data:   The message to be sent.
-//   nbits:  The bit size of the message being sent. typically kSamsungBits.
-//   repeat: The number of times the message is to be repeated.
-//
-// Status: STABLE / Should be working.
-//
-// Ref: http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
+/// Send a 32-bit Samsung formatted message.
+/// Status: STABLE / Should be working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
+/// @note Samsung has a separate message to indicate a repeat, like NEC does.
+/// @todo Confirm that is actually how Samsung sends a repeat.
+///   The refdoc doesn't indicate it is true.
 void IRsend::sendSAMSUNG(const uint64_t data, const uint16_t nbits,
                          const uint16_t repeat) {
   sendGeneric(kSamsungHdrMark, kSamsungHdrSpace, kSamsungBitMark,
@@ -83,16 +80,12 @@ void IRsend::sendSAMSUNG(const uint64_t data, const uint16_t nbits,
               nbits, 38, true, repeat, 33);
 }
 
-// Construct a raw Samsung message from the supplied customer(address) &
-// command.
-//
-// Args:
-//   customer: The customer code. (aka. Address)
-//   command:  The command code.
-// Returns:
-//   A raw 32-bit Samsung message suitable for sendSAMSUNG().
-//
-// Status: STABLE / Should be working.
+/// Construct a raw Samsung message from the supplied customer(address) &
+/// command.
+/// Status: STABLE / Should be working.
+/// @param[in] customer The customer code. (aka. Address)
+/// @param[in] command The command code.
+/// @return A raw 32-bit Samsung message suitable for `sendSAMSUNG()`.
 uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
   uint8_t revcustomer = reverseBits(customer, sizeof(customer) * 8);
   uint8_t revcommand = reverseBits(command, sizeof(command) * 8);
@@ -102,27 +95,19 @@ uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
 #endif
 
 #if DECODE_SAMSUNG
-// Decode the supplied Samsung message.
-// Samsung messages whilst 32 bits in size, only contain 16 bits of distinct
-// data. e.g. In transmition order:
-//   customer_byte + customer_byte(same) + address_byte + invert(address_byte)
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   Nr. of bits to expect in the data portion. Typically kSamsungBits.
-//   strict:  Flag to indicate if we strictly adhere to the specification.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE
-//
-// Note:
-//   LG 32bit protocol appears near identical to the Samsung protocol.
-//   They differ on their compliance criteria and how they repeat.
-// Ref:
-//  http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
+/// Decode the supplied Samsung 32-bit message.
+/// Status: STABLE
+/// @note Samsung messages whilst 32 bits in size, only contain 16 bits of
+///   distinct data. e.g. In transmition order:
+///   customer_byte + customer_byte(same) + address_byte + invert(address_byte)
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @note LG 32bit protocol appears near identical to the Samsung protocol.
+///   They differ on their compliance criteria and how they repeat.
+/// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
 bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t offset,
                            const uint16_t nbits, const bool strict) {
   if (strict && nbits != kSamsungBits)
@@ -159,20 +144,12 @@ bool IRrecv::decodeSAMSUNG(decode_results *results, uint16_t offset,
 #endif
 
 #if SEND_SAMSUNG36
-// Send a Samsung 36-bit formatted message.
-//
-// Args:
-//   data:   The message to be sent.
-//   nbits:  The bit size of the message being sent. typically kSamsung36Bits.
-//   repeat: The number of times the message is to be repeated.
-//
-// Status: Alpha / Experimental.
-//
-// Note:
-//   Protocol is used by Samsung Bluray Remote: ak59-00167a
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/621
+/// Send a Samsung 36-bit formatted message.
+/// Status: Alpha / Experimental.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/621
 void IRsend::sendSamsung36(const uint64_t data, const uint16_t nbits,
                            const uint16_t repeat) {
   if (nbits < 16) return;  // To small to send.
@@ -196,25 +173,14 @@ void IRsend::sendSamsung36(const uint64_t data, const uint16_t nbits,
 #endif  // SEND_SAMSUNG36
 
 #if DECODE_SAMSUNG36
-// Decode the supplied Samsung36 message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   Nr. of bits to expect in the data portion.
-//            Typically kSamsung36Bits.
-//   strict:  Flag to indicate if we strictly adhere to the specification.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: Alpha / Experimental
-//
-// Note:
-//   Protocol is used by Samsung Bluray Remote: ak59-00167a
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/621
+/// Decode the supplied Samsung36 message.
+/// Status: Alpha / Experimental
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/621
 bool IRrecv::decodeSamsung36(decode_results *results, uint16_t offset,
                              const uint16_t nbits, const bool strict) {
   if (results->rawlen < 2 * nbits + kHeader + kFooter * 2 - 1 + offset)
@@ -258,17 +224,12 @@ bool IRrecv::decodeSamsung36(decode_results *results, uint16_t offset,
 #endif  // DECODE_SAMSUNG36
 
 #if SEND_SAMSUNG_AC
-// Send a Samsung A/C message.
-//
-// Args:
-//   data: An array of bytes containing the IR command.
-//   nbytes: Nr. of bytes of data in the array. (>=kSamsungAcStateLength)
-//   repeat: Nr. of times the message is to be repeated. (Default = 0).
-//
-// Status: Stable / Known working.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+/// Send a Samsung A/C message.
+/// Status: Stable / Known working.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
                            const uint16_t repeat) {
   if (nbytes < kSamsungAcStateLength && nbytes % kSamsungAcSectionLength)
@@ -294,16 +255,21 @@ void IRsend::sendSamsungAC(const uint8_t data[], const uint16_t nbytes,
 }
 #endif  // SEND_SAMSUNG_AC
 
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRSamsungAc object.
 IRSamsungAc::IRSamsungAc(const uint16_t pin, const bool inverted,
                          const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) {
   this->stateReset();
 }
 
-// Reset the internal state of the emulation.
-// Args:
-//   forcepower: A flag indicating if force sending a special power message
-//              with the first `send()` call. Default: true
+/// Reset the internal state of the emulation.
+/// @param[in] forcepower A flag indicating if force sending a special power
+///   message with the first `send()` call.
+/// @param[in] initialPower Set the initial power state. True, on. False, off.
 void IRSamsungAc::stateReset(const bool forcepower, const bool initialPower) {
   static const uint8_t kReset[kSamsungAcExtendedStateLength] = {
       0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0, 0x01, 0x02, 0xAE, 0x71, 0x00,
@@ -314,8 +280,13 @@ void IRSamsungAc::stateReset(const bool forcepower, const bool initialPower) {
   setPower(initialPower);
 }
 
+/// Set up hardware to be able to send a message.
 void IRSamsungAc::begin(void) { _irsend.begin(); }
 
+/// Calculate the checksum for a given state.
+/// @param[in] state The array to calc the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return The calculated checksum value.
 uint8_t IRSamsungAc::calcChecksum(const uint8_t state[],
                                   const uint16_t length) {
   uint8_t sum = 0;
@@ -331,6 +302,10 @@ uint8_t IRSamsungAc::calcChecksum(const uint8_t state[],
   return GETBITS8(28 - sum, kLowNibble, kNibbleSize);
 }
 
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRSamsungAc::validChecksum(const uint8_t state[], const uint16_t length) {
   if (length < kSamsungAcStateLength)
     return true;  // No checksum to compare with. Assume okay.
@@ -342,7 +317,8 @@ bool IRSamsungAc::validChecksum(const uint8_t state[], const uint16_t length) {
           IRSamsungAc::calcChecksum(state, length - (7 + offset)));
 }
 
-// Update the checksum for the internal state.
+/// Update the checksum for the internal state.
+/// @param[in] length The length/size of the nternal array to checksum.
 void IRSamsungAc::checksum(uint16_t length) {
   if (length < 13) return;
   setBits(&remote_state[length - 6], kHighNibble, kNibbleSize,
@@ -352,8 +328,11 @@ void IRSamsungAc::checksum(uint16_t length) {
 }
 
 #if SEND_SAMSUNG_AC
-// Use for most function/mode/settings changes to the unit.
-// i.e. When the device is already running.
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
+/// @param[in] calcchecksum Do we update the checksum before sending?
+/// @note Use for most function/mode/settings changes to the unit.
+///   i.e. When the device is already running.
 void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) this->checksum();
   // Do we need to send a the special power on/off message?
@@ -369,9 +348,12 @@ void IRSamsungAc::send(const uint16_t repeat, const bool calcchecksum) {
   _irsend.sendSamsungAC(remote_state, kSamsungAcStateLength, repeat);
 }
 
-// Use this for when you need to power on/off the device.
-// Samsung A/C requires an extended length message when you want to
-// change the power operating mode of the A/C unit.
+/// Send the extended current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
+/// @param[in] calcchecksum Do we update the checksum before sending?
+/// @note Use this for when you need to power on/off the device.
+/// Samsung A/C requires an extended length message when you want to
+/// change the power operating mode of the A/C unit.
 void IRSamsungAc::sendExtended(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) this->checksum();
   uint8_t extended_state[kSamsungAcExtendedStateLength] = {
@@ -389,9 +371,10 @@ void IRSamsungAc::sendExtended(const uint16_t repeat, const bool calcchecksum) {
   _irsend.sendSamsungAC(extended_state, kSamsungAcExtendedStateLength, repeat);
 }
 
-// Send the special extended "On" message as the library can't seem to reproduce
-// this message automatically.
-// See: https://github.com/crankyoldgit/IRremoteESP8266/issues/604#issuecomment-475020036
+/// Send the special extended "On" message as the library can't seem to
+/// reproduce this message automatically.
+/// @param[in] repeat Nr. of times the message will be repeated.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/604#issuecomment-475020036
 void IRSamsungAc::sendOn(const uint16_t repeat) {
   const uint8_t extended_state[21] = {
       0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0,
@@ -401,9 +384,10 @@ void IRSamsungAc::sendOn(const uint16_t repeat) {
   _lastsentpowerstate = true;  // On
 }
 
-// Send the special extended "Off" message as the library can't seem to
-// reproduce this message automatically.
-// See: https://github.com/crankyoldgit/IRremoteESP8266/issues/604#issuecomment-475020036
+/// Send the special extended "Off" message as the library can't seem to
+/// reproduce this message automatically.
+/// @param[in] repeat Nr. of times the message will be repeated.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/604#issuecomment-475020036
 void IRSamsungAc::sendOff(const uint16_t repeat) {
   const uint8_t extended_state[21] = {
       0x02, 0xB2, 0x0F, 0x00, 0x00, 0x00, 0xC0,
@@ -414,11 +398,16 @@ void IRSamsungAc::sendOff(const uint16_t repeat) {
 }
 #endif  // SEND_SAMSUNG_AC
 
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
 uint8_t *IRSamsungAc::getRaw(void) {
   this->checksum();
   return remote_state;
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
+/// @param[in] length The length/size of the new_code array.
 void IRSamsungAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote_state, new_code, std::min(length,
                                           kSamsungAcExtendedStateLength));
@@ -429,23 +418,30 @@ void IRSamsungAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   }
 }
 
+/// Set the requested power state of the A/C to on.
 void IRSamsungAc::on(void) { setPower(true); }
 
+/// Set the requested power state of the A/C to off.
 void IRSamsungAc::off(void) { setPower(false); }
 
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setPower(const bool on) {
   setBit(&remote_state[1], kSamsungAcPower1Offset, !on);  // Cleared when on.
   setBits(&remote_state[6], kSamsungAcPower6Offset, kSamsungAcPower6Size,
           on ? 0b11 : 0b00);
 }
 
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getPower(void) {
   return (GETBITS8(remote_state[6], kSamsungAcPower6Offset,
                    kSamsungAcPower6Size) == 0b11) &&
       !GETBIT8(remote_state[1], kSamsungAcPower1Offset);
 }
 
-// Set the temp. in deg C
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
 void IRSamsungAc::setTemp(const uint8_t temp) {
   uint8_t newtemp = std::max(kSamsungAcMinTemp, temp);
   newtemp = std::min(kSamsungAcMaxTemp, newtemp);
@@ -453,12 +449,15 @@ void IRSamsungAc::setTemp(const uint8_t temp) {
           newtemp - kSamsungAcMinTemp);
 }
 
-// Return the set temp. in deg C
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRSamsungAc::getTemp(void) {
   return GETBITS8(remote_state[11], kHighNibble, kNibbleSize) +
       kSamsungAcMinTemp;
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
 void IRSamsungAc::setMode(const uint8_t mode) {
   // If we get an unexpected mode, default to AUTO.
   uint8_t newmode = mode;
@@ -475,10 +474,14 @@ void IRSamsungAc::setMode(const uint8_t mode) {
   }
 }
 
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRSamsungAc::getMode(void) {
   return GETBITS8(remote_state[12], kSamsungAcModeOffset, kModeBitsSize);
 }
 
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
 void IRSamsungAc::setFan(const uint8_t speed) {
   switch (speed) {
     case kSamsungAcFanAuto:
@@ -497,47 +500,65 @@ void IRSamsungAc::setFan(const uint8_t speed) {
   setBits(&remote_state[12], kSamsungAcFanOffest, kSamsungAcFanSize, speed);
 }
 
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRSamsungAc::getFan(void) {
   return GETBITS8(remote_state[12], kSamsungAcFanOffest, kSamsungAcFanSize);
 }
 
+/// Get the vertical swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
+/// @todo (Hollako) Explain why sometimes the LSB of remote_state[9] is a 1.
+/// e.g. 0xAE or 0XAF for swing move.
 bool IRSamsungAc::getSwing(void) {
-  // TODO(Hollako): Explain why sometimes the LSB of remote_state[9] is a 1.
-  // e.g. 0xAE or 0XAF for swing move.
   return GETBITS8(remote_state[9], kSamsungAcSwingOffset,
                   kSamsungAcSwingSize) == kSamsungAcSwingMove;
 }
 
+/// Set the vertical swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @todo (Hollako) Explain why sometimes the LSB of remote_state[9] is a 1.
+///   e.g. 0xAE or 0XAF for swing move.
 void IRSamsungAc::setSwing(const bool on) {
-  // TODO(Hollako): Explain why sometimes the LSB of remote_state[9] is a 1.
-  // e.g. 0xAE or 0XAF for swing move.
   setBits(&remote_state[9], kSamsungAcSwingOffset, kSamsungAcSwingSize,
           on ? kSamsungAcSwingMove : kSamsungAcSwingStop);
 }
 
+/// Get the Beep setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getBeep(void) {
   return GETBIT8(remote_state[13], kSamsungAcBeepOffset);
 }
 
+/// Set the Beep setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setBeep(const bool on) {
   setBit(&remote_state[13], kSamsungAcBeepOffset, on);
 }
 
+/// Get the Clean setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getClean(void) {
   return GETBIT8(remote_state[10], kSamsungAcClean10Offset) &&
          GETBIT8(remote_state[11], kSamsungAcClean11Offset);
 }
 
+/// Set the Clean setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setClean(const bool on) {
   setBit(&remote_state[10], kSamsungAcClean10Offset, on);
   setBit(&remote_state[11], kSamsungAcClean11Offset, on);
 }
 
+/// Get the Quiet setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getQuiet(void) {
   return !GETBIT8(remote_state[1], kSamsungAcQuiet1Offset) &&
          GETBIT8(remote_state[5], kSamsungAcQuiet5Offset);
 }
 
+/// Set the Quiet setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setQuiet(const bool on) {
   setBit(&remote_state[1], kSamsungAcQuiet1Offset, !on);  // Cleared when on.
   setBit(&remote_state[5], kSamsungAcQuiet5Offset, on);
@@ -548,6 +569,8 @@ void IRSamsungAc::setQuiet(const bool on) {
   }
 }
 
+/// Get the Powerful (Turbo) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getPowerful(void) {
   return !(remote_state[8] & kSamsungAcPowerfulMask8) &&
          (GETBITS8(remote_state[10], kSamsungAcPowerful10Offset,
@@ -555,6 +578,8 @@ bool IRSamsungAc::getPowerful(void) {
          (this->getFan() == kSamsungAcFanTurbo);
 }
 
+/// Set the Powerful (Turbo) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setPowerful(const bool on) {
   uint8_t off_value = this->getBreeze() ? kSamsungAcBreezeOn : 0b000;
   setBits(&remote_state[10], kSamsungAcPowerful10Offset,
@@ -571,16 +596,18 @@ void IRSamsungAc::setPowerful(const bool on) {
   }
 }
 
-// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
-// Are the vanes closed over the fan outlet, to stop direct wind? Aka. WindFree
+/// Are the vanes closed over the fan outlet, to stop direct wind? Aka. WindFree
+/// @return true, the setting is on. false, the setting is off.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
 bool IRSamsungAc::getBreeze(void) {
   return (GETBITS8(remote_state[10], kSamsungAcBreezeOffset,
                    kSamsungAcBreezeSize) == kSamsungAcBreezeOn) &&
          (this->getFan() == kSamsungAcFanAuto && !getSwing());
 }
 
-// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
-// Closes the vanes over the fan outlet, to stop direct wind. Aka. WindFree
+/// Closes the vanes over the fan outlet, to stop direct wind. Aka. WindFree
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
 void IRSamsungAc::setBreeze(const bool on) {
   uint8_t off_value = this->getPowerful() ? kSamsungAcPowerful10On : 0b000;
   setBits(&remote_state[10], kSamsungAcBreezeOffset,
@@ -591,23 +618,33 @@ void IRSamsungAc::setBreeze(const bool on) {
   }
 }
 
+/// Get the Display (Light/LED) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getDisplay(void) {
   return GETBIT8(remote_state[10], kSamsungAcDisplayOffset);
 }
 
+/// Set the Display (Light/LED) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setDisplay(const bool on) {
   setBit(&remote_state[10], kSamsungAcDisplayOffset, on);
 }
 
+/// Get the Ion (Filter) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSamsungAc::getIon(void) {
   return GETBIT8(remote_state[11], kSamsungAcIonOffset);
 }
 
+/// Set the Ion (Filter) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSamsungAc::setIon(const bool on) {
   setBit(&remote_state[11], kSamsungAcIonOffset, on);
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRSamsungAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kSamsungAcCool;
@@ -618,7 +655,9 @@ uint8_t IRSamsungAc::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRSamsungAc::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -630,7 +669,9 @@ uint8_t IRSamsungAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRSamsungAc::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kSamsungAcCool: return stdAc::opmode_t::kCool;
@@ -641,7 +682,9 @@ stdAc::opmode_t IRSamsungAc::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRSamsungAc::toCommonFanSpeed(const uint8_t spd) {
   switch (spd) {
     case kSamsungAcFanTurbo: return stdAc::fanspeed_t::kMax;
@@ -652,7 +695,9 @@ stdAc::fanspeed_t IRSamsungAc::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRSamsungAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::SAMSUNG_AC;
@@ -678,7 +723,8 @@ stdAc::state_t IRSamsungAc::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRSamsungAc::toString(void) {
   String result = "";
   result.reserve(115);  // Reserve some heap for the string to reduce fragging.
@@ -723,21 +769,14 @@ String IRSamsungAc::toString(void) {
 }
 
 #if DECODE_SAMSUNG_AC
-// Decode the supplied Samsung A/C message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kSamsungAcBits
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: Stable / Known to be working.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+/// Decode the supplied Samsung A/C message.
+/// Status: Stable / Known to be working.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/505
 bool IRrecv::decodeSamsungAC(decode_results *results, uint16_t offset,
                              const uint16_t nbits, const bool strict) {
   if (results->rawlen < 2 * nbits + kHeader * 3 + kFooter * 2 - 1 + offset)

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -1,6 +1,23 @@
-// Samsung A/C
-//
 // Copyright 2018 David Conran
+/// @file
+/// @brief Support for Samsung protocols.
+/// Samsung originally added from https://github.com/shirriff/Arduino-IRremote/
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/505
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/621
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
+/// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
+
+// Supports:
+//   Brand: Samsung,  Model: UA55H6300 TV (SAMSUNG)
+//   Brand: Samsung,  Model: BN59-01178B TV remote (SAMSUNG)
+//   Brand: Samsung,  Model: DB63-03556X003 remote
+//   Brand: Samsung,  Model: DB93-16761C remote
+//   Brand: Samsung,  Model: IEC-R03 remote
+//   Brand: Samsung,  Model: AK59-00167A Bluray remote (SAMSUNG36)
+//   Brand: Samsung,  Model: AR09FSSDAWKNFA A/C (SAMSUNG_AC)
+//   Brand: Samsung,  Model: AR12KSFPEWQNET A/C (SAMSUNG_AC)
+//   Brand: Samsung,  Model: AR12HSSDBWKNEU A/C (SAMSUNG_AC)
+//   Brand: Samsung,  Model: AR12NXCXAWKXEU A/C (SAMSUNG_AC)
 
 #ifndef IR_SAMSUNG_H_
 #define IR_SAMSUNG_H_
@@ -16,21 +33,9 @@
 #include "IRsend_test.h"
 #endif
 
-// Supports:
-//   Brand: Samsung,  Model: UA55H6300 TV
-//   Brand: Samsung,  Model: DB63-03556X003 remote
-//   Brand: Samsung,  Model: DB93-16761C remote
-//   Brand: Samsung,  Model: IEC-R03 remote
-//   Brand: Samsung,  Model: AR09FSSDAWKNFA A/C
-//   Brand: Samsung,  Model: AR12KSFPEWQNET A/C
-//   Brand: Samsung,  Model: AR12HSSDBWKNEU A/C
-//   Brand: Samsung,  Model: AR12NXCXAWKXEU A/C
-
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/505
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
-
 // Constants
+
+// SamsungAc
 // Byte[1]
 // Checksum                                        0b11110000 ???
 const uint8_t kSamsungAcPower1Offset = 5;  // Mask 0b00100000
@@ -86,11 +91,11 @@ const uint16_t kSamsungAcSectionLength = 7;
 const uint64_t kSamsungAcPowerSection = 0x1D20F00000000;
 
 // Classes
+/// Class for handling detailed Samsung A/C messages.
 class IRSamsungAc {
  public:
   explicit IRSamsungAc(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
-
   void stateReset(const bool forcepower = true, const bool initialPower = true);
 #if SEND_SAMSUNG_AC
   void send(const uint16_t repeat = kSamsungAcDefaultRepeat,
@@ -99,6 +104,9 @@ class IRSamsungAc {
                     const bool calcchecksum = true);
   void sendOn(const uint16_t repeat = kSamsungAcDefaultRepeat);
   void sendOff(const uint16_t repeat = kSamsungAcDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SAMSUNG_AC
   void begin(void);
@@ -128,7 +136,6 @@ class IRSamsungAc {
   bool getDisplay(void);
   void setIon(const bool on);
   bool getIon(void);
-
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kSamsungAcStateLength);
@@ -145,13 +152,14 @@ class IRSamsungAc {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  // The state of the IR remote in IR code form.
-  uint8_t remote_state[kSamsungAcExtendedStateLength];
-  bool _forcepower;  // Hack to know when we need to send a special power mesg.
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote_state[kSamsungAcExtendedStateLength];  ///< State in code form.
+  bool _forcepower;  ///< Hack to know when we need to send a special power mesg
   bool _lastsentpowerstate;
   void checksum(const uint16_t length = kSamsungAcStateLength);
 };

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -1,7 +1,15 @@
 // Copyright 2009 Ken Shirriff
 // Copyright 2017, 2019 David Conran
 
-// Sharp remote emulation
+/// @file
+/// @brief Support for Sharp protocols.
+/// @see http://www.sbprojects.com/knowledge/ir/sharp.htm
+/// @see http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
+/// @see http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+/// @see http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+/// @see GlobalCache's IR Control Tower data.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/638
+/// @see https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
 
 #include "ir_Sharp.h"
 #include <algorithm>
@@ -16,9 +24,6 @@
 
 // Constants
 // period time = 1/38000Hz = 26.316 microseconds.
-// Ref:
-//   GlobalCache's IR Control Tower data.
-//   http://www.sbprojects.com/knowledge/ir/sharp.php
 const uint16_t kSharpTick = 26;
 const uint16_t kSharpBitMarkTicks = 10;
 const uint16_t kSharpBitMark = kSharpBitMarkTicks * kSharpTick;
@@ -44,28 +49,18 @@ using irutils::minsToString;
 using irutils::setBit;
 using irutils::setBits;
 
+// Also used by Denon protocol
 #if (SEND_SHARP || SEND_DENON)
-// Send a (raw) Sharp message
-//
-// Args:
-//   data:   Contents of the message to be sent.
-//   nbits:  Nr. of bits of data to be sent. Typically kSharpBits.
-//   repeat: Nr. of additional times the message is to be sent.
-//
-// Status: STABLE / Working fine.
-//
-// Notes:
-//   This procedure handles the inversion of bits required per protocol.
-//   The protocol spec says to send the LSB first, but legacy code & usage
-//   has us sending the MSB first. Grrrr. Normal invocation of encodeSharp()
-//   handles this for you, assuming you are using the correct/standard values.
-//   e.g. sendSharpRaw(encodeSharp(address, command));
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sharp.htm
-//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
-//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
-//   http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+/// Send a (raw) Sharp message
+/// @note Status: STABLE / Working fine.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note his procedure handles the inversion of bits required per protocol.
+///   The protocol spec says to send the LSB first, but legacy code & usage
+///   has us sending the MSB first. Grrrr. Normal invocation of encodeSharp()
+///   handles this for you, assuming you are using the correct/standard values.
+///   e.g. sendSharpRaw(encodeSharp(address, command));
 void IRsend::sendSharpRaw(const uint64_t data, const uint16_t nbits,
                           const uint16_t repeat) {
   uint64_t tempdata = data;
@@ -87,30 +82,20 @@ void IRsend::sendSharpRaw(const uint64_t data, const uint16_t nbits,
   }
 }
 
-// Encode a (raw) Sharp message from it's components.
-//
-// Args:
-//   address:   The value of the address to be sent.
-//   command:   The value of the address to be sent. (8 bits)
-//   expansion: The value of the expansion bit to use. (0 or 1, typically 1)
-//   check:     The value of the check bit to use. (0 or 1, typically 0)
-//   MSBfirst:  Flag indicating MSB first or LSB first order. (Default: false)
-// Returns:
-//   An uint32_t containing the raw Sharp message for sendSharpRaw().
-//
-// Status: STABLE / Works okay.
-//
-// Notes:
-//   Assumes the standard Sharp bit sizes.
-//   Historically sendSharp() sends address & command in
-//     MSB first order. This is actually incorrect. It should be sent in LSB
-//     order. The behaviour of sendSharp() hasn't been changed to maintain
-//     backward compatibility.
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sharp.htm
-//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
-//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+/// Encode a (raw) Sharp message from it's components.
+/// Status: STABLE / Works okay.
+/// @param[in] address The value of the address to be sent.
+/// @param[in] command The value of the address to be sent. (8 bits)
+/// @param[in] expansion The value of the expansion bit to use.
+///   (0 or 1, typically 1)
+/// @param[in] check The value of the check bit to use. (0 or 1, typically 0)
+/// @param[in] MSBfirst Flag indicating MSB first or LSB first order.
+/// @return A uint32_t containing the raw Sharp message for `sendSharpRaw()`.
+/// @note Assumes the standard Sharp bit sizes.
+///   Historically sendSharp() sends address & command in
+///   MSB first order. This is actually incorrect. It should be sent in LSB
+///   order. The behaviour of sendSharp() hasn't been changed to maintain
+///   backward compatibility.
 uint32_t IRsend::encodeSharp(const uint16_t address, const uint16_t command,
                              const uint16_t expansion, const uint16_t check,
                              const bool MSBfirst) {
@@ -129,60 +114,45 @@ uint32_t IRsend::encodeSharp(const uint16_t address, const uint16_t command,
          (tempexpansion << 1) | tempcheck;
 }
 
-// Send a Sharp message
-//
-// Args:
-//   address:  Address value to be sent.
-//   command:  Command value to be sent.
-//   nbits:    Nr. of bits of data to be sent. Typically kSharpBits.
-//   repeat:   Nr. of additional times the message is to be sent.
-//
-// Status:  DEPRICATED / Previously working fine.
-//
-// Notes:
-//   This procedure has a non-standard invocation style compared to similar
-//     sendProtocol() routines. This is due to legacy, compatibility, & historic
-//     reasons. Normally the calling syntax version is like sendSharpRaw().
-//   This procedure transmits the address & command in MSB first order, which is
-//     incorrect. This behaviour is left as-is to maintain backward
-//     compatibility with legacy code.
-//   In short, you should use sendSharpRaw(), encodeSharp(), and the correct
-//     values of address & command instead of using this, & the wrong values.
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sharp.htm
-//   http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
-//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+/// Send a Sharp message
+/// Status:  DEPRECATED / Previously working fine.
+/// @deprecated Only use this if you are using legacy from the original
+///   Arduino-IRremote library. 99% of the time, you will want to use
+///   `sendSharpRaw()` instead
+/// @param[in] address Address value to be sent.
+/// @param[in] command  Command value to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note This procedure has a non-standard invocation style compared to similar
+///   sendProtocol() routines. This is due to legacy, compatibility, & historic
+///   reasons. Normally the calling syntax version is like sendSharpRaw().
+///  This procedure transmits the address & command in MSB first order, which is
+///  incorrect. This behaviour is left as-is to maintain backward
+///  compatibility with legacy code.
+///  In short, you should use sendSharpRaw(), encodeSharp(), and the correct
+///  values of address & command instead of using this, & the wrong values.
 void IRsend::sendSharp(const uint16_t address, uint16_t const command,
                        const uint16_t nbits, const uint16_t repeat) {
   sendSharpRaw(encodeSharp(address, command, 1, 0, true), nbits, repeat);
 }
 #endif  // (SEND_SHARP || SEND_DENON)
 
+// Used by decodeDenon too.
 #if (DECODE_SHARP || DECODE_DENON)
-// Decode the supplied Sharp message.
-//
-// Args:
-//   results:   Ptr to the data to decode and where to store the decode result.
-//   offset:    The starting index to use when attempting to decode the raw data
-//              Typically/Defaults to kStartOffset.
-//   nbits:     Nr. of data bits to expect. Typically kSharpBits.
-//   strict:    Flag indicating if we should perform strict matching.
-//   expansion: Should we expect the expansion bit to be set. Default is true.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Working fine.
-//
-// Note:
-//   This procedure returns a value suitable for use in sendSharpRaw().
-// TODO(crankyoldgit): Need to ensure capture of the inverted message as it can
-//   be missed due to the interrupt timeout used to detect an end of message.
-//   Several compliance checks are disabled until that is resolved.
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sharp.php
-//   http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
-//   http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+/// Decode the supplied Sharp message.
+/// Status: STABLE / Working fine.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @param[in] expansion Should we expect the expansion bit to be set.
+///   Default is true.
+/// @return True if it can decode it, false if it can't.
+/// @note This procedure returns a value suitable for use in `sendSharpRaw()`.
+/// @todo Need to ensure capture of the inverted message as it can
+///   be missed due to the interrupt timeout used to detect an end of message.
+///   Several compliance checks are disabled until that is resolved.
 bool IRrecv::decodeSharp(decode_results *results, uint16_t offset,
                          const uint16_t nbits, const bool strict,
                          const bool expansion) {
@@ -247,18 +217,13 @@ bool IRrecv::decodeSharp(decode_results *results, uint16_t offset,
 #endif  // (DECODE_SHARP || DECODE_DENON)
 
 #if SEND_SHARP_AC
-// Send a Sharp A/C message.
-//
-// Args:
-//   data: An array of kSharpAcStateLength bytes containing the IR command.
-//   nbytes: Nr. of bytes of data to send. i.e. length of `data`.
-//   repeat: Nr. of times the message should be repeated.
-//
-// Status: Alpha / Untested.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/638
-//   https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+/// Send a Sharp A/C message.
+/// Status: Alpha / Untested.
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/638
+/// @see https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
 void IRsend::sendSharpAc(const unsigned char data[], const uint16_t nbytes,
                          const uint16_t repeat) {
   if (nbytes < kSharpAcStateLength)
@@ -272,6 +237,11 @@ void IRsend::sendSharpAc(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_SHARP_AC
 
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRSharpAc object.
 IRSharpAc::IRSharpAc(const uint16_t pin, const bool inverted,
                      const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
@@ -279,17 +249,17 @@ IRSharpAc::IRSharpAc(const uint16_t pin, const bool inverted,
 void IRSharpAc::begin(void) { _irsend.begin(); }
 
 #if SEND_SHARP_AC
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
 void IRSharpAc::send(const uint16_t repeat) {
   _irsend.sendSharpAc(getRaw(), kSharpAcStateLength, repeat);
 }
 #endif  // SEND_SHARP_AC
 
-// Calculate the checksum for a given state.
-// Args:
-//   state:  The array to verify the checksums of.
-//   length: The size of the state.
-// Returns:
-//   The 4 bit checksum.
+/// Calculate the checksum for a given state.
+/// @param[in] state The array to calc the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return The calculated 4-bit checksum value.
 uint8_t IRSharpAc::calcChecksum(uint8_t state[], const uint16_t length) {
   uint8_t xorsum = xorBytes(state, length - 1);
   xorsum ^= GETBITS8(state[length - 1], kLowNibble, kNibbleSize);
@@ -297,23 +267,22 @@ uint8_t IRSharpAc::calcChecksum(uint8_t state[], const uint16_t length) {
   return GETBITS8(xorsum, kLowNibble, kNibbleSize);
 }
 
-// Verify the checksums are valid for a given state.
-// Args:
-//   state:  The array to verify the checksums of.
-//   length: The size of the state.
-// Returns:
-//   A boolean.
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRSharpAc::validChecksum(uint8_t state[], const uint16_t length) {
   return GETBITS8(state[length - 1], kHighNibble, kNibbleSize) ==
       IRSharpAc::calcChecksum(state, length);
 }
 
-// Calculate and set the checksum values for the internal state.
+/// Calculate and set the checksum values for the internal state.
 void IRSharpAc::checksum(void) {
   setBits(&remote[kSharpAcStateLength - 1], kHighNibble, kNibbleSize,
           this->calcChecksum(remote));
 }
 
+/// Reset the state of the remote to a known good state/sequence.
 void IRSharpAc::stateReset(void) {
   static const uint8_t reset[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0x00, 0x01, 0x00, 0x00, 0x08, 0x80, 0x00, 0xE0,
@@ -324,31 +293,42 @@ void IRSharpAc::stateReset(void) {
   _fan = getFan();
 }
 
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
 uint8_t *IRSharpAc::getRaw(void) {
   this->checksum();  // Ensure correct settings before sending.
   return remote;
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
+/// @param[in] length The length/size of the new_code array.
 void IRSharpAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote, new_code, std::min(length, kSharpAcStateLength));
 }
 
+/// Set the value of the Power Special setting without any checks.
+/// @param[in] value The value to set Power Special to.
 void IRSharpAc::setPowerSpecial(const uint8_t value) {
   setBits(&remote[kSharpAcBytePowerSpecial], kSharpAcPowerSetSpecialOffset,
           kSharpAcPowerSpecialSize, value);
 }
 
+/// Get the value of the Power Special setting.
+/// @return The setting's value.
 uint8_t IRSharpAc::getPowerSpecial(void) {
   return GETBITS8(remote[kSharpAcBytePowerSpecial],
                   kSharpAcPowerSetSpecialOffset, kSharpAcPowerSpecialSize);
 }
 
-// Clear the "special"/non-normal bits in the power section.
-// e.g. for normal/common command modes.
+/// Clear the "special"/non-normal bits in the power section.
+/// e.g. for normal/common command modes.
 void IRSharpAc::clearPowerSpecial(void) {
   setPowerSpecial(getPowerSpecial() & kSharpAcPowerOn);
 }
 
+/// Is one of the special power states in use?
+/// @return true, it is. false, it isn't.
 bool IRSharpAc::isPowerSpecial(void) {
   switch (getPowerSpecial()) {
     case kSharpAcPowerSetSpecialOff:
@@ -358,10 +338,15 @@ bool IRSharpAc::isPowerSpecial(void) {
   }
 }
 
+/// Set the requested power state of the A/C to on.
 void IRSharpAc::on(void) { setPower(true); }
 
+/// Set the requested power state of the A/C to off.
 void IRSharpAc::off(void) { setPower(false); }
 
+/// Change the power setting, including the previous power state.
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @param[in] prev_on true, the setting is on. false, the setting is off.
 void IRSharpAc::setPower(const bool on, const bool prev_on) {
   setPowerSpecial(on ? (prev_on ? kSharpAcPowerOn : kSharpAcPowerOnFromOff)
                      : kSharpAcPowerOff);
@@ -370,6 +355,8 @@ void IRSharpAc::setPower(const bool on, const bool prev_on) {
   setSpecial(kSharpAcSpecialPower);
 }
 
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getPower(void) {
   switch (getPowerSpecial()) {
     case kSharpAcPowerUnknown:
@@ -378,6 +365,8 @@ bool IRSharpAc::getPower(void) {
   }
 }
 
+/// Set the value of the Special (button/command?) setting.
+/// @param[in] mode The value to set Special to.
 void IRSharpAc::setSpecial(const uint8_t mode) {
   switch (mode) {
     case kSharpAcSpecialPower:
@@ -394,12 +383,13 @@ void IRSharpAc::setSpecial(const uint8_t mode) {
   }
 }
 
+/// Get the value of the Special (button/command?) setting.
+/// @return The setting's value.
 uint8_t IRSharpAc::getSpecial(void) { return remote[kSharpAcByteSpecial]; }
 
-// Set the temp in deg C
-// Args:
-//   temp: Desired Temperature (Celsius)
-//   save: Do we save this Temperature as a user set temp? (Default: true)
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
+/// @param[in] save Do we save this setting as a user set one?
 void IRSharpAc::setTemp(const uint8_t temp, const bool save) {
   switch (this->getMode()) {
     // Auto & Dry don't allow temp changes and have a special temp.
@@ -419,15 +409,22 @@ void IRSharpAc::setTemp(const uint8_t temp, const bool save) {
   clearPowerSpecial();
 }
 
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRSharpAc::getTemp(void) {
   return GETBITS8(remote[kSharpAcByteTemp], kLowNibble, kNibbleSize) +
       kSharpAcMinTemp;
 }
 
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRSharpAc::getMode(void) {
   return GETBITS8(remote[kSharpAcByteMode], kLowNibble, kSharpAcModeSize);
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @param[in] save Do we save this setting as a user set one?
 void IRSharpAc::setMode(const uint8_t mode, const bool save) {
   switch (mode) {
     case kSharpAcAuto:
@@ -452,7 +449,9 @@ void IRSharpAc::setMode(const uint8_t mode, const bool save) {
   clearPowerSpecial();
 }
 
-// Set the speed of the fan
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
+/// @param[in] save Do we save this setting as a user set one?
 void IRSharpAc::setFan(const uint8_t speed, const bool save) {
   switch (speed) {
     case kSharpAcFanAuto:
@@ -472,57 +471,76 @@ void IRSharpAc::setFan(const uint8_t speed, const bool save) {
   clearPowerSpecial();
 }
 
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRSharpAc::getFan(void) {
   return GETBITS8(remote[kSharpAcByteFan], kSharpAcFanOffset, kSharpAcFanSize);
 }
 
+/// Get the Turbo setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getTurbo(void) {
   return (getPowerSpecial() == kSharpAcPowerSetSpecialOn) &&
          (getSpecial() == kSharpAcSpecialTurbo);
 }
 
-// Note: If you use this method, you will need to send it before making
-//       other changes to the settings, as they may overwrite some of the bits
-//       used by this setting.
+/// Set the Turbo setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @note If you use this method, you will need to send it before making
+///   other changes to the settings, as they may overwrite some of the bits
+///   used by this setting.
 void IRSharpAc::setTurbo(const bool on) {
   if (on) setFan(kSharpAcFanMax);
   setPowerSpecial(on ? kSharpAcPowerSetSpecialOn : kSharpAcPowerSetSpecialOff);
   setSpecial(kSharpAcSpecialTurbo);
 }
 
+/// Get the (vertical) Swing Toggle setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getSwingToggle(void) {
   return GETBITS8(remote[kSharpAcByteSwing], kSharpAcSwingOffset,
                   kSharpAcSwingSize) == kSharpAcSwingToggle;
 }
 
+/// Set the (vertical) Swing Toggle setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSharpAc::setSwingToggle(const bool on) {
   setBits(&remote[kSharpAcByteSwing], kSharpAcSwingOffset, kSharpAcSwingSize,
           on ? kSharpAcSwingToggle : kSharpAcSwingNoToggle);
   if (on) setSpecial(kSharpAcSpecialSwing);
 }
 
+/// Get the Ion (Filter) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getIon(void) {
   return GETBIT8(remote[kSharpAcByteIon], kSharpAcBitIonOffset);
 }
 
+/// Set the Ion (Filter) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRSharpAc::setIon(const bool on) {
   setBit(&remote[kSharpAcByteIon], kSharpAcBitIonOffset, on);
   clearPowerSpecial();
   if (on) setSpecial(kSharpAcSpecialSwing);
 }
 
+/// Get the Economical mode toggle setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getEconoToggle(void) {
   return (getPowerSpecial() == kSharpAcPowerSetSpecialOn) &&
          (getSpecial() == kSharpAcSpecialTempEcono);
 }
 
-// Warning: Probably incompatible with `setTurbo()`
+/// Set the Economical mode toggle setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @warning Probably incompatible with `setTurbo()`
 void IRSharpAc::setEconoToggle(const bool on) {
   if (on) setSpecial(kSharpAcSpecialTempEcono);
   setPowerSpecial(on ? kSharpAcPowerSetSpecialOn : kSharpAcPowerSetSpecialOff);
 }
 
-// Returns how long the timer is set for, in minutes.
+/// Get how long the timer is set for, in minutes.
+/// @return The time in nr of minutes.
 uint16_t IRSharpAc::getTimerTime(void) {
   return GETBITS8(remote[kSharpAcByteTimer], kSharpAcTimerHoursOffset,
                   kSharpAcTimerHoursSize) * kSharpAcTimerIncrement * 2 +
@@ -530,21 +548,23 @@ uint16_t IRSharpAc::getTimerTime(void) {
                                                       : 0);
 }
 
+/// Is the Timer enabled?
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getTimerEnabled(void) {
   return GETBIT8(remote[kSharpAcByteTimer], kSharpAcBitTimerEnabled);
 }
 
+/// Get the current timer type.
+/// @return true, It's an "On" timer. false, It's an "Off" timer.
 bool IRSharpAc::getTimerType(void) {
   return GETBIT8(remote[kSharpAcByteTimer], kSharpAcBitTimerType);
 }
 
-// Set or cancel the timer function.
-// Args:
-//   enable:     Is the timer to be enabled (true) or canceled(false)?
-//   timer_type: An On (true) or an Off (false). Ignored if canceled.
-//   mins:       Nr. of minutes the timer is to be set to.
-//                 Rounds down to 30 min increments.
-//                 (max: 720 mins (12h), 0 is Off)
+/// Set or cancel the timer function.
+/// @param[in] enable Is the timer to be enabled (true) or canceled(false)?
+/// @param[in] timer_type An On (true) or an Off (false). Ignored if canceled.
+/// @param[in] mins Nr. of minutes the timer is to be set to.
+/// @note Rounds down to 30 min increments. (max: 720 mins (12h), 0 is Off)
 void IRSharpAc::setTimer(bool enable, bool timer_type, uint16_t mins) {
   uint8_t half_hours = std::min(mins / kSharpAcTimerIncrement,
                                 kSharpAcTimerHoursMax * 2);
@@ -563,11 +583,15 @@ void IRSharpAc::setTimer(bool enable, bool timer_type, uint16_t mins) {
   setPowerSpecial(kSharpAcPowerTimerSetting);
 }
 
+/// Get the Clean setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRSharpAc::getClean(void) {
   return GETBIT8(remote[kSharpAcByteClean], kSharpAcBitCleanOffset);
 }
 
-// Note: Officially A/C unit needs to be "Off" before clean mode can be entered.
+/// Set the Economical mode toggle setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+/// @note Officially A/C unit needs to be "Off" before clean mode can be entered
 void IRSharpAc::setClean(const bool on) {
   // Clean mode appears to be just default dry mode, with an extra bit set.
   if (on) {
@@ -582,7 +606,9 @@ void IRSharpAc::setClean(const bool on) {
   clearPowerSpecial();
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRSharpAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kSharpAcCool;
@@ -593,7 +619,9 @@ uint8_t IRSharpAc::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRSharpAc::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -605,7 +633,9 @@ uint8_t IRSharpAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRSharpAc::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kSharpAcCool: return stdAc::opmode_t::kCool;
@@ -615,7 +645,9 @@ stdAc::opmode_t IRSharpAc::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] speed The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRSharpAc::toCommonFanSpeed(const uint8_t speed) {
   switch (speed) {
     case kSharpAcFanMax:  return stdAc::fanspeed_t::kMax;
@@ -626,7 +658,8 @@ stdAc::fanspeed_t IRSharpAc::toCommonFanSpeed(const uint8_t speed) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRSharpAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::SHARP_AC;
@@ -652,7 +685,8 @@ stdAc::state_t IRSharpAc::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRSharpAc::toString(void) {
   String result = "";
   result.reserve(135);  // Reserve some heap for the string to reduce fragging.
@@ -676,21 +710,16 @@ String IRSharpAc::toString(void) {
 }
 
 #if DECODE_SHARP_AC
-// Decode the supplied Sharp A/C message.
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   Nr. of bits to expect in the data portion. (kSharpAcBits)
-//   strict:  Flag to indicate if we strictly adhere to the specification.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Known working.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/638
-//   https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+/// Decode the supplied Sharp A/C message.
+/// Status: STABLE / Known working.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/638
+/// @see https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
 bool IRrecv::decodeSharpAc(decode_results *results, uint16_t offset,
                            const uint16_t nbits, const bool strict) {
   // Compliance

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -1,5 +1,15 @@
 // Copyright 2019 crankyoldgit
 
+/// @file
+/// @brief Support for Sharp protocols.
+/// @see http://www.sbprojects.com/knowledge/ir/sharp.htm
+/// @see http://lirc.sourceforge.net/remotes/sharp/GA538WJSA
+/// @see http://www.mwftr.com/ucF08/LEC14%20PIC%20IR.pdf
+/// @see http://www.hifi-remote.com/johnsfine/DecodeIR.html#Sharp
+/// @see GlobalCache's IR Control Tower data.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/638
+/// @see https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+
 // Supports:
 //   Brand: Sharp,  Model: LC-52D62U TV
 //   Brand: Sharp,  Model: AY-ZP40KR A/C
@@ -93,14 +103,17 @@ const uint8_t kSharpAcByteIon = 11;
 const uint8_t kSharpAcBitIonOffset = 2;  // Mask 0b00000x00
 // Byte[12] (Checksum)
 
-
+// Classes
+/// Class for handling detailed Sharp A/C messages.
 class IRSharpAc {
  public:
   explicit IRSharpAc(const uint16_t pin, const bool inverted = false,
                      const bool use_modulation = true);
-
 #if SEND_SHARP_AC
   void send(const uint16_t repeat = kSharpAcDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SHARP_AC
   void begin(void);
@@ -145,15 +158,16 @@ class IRSharpAc {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  // # of bytes per command
-  uint8_t remote[kSharpAcStateLength];
-  uint8_t _temp;  // Saved copy of the desired temp.
-  uint8_t _mode;  // Saved copy of the desired mode.
-  uint8_t _fan;  // Saved copy of the desired fan speed.
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote[kSharpAcStateLength];  ///< State of the remote in IR code form
+  uint8_t _temp;  ///< Saved copy of the desired temp.
+  uint8_t _mode;  ///< Saved copy of the desired mode.
+  uint8_t _fan;  ///< Saved copy of the desired fan speed.
   void stateReset(void);
   void checksum(void);
   static uint8_t calcChecksum(uint8_t state[],

--- a/src/ir_Sherwood.cpp
+++ b/src/ir_Sherwood.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 David Conran
 
-// Sherwood IR remote emulation
+/// @file
+/// @brief Support for Sherwood protocols.
 
 // Supports:
 //   Brand: Sherwood,  Model: RC-138 remote
@@ -10,19 +11,14 @@
 #include "IRsend.h"
 
 #if SEND_SHERWOOD
-// Send an IR command to a Sherwood device.
-//
-// Args:
-//   data:   The contents of the command you want to send.
-//   nbits:  The bit size of the command being sent. (kSherwoodBits)
-//   repeat: The nr. of times you want the command to be repeated. (Default: 1)
-//
-// Status: STABLE / Known working.
-//
-// Note:
-//   Sherwood remote codes appear to be NEC codes with a manditory repeat code.
-//   i.e. repeat should be >= kSherwoodMinRepeat (1).
+/// Send an IR command to a Sherwood device.
+/// Status: STABLE / Known working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note Sherwood remote codes appear to be NEC codes with a manditory repeat
+///   code. i.e. repeat should be >= kSherwoodMinRepeat (1).
 void IRsend::sendSherwood(uint64_t data, uint16_t nbits, uint16_t repeat) {
   sendNEC(data, nbits, std::max((uint16_t)kSherwoodMinRepeat, repeat));
 }
-#endif
+#endif  // SEND_SHERWOOD

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -2,7 +2,12 @@
 // Copyright 2016 marcosamarinho
 // Copyright 2017,2020 David Conran
 
-// Sony Remote Emulation
+/// @file
+/// @brief Support for Sony SIRC(Serial Infra-Red Control) protocols.
+/// Sony originally added from https://github.com/shirriff/Arduino-IRremote/
+/// Updates from marcosamarinho
+/// @see http://www.sbprojects.com/knowledge/ir/sirc.php
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1018
 
 // Supports:
 //   Brand: Sony,  Model: HT-CT380 Soundbar (Uses 38kHz & 3 repeats)
@@ -12,12 +17,8 @@
 #include "IRsend.h"
 #include "IRutils.h"
 
-// Sony originally added from https://github.com/shirriff/Arduino-IRremote/
-// Updates from marcosamarinho
 
 // Constants
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sirc.php
 const uint16_t kSonyTick = 200;
 const uint16_t kSonyHdrMarkTicks = 12;
 const uint16_t kSonyHdrMark = kSonyHdrMarkTicks * kSonyTick;
@@ -35,80 +36,57 @@ const uint16_t kSonyStdFreq = 40000;  // kHz
 const uint16_t kSonyAltFreq = 38000;  // kHz
 
 #if SEND_SONY
-// Send a standard Sony/SIRC(Serial Infra-Red Control) message. (40kHz)
-//
-// Args:
-//   data: message to be sent.
-//   nbits: Nr. of bits of the message to be sent.
-//   repeat: Nr. of additional times the message is to be sent. (Default: 2)
-//
-// Status: STABLE / Known working.
-//
-// Notes:
-//   sendSony() should typically be called with repeat=2 as Sony devices
-//   expect the message to be sent at least 3 times.
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sirc.php
-void IRsend::sendSony(uint64_t data, uint16_t nbits, uint16_t repeat) {
+/// Send a standard Sony/SIRC(Serial Infra-Red Control) message. (40kHz)
+/// Status: STABLE / Known working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note sendSony() should typically be called with repeat=2 as Sony devices
+///   expect the message to be sent at least 3 times.
+void IRsend::sendSony(const uint64_t data, const uint16_t nbits,
+                      const uint16_t repeat) {
   _sendSony(data, nbits, repeat, kSonyStdFreq);
 }
 
-// Send an alternative 38kHz Sony/SIRC(Serial Infra-Red Control) message.
-//
-// Args:
-//   data: message to be sent.
-//   nbits: Nr. of bits of the message to be sent.
-//   repeat: Nr. of additional times the message is to be sent. (Default: 3)
-//
-// Status: STABLE / Known working.
-//
-// Notes:
-//   - `sendSony38()`` should typically be called with repeat=3 as these Sony
-//      devices expect the message to be sent at least 4 times.
-//   - Messages send via this method will be detected by this library as just
-//     `SONY`, not `SONY_38K` as the library has no way to determine the
-//     modulation frequency used. Hence, there is no `decodeSony38()`.
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sirc.php
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1018
-void IRsend::sendSony38(uint64_t data, uint16_t nbits, uint16_t repeat) {
+/// Send an alternative 38kHz Sony/SIRC(Serial Infra-Red Control) message.
+/// Status: STABLE / Known working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note `sendSony38()` should typically be called with repeat=3 as these Sony
+///   devices expect the message to be sent at least 4 times.
+/// @warning Messages send via this method will be detected by this library as
+///   just `SONY`, not `SONY_38K` as the library has no way to determine the
+///   modulation frequency used. Hence, there is no `decodeSony38()`.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1018
+void IRsend::sendSony38(const uint64_t data, const uint16_t nbits,
+                        const uint16_t repeat) {
   _sendSony(data, nbits, repeat, kSonyAltFreq);
 }
 
-// Internal procedure to generate a Sony/SIRC(Serial Infra-Red Control) message.
-//
-// Args:
-//   data: message to be sent.
-//   nbits: Nr. of bits of the message to be sent.
-//   repeat: Nr. of additional times the message is to be sent.
-//   freq: Frequency of the modulation to transmit at. (Hz or kHz)
-//
-// Status: STABLE / Known working.
-//
-// Ref:
-//   http://www.sbprojects.com/knowledge/ir/sirc.php
-void IRsend::_sendSony(uint64_t data, uint16_t nbits, uint16_t repeat,
-                      uint16_t freq) {
+/// Internal procedure to generate a Sony/SIRC(Serial Infra-Red Control) message
+/// Status: STABLE / Known working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @param[in] freq Frequency of the modulation to transmit at. (Hz or kHz)
+void IRsend::_sendSony(const uint64_t data, const uint16_t nbits,
+                       const uint16_t repeat, const uint16_t freq) {
   sendGeneric(kSonyHdrMark, kSonySpace, kSonyOneMark, kSonySpace, kSonyZeroMark,
               kSonySpace,
               0,  // No Footer mark.
               kSonyMinGap, kSonyRptLength, data, nbits, freq, true, repeat, 33);
 }
 
-// Convert Sony/SIRC command, address, & extended bits into sendSony format.
-// Args:
-//   nbits:    Sony protocol bit size.
-//   command:  Sony command bits.
-//   address:  Sony address bits.
-//   extended: Sony extended bits.
-// Returns:
-//   A sendSony compatible data message.
-//
-// Status: STABLE / Should be working.
-uint32_t IRsend::encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
-                            uint16_t extended) {
+/// Convert Sony/SIRC command, address, & extended bits into sendSony format.
+/// Status: STABLE / Should be working.
+/// @param[in] nbits Sony protocol bit size.
+/// @param[in] command Sony command bits.
+/// @param[in] address Sony address bits.
+/// @param[in] extended Sony extended bits.
+/// @return A `sendSony()` etc compatible data message.
+uint32_t IRsend::encodeSony(const uint16_t nbits, const uint16_t command,
+                            const uint16_t address, const uint16_t extended) {
   uint32_t result = 0;
   switch (nbits) {
     case 12:  // 5 address bits.
@@ -127,26 +105,19 @@ uint32_t IRsend::encodeSony(uint16_t nbits, uint16_t command, uint16_t address,
   result = (result << 7) | (command & 0x7F);  // All sizes have 7 command bits.
   return reverseBits(result, nbits);  // sendSony uses reverse ordered bits.
 }
-#endif
+#endif  // SEND_SONY
 
 #if DECODE_SONY
-// Decode the supplied Sony/SIRC message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect.
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Should be working. strict mode is ALPHA / Untested.
-//
-// Notes:
-//   SONY protocol, SIRC (Serial Infra-Red Control) can be 12,15,20 bits long.
-// Ref:
-// http://www.sbprojects.com/knowledge/ir/sirc.php
+/// Decode the supplied Sony/SIRC message.
+/// Status: STABLE / Should be working. strict mode is ALPHA / Untested.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
+/// @note SONY protocol, SIRC (Serial Infra-Red Control) can be 12, 15, or 20
+///   bits long.
 bool IRrecv::decodeSony(decode_results *results, uint16_t offset,
                         const uint16_t nbits, const bool strict) {
   if (results->rawlen <= 2 * nbits + kHeader - 1 + offset)
@@ -217,4 +188,4 @@ bool IRrecv::decodeSony(decode_results *results, uint16_t offset,
   }
   return true;
 }
-#endif
+#endif  // DECODE_SONY

--- a/src/ir_Symphony.cpp
+++ b/src/ir_Symphony.cpp
@@ -1,6 +1,10 @@
 // Copyright 2020 David Conran
 
-// Send & decode support for Symphony added by David Conran
+/// @file
+/// @brief Support for Symphony protocols.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1057
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1105
+/// @see https://www.alldatasheet.com/datasheet-pdf/pdf/124369/ANALOGICTECH/SM5021B.html
 
 // Supports:
 //   Brand: Symphony,  Model: Air Cooler 3Di
@@ -22,8 +26,6 @@
 #include "IRutils.h"
 
 // Constants
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1057
 const uint16_t kSymphonyZeroMark = 400;
 const uint16_t kSymphonyZeroSpace = 1250;
 const uint16_t kSymphonyOneMark = kSymphonyZeroSpace;
@@ -32,19 +34,11 @@ const uint32_t kSymphonyFooterGap = 4 * (kSymphonyZeroMark +
                                          kSymphonyZeroSpace);
 
 #if SEND_SYMPHONY
-// Send a Symphony packet.
-//
-// Args:
-//   data: The data we want to send. MSB first.
-//   nbits: The number of bits of data to send. (Typically 12, 24, or 32[Nokia])
-//   repeat: The nr. of times the message should be sent.
-//
-// Status:  STABLE / Should be working.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1057
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1105
-//   https://www.alldatasheet.com/datasheet-pdf/pdf/124369/ANALOGICTECH/SM5021B.html
+/// Send a Symphony packet.
+/// Status:  STABLE / Should be working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendSymphony(uint64_t data, uint16_t nbits, uint16_t repeat) {
   sendGeneric(0, 0,
               kSymphonyOneMark, kSymphonyOneSpace,
@@ -55,23 +49,14 @@ void IRsend::sendSymphony(uint64_t data, uint16_t nbits, uint16_t repeat) {
 #endif  // SEND_SYMPHONY
 
 #if DECODE_SYMPHONY
-// Decode a Symphony packet if possible.
-// Places successful decode information in the results pointer.
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   Nr. of bits to expect in the data portion. Typically kSymphonyBits
-//   strict:  Flag to indicate if we strictly adhere to the specification.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status:  STABLE / Should be working.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1057
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/1105
-//   https://www.alldatasheet.com/datasheet-pdf/pdf/124369/ANALOGICTECH/SM5021B.html
+/// Decode the supplied Symphony packet/message.
+/// Status: STABLE / Should be working.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeSymphony(decode_results *results, uint16_t offset,
                             const uint16_t nbits, const bool strict) {
   uint64_t data = 0;


### PR DESCRIPTION
Document & doxify all the methods for protocols beginning with `S`:
* Samsung
* Sanyo
* Sharp
* Sherwood
* Sony
* Symphony

Includes some changes of parameters to `const`s where appropriate, and some doxygen comments for Neoclima too