### PR TITLE
Consolidate common code: Inverted byte pairs

### DIFF
--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -52,6 +52,8 @@ using irutils::addModeToString;
 using irutils::addModelToString;
 using irutils::addFanToString;
 using irutils::addTempToString;
+using irutils::checkInvertedBytePairs;
+using irutils::invertBytePairs;
 using irutils::minsToString;
 using irutils::setBit;
 using irutils::setBits;
@@ -1047,8 +1049,7 @@ void IRHitachiAc424::stateReset(void) {
 
 /// Update the internal consistency check for the protocol.
 void IRHitachiAc424::setInvertedStates(void) {
-  for (uint8_t i = 3; i < kHitachiAc424StateLength - 1; i += 2)
-    remote_state[i + 1] = ~remote_state[i];
+  invertBytePairs(remote_state + 3, kHitachiAc424StateLength - 3);
 }
 
 /// Set up hardware to be able to send a message.
@@ -1402,8 +1403,7 @@ void IRHitachiAc3::stateReset(void) {
 /// @param[in] length The size of the state array.
 /// @note This is this protocols integrity check.
 void IRHitachiAc3::setInvertedStates(const uint16_t length) {
-  for (uint8_t i = 3; i < length - 1; i += 2)
-    remote_state[i + 1] = ~remote_state[i];
+  if (length > 3) invertBytePairs(remote_state + 3, length - 3);
 }
 
 /// Check if every second byte of the state, after the fixed header
@@ -1413,9 +1413,7 @@ void IRHitachiAc3::setInvertedStates(const uint16_t length) {
 /// @note This is this protocols integrity check.
 bool IRHitachiAc3::hasInvertedStates(const uint8_t state[],
                                      const uint16_t length) {
-  for (uint8_t i = 3; i < length - 1; i += 2)
-    if ((state[i + 1] ^ state[i]) != 0xFF) return false;
-  return true;
+  return (length <= 3 || checkInvertedBytePairs(state + 3, length - 3));
 }
 
 /// Set up hardware to be able to send a message.

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -33,6 +33,8 @@ using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addTempToString;
+using irutils::checkInvertedBytePairs;
+using irutils::invertBytePairs;
 using irutils::setBit;
 using irutils::setBits;
 
@@ -321,32 +323,24 @@ bool IRMitsubishiHeavy152Ac::checkZmsSig(const uint8_t *state) {
 }
 
 /// Calculate the checksum for the current internal state of the remote.
-/// Note: Technically it has no checksum, but does has inverted byte pairs.
+/// Note: Technically it has no checksum, but does have inverted byte pairs.
 void IRMitsubishiHeavy152Ac::checksum(void) {
-  for (uint8_t i = kMitsubishiHeavySigLength - 2;
-       i < kMitsubishiHeavy152StateLength;
-       i += 2) {
-    remote_state[i + 1] = ~remote_state[i];
-  }
+  const uint8_t kOffset = kMitsubishiHeavySigLength - 2;
+  invertBytePairs(remote_state + kOffset,
+                  kMitsubishiHeavy152StateLength - kOffset);
 }
 
 /// Verify the checksum is valid for a given state.
 /// @param[in] state The array to verify the checksum of.
 /// @param[in] length The length/size of the state array.
 /// @return true, if the state has a valid checksum. Otherwise, false.
-/// Note: Technically it has no checksum, but does has inverted byte pairs.
+/// Note: Technically it has no checksum, but does have inverted byte pairs.
 bool IRMitsubishiHeavy152Ac::validChecksum(const uint8_t *state,
                                            const uint16_t length) {
   // Assume anything too short is fine.
   if (length < kMitsubishiHeavySigLength) return true;
-  // Check all the byte pairs.
-  for (uint16_t i = kMitsubishiHeavySigLength - 2;
-       i < length;
-       i += 2) {
-    // XOR of a byte and it's self inverted should be 0xFF;
-    if ((state[i] ^ state[i + 1]) != 0xFF) return false;
-  }
-  return true;
+  const uint8_t kOffset = kMitsubishiHeavySigLength - 2;
+  return checkInvertedBytePairs(state + kOffset, length - kOffset);
 }
 
 /// Convert a stdAc::opmode_t enum into its native mode.
@@ -856,20 +850,18 @@ bool IRMitsubishiHeavy88Ac::checkZjsSig(const uint8_t *state) {
 }
 
 /// Calculate the checksum for the current internal state of the remote.
-/// Note: Technically it has no checksum, but does has inverted byte pairs.
+/// Note: Technically it has no checksum, but does have inverted byte pairs.
 void IRMitsubishiHeavy88Ac::checksum(void) {
-  for (uint8_t i = kMitsubishiHeavySigLength - 2;
-       i < kMitsubishiHeavy88StateLength;
-       i += 2) {
-    remote_state[i + 1] = ~remote_state[i];
-  }
+  const uint8_t kOffset = kMitsubishiHeavySigLength - 2;
+  invertBytePairs(remote_state + kOffset,
+                  kMitsubishiHeavy88StateLength - kOffset);
 }
 
 /// Verify the checksum is valid for a given state.
 /// @param[in] state The array to verify the checksum of.
 /// @param[in] length The length/size of the state array.
 /// @return true, if the state has a valid checksum. Otherwise, false.
-/// Note: Technically it has no checksum, but does has inverted byte pairs.
+/// Note: Technically it has no checksum, but does have inverted byte pairs.
 bool IRMitsubishiHeavy88Ac::validChecksum(const uint8_t *state,
                                            const uint16_t length) {
   return IRMitsubishiHeavy152Ac::validChecksum(state, length);


### PR DESCRIPTION
Use `invertBytePairs()` & `checkInvertedBytePairs()` where possible to reduce duplicate code.