### PR TITLE
Total Vexation With Doxygen!

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -337,8 +337,8 @@ class IRsend {
                   uint16_t repeat = kCoolixDefaultRepeat);
 #endif
 #if SEND_WHYNTER
-  void sendWhynter(uint64_t data, uint16_t nbits = kWhynterBits,
-                   uint16_t repeat = kNoRepeat);
+  void sendWhynter(const uint64_t data, const uint16_t nbits = kWhynterBits,
+                   const uint16_t repeat = kNoRepeat);
 #endif
 #if SEND_MITSUBISHI
   void sendMitsubishi(uint64_t data, uint16_t nbits = kMitsubishiBits,

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -105,6 +105,7 @@ uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
 ///   raw data. Typically/Defaults to kStartOffset.
 /// @param[in] nbits The number of data bits to expect.
 /// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 /// @note LG 32bit protocol appears near identical to the Samsung protocol.
 ///   They differ on their compliance criteria and how they repeat.
 /// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
@@ -180,6 +181,7 @@ void IRsend::sendSamsung36(const uint64_t data, const uint16_t nbits,
 ///   raw data. Typically/Defaults to kStartOffset.
 /// @param[in] nbits The number of data bits to expect.
 /// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/621
 bool IRrecv::decodeSamsung36(decode_results *results, uint16_t offset,
                              const uint16_t nbits, const bool strict) {
@@ -775,6 +777,7 @@ String IRSamsungAc::toString(void) {
 ///   raw data. Typically/Defaults to kStartOffset.
 /// @param[in] nbits The number of data bits to expect.
 /// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/505
 bool IRrecv::decodeSamsungAC(decode_results *results, uint16_t offset,
                              const uint16_t nbits, const bool strict) {

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -318,7 +318,7 @@ bool IRSamsungAc::validChecksum(const uint8_t state[], const uint16_t length) {
 }
 
 /// Update the checksum for the internal state.
-/// @param[in] length The length/size of the nternal array to checksum.
+/// @param[in] length The length/size of the internal array to checksum.
 void IRSamsungAc::checksum(uint16_t length) {
   if (length < 13) return;
   setBits(&remote_state[length - 6], kHighNibble, kNibbleSize,
@@ -694,7 +694,6 @@ stdAc::fanspeed_t IRSamsungAc::toCommonFanSpeed(const uint8_t spd) {
     default:                 return stdAc::fanspeed_t::kAuto;
   }
 }
-
 
 /// Convert the current internal state into its stdAc::state_t equivilant.
 /// @return The stdAc equivilant of the native settings.

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -110,10 +110,10 @@ void IRTcl112Ac::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote_state, new_code, std::min(length, kTcl112AcStateLength));
 }
 
-// Set the requested power state of the A/C to on.
+/// Set the requested power state of the A/C to on.
 void IRTcl112Ac::on(void) { this->setPower(true); }
 
-// Set the requested power state of the A/C to off.
+/// Set the requested power state of the A/C to off.
 void IRTcl112Ac::off(void) { this->setPower(false); }
 
 /// Change the power setting.

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -1,5 +1,8 @@
 // Copyright 2019 David Conran
 
+/// @file
+/// @brief Support for TCL protocols.
+
 #include "ir_Tcl.h"
 #include <algorithm>
 #include <cstring>
@@ -22,6 +25,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_TCL112AC
+/// Send a TCL 112-bit A/C message.
+/// Status: Beta / Probably working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendTcl112Ac(const unsigned char data[], const uint16_t nbytes,
                           const uint16_t repeat) {
   sendGeneric(kTcl112AcHdrMark, kTcl112AcHdrSpace,
@@ -32,24 +40,30 @@ void IRsend::sendTcl112Ac(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TCL112AC
 
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRTcl112Ac object.
 IRTcl112Ac::IRTcl112Ac(const uint16_t pin, const bool inverted,
                        const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
+/// Set up hardware to be able to send a message.
 void IRTcl112Ac::begin(void) { this->_irsend.begin(); }
 
 #if SEND_TCL112AC
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
 void IRTcl112Ac::send(const uint16_t repeat) {
   this->_irsend.sendTcl112Ac(getRaw(), kTcl112AcStateLength, repeat);
 }
 #endif  // SEND_TCL112AC
 
-// Calculate the checksum for a given array.
-// Args:
-//   state:  The array to calculate the checksum over.
-//   length: The size of the array.
-// Returns:
-//   The 8 bit checksum value.
+/// Calculate the checksum for a given state.
+/// @param[in] state The array to calc the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return The calculated checksum value.
 uint8_t IRTcl112Ac::calcChecksum(uint8_t state[], const uint16_t length) {
   if (length)
     return sumBytes(state, length - 1);
@@ -57,23 +71,23 @@ uint8_t IRTcl112Ac::calcChecksum(uint8_t state[], const uint16_t length) {
     return 0;
 }
 
-// Calculate & set the checksum for the current internal state of the remote.
+/// Calculate & set the checksum for the current internal state of the remote.
+/// @param[in] length The length/size of the internal array to checksum.
 void IRTcl112Ac::checksum(const uint16_t length) {
   // Stored the checksum value in the last byte.
   if (length > 1)
     remote_state[length - 1] = calcChecksum(remote_state, length);
 }
 
-// Verify the checksum is valid for a given state.
-// Args:
-//   state:  The array to verify the checksum of.
-//   length: The size of the state.
-// Returns:
-//   A boolean.
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRTcl112Ac::validChecksum(uint8_t state[], const uint16_t length) {
   return (length > 1 && state[length - 1] == calcChecksum(state, length));
 }
 
+/// Reset the internal state of the emulation. (On, Cool, 24C)
 void IRTcl112Ac::stateReset(void) {
   // A known good state. (On, Cool, 24C)
   static const uint8_t reset[kTcl112AcStateLength] = {
@@ -82,11 +96,16 @@ void IRTcl112Ac::stateReset(void) {
   memcpy(remote_state, reset, kTcl112AcStateLength);
 }
 
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
 uint8_t* IRTcl112Ac::getRaw(void) {
   this->checksum();
   return remote_state;
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
+/// @param[in] length The length/size of the new_code array.
 void IRTcl112Ac::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote_state, new_code, std::min(length, kTcl112AcStateLength));
 }
@@ -97,26 +116,28 @@ void IRTcl112Ac::on(void) { this->setPower(true); }
 // Set the requested power state of the A/C to off.
 void IRTcl112Ac::off(void) { this->setPower(false); }
 
-// Set the requested power state of the A/C.
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setPower(const bool on) {
   setBit(&remote_state[5], kTcl112AcPowerOffset, on);
 }
 
-// Return the requested power state of the A/C.
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getPower(void) {
   return GETBIT8(remote_state[5], kTcl112AcPowerOffset);
 }
 
-// Get the requested climate operation mode of the a/c unit.
-// Returns:
-//   A uint8_t containing the A/C mode.
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRTcl112Ac::getMode(void) {
   return remote_state[6] & 0xF;
 }
 
-// Set the requested climate operation mode of the a/c unit.
-// Note: Fan/Ventilation mode sets the fan speed to high.
-//       Unknown values default to Auto.
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @note Fan/Ventilation mode sets the fan speed to high.
+///   Unknown values default to Auto.
 void IRTcl112Ac::setMode(const uint8_t mode) {
   // If we get an unexpected mode, default to AUTO.
   switch (mode) {
@@ -134,6 +155,9 @@ void IRTcl112Ac::setMode(const uint8_t mode) {
   }
 }
 
+/// Set the temperature.
+/// @param[in] celsius The temperature in degrees celsius.
+/// @note The temperature resolution is 0.5 of a degree.
 void IRTcl112Ac::setTemp(const float celsius) {
   // Make sure we have desired temp in the correct range.
   float safecelsius = std::max(celsius, kTcl112AcTempMin);
@@ -146,6 +170,9 @@ void IRTcl112Ac::setTemp(const float celsius) {
           (uint8_t)kTcl112AcTempMax - nrHalfDegrees / 2);
 }
 
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
+/// @note The temperature resolution is 0.5 of a degree.
 float IRTcl112Ac::getTemp(void) {
   float result = kTcl112AcTempMax - GETBITS8(remote_state[7], kLowNibble,
                                              kNibbleSize);
@@ -153,8 +180,9 @@ float IRTcl112Ac::getTemp(void) {
   return result;
 }
 
-// Set the speed of the fan.
-// Unknown speeds will default to Auto.
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
+/// @note Unknown speeds will default to Auto.
 void IRTcl112Ac::setFan(const uint8_t speed) {
   switch (speed) {
     case kTcl112AcFanAuto:
@@ -168,63 +196,75 @@ void IRTcl112Ac::setFan(const uint8_t speed) {
   }
 }
 
-// Return the currect fan speed.
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRTcl112Ac::getFan(void) {
   return GETBITS8(remote_state[8], kLowNibble, kTcl112AcFanSize);
 }
 
-// Control economy mode.
+/// Set the economy setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setEcono(const bool on) {
   setBit(&remote_state[5], kTcl112AcBitEconoOffset, on);
 }
 
-// Return the economy state of the A/C.
+/// Get the economy setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getEcono(void) {
   return GETBIT8(remote_state[5],  kTcl112AcBitEconoOffset);
 }
 
-// Control Health mode.
+/// Set the Health (Filter) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setHealth(const bool on) {
   setBit(&remote_state[6], kTcl112AcBitHealthOffset, on);
 }
 
-// Return the Health mode state of the A/C.
+/// Get the Health (Filter) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getHealth(void) {
   return GETBIT8(remote_state[6], kTcl112AcBitHealthOffset);
 }
 
-// Control Light/Display mode.
+/// Set the Light (LED/Display) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setLight(const bool on) {
   setBit(&remote_state[5], kTcl112AcBitLightOffset, !on);  // Cleared when on.
 }
 
-// Return the Light/Display mode state of the A/C.
+/// Get the Light (LED/Display) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getLight(void) {
   return !GETBIT8(remote_state[5],  kTcl112AcBitLightOffset);
 }
 
-// Control Horizontal Swing.
+/// Set the horizontal swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setSwingHorizontal(const bool on) {
   setBit(&remote_state[12], kTcl112AcBitSwingHOffset, on);
 }
 
-// Return the Horizontal Swing state of the A/C.
+/// Get the horizontal swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getSwingHorizontal(void) {
   return GETBIT8(remote_state[12], kTcl112AcBitSwingHOffset);
 }
 
-// Control Vertical Swing.
+/// Set the vertical swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setSwingVertical(const bool on) {
   setBits(&remote_state[8], kTcl112AcSwingVOffset, kTcl112AcSwingVSize,
           on ? kTcl112AcSwingVOn : kTcl112AcSwingVOff);
 }
 
-// Return the Vertical Swing state of the A/C.
+/// Get the vertical swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getSwingVertical(void) {
   return GETBITS8(remote_state[8], kTcl112AcSwingVOffset, kTcl112AcSwingVSize);
 }
 
-// Control the Turbo setting.
+/// Set the Turbo setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTcl112Ac::setTurbo(const bool on) {
   setBit(&remote_state[6], kTcl112AcBitTurboOffset, on);
   if (on) {
@@ -233,12 +273,15 @@ void IRTcl112Ac::setTurbo(const bool on) {
   }
 }
 
-// Return the Turbo setting state of the A/C.
+/// Get the Turbo setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTcl112Ac::getTurbo(void) {
   return GETBIT8(remote_state[6], kTcl112AcBitTurboOffset);
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTcl112Ac::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kTcl112AcCool;
@@ -249,7 +292,9 @@ uint8_t IRTcl112Ac::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTcl112Ac::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -261,7 +306,9 @@ uint8_t IRTcl112Ac::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRTcl112Ac::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kTcl112AcCool: return stdAc::opmode_t::kCool;
@@ -272,7 +319,9 @@ stdAc::opmode_t IRTcl112Ac::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRTcl112Ac::toCommonFanSpeed(const uint8_t spd) {
   switch (spd) {
     case kTcl112AcFanHigh: return stdAc::fanspeed_t::kMax;
@@ -282,7 +331,8 @@ stdAc::fanspeed_t IRTcl112Ac::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRTcl112Ac::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::TCL112AC;
@@ -309,7 +359,8 @@ stdAc::state_t IRTcl112Ac::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRTcl112Ac::toString(void) {
   String result = "";
   result.reserve(140);  // Reserve some heap for the string to reduce fragging.
@@ -332,7 +383,8 @@ String IRTcl112Ac::toString(void) {
 }
 
 #if DECODE_TCL112AC
-// NOTE: There is no `decodedecodeTcl112Ac()`.
-//       It's the same as `decodeMitsubishi112()`. A shared routine is used.
-//       You can find it in: ir_Mitsubishi.cpp
+/// @file
+/// @note There is no `decodedecodeTcl112Ac()`.
+///   It's the same as `decodeMitsubishi112()`. A shared routine is used.
+///   You can find it in: ir_Mitsubishi.cpp
 #endif  // DECODE_TCL112AC

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -59,7 +59,7 @@ const uint8_t kTcl112AcSwingVOff =   0b000;
 const uint8_t kTcl112AcBitTurboOffset = 6;
 
 // Classes
-/// Class for handling detailed Samsung A/C messages.
+/// Class for handling detailed TCL A/C messages.
 class IRTcl112Ac {
  public:
   explicit IRTcl112Ac(const uint16_t pin, const bool inverted = false,

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -1,5 +1,8 @@
 // Copyright 2019 David Conran
 
+/// @file
+/// @brief Support for TCL protocols.
+
 // Supports:
 //   Brand: Leberg,  Model: LBS-TOR07 A/C
 
@@ -55,17 +58,21 @@ const uint8_t kTcl112AcSwingVOn =    0b111;
 const uint8_t kTcl112AcSwingVOff =   0b000;
 const uint8_t kTcl112AcBitTurboOffset = 6;
 
-
+// Classes
+/// Class for handling detailed Samsung A/C messages.
 class IRTcl112Ac {
  public:
   explicit IRTcl112Ac(const uint16_t pin, const bool inverted = false,
                       const bool use_modulation = true);
-
 #if SEND_TCL112AC
   void send(const uint16_t repeat = kTcl112AcDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TCL
   void begin(void);
+  void stateReset(void);
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kTcl112AcStateLength);
@@ -104,12 +111,13 @@ class IRTcl112Ac {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  uint8_t remote_state[kTcl112AcStateLength];
-  void stateReset(void);
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote_state[kTcl112AcStateLength];  ///< The State in IR code form.
   void checksum(const uint16_t length = kTcl112AcStateLength);
 };
 

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Fabien Valthier
-/*
-Node MCU/ESP8266 Sketch to emulate Teco
-*/
+
+/// @file
+/// @brief Support for Teco protocols.
 
 #include "ir_Teco.h"
 #include <algorithm>
@@ -31,12 +31,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_TECO
-// Send a Teco A/C message.
-//
-// Args:
-//   data:   Contents of the message to be sent.
-//   nbits:  Nr. of bits of data to be sent. Typically kTecoBits.
-//   repeat: Nr. of additional times the message is to be sent.
+/// Send a Teco A/C message.
+/// Status: Beta / Probably working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendTeco(const uint64_t data, const uint16_t nbits,
                       const uint16_t repeat) {
   sendGeneric(kTecoHdrMark, kTecoHdrSpace, kTecoBitMark, kTecoOneSpace,
@@ -45,40 +44,60 @@ void IRsend::sendTeco(const uint64_t data, const uint16_t nbits,
 }
 #endif  // SEND_TECO
 
-// Class for decoding and constructing Teco AC messages.
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRTecoAc object.
 IRTecoAc::IRTecoAc(const uint16_t pin, const bool inverted,
                    const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
+/// Set up hardware to be able to send a message.
 void IRTecoAc::begin(void) { _irsend.begin(); }
 
 #if SEND_TECO
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
 void IRTecoAc::send(const uint16_t repeat) {
   _irsend.sendTeco(remote_state, kTecoBits, repeat);
 }
 #endif  // SEND_TECO
 
+/// Reset the internal state of the emulation.
+/// @note Mode:auto, Power:Off, fan:auto, temp:16, swing:off, sleep:off
 void IRTecoAc::stateReset(void) {
-  // Mode:auto, Power:Off, fan:auto, temp:16, swing:off, sleep:off
   remote_state = kTecoReset;
 }
 
+/// Get a copy of the internal state/code for this protocol.
+/// @return A code for this protocol based on the current internal state.
 uint64_t IRTecoAc::getRaw(void) { return remote_state; }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
 void IRTecoAc::setRaw(const uint64_t new_code) { remote_state = new_code; }
 
+/// Set the requested power state of the A/C to on.
 void IRTecoAc::on(void) { setPower(true); }
 
+/// Set the requested power state of the A/C to off.
 void IRTecoAc::off(void) { setPower(false); }
 
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setPower(const bool on) {
   setBit(&remote_state, kTecoPowerOffset, on);
 }
 
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getPower(void) {
   return GETBIT64(remote_state, kTecoPowerOffset);
 }
 
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
 void IRTecoAc::setTemp(const uint8_t temp) {
   uint8_t newtemp = temp;
   newtemp = std::min(newtemp, kTecoMaxTemp);
@@ -87,11 +106,14 @@ void IRTecoAc::setTemp(const uint8_t temp) {
           newtemp - kTecoMinTemp);
 }
 
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRTecoAc::getTemp(void) {
   return GETBITS64(remote_state, kTecoTempOffset, kTecoTempSize) + kTecoMinTemp;
 }
 
-// Set the speed of the fan
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
 void IRTecoAc::setFan(const uint8_t speed) {
   uint8_t newspeed = speed;
   switch (speed) {
@@ -104,10 +126,14 @@ void IRTecoAc::setFan(const uint8_t speed) {
   setBits(&remote_state, kTecoFanOffset, kTecoFanSize, newspeed);
 }
 
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRTecoAc::getFan(void) {
   return GETBITS64(remote_state, kTecoFanOffset, kTecoFanSize);
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
 void IRTecoAc::setMode(const uint8_t mode) {
   uint8_t newmode = mode;
   switch (mode) {
@@ -121,54 +147,80 @@ void IRTecoAc::setMode(const uint8_t mode) {
   setBits(&remote_state, kTecoModeOffset, kModeBitsSize, newmode);
 }
 
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRTecoAc::getMode(void) {
   return GETBITS64(remote_state, kTecoModeOffset, kModeBitsSize);
 }
 
+/// Set the (vertical) swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setSwing(const bool on) {
   setBit(&remote_state, kTecoSwingOffset, on);
 }
 
+/// Get the (vertical) swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getSwing(void) {
   return GETBIT64(remote_state, kTecoSwingOffset);
 }
 
+/// Set the Sleep setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setSleep(const bool on) {
   setBit(&remote_state, kTecoSleepOffset, on);
 }
 
+/// Get the Sleep setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getSleep(void) {
   return GETBIT64(remote_state, kTecoSleepOffset);
 }
 
+/// Set the Light (LED/Display) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setLight(const bool on) {
   setBit(&remote_state, kTecoLightOffset, on);
 }
 
+/// Get the Light (LED/Display) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getLight(void) {
   return GETBIT64(remote_state,  kTecoLightOffset);
 }
 
+/// Set the Humid setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setHumid(const bool on) {
   setBit(&remote_state, kTecoHumidOffset, on);
 }
 
+/// Get the Humid setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getHumid(void) {
   return GETBIT64(remote_state, kTecoHumidOffset);
 }
 
+/// Set the Save setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTecoAc::setSave(const bool on) {
   setBit(&remote_state, kTecoSaveOffset, on);
 }
 
+/// Get the Save setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getSave(void) {
   return GETBIT64(remote_state, kTecoSaveOffset);
 }
 
+/// Is the timer function enabled?
+/// @return true, the setting is on. false, the setting is off.
 bool IRTecoAc::getTimerEnabled(void) {
   return GETBIT64(remote_state, kTecoTimerOnOffset);
 }
 
+/// Get the timer time for when the A/C unit will switch power state.
+/// @return The number of minutes left on the timer. `0` means off.
 uint16_t IRTecoAc::getTimer(void) {
   uint16_t mins = 0;
   if (getTimerEnabled()) {
@@ -181,11 +233,10 @@ uint16_t IRTecoAc::getTimer(void) {
   return mins;
 }
 
-// Set the timer for when the A/C unit will switch power state.
-// Args:
-//   nr_mins: Number of minutes before power state change.
-//            `0` will clear the timer. Max is 24 hrs.
-//            Time is stored internaly in increments of 30 mins.
+/// Set the timer for when the A/C unit will switch power state.
+/// @param[in] nr_mins Number of minutes before power state change.
+///   `0` will clear the timer. Max is 24 hrs.
+/// @note Time is stored internaly in increments of 30 mins.
 void IRTecoAc::setTimer(const uint16_t nr_mins) {
   uint16_t mins = std::min(nr_mins, (uint16_t)(24 * 60));  // Limit to 24 hrs.
   uint8_t hours = mins / 60;
@@ -200,7 +251,9 @@ void IRTecoAc::setTimer(const uint16_t nr_mins) {
           hours / 10);
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTecoAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kTecoCool;
@@ -211,7 +264,9 @@ uint8_t IRTecoAc::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTecoAc::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -223,7 +278,9 @@ uint8_t IRTecoAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRTecoAc::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kTecoCool: return stdAc::opmode_t::kCool;
@@ -234,7 +291,9 @@ stdAc::opmode_t IRTecoAc::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] speed The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRTecoAc::toCommonFanSpeed(const uint8_t speed) {
   switch (speed) {
     case kTecoFanHigh: return stdAc::fanspeed_t::kMax;
@@ -244,7 +303,8 @@ stdAc::fanspeed_t IRTecoAc::toCommonFanSpeed(const uint8_t speed) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRTecoAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::TECO;
@@ -270,7 +330,8 @@ stdAc::state_t IRTecoAc::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRTecoAc::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
@@ -294,18 +355,14 @@ String IRTecoAc::toString(void) {
 }
 
 #if DECODE_TECO
-// Decode the supplied Teco message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kTecoBits.
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Tested.
+/// Decode the supplied Teco message.
+/// Status: STABLE / Tested.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeTeco(decode_results* results, uint16_t offset,
                         const uint16_t nbits, const bool strict) {
   if (strict && nbits != kTecoBits) return false;  // Not what is expected

--- a/src/ir_Teco.h
+++ b/src/ir_Teco.h
@@ -1,5 +1,12 @@
 // Copyright 2019 Fabien Valthier
 
+/// @file
+/// @brief Support for Teco protocols.
+
+// Supports:
+//   Brand: Alaska,  Model: SAC9010QC A/C
+//   Brand: Alaska,  Model: SAC9010QC remote
+
 #ifndef IR_TECO_H_
 #define IR_TECO_H_
 
@@ -11,10 +18,6 @@
 #ifdef UNIT_TEST
 #include "IRsend_test.h"
 #endif
-
-// Supports:
-//   Brand: Alaska,  Model: SAC9010QC A/C
-//   Brand: Alaska,  Model: SAC9010QC remote
 
 // Constants.
 const uint8_t kTecoAuto = 0;
@@ -100,14 +103,18 @@ const uint64_t kTecoReset =      0b01001010000000000000010000000000000;
 */
 
 // Classes
+/// Class for handling detailed Teco A/C messages.
 class IRTecoAc {
  public:
   explicit IRTecoAc(const uint16_t pin, const bool inverted = false,
                     const bool use_modulation = true);
-
   void stateReset(void);
 #if SEND_TECO
   void send(const uint16_t repeat = kTecoDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
+  int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TECO
   void begin(void);
   void on(void);
@@ -155,12 +162,13 @@ class IRTecoAc {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  // The state of the IR remote in IR code form.
-  uint64_t remote_state;
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint64_t remote_state;  ///< The state of the IR remote in IR code form.
   bool getTimerEnabled(void);
 };
 

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -37,7 +37,7 @@ using irutils::setBits;
 
 #if SEND_TOSHIBA_AC
 /// Send a Toshiba A/C message.
-/// Status: StABLE / Working.
+/// Status: STABLE / Working.
 /// @param[in] data The message to be sent.
 /// @param[in] nbytes The number of bytes of message to be sent.
 /// @param[in] repeat The number of times the command is to be repeated.

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -1,7 +1,9 @@
 // Copyright 2017 David Conran
 
-// Toshiba A/C support added by David Conran
-
+/// @file
+/// @brief Support for Toshiba protocols.
+/// @see https://github.com/r45635/HVAC-IR-Control
+/// @see https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266T.ino#L77
 
 #include "ir_Toshiba.h"
 #include <algorithm>
@@ -17,8 +19,6 @@
 // Constants
 
 // Toshiba A/C
-// Ref:
-//   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266T.ino#L77
 const uint16_t kToshibaAcHdrMark = 4400;
 const uint16_t kToshibaAcHdrSpace = 4300;
 const uint16_t kToshibaAcBitMark = 543;
@@ -36,16 +36,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_TOSHIBA_AC
-// Send a Toshiba A/C message.
-//
-// Args:
-//   data: An array of bytes containing the IR command.
-//   nbytes: Nr. of bytes of data in the array. (>=kToshibaACStateLength)
-//   repeat: Nr. of times the message is to be repeated.
-//          (Default = kToshibaACMinRepeat).
-//
-// Status: StABLE / Working.
-//
+/// Send a Toshiba A/C message.
+/// Status: StABLE / Working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendToshibaAC(const unsigned char data[], const uint16_t nbytes,
                            const uint16_t repeat) {
   if (nbytes < kToshibaACStateLength)
@@ -57,56 +52,53 @@ void IRsend::sendToshibaAC(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TOSHIBA_AC
 
-// Code to emulate Toshiba A/C IR remote control unit.
-// Inspired and derived from the work done at:
-//   https://github.com/r45635/HVAC-IR-Control
-//
-// Status:  STABLE / Working.
-//
-// Initialise the object.
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRToshibaAC object.
 IRToshibaAC::IRToshibaAC(const uint16_t pin, const bool inverted,
                          const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
-// Reset the state of the remote to a known good state/sequence.
+/// Reset the state of the remote to a known good state/sequence.
+/// @see https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266T.ino#L103
 void IRToshibaAC::stateReset(void) {
-  // The state of the IR remote in IR code form.
-  // Known good state obtained from:
-  //   https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266T.ino#L103
   static const uint8_t kReset[kToshibaACStateLength] = {
       0xF2, 0x0D, 0x03, 0xFC, 0x01};
   memcpy(remote_state, kReset, kToshibaACStateLength);
   mode_state = getMode(true);
 }
 
-// Configure the pin for output.
+/// Set up hardware to be able to send a message.
 void IRToshibaAC::begin(void) { _irsend.begin(); }
 
 #if SEND_TOSHIBA_AC
-// Send the current desired state to the IR LED.
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
 void IRToshibaAC::send(const uint16_t repeat) {
   _irsend.sendToshibaAC(getRaw(), kToshibaACStateLength, repeat);
 }
 #endif  // SEND_TOSHIBA_AC
 
-// Return a pointer to the internal state date of the remote.
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
 uint8_t* IRToshibaAC::getRaw(void) {
   this->checksum();
   return remote_state;
 }
 
-// Override the internal state with the new state.
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] newState A valid code for this protocol.
 void IRToshibaAC::setRaw(const uint8_t newState[]) {
   memcpy(remote_state, newState, kToshibaACStateLength);
   mode_state = this->getMode(true);
 }
 
-// Calculate the checksum for a given array.
-// Args:
-//   state:  The array to calculate the checksum over.
-//   length: The size of the array.
-// Returns:
-//   The 8 bit checksum value.
+/// Calculate the checksum for a given state.
+/// @param[in] state The array to calc the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return The calculated checksum value.
 uint8_t IRToshibaAC::calcChecksum(const uint8_t state[],
                                   const uint16_t length) {
   uint8_t checksum = 0;
@@ -118,31 +110,32 @@ uint8_t IRToshibaAC::calcChecksum(const uint8_t state[],
   return checksum;
 }
 
-// Verify the checksum is valid for a given state.
-// Args:
-//   state:  The array to verify the checksum of.
-//   length: The size of the state.
-// Returns:
-//   A boolean.
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRToshibaAC::validChecksum(const uint8_t state[], const uint16_t length) {
   return (length > 1 && state[length - 1] == IRToshibaAC::calcChecksum(state,
                                                                        length));
 }
 
-// Calculate & set the checksum for the current internal state of the remote.
+/// Calculate & set the checksum for the current internal state of the remote.
+/// @param[in] length The length/size of the internal array to checksum.
+
 void IRToshibaAC::checksum(const uint16_t length) {
   // Stored the checksum value in the last byte.
   if (length > 1) remote_state[length - 1] = this->calcChecksum(remote_state,
                                                                 length);
 }
 
-// Set the requested power state of the A/C to on.
+/// Set the requested power state of the A/C to on.
 void IRToshibaAC::on(void) { setPower(true); }
 
-// Set the requested power state of the A/C to off.
+/// Set the requested power state of the A/C to off.
 void IRToshibaAC::off(void) { setPower(false); }
 
-// Set the requested power state of the A/C.
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRToshibaAC::setPower(const bool on) {
   setBit(&remote_state[6], kToshibaAcPowerOffset, !on);  // Cleared when on.
   if (on)
@@ -152,12 +145,15 @@ void IRToshibaAC::setPower(const bool on) {
             kToshibaAcHeat);
 }
 
-// Return the requested power state of the A/C.
+
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRToshibaAC::getPower(void) {
   return !GETBIT8(remote_state[6], kToshibaAcPowerOffset);
 }
 
-// Set the temp. in deg C
+/// Set the temperature.
+/// @param[in] degrees The temperature in degrees celsius.
 void IRToshibaAC::setTemp(const uint8_t degrees) {
   uint8_t temp = std::max((uint8_t)kToshibaAcMinTemp, degrees);
   temp = std::min((uint8_t)kToshibaAcMaxTemp, temp);
@@ -165,14 +161,15 @@ void IRToshibaAC::setTemp(const uint8_t degrees) {
           temp - kToshibaAcMinTemp);
 }
 
-// Return the set temp. in deg C
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRToshibaAC::getTemp(void) {
   return GETBITS8(remote_state[5], kToshibaAcTempOffset, kToshibaAcTempSize) +
       kToshibaAcMinTemp;
 }
 
-// Set the speed of the fan, 0-5.
-// 0 is auto, 1-5 is the speed, 5 is Max.
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting (0 is Auto, 1-5 is the speed, 5 is Max)
 void IRToshibaAC::setFan(const uint8_t speed) {
   uint8_t fan = speed;
   // Bounds check
@@ -182,7 +179,8 @@ void IRToshibaAC::setFan(const uint8_t speed) {
   setBits(&remote_state[6], kToshibaAcFanOffset, kToshibaAcFanSize, fan);
 }
 
-// Return the requested state of the unit's fan.
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRToshibaAC::getFan(void) {
   uint8_t fan = GETBITS8(remote_state[6], kToshibaAcFanOffset,
                          kToshibaAcFanSize);
@@ -190,11 +188,9 @@ uint8_t IRToshibaAC::getFan(void) {
   return --fan;
 }
 
-// Get the requested climate operation mode of the a/c unit.
-// Args:
-//   useRaw:  Indicate to get the mode from the state array. (Default: false)
-// Returns:
-//   A uint8_t containing the A/C mode.
+/// Get the operating mode setting of the A/C.
+/// @param[in] useRaw Indicate to get the mode from the internal state array.
+/// @return The current operating mode setting.
 uint8_t IRToshibaAC::getMode(const bool useRaw) {
   if (useRaw)
     return GETBITS8(remote_state[6], kToshibaAcModeOffset, kToshibaAcModeSize);
@@ -202,9 +198,10 @@ uint8_t IRToshibaAC::getMode(const bool useRaw) {
     return mode_state;
 }
 
-// Set the requested climate operation mode of the a/c unit.
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @note If we get an unexpected mode, default to AUTO.
 void IRToshibaAC::setMode(const uint8_t mode) {
-  // If we get an unexpected mode, default to AUTO.
   switch (mode) {
     case kToshibaAcAuto:
     case kToshibaAcCool:
@@ -220,7 +217,9 @@ void IRToshibaAC::setMode(const uint8_t mode) {
   }
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRToshibaAC::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kToshibaAcCool;
@@ -231,7 +230,9 @@ uint8_t IRToshibaAC::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRToshibaAC::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:    return kToshibaAcFanMax - 4;
@@ -243,7 +244,9 @@ uint8_t IRToshibaAC::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRToshibaAC::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kToshibaAcCool: return stdAc::opmode_t::kCool;
@@ -253,7 +256,9 @@ stdAc::opmode_t IRToshibaAC::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRToshibaAC::toCommonFanSpeed(const uint8_t spd) {
   switch (spd) {
     case kToshibaAcFanMax:     return stdAc::fanspeed_t::kMax;
@@ -265,7 +270,8 @@ stdAc::fanspeed_t IRToshibaAC::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRToshibaAC::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::TOSHIBA_AC;
@@ -290,7 +296,8 @@ stdAc::state_t IRToshibaAC::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRToshibaAC::toString(void) {
   String result = "";
   result.reserve(40);
@@ -305,21 +312,14 @@ String IRToshibaAC::toString(void) {
 }
 
 #if DECODE_TOSHIBA_AC
-// Decode a Toshiba AC IR message if possible.
-// Places successful decode information in the results pointer.
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kToshibaACBits.
-//   strict:  Flag to indicate if we strictly adhere to the specification.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status:  STABLE / Working.
-//
-// Ref:
-//
+/// Decode the supplied Toshiba A/C message.
+/// Status:  STABLE / Working.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeToshibaAC(decode_results* results, uint16_t offset,
                              const uint16_t nbits, const bool strict) {
   // Compliance

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -1,6 +1,9 @@
 // Copyright 2017 David Conran
 
-// Toshiba A/C support added by David Conran
+/// @file
+/// @brief Support for Toshiba protocols.
+/// @see https://github.com/r45635/HVAC-IR-Control
+/// @see https://github.com/r45635/HVAC-IR-Control/blob/master/HVAC_ESP8266/HVAC_ESP8266T.ino#L77
 
 // Supports:
 //   Brand: Toshiba,  Model: RAS-B13N3KV2
@@ -54,14 +57,18 @@ const uint8_t kToshibaAcMaxTemp = 30;  // 30C
 #define TOSHIBA_AC_MIN_TEMP kToshibaAcMinTemp
 #define TOSHIBA_AC_MAX_TEMP kToshibaAcMaxTemp
 
+// Classes
+/// Class for handling detailed Toshiba A/C messages.
 class IRToshibaAC {
  public:
   explicit IRToshibaAC(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
-
   void stateReset(void);
 #if SEND_TOSHIBA_AC
   void send(const uint16_t repeat = kToshibaACMinRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TOSHIBA_AC
   void begin(void);
@@ -88,11 +95,13 @@ class IRToshibaAC {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  uint8_t remote_state[kToshibaACStateLength];
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote_state[kToshibaACStateLength];  ///< The state in IR code form.
   void checksum(const uint16_t length = kToshibaACStateLength);
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kToshibaACStateLength);

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -314,7 +314,7 @@ String IRTrotecESP::toString(void) {
 bool IRrecv::decodeTrotec(decode_results *results, uint16_t offset,
                           const uint16_t nbits, const bool strict) {
   if (results->rawlen <= 2 * nbits + kHeader + 2 * kFooter - 1 + offset)
-    return false;  // Can't possibly be a valid Samsung A/C message.
+    return false;  // Can't possibly be a valid Trotec A/C message.
   if (strict && nbits != kTrotecBits) return false;
 
   uint16_t used;

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -1,6 +1,11 @@
 // Copyright 2017 stufisher
 // Copyright 2019 crankyoldgit
 
+/// @file
+/// @brief Support for Trotec protocols.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/pull/279
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1176
+
 #include "ir_Trotec.h"
 #include <algorithm>
 #include <cstring>
@@ -30,7 +35,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_TROTEC
-
+/// Send a Trotec message.
+/// Status: Beta / Probably Working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendTrotec(const unsigned char data[], const uint16_t nbytes,
                         const uint16_t repeat) {
   if (nbytes < kTrotecStateLength) return;
@@ -49,33 +58,50 @@ void IRsend::sendTrotec(const unsigned char data[], const uint16_t nbytes,
 }
 #endif  // SEND_TROTEC
 
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRTrotecESP object.
 IRTrotecESP::IRTrotecESP(const uint16_t pin, const bool inverted,
                          const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
+/// Set up hardware to be able to send a message.
 void IRTrotecESP::begin(void) { _irsend.begin(); }
 
 #if SEND_TROTEC
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
 void IRTrotecESP::send(const uint16_t repeat) {
-  this->checksum();
-  _irsend.sendTrotec(remote_state, kTrotecStateLength, repeat);
+  _irsend.sendTrotec(getRaw(), kTrotecStateLength, repeat);
 }
 #endif  // SEND_TROTEC
 
+/// Calculate the checksum for a given state.
+/// @param[in] state The array to calc the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return The calculated checksum value.
 uint8_t IRTrotecESP::calcChecksum(const uint8_t state[],
                                   const uint16_t length) {
   return sumBytes(state + 2, length - 3);
 }
 
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRTrotecESP::validChecksum(const uint8_t state[], const uint16_t length) {
   return state[length - 1] == calcChecksum(state, length);
 }
 
+/// Calculate & set the checksum for the current internal state of the remote.
 void IRTrotecESP::checksum(void) {
   remote_state[kTrotecStateLength - 1] = sumBytes(remote_state + 2,
                                                   kTrotecStateLength - 3);
 }
 
+/// Reset the state of the remote to a known good state/sequence.
 void IRTrotecESP::stateReset(void) {
   for (uint8_t i = 2; i < kTrotecStateLength; i++) remote_state[i] = 0x0;
 
@@ -88,41 +114,65 @@ void IRTrotecESP::stateReset(void) {
   this->setMode(kTrotecAuto);
 }
 
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
 uint8_t* IRTrotecESP::getRaw(void) {
   this->checksum();
   return remote_state;
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] state A valid code for this protocol.
 void IRTrotecESP::setRaw(const uint8_t state[]) {
   memcpy(remote_state, state, kTrotecStateLength);
 }
 
+/// Set the requested power state of the A/C to on.
+void IRTrotecESP::on(void) { this->setPower(true); }
+
+/// Set the requested power state of the A/C to off.
+void IRTrotecESP::off(void) { this->setPower(false); }
+
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTrotecESP::setPower(const bool on) {
   setBit(&remote_state[2], kTrotecPowerBitOffset, on);
 }
 
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTrotecESP::getPower(void) {
   return GETBIT8(remote_state[2], kTrotecPowerBitOffset);
 }
 
+/// Set the speed of the fan.
+/// @param[in] fan The desired setting.
 void IRTrotecESP::setSpeed(const uint8_t fan) {
   uint8_t speed = std::min(fan, kTrotecFanHigh);
   setBits(&remote_state[2], kTrotecFanOffset, kTrotecFanSize, speed);
 }
 
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRTrotecESP::getSpeed(void) {
   return GETBITS8(remote_state[2], kTrotecFanOffset, kTrotecFanSize);
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
 void IRTrotecESP::setMode(const uint8_t mode) {
   setBits(&remote_state[2], kTrotecModeOffset, kTrotecModeSize,
           (mode > kTrotecFan) ? kTrotecAuto : mode);
 }
 
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRTrotecESP::getMode(void) {
   return GETBITS8(remote_state[2], kTrotecModeOffset, kTrotecModeSize);
 }
 
+/// Set the temperature.
+/// @param[in] celsius The temperature in degrees celsius.
 void IRTrotecESP::setTemp(const uint8_t celsius) {
   uint8_t temp = std::max(celsius, kTrotecMinTemp);
   temp = std::min(temp, kTrotecMaxTemp);
@@ -130,27 +180,39 @@ void IRTrotecESP::setTemp(const uint8_t celsius) {
           temp - kTrotecMinTemp);
 }
 
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRTrotecESP::getTemp(void) {
   return GETBITS8(remote_state[3], kTrotecTempOffset, kTrotecTempSize) +
       kTrotecMinTemp;
 }
 
+/// Set the Sleep setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRTrotecESP::setSleep(const bool on) {
   setBit(&remote_state[3], kTrotecSleepBitOffset, on);
 }
 
+/// Get the Sleep setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRTrotecESP::getSleep(void) {
   return GETBIT8(remote_state[3], kTrotecSleepBitOffset);
 }
 
+/// Set the timer time in nr. of Hours.
+/// @param[in] timer Nr. of Hours. Max is `kTrotecMaxTimer`
 void IRTrotecESP::setTimer(const uint8_t timer) {
   setBit(&remote_state[5], kTrotecTimerBitOffset, timer);
   remote_state[6] = (timer > kTrotecMaxTimer) ? kTrotecMaxTimer : timer;
 }
 
+/// Get the timer time in nr. of Hours.
+/// @return Nr. of Hours.
 uint8_t IRTrotecESP::getTimer(void) { return remote_state[6]; }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTrotecESP::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kTrotecCool;
@@ -161,7 +223,9 @@ uint8_t IRTrotecESP::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRTrotecESP::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -173,8 +237,9 @@ uint8_t IRTrotecESP::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRTrotecESP::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kTrotecCool: return stdAc::opmode_t::kCool;
@@ -184,7 +249,9 @@ stdAc::opmode_t IRTrotecESP::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRTrotecESP::toCommonFanSpeed(const uint8_t spd) {
   switch (spd) {
     case kTrotecFanHigh: return stdAc::fanspeed_t::kMax;
@@ -194,7 +261,8 @@ stdAc::fanspeed_t IRTrotecESP::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRTrotecESP::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::TROTEC;
@@ -219,7 +287,8 @@ stdAc::state_t IRTrotecESP::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRTrotecESP::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
@@ -234,20 +303,14 @@ String IRTrotecESP::toString(void) {
 }
 
 #if DECODE_TROTEC
-// Decode the supplied Trotec message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kTrotecBits.
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Works. Untested on real devices.
-//
-// Ref:
+/// Decode the supplied Trotec message.
+/// Status: STABLE / Works. Untested on real devices.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeTrotec(decode_results *results, uint16_t offset,
                           const uint16_t nbits, const bool strict) {
   if (results->rawlen <= 2 * nbits + kHeader + 2 * kFooter - 1 + offset)

--- a/src/ir_Trotec.h
+++ b/src/ir_Trotec.h
@@ -2,7 +2,7 @@
 // Copyright 2019 crankyoldgit
 
 /// @file
-/// @brief Trotec A/C
+/// @brief Support for Trotec protocols.
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/pull/279
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1176
 
@@ -71,17 +71,24 @@ const uint8_t kTrotecMaxTimer = 23;
 #define TROTEC_MAX_TEMP kTrotecMaxTemp
 #define TROTEC_MAX_TIMER kTrotecMaxTimer
 
+// Class
+/// Class for handling detailed Trotec A/C messages.
 class IRTrotecESP {
  public:
   explicit IRTrotecESP(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
-
 #if SEND_TROTEC
   void send(const uint16_t repeat = kTrotecDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_TROTEC
   void begin(void);
+  void stateReset(void);
 
+  void on(void);
+  void off(void);
   void setPower(const bool state);
   bool getPower(void);
 
@@ -113,14 +120,15 @@ class IRTrotecESP {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  uint8_t remote_state[kTrotecStateLength];
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote_state[kTrotecStateLength];  ///< Remote state in IR code form.
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kTrotecStateLength);
-  void stateReset(void);
   void checksum(void);
 };
 

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -167,9 +167,8 @@ uint8_t IRVestelAc::getFan(void) {
   return GETBITS64(remote_state, kVestelAcFanOffset, kVestelAcFanSize);
 }
 
-// Get the requested climate operation mode of the a/c unit.
-// Returns:
-//   A uint8_t containing the A/C mode.
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRVestelAc::getMode(void) {
   return GETBITS64(remote_state, kVestelAcModeOffset, kModeBitsSize);
 }

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -1,7 +1,9 @@
 // Copyright 2018 Erdem U. Altinyurt
 // Copyright 2019 David Conran
 
-// Vestel added by Erdem U. Altinyurt
+/// @file
+/// @brief Support for Vestel protocols.
+/// Vestel added by Erdem U. Altinyurt
 
 #include "ir_Vestel.h"
 #include <algorithm>
@@ -28,14 +30,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_VESTEL_AC
-// Send a Vestel message
-//
-// Args:
-//   data:   Contents of the message to be sent.
-//   nbits:  Nr. of bits of data to be sent. Typically kVestelBits.
-//
-// Status: STABLE / Working.
-//
+/// Send a Vestel message
+/// Status: STABLE / Working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendVestelAc(const uint64_t data, const uint16_t nbits,
                           const uint16_t repeat) {
   if (nbits % 8 != 0) return;  // nbits is required to be a multiple of 8.
@@ -46,41 +45,46 @@ void IRsend::sendVestelAc(const uint64_t data, const uint16_t nbits,
               kVestelAcBitMark, 100000,              // Footer + repeat gap
               data, nbits, 38, false, repeat, 50);
 }
-#endif
+#endif  // SEND_VESTEL_AC
 
-// Code to emulate Vestel A/C IR remote control unit.
-
-// Initialise the object.
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRVestelAc object.
 IRVestelAc::IRVestelAc(const uint16_t pin, const bool inverted,
                        const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
-// Reset the state of the remote to a known good state/sequence.
+/// Reset the state of the remote to a known good state/sequence.
+/// @note Power On, Mode Auto, Fan Auto, Temp = 25C/77F
 void IRVestelAc::stateReset(void) {
-  // Power On, Mode Auto, Fan Auto, Temp = 25C/77F
   remote_state = kVestelAcStateDefault;
   remote_time_state = kVestelAcTimeStateDefault;
   use_time_state = false;
 }
 
-// Configure the pin for output.
-void IRVestelAc::begin(void) {
-  _irsend.begin();
-}
+/// Set up hardware to be able to send a message.
+void IRVestelAc::begin(void) { _irsend.begin(); }
 
 #if SEND_VESTEL_AC
-// Send the current desired state to the IR LED.
-void IRVestelAc::send(void) { _irsend.sendVestelAc(getRaw()); }
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
+void IRVestelAc::send(const uint16_t repeat) {
+  _irsend.sendVestelAc(getRaw(), kVestelAcBits, repeat);
+}
 #endif  // SEND_VESTEL_AC
 
-// Return the internal state date of the remote.
+/// Get a copy of the internal state/code for this protocol.
+/// @return A code for this protocol based on the current internal state.
 uint64_t IRVestelAc::getRaw(void) {
   this->checksum();
   if (use_time_state) return remote_time_state;
   return remote_state;
 }
 
-// Override the internal state with the new state.
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] newState A valid code for this protocol.
 void IRVestelAc::setRaw(const uint8_t* newState) {
   uint64_t upState = 0;
   for (int i = 0; i < 7; i++)
@@ -88,6 +92,8 @@ void IRVestelAc::setRaw(const uint8_t* newState) {
   this->setRaw(upState);
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] newState A valid code for this protocol.
 void IRVestelAc::setRaw(const uint64_t newState) {
   use_time_state = false;
   remote_state = newState;
@@ -100,25 +106,28 @@ void IRVestelAc::setRaw(const uint64_t newState) {
   }
 }
 
-// Set the requested power state of the A/C to on.
+/// Set the requested power state of the A/C to on.
 void IRVestelAc::on(void) { setPower(true); }
 
-// Set the requested power state of the A/C to off.
+/// Set the requested power state of the A/C to off.
 void IRVestelAc::off(void) { setPower(false); }
 
-// Set the requested power state of the A/C.
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setPower(const bool on) {
   setBits(&remote_state, kVestelAcPowerOffset, kVestelAcPowerSize,
           on ? 0b11 : 0b00);
   use_time_state = false;
 }
 
-// Return the requested power state of the A/C.
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::getPower(void) {
   return GETBITS64(remote_state, kVestelAcPowerOffset, kVestelAcPowerSize);
 }
 
-// Set the temperature in Celsius degrees.
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
 void IRVestelAc::setTemp(const uint8_t temp) {
   uint8_t new_temp = std::max(kVestelAcMinTempC, temp);
   new_temp = std::min(kVestelAcMaxTemp, new_temp);
@@ -127,13 +136,15 @@ void IRVestelAc::setTemp(const uint8_t temp) {
   use_time_state = false;
 }
 
-// Return the set temperature.
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRVestelAc::getTemp(void) {
   return GETBITS64(remote_state, kVestelAcTempOffset, kNibbleSize) +
       kVestelAcMinTempH;
 }
 
-// Set the speed of the fan,
+/// Set the speed of the fan.
+/// @param[in] fan The desired setting.
 void IRVestelAc::setFan(const uint8_t fan) {
   switch (fan) {
     case kVestelAcFanLow:
@@ -150,7 +161,8 @@ void IRVestelAc::setFan(const uint8_t fan) {
   use_time_state = false;
 }
 
-// Return the requested state of the unit's fan.
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRVestelAc::getFan(void) {
   return GETBITS64(remote_state, kVestelAcFanOffset, kVestelAcFanSize);
 }
@@ -162,9 +174,10 @@ uint8_t IRVestelAc::getMode(void) {
   return GETBITS64(remote_state, kVestelAcModeOffset, kModeBitsSize);
 }
 
-// Set the requested climate operation mode of the a/c unit.
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @note If we get an unexpected mode, default to AUTO.
 void IRVestelAc::setMode(const uint8_t mode) {
-  // If we get an unexpected mode, default to AUTO.
   switch (mode) {
     case kVestelAcAuto:
     case kVestelAcCool:
@@ -179,7 +192,8 @@ void IRVestelAc::setMode(const uint8_t mode) {
   use_time_state = false;
 }
 
-// Set Auto mode of AC.
+/// Set Auto mode/level of the A/C.
+/// @param[in] autoLevel The auto mode/level setting.
 void IRVestelAc::setAuto(const int8_t autoLevel) {
   if (autoLevel < -2 || autoLevel > 2) return;
   setMode(kVestelAcAuto);
@@ -196,18 +210,23 @@ void IRVestelAc::setAuto(const int8_t autoLevel) {
     setTemp(17);
 }
 
+/// Set the timer to be active on the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setTimerActive(const bool on) {
   setBit(&remote_time_state, kVestelAcTimerFlagOffset, on);
   use_time_state = true;
 }
 
+/// Get if the Timer is active on the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::isTimerActive(void) {
   return GETBIT64(remote_time_state, kVestelAcTimerFlagOffset);
 }
 
-// Set Timer option of AC.
-// Valid time arguments are 0, 0.5, 1, 2, 3 and 5 hours (in min). 0 disables the
-// timer.
+/// Set Timer option of A/C.
+/// @param[in] minutes Nr of minutes the timer is to be set for.
+/// @note Valid arguments are 0, 0.5, 1, 2, 3 and 5 hours (in minutes).
+///   0 disables the timer.
 void IRVestelAc::setTimer(const uint16_t minutes) {
   // Clear both On & Off timers.
   remote_time_state &= ~((uint64_t)0xFFFF << kVestelAcOffTimeOffset);
@@ -221,9 +240,12 @@ void IRVestelAc::setTimer(const uint16_t minutes) {
   use_time_state = true;
 }
 
+/// Get the Timer time of A/C.
+/// @return The number of minutes of time on the timer.
 uint16_t IRVestelAc::getTimer(void) { return getOffTimer(); }
 
-// Set the AC's internal clock
+/// Set the A/C's internal clock.
+/// @param[in] minutes The time expressed in nr. of minutes past midnight.
 void IRVestelAc::setTime(const uint16_t minutes) {
   setBits(&remote_time_state, kVestelAcHourOffset, kVestelAcHourSize,
           minutes / 60);
@@ -232,22 +254,30 @@ void IRVestelAc::setTime(const uint16_t minutes) {
   use_time_state = true;
 }
 
+/// Get the A/C's internal clock's time.
+/// @return The time expressed in nr. of minutes past midnight.
 uint16_t IRVestelAc::getTime(void) {
   return GETBITS64(remote_time_state, kVestelAcHourOffset, kVestelAcHourSize) *
       60 + GETBITS64(remote_time_state, kVestelAcMinuteOffset,
                      kVestelAcMinuteSize);
 }
 
+/// Set the On timer to be active on the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setOnTimerActive(const bool on) {
   setBit(&remote_time_state, kVestelAcOnTimerFlagOffset, on);
   use_time_state = true;
 }
 
+/// Get if the On Timer is active on the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::isOnTimerActive(void) {
   return GETBIT64(remote_time_state, kVestelAcOnTimerFlagOffset);
 }
 
-// Set a given timer (via offset). Takes time in nr. of minutes.
+/// Set a given timer time at a given bit offset.
+/// @param[in] minutes Time in nr. of minutes.
+/// @param[in] offset Nr. of bits offset from the start of the state.
 void IRVestelAc::_setTimer(const uint16_t minutes, const uint8_t offset) {
   setBits(&remote_time_state, offset, kVestelAcTimerSize,
           ((minutes / 60) << 3) + (minutes % 60) / 10);
@@ -255,112 +285,129 @@ void IRVestelAc::_setTimer(const uint16_t minutes, const uint8_t offset) {
   use_time_state = true;
 }
 
-// Get the number of mins a timer is set for.
+/// Get the number of minutes a timer is set for.
+/// @param[in] offset Nr. of bits offset from the start of the state.
+/// @return The time expressed in nr. of minutes.
 uint16_t IRVestelAc::_getTimer(const uint8_t offset) {
   return GETBITS64(remote_time_state, offset + kVestelAcTimerMinsSize,
                    kVestelAcTimerHourSize) * 60 +  // Hrs
       GETBITS64(remote_time_state, offset, kVestelAcTimerMinsSize) * 10;  // Min
 }
-// Set AC's wake up time. Takes time in minute.
+
+/// Set the On timer time on the A/C.
+/// @param[in] minutes Time in nr. of minutes.
 void IRVestelAc::setOnTimer(const uint16_t minutes) {
   setOnTimerActive(minutes);
   _setTimer(minutes, kVestelAcOnTimeOffset);
 }
 
+/// Get the A/C's On Timer time.
+/// @return The time expressed in nr. of minutes.
 uint16_t IRVestelAc::getOnTimer(void) {
   return _getTimer(kVestelAcOnTimeOffset);
 }
 
+/// Set the Off timer to be active on the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setOffTimerActive(const bool on) {
   setBit(&remote_time_state, kVestelAcOffTimerFlagOffset, on);
   use_time_state = true;
 }
 
+/// Get if the Off Timer is active on the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::isOffTimerActive(void) {
   return GETBIT64(remote_time_state, kVestelAcOffTimerFlagOffset);
 }
 
-// Set AC's turn off time. Takes time in minute.
+/// Set the Off timer time on the A/C.
+/// @param[in] minutes Time in nr. of minutes.
 void IRVestelAc::setOffTimer(const uint16_t minutes) {
   setOffTimerActive(minutes);
   _setTimer(minutes, kVestelAcOffTimeOffset);
 }
 
+/// Get the A/C's Off Timer time.
+/// @return The time expressed in nr. of minutes.
 uint16_t IRVestelAc::getOffTimer(void) {
   return _getTimer(kVestelAcOffTimeOffset);
 }
 
-// Set the Sleep state of the A/C.
+/// Set the Sleep setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setSleep(const bool on) {
   setBits(&remote_state, kVestelAcTurboSleepOffset, kNibbleSize,
           on ? kVestelAcSleep : kVestelAcNormal);
   use_time_state = false;
 }
 
-// Return the Sleep state of the A/C.
+/// Get the Sleep setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::getSleep(void) {
   return GETBITS64(remote_state, kVestelAcTurboSleepOffset, kNibbleSize) ==
       kVestelAcSleep;
 }
 
-// Set the Turbo state of the A/C.
+/// Set the Turbo setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setTurbo(const bool on) {
   setBits(&remote_state, kVestelAcTurboSleepOffset, kNibbleSize,
           on ? kVestelAcTurbo : kVestelAcNormal);
   use_time_state = false;
 }
 
-// Return the Turbo state of the A/C.
+/// Get the Turbo setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::getTurbo(void) {
   return GETBITS64(remote_state, kVestelAcTurboSleepOffset, kNibbleSize) ==
       kVestelAcTurbo;
 }
 
-// Set the Ion state of the A/C.
+/// Set the Ion (Filter) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setIon(const bool on) {
   setBit(&remote_state, kVestelAcIonOffset, on);
   use_time_state = false;
 }
 
-// Return the Ion state of the A/C.
+/// Get the Ion (Filter) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::getIon(void) {
   return GETBIT64(remote_state, kVestelAcIonOffset);
 }
 
-// Set the Swing Roaming state of the A/C.
+/// Set the Swing Roaming setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRVestelAc::setSwing(const bool on) {
   setBits(&remote_state, kVestelAcSwingOffset, kNibbleSize,
           on ? kVestelAcSwing : 0xF);
   use_time_state = false;
 }
 
-// Return the Swing Roaming state of the A/C.
+/// Get the Swing Roaming setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRVestelAc::getSwing(void) {
   return GETBITS64(remote_state, kVestelAcSwingOffset, kNibbleSize) ==
       kVestelAcSwing;
 }
 
-// Calculate the checksum for a given array.
-// Args:
-//   state:  The state to calculate the checksum over.
-// Returns:
-//   The 8 bit checksum value.
+/// Calculate the checksum for a given state.
+/// @param[in] state The state to calc the checksum of.
+/// @return The calculated checksum value.
 uint8_t IRVestelAc::calcChecksum(const uint64_t state) {
   // Just counts the set bits +1 on stream and take inverse after mask
   return 0xFF - countBits(GETBITS64(state, 20, 44), 44, true, 2);
 }
 
-// Verify the checksum is valid for a given state.
-// Args:
-//   state:  The state to verify the checksum of.
-// Returns:
-//   A boolean.
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The state to verify the checksum of.
+/// @return true, if the state has a valid checksum. Otherwise, false.
 bool IRVestelAc::validChecksum(const uint64_t state) {
   return GETBITS64(state, kVestelAcChecksumOffset, kVestelAcChecksumSize) ==
       IRVestelAc::calcChecksum(state);
 }
 
-// Calculate & set the checksum for the current internal state of the remote.
+/// Calculate & set the checksum for the current internal state of the remote.
 void IRVestelAc::checksum(void) {
   // Stored the checksum value in the last byte.
   setBits(&remote_state, kVestelAcChecksumOffset, kVestelAcChecksumSize,
@@ -369,12 +416,16 @@ void IRVestelAc::checksum(void) {
           this->calcChecksum(remote_time_state));
 }
 
+/// Is the current state a time command?
+/// @return true, if the state is a time message. Otherwise, false.
 bool IRVestelAc::isTimeCommand(void) {
   return !GETBITS64(remote_state, kVestelAcPowerOffset, kNibbleSize) ||
       use_time_state;
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRVestelAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kVestelAcCool;
@@ -385,7 +436,9 @@ uint8_t IRVestelAc::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRVestelAc::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -397,7 +450,9 @@ uint8_t IRVestelAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRVestelAc::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kVestelAcCool: return stdAc::opmode_t::kCool;
@@ -408,7 +463,9 @@ stdAc::opmode_t IRVestelAc::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRVestelAc::toCommonFanSpeed(const uint8_t spd) {
   switch (spd) {
     case kVestelAcFanHigh: return stdAc::fanspeed_t::kMax;
@@ -418,7 +475,8 @@ stdAc::fanspeed_t IRVestelAc::toCommonFanSpeed(const uint8_t spd) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRVestelAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::VESTEL_AC;
@@ -444,7 +502,8 @@ stdAc::state_t IRVestelAc::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRVestelAc::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
@@ -504,19 +563,14 @@ String IRVestelAc::toString(void) {
 }
 
 #if DECODE_VESTEL_AC
-// Decode the supplied Vestel message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kVestelBits.
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: Alpha / Needs testing against a real device.
-//
+/// Decode the supplied Vestel message.
+/// Status: Alpha / Needs testing against a real device.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeVestelAc(decode_results* results, uint16_t offset,
                             const uint16_t nbits, const bool strict) {
   if (nbits % 8 != 0)  // nbits has to be a multiple of nr. of bits in a byte.

--- a/src/ir_Vestel.h
+++ b/src/ir_Vestel.h
@@ -1,6 +1,10 @@
 // Copyright 2018 Erdem U. Altinyurt
 // Copyright 2019 David Conran
 
+/// @file
+/// @brief Support for Vestel protocols.
+/// Vestel added by Erdem U. Altinyurt
+
 // Supports:
 //   Brand: Vestel,  Model: BIOX CXP-9 A/C (9K BTU)
 
@@ -18,7 +22,6 @@
 #include "IRsend_test.h"
 #endif
 
-// Vestel added by Erdem U. Altinyurt
 
 // Structure of a Command message (56 bits)
 //   Signature: 12 bits. e.g. 0x201
@@ -108,14 +111,18 @@ const uint8_t kVestelAcMinuteSize = 8;  // Nr. of bits
 const uint64_t kVestelAcStateDefault = 0x0F00D9001FEF201ULL;
 const uint64_t kVestelAcTimeStateDefault = 0x201ULL;
 
+// Classes
+/// Class for handling detailed Vestel A/C messages.
 class IRVestelAc {
  public:
   explicit IRVestelAc(const uint16_t pin, const bool inverted = false,
                       const bool use_modulation = true);
-
   void stateReset(void);
 #if SEND_VESTEL_AC
-  void send(void);
+  void send(const uint16_t repeat = kNoRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_VESTEL_AC
   void begin(void);
@@ -167,12 +174,14 @@ class IRVestelAc {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  uint64_t remote_state;
-  uint64_t remote_time_state;
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint64_t remote_state;  ///< The state of the IR remote in IR code form.
+  uint64_t remote_time_state;   ///< The time state of the remote in code form.
   bool use_time_state;
   void checksum(void);
   void _setTimer(const uint16_t minutes, const uint8_t offset);

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -1,13 +1,12 @@
 // Copyright 2018 David Conran
-//
-// Code to emulate Whirlpool protocol compatible devices.
-//
-// Note: Smart, iFeel, AroundU, PowerSave, & Silent modes are unsupported.
-//       Advanced 6thSense, Dehumidify, & Sleep modes are not supported.
-//       FYI:
-//         Dim == !Light
-//         Jet == Super == Turbo
-//
+
+/// @file
+/// @brief Support for Whirlpool protocols.
+/// Decoding help from: \@redmusicxd, \@josh929800, \@raducostea
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/509
+/// @note Smart, iFeel, AroundU, PowerSave, & Silent modes are unsupported.
+///   Advanced 6thSense, Dehumidify, & Sleep modes are not supported.
+/// @note Dim == !Light, Jet == Super == Turbo
 
 #include "ir_Whirlpool.h"
 #include <algorithm>
@@ -22,7 +21,6 @@
 #include "IRutils.h"
 
 // Constants
-// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/509
 const uint16_t kWhirlpoolAcHdrMark = 8950;
 const uint16_t kWhirlpoolAcHdrSpace = 4484;
 const uint16_t kWhirlpoolAcBitMark = 597;
@@ -44,17 +42,11 @@ using irutils::setBit;
 using irutils::setBits;
 
 #if SEND_WHIRLPOOL_AC
-// Send a Whirlpool A/C message.
-//
-// Args:
-//   data: An array of bytes containing the IR command.
-//   nbytes: Nr. of bytes of data in the array. (>=kWhirlpoolAcStateLength)
-//   repeat: Nr. of times the message is to be repeated. (Default = 0).
-//
-// Status: BETA / Probably works.
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/509
+/// Send a Whirlpool A/C message.
+/// Status: BETA / Probably works.
+/// @param[in] data The message to be sent.
+/// @param[in] nbytes The number of bytes of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
 void IRsend::sendWhirlpoolAC(const unsigned char data[], const uint16_t nbytes,
                              const uint16_t repeat) {
   if (nbytes < kWhirlpoolAcStateLength)
@@ -84,13 +76,17 @@ void IRsend::sendWhirlpoolAC(const unsigned char data[], const uint16_t nbytes,
 #endif  // SEND_WHIRLPOOL_AC
 
 // Class for emulating a Whirlpool A/C remote.
-// Decoding help from:
-//   @redmusicxd, @josh929800, @raducostea
 
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+/// @return An IRWhirlpoolAc object.
 IRWhirlpoolAc::IRWhirlpoolAc(const uint16_t pin, const bool inverted,
                              const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
 
+/// Reset the state of the remote to a known good state/sequence.
 void IRWhirlpoolAc::stateReset(void) {
   for (uint8_t i = 2; i < kWhirlpoolAcStateLength; i++) remote_state[i] = 0x0;
   remote_state[0] = 0x83;
@@ -99,9 +95,15 @@ void IRWhirlpoolAc::stateReset(void) {
   this->_setTemp(kWhirlpoolAcAutoTemp);  // Default to a sane value.
 }
 
+/// Set up hardware to be able to send a message.
 void IRWhirlpoolAc::begin(void) { _irsend.begin(); }
 
-bool IRWhirlpoolAc::validChecksum(uint8_t state[], const uint16_t length) {
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length/size of the array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
+bool IRWhirlpoolAc::validChecksum(const uint8_t state[],
+                                  const uint16_t length) {
   if (length > kWhirlpoolAcChecksumByte1 &&
       state[kWhirlpoolAcChecksumByte1] !=
           xorBytes(state + 2, kWhirlpoolAcChecksumByte1 - 1 - 2)) {
@@ -119,7 +121,8 @@ bool IRWhirlpoolAc::validChecksum(uint8_t state[], const uint16_t length) {
   return true;
 }
 
-// Update the checksum for the internal state.
+/// Calculate & set the checksum for the current internal state of the remote.
+/// @param[in] length The length/size of the internal state array.
 void IRWhirlpoolAc::checksum(uint16_t length) {
   if (length >= kWhirlpoolAcChecksumByte1)
     remote_state[kWhirlpoolAcChecksumByte1] =
@@ -131,21 +134,32 @@ void IRWhirlpoolAc::checksum(uint16_t length) {
 }
 
 #if SEND_WHIRLPOOL_AC
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
+/// @param[in] calcchecksum Do we need to calculate the checksum?.
 void IRWhirlpoolAc::send(const uint16_t repeat, const bool calcchecksum) {
   if (calcchecksum) this->checksum();
   _irsend.sendWhirlpoolAC(remote_state, kWhirlpoolAcStateLength, repeat);
 }
 #endif  // SEND_WHIRLPOOL_AC
 
+/// Get a copy of the internal state/code for this protocol.
+/// @param[in] calcchecksum Do we need to calculate the checksum?.
+/// @return A code for this protocol based on the current internal state.
 uint8_t *IRWhirlpoolAc::getRaw(const bool calcchecksum) {
   if (calcchecksum) this->checksum();
   return remote_state;
 }
 
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
+/// @param[in] length The length/size of the new_code array.
 void IRWhirlpoolAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote_state, new_code, std::min(length, kWhirlpoolAcStateLength));
 }
 
+/// Get/Detect the model of the A/C.
+/// @return The enum of the compatible model.
 whirlpool_ac_remote_model_t IRWhirlpoolAc::getModel(void) {
   if (GETBIT8(remote_state[kWhirlpoolAcAltTempPos], kWhirlpoolAcAltTempOffset))
     return DG11J191;
@@ -153,6 +167,8 @@ whirlpool_ac_remote_model_t IRWhirlpoolAc::getModel(void) {
     return DG11J13A;
 }
 
+/// Set the model of the A/C to emulate.
+/// @param[in] model The enum of the appropriate model.
 void IRWhirlpoolAc::setModel(const whirlpool_ac_remote_model_t model) {
   switch (model) {
     case DG11J191:
@@ -167,7 +183,8 @@ void IRWhirlpoolAc::setModel(const whirlpool_ac_remote_model_t model) {
   this->_setTemp(_desiredtemp);  // Different models have different temp values.
 }
 
-// Return the temp. offset in deg C for the current model.
+/// Calculate the temp. offset in deg C for the current model.
+/// @return The temperature offset.
 int8_t IRWhirlpoolAc::getTempOffset(void) {
   switch (this->getModel()) {
     case whirlpool_ac_remote_model_t::DG11J191: return -2;
@@ -175,7 +192,10 @@ int8_t IRWhirlpoolAc::getTempOffset(void) {
   }
 }
 
-// Set the temp. in deg C
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
+/// @param[in] remember Do we save this temperature?
+/// @note Internal use only.
 void IRWhirlpoolAc::_setTemp(const uint8_t temp, const bool remember) {
   if (remember) _desiredtemp = temp;
   int8_t offset = this->getTempOffset();  // Cache the min temp for the model.
@@ -185,19 +205,24 @@ void IRWhirlpoolAc::_setTemp(const uint8_t temp, const bool remember) {
           newtemp - (kWhirlpoolAcMinTemp + offset));
 }
 
-// Set the temp. in deg C
+/// Set the temperature.
+/// @param[in] temp The temperature in degrees celsius.
 void IRWhirlpoolAc::setTemp(const uint8_t temp) {
   this->_setTemp(temp);
   this->setSuper(false);  // Changing temp cancels Super/Jet mode.
   this->setCommand(kWhirlpoolAcCommandTemp);
 }
 
-// Return the set temp. in deg C
+/// Get the current temperature setting.
+/// @return The current setting for temp. in degrees celsius.
 uint8_t IRWhirlpoolAc::getTemp(void) {
   return GETBITS8(remote_state[kWhirlpoolAcTempPos], kHighNibble, kNibbleSize) +
       kWhirlpoolAcMinTemp + this->getTempOffset();
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @note Internal use only.
 void IRWhirlpoolAc::_setMode(const uint8_t mode) {
   switch (mode) {
     case kWhirlpoolAcAuto:
@@ -219,16 +244,22 @@ void IRWhirlpoolAc::_setMode(const uint8_t mode) {
   if (mode == kWhirlpoolAcAuto) this->setCommand(kWhirlpoolAcCommand6thSense);
 }
 
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
 void IRWhirlpoolAc::setMode(const uint8_t mode) {
     this->setSuper(false);  // Changing mode cancels Super/Jet mode.
     this->_setMode(mode);
 }
 
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
 uint8_t IRWhirlpoolAc::getMode(void) {
   return GETBITS8(remote_state[kWhirlpoolAcModePos], kWhirlpoolAcModeOffset,
                   kModeBitsSize);
 }
 
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
 void IRWhirlpoolAc::setFan(const uint8_t speed) {
   switch (speed) {
     case kWhirlpoolAcFanAuto:
@@ -243,32 +274,45 @@ void IRWhirlpoolAc::setFan(const uint8_t speed) {
   }
 }
 
+/// Get the current fan speed setting.
+/// @return The current fan speed/mode.
 uint8_t IRWhirlpoolAc::getFan(void) {
   return GETBITS8(remote_state[kWhirlpoolAcFanPos], kWhirlpoolAcFanOffset,
                   kWhirlpoolAcFanSize);
 }
 
+/// Set the (vertical) swing setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRWhirlpoolAc::setSwing(const bool on) {
   setBit(&remote_state[kWhirlpoolAcFanPos], kWhirlpoolAcSwing1Offset, on);
   setBit(&remote_state[kWhirlpoolAcOffTimerPos], kWhirlpoolAcSwing2Offset, on);
   setCommand(kWhirlpoolAcCommandSwing);
 }
 
+/// Get the (vertical) swing setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRWhirlpoolAc::getSwing(void) {
   return GETBIT8(remote_state[kWhirlpoolAcFanPos], kWhirlpoolAcSwing1Offset) &&
          GETBIT8(remote_state[kWhirlpoolAcOffTimerPos],
                  kWhirlpoolAcSwing2Offset);
 }
 
+/// Set the Light (Display/LED) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRWhirlpoolAc::setLight(const bool on) {
   // Cleared when on.
   setBit(&remote_state[kWhirlpoolAcClockPos], kWhirlpoolAcLightOffset, !on);
 }
 
+/// Get the Light (Display/LED) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRWhirlpoolAc::getLight(void) {
   return !GETBIT8(remote_state[kWhirlpoolAcClockPos], kWhirlpoolAcLightOffset);
 }
 
+/// Set the time in nr. of minutes past midnight.
+/// @param[in] pos The byte offset to write to.
+/// @param[in] minspastmidnight Nr. of minutes past midnight.
 void IRWhirlpoolAc::setTime(const uint16_t pos,
                             const uint16_t minspastmidnight) {
   // Hours
@@ -279,6 +323,9 @@ void IRWhirlpoolAc::setTime(const uint16_t pos,
           kWhirlpoolAcMinuteSize, minspastmidnight % 60);
 }
 
+/// Get the time in nr. of minutes past midnight.
+/// @param[in] pos The byte offset to read from.
+/// @return The time in Nr. of minutes past midnight.
 uint16_t IRWhirlpoolAc::getTime(const uint16_t pos) {
   return GETBITS8(remote_state[pos], kWhirlpoolAcHourOffset,
                   kWhirlpoolAcHourSize) * 60 +
@@ -286,56 +333,84 @@ uint16_t IRWhirlpoolAc::getTime(const uint16_t pos) {
                   kWhirlpoolAcMinuteSize);
 }
 
+/// Is the timer enabled at the given byte offset?
+/// @param[in] pos The byte offset to read from.
+/// @return true, the Timer is on. false, the Timer is off.
 bool IRWhirlpoolAc::isTimerEnabled(const uint16_t pos) {
   return GETBIT8(remote_state[pos - 1], kWhirlpoolAcTimerEnableOffset);
 }
 
+/// Enable the timer enabled at the given byte offset.
+/// @param[in] pos The byte offset to write to.
+/// @param[in] on true, the timer is enabled. false, the timer is disabled.
 void IRWhirlpoolAc::enableTimer(const uint16_t pos, const bool on) {
   setBit(&remote_state[pos - 1], kWhirlpoolAcTimerEnableOffset, on);
 }
 
+/// Set the clock time in nr. of minutes past midnight.
+/// @param[in] minspastmidnight The time expressed as minutes past midnight.
 void IRWhirlpoolAc::setClock(const uint16_t minspastmidnight) {
   this->setTime(kWhirlpoolAcClockPos, minspastmidnight);
 }
 
+/// Get the clock time in nr. of minutes past midnight.
+/// @return The time expressed as the Nr. of minutes past midnight.
 uint16_t IRWhirlpoolAc::getClock(void) {
   return this->getTime(kWhirlpoolAcClockPos);
 }
 
+/// Set the Off Timer time.
+/// @param[in] minspastmidnight The time expressed as minutes past midnight.
 void IRWhirlpoolAc::setOffTimer(const uint16_t minspastmidnight) {
   this->setTime(kWhirlpoolAcOffTimerPos, minspastmidnight);
 }
 
+/// Get the Off Timer time..
+/// @return The time expressed as the Nr. of minutes past midnight.
 uint16_t IRWhirlpoolAc::getOffTimer(void) {
   return this->getTime(kWhirlpoolAcOffTimerPos);
 }
 
+/// Is the Off timer enabled?
+/// @return true, the Timer is enabled. false, the Timer is disabled.
 bool IRWhirlpoolAc::isOffTimerEnabled(void) {
   return this->isTimerEnabled(kWhirlpoolAcOffTimerPos);
 }
 
+/// Enable the Off Timer.
+/// @param[in] on true, the timer is enabled. false, the timer is disabled.
 void IRWhirlpoolAc::enableOffTimer(const bool on) {
   this->enableTimer(kWhirlpoolAcOffTimerPos, on);
   this->setCommand(kWhirlpoolAcCommandOffTimer);
 }
 
+/// Set the On Timer time.
+/// @param[in] minspastmidnight The time expressed as minutes past midnight.
 void IRWhirlpoolAc::setOnTimer(const uint16_t minspastmidnight) {
   this->setTime(kWhirlpoolAcOnTimerPos, minspastmidnight);
 }
 
+/// Get the On Timer time..
+/// @return The time expressed as the Nr. of minutes past midnight.
 uint16_t IRWhirlpoolAc::getOnTimer(void) {
   return this->getTime(kWhirlpoolAcOnTimerPos);
 }
 
+/// Is the On timer enabled?
+/// @return true, the Timer is enabled. false, the Timer is disabled.
 bool IRWhirlpoolAc::isOnTimerEnabled(void) {
   return this->isTimerEnabled(kWhirlpoolAcOnTimerPos);
 }
 
+/// Enable the On Timer.
+/// @param[in] on true, the timer is enabled. false, the timer is disabled.
 void IRWhirlpoolAc::enableOnTimer(const bool on) {
   this->enableTimer(kWhirlpoolAcOnTimerPos, on);
   this->setCommand(kWhirlpoolAcCommandOnTimer);
 }
 
+/// Change the power toggle setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRWhirlpoolAc::setPowerToggle(const bool on) {
   setBit(&remote_state[kWhirlpoolAcPowerTogglePos],
          kWhirlpoolAcPowerToggleOffset, on);
@@ -343,15 +418,21 @@ void IRWhirlpoolAc::setPowerToggle(const bool on) {
   this->setCommand(kWhirlpoolAcCommandPower);
 }
 
+/// Get the value of the current power toggle setting.
+/// @return true, the setting is on. false, the setting is off.
 bool IRWhirlpoolAc::getPowerToggle(void) {
   return GETBIT8(remote_state[kWhirlpoolAcPowerTogglePos],
                  kWhirlpoolAcPowerToggleOffset);
 }
 
+/// Get the Command (Button) setting of the A/C.
+/// @return The current Command (Button) of the A/C.
 uint8_t IRWhirlpoolAc::getCommand(void) {
   return remote_state[kWhirlpoolAcCommandPos];
 }
 
+/// Set the Sleep setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRWhirlpoolAc::setSleep(const bool on) {
   setBit(&remote_state[kWhirlpoolAcSleepPos],
          kWhirlpoolAcSleepOffset, on);
@@ -359,11 +440,14 @@ void IRWhirlpoolAc::setSleep(const bool on) {
   this->setCommand(kWhirlpoolAcCommandSleep);
 }
 
+/// Get the Sleep setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRWhirlpoolAc::getSleep(void) {
   return GETBIT8(remote_state[kWhirlpoolAcSleepPos], kWhirlpoolAcSleepOffset);
 }
 
-// AKA Jet/Turbo mode.
+/// Set the Super (Turbo/Jet) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
 void IRWhirlpoolAc::setSuper(const bool on) {
   if (on) {
     this->setFan(kWhirlpoolAcFanHigh);
@@ -384,15 +468,21 @@ void IRWhirlpoolAc::setSuper(const bool on) {
   this->setCommand(kWhirlpoolAcCommandSuper);
 }
 
+/// Get the Super (Turbo/Jet) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
 bool IRWhirlpoolAc::getSuper(void) {
   return remote_state[kWhirlpoolAcSuperPos] & kWhirlpoolAcSuperMask;
 }
 
+/// Set the Command (Button) setting of the A/C.
+/// @param[in] code The current Command (Button) of the A/C.
 void IRWhirlpoolAc::setCommand(const uint8_t code) {
   remote_state[kWhirlpoolAcCommandPos] = code;
 }
 
-// Convert a standard A/C mode into its native mode.
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRWhirlpoolAc::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kCool: return kWhirlpoolAcCool;
@@ -403,7 +493,9 @@ uint8_t IRWhirlpoolAc::convertMode(const stdAc::opmode_t mode) {
   }
 }
 
-// Convert a standard A/C Fan speed into its native fan speed.
+/// Convert a stdAc::fanspeed_t enum into it's native speed.
+/// @param[in] speed The enum to be converted.
+/// @return The native equivilant of the enum.
 uint8_t IRWhirlpoolAc::convertFan(const stdAc::fanspeed_t speed) {
   switch (speed) {
     case stdAc::fanspeed_t::kMin:
@@ -415,7 +507,9 @@ uint8_t IRWhirlpoolAc::convertFan(const stdAc::fanspeed_t speed) {
   }
 }
 
-// Convert a native mode to it's common equivalent.
+/// Convert a native mode into its stdAc equivilant.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::opmode_t IRWhirlpoolAc::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kWhirlpoolAcCool: return stdAc::opmode_t::kCool;
@@ -426,7 +520,9 @@ stdAc::opmode_t IRWhirlpoolAc::toCommonMode(const uint8_t mode) {
   }
 }
 
-// Convert a native fan speed to it's common equivalent.
+/// Convert a native fan speed into its stdAc equivilant.
+/// @param[in] speed The native setting to be converted.
+/// @return The stdAc equivilant of the native setting.
 stdAc::fanspeed_t IRWhirlpoolAc::toCommonFanSpeed(const uint8_t speed) {
   switch (speed) {
     case kWhirlpoolAcFanHigh:   return stdAc::fanspeed_t::kMax;
@@ -436,7 +532,8 @@ stdAc::fanspeed_t IRWhirlpoolAc::toCommonFanSpeed(const uint8_t speed) {
   }
 }
 
-// Convert the A/C state to it's common equivalent.
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
 stdAc::state_t IRWhirlpoolAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::WHIRLPOOL_AC;
@@ -462,7 +559,8 @@ stdAc::state_t IRWhirlpoolAc::toCommon(void) {
   return result;
 }
 
-// Convert the internal state into a human readable string.
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
 String IRWhirlpoolAc::toString(void) {
   String result = "";
   result.reserve(200);  // Reserve some heap for the string to reduce fragging.
@@ -533,22 +631,15 @@ String IRWhirlpoolAc::toString(void) {
 }
 
 #if DECODE_WHIRLPOOL_AC
-// Decode the supplied Whirlpool A/C message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   The number of data bits to expect. Typically kWhirlpoolAcBits
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Working as intended.
-//
-//
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/509
+
+/// Decode the supplied Whirlpool A/C message.
+/// Status: STABLE / Working as intended.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
 bool IRrecv::decodeWhirlpoolAC(decode_results *results, uint16_t offset,
                                const uint16_t nbits, const bool strict) {
   if (results->rawlen < 2 * nbits + 4 + kHeader + kFooter - 1 + offset)

--- a/src/ir_Whirlpool.h
+++ b/src/ir_Whirlpool.h
@@ -1,6 +1,12 @@
-// Whirlpool A/C
-//
 // Copyright 2018 David Conran
+
+/// @file
+/// @brief Support for Whirlpool protocols.
+/// Decoding help from: \@redmusicxd, \@josh929800, \@raducostea
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/509
+/// @note Smart, iFeel, AroundU, PowerSave, & Silent modes are unsupported.
+///   Advanced 6thSense, Dehumidify, & Sleep modes are not supported.
+/// @note Dim == !Light, Jet == Super == Turbo
 
 // Supports:
 //   Brand: Whirlpool,  Model: DG11J1-3A remote
@@ -25,9 +31,6 @@
 #ifdef UNIT_TEST
 #include "IRsend_test.h"
 #endif
-
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/509
 
 // Constants
 const uint8_t kWhirlpoolAcChecksumByte1 = 13;
@@ -84,15 +87,18 @@ const uint8_t kWhirlpoolAcAltTempOffset = 3;
 const uint8_t kWhirlpoolAcAltTempPos = 18;
 
 // Classes
+/// Class for handling detailed Whirlpool A/C messages.
 class IRWhirlpoolAc {
  public:
   explicit IRWhirlpoolAc(const uint16_t pin, const bool inverted = false,
                          const bool use_modulation = true);
-
   void stateReset(void);
 #if SEND_WHIRLPOOL_AC
   void send(const uint16_t repeat = kWhirlpoolAcDefaultRepeat,
             const bool calcchecksum = true);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_WHIRLPOOL_AC
   void begin(void);
@@ -131,7 +137,7 @@ class IRWhirlpoolAc {
   uint8_t* getRaw(const bool calcchecksum = true);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kWhirlpoolAcStateLength);
-  static bool validChecksum(uint8_t state[],
+  static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kWhirlpoolAcStateLength);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
@@ -142,13 +148,14 @@ class IRWhirlpoolAc {
 #ifndef UNIT_TEST
 
  private:
-  IRsend _irsend;
-#else
-  IRsendTest _irsend;
-#endif
-  // The state of the IR remote in IR code form.
-  uint8_t remote_state[kWhirlpoolAcStateLength];
-  uint8_t _desiredtemp;
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  uint8_t remote_state[kWhirlpoolAcStateLength];  ///< The state in IR code form
+  uint8_t _desiredtemp;  ///< The last user explicitly set temperature.
   void checksum(const uint16_t length = kWhirlpoolAcStateLength);
   uint16_t getTime(const uint16_t pos);
   void setTime(const uint16_t pos, const uint16_t minspastmidnight);

--- a/src/ir_Whynter.cpp
+++ b/src/ir_Whynter.cpp
@@ -1,8 +1,10 @@
 // Copyright 2009 Ken Shirriff
 // Copyright 2017 David Conran
 
-// Whynter A/C ARC-110WD added by Francesco Meschia
-// Whynter originally added from https://github.com/shirriff/Arduino-IRremote/
+/// @file
+/// @brief Support for Whynter protocols.
+/// Whynter A/C ARC-110WD added by Francesco Meschia
+/// Whynter originally added from https://github.com/shirriff/Arduino-IRremote/
 
 // Supports:
 //   Brand: Whynter,  Model: ARC-110WD A/C
@@ -13,7 +15,6 @@
 #include "IRutils.h"
 
 // Constants
-
 const uint16_t kWhynterTick = 50;
 const uint16_t kWhynterHdrMarkTicks = 57;
 const uint16_t kWhynterHdrMark = kWhynterHdrMarkTicks * kWhynterTick;
@@ -35,18 +36,14 @@ const uint16_t kWhynterMinGapTicks =
 const uint16_t kWhynterMinGap = kWhynterMinGapTicks * kWhynterTick;
 
 #if SEND_WHYNTER
-// Send a Whynter message.
-//
-// Args:
-//   data: message to be sent.
-//   nbits: Nr. of bits of the message to be sent.
-//   repeat: Nr. of additional times the message is to be sent.
-//
-// Status: STABLE
-//
-// Ref:
-//   https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Whynter.cpp
-void IRsend::sendWhynter(uint64_t data, uint16_t nbits, uint16_t repeat) {
+/// Send a Whynter message.
+/// Status: STABLE
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @see https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Whynter.cpp
+void IRsend::sendWhynter(const uint64_t data, const uint16_t nbits,
+                         const uint16_t repeat) {
   // Set IR carrier frequency
   enableIROut(38);
 
@@ -62,24 +59,18 @@ void IRsend::sendWhynter(uint64_t data, uint16_t nbits, uint16_t repeat) {
         50);
   }
 }
-#endif
+#endif  // SEND_WHYNTER
 
 #if DECODE_WHYNTER
-// Decode the supplied Whynter message.
-//
-// Args:
-//   results: Ptr to the data to decode and where to store the decode result.
-//   offset:  The starting index to use when attempting to decode the raw data.
-//            Typically/Defaults to kStartOffset.
-//   nbits:   Nr. of data bits to expect.
-//   strict:  Flag indicating if we should perform strict matching.
-// Returns:
-//   boolean: True if it can decode it, false if it can't.
-//
-// Status: STABLE / Working. Strict mode is ALPHA.
-//
-// Ref:
-//   https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Whynter.cpp
+/// Decode the supplied Whynter message.
+/// Status: STABLE / Working. Strict mode is ALPHA.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
+/// @see https://github.com/z3t0/Arduino-IRremote/blob/master/ir_Whynter.cpp
 bool IRrecv::decodeWhynter(decode_results *results, uint16_t offset,
                            const uint16_t nbits, const bool strict) {
   if (results->rawlen <= 2 * nbits + 2 * kHeader + kFooter - 1 + offset)
@@ -109,4 +100,4 @@ bool IRrecv::decodeWhynter(decode_results *results, uint16_t offset,
   results->command = 0;
   return true;
 }
-#endif
+#endif  // DECODE_WHYNTER


### PR DESCRIPTION
Comment all methods and doxify the comments in all protocols starting with: `T`, `V`, & `W`.
* TCL
* Teco
* Toshiba
* Trotec
* Vestel
* Whirlpool
* Whynter

Minor clean ups along the way.
- This should complete the Doxification of all the Protocol files (and pretty much every method/function/api in the library)