### PR TITLE
Voltas: Add detailed support for Voltas A/Cs

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1892,6 +1892,7 @@ void IRac::vestel(IRVestelAc *ac,
 #if SEND_VOLTAS
 /// Send a Voltas A/C message with the supplied settings.
 /// @param[in, out] ac A Ptr to an IRVoltas object to use.
+/// @param[in] model The A/C model to use.
 /// @param[in] on The power setting.
 /// @param[in] mode The operation mode setting.
 /// @param[in] degrees The temperature setting in degrees.
@@ -1902,11 +1903,13 @@ void IRac::vestel(IRVestelAc *ac,
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] light Turn on the LED/Display mode.
 void IRac::voltas(IRVoltas *ac,
+                  const voltas_ac_remote_model_t model,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                   const bool turbo, const bool econo, const bool light) {
   ac->begin();
+  ac->setModel(model);
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -2495,8 +2498,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case VOLTAS:
     {
       IRVoltas ac(_pin, _inverted, _modulation);
-      voltas(&ac, send.power, send.mode, degC, send.fanspeed,
-             send.swingv, send.swingh, send.turbo, send.econo, send.light);
+      voltas(&ac, (voltas_ac_remote_model_t)send.model, send.power, send.mode,
+             degC, send.fanspeed, send.swingv, send.swingh, send.turbo,
+             send.econo, send.light);
       break;
     }
 #endif  // SEND_VOLTAS
@@ -2716,6 +2720,11 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return fujitsu_ac_remote_model_t::ARJW2;
   } else if (!strcasecmp(str, "ARRY4")) {
     return fujitsu_ac_remote_model_t::ARRY4;
+  // LG A/C models
+  } else if (!strcasecmp(str, "GE6711AR2853M")) {
+    return lg_ac_remote_model_t::GE6711AR2853M;
+  } else if (!strcasecmp(str, "AKB75215403")) {
+    return lg_ac_remote_model_t::AKB75215403;
   // Panasonic A/C families
   } else if (!strcasecmp(str, "LKE") || !strcasecmp(str, "PANASONICLKE")) {
     return panasonic_ac_remote_model_t::kPanasonicLke;
@@ -2730,6 +2739,9 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return panasonic_ac_remote_model_t::kPanasonicCkp;
   } else if (!strcasecmp(str, "RKR") || !strcasecmp(str, "PANASONICRKR")) {
     return panasonic_ac_remote_model_t::kPanasonicRkr;
+  // Voltas A/C models
+  } else if (!strcasecmp(str, "122LZF")) {
+    return voltas_ac_remote_model_t::kVoltas122LZF;
   // Whirlpool A/C models
   } else if (!strcasecmp(str, "DG11J13A") || !strcasecmp(str, "DG11J104") ||
              !strcasecmp(str, "DG11J1-04")) {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3572,9 +3572,9 @@ namespace IRAcUtils {
 #endif  // DECODE_VESTEL_AC
 #if DECODE_VOLTAS
       case decode_type_t::VOLTAS: {
-        IRVestelAc ac(kGpioUnused);
+        IRVoltas ac(kGpioUnused);
         ac.setRaw(decode->state);
-        *result = ac.toCommon();
+        *result = ac.toCommon(prev);
         break;
       }
 #endif  // DECODE_VOLTAS

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -42,6 +42,7 @@
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
 #include "ir_Vestel.h"
+#include "ir_Voltas.h"
 #include "ir_Whirlpool.h"
 
 /// Class constructor
@@ -3112,6 +3113,13 @@ namespace IRAcUtils {
         return ac.toString();
       }
 #endif  // DECODE_VESTEL_AC
+#if DECODE_VOLTAS
+      case decode_type_t::VOLTAS: {
+        IRVoltas ac(kGpioUnused);
+        ac.setRaw(result->state);
+        return ac.toString();
+      }
+#endif  // DECODE_VOLTAS
 #if DECODE_TECO
       case decode_type_t::TECO: {
         IRTecoAc ac(kGpioUnused);
@@ -3513,6 +3521,14 @@ namespace IRAcUtils {
         break;
       }
 #endif  // DECODE_VESTEL_AC
+#if DECODE_VOLTAS
+      case decode_type_t::VOLTAS: {
+        IRVestelAc ac(kGpioUnused);
+        ac.setRaw(decode->state);
+        *result = ac.toCommon();
+        break;
+      }
+#endif  // DECODE_VOLTAS
 #if DECODE_WHIRLPOOL_AC
       case decode_type_t::WHIRLPOOL_AC: {
         IRWhirlpoolAc ac(kGpioUnused);

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -263,6 +263,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_VESTEL_AC
     case decode_type_t::VESTEL_AC:
 #endif
+#if SEND_VOLTAS
+    case decode_type_t::VOLTAS:
+#endif
 #if SEND_WHIRLPOOL_AC
     case decode_type_t::WHIRLPOOL_AC:
 #endif
@@ -1886,6 +1889,43 @@ void IRac::vestel(IRVestelAc *ac,
 }
 #endif  // SEND_VESTEL_AC
 
+#if SEND_VOLTAS
+/// Send a Voltas A/C message with the supplied settings.
+/// @param[in, out] ac A Ptr to an IRVoltas object to use.
+/// @param[in] on The power setting.
+/// @param[in] mode The operation mode setting.
+/// @param[in] degrees The temperature setting in degrees.
+/// @param[in] fan The speed setting for the fan.
+/// @param[in] swingv The vertical swing setting.
+/// @param[in] swingh The horizontal swing setting.
+/// @param[in] turbo Run the device in turbo/powerful mode.
+/// @param[in] econo Run the device in economical mode.
+/// @param[in] light Turn on the LED/Display mode.
+void IRac::voltas(IRVoltas *ac,
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan,
+                  const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+                  const bool turbo, const bool econo, const bool light) {
+  ac->begin();
+  ac->setPower(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingV(swingv != stdAc::swingv_t::kOff);
+  ac->setSwingH(swingh != stdAc::swingh_t::kOff);
+  // No Quiet setting available.
+  ac->setTurbo(turbo);
+  ac->setEcono(econo);
+  ac->setLight(light);
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_VOLTAS
+
 #if SEND_WHIRLPOOL_AC
 /// Send a Whirlpool A/C message with the supplied settings.
 /// @param[in, out] ac A Ptr to an IRWhirlpoolAc object to use.
@@ -2451,6 +2491,15 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       break;
     }
 #endif  // SEND_VESTEL_AC
+#if SEND_VOLTAS
+    case VOLTAS:
+    {
+      IRVoltas ac(_pin, _inverted, _modulation);
+      voltas(&ac, send.power, send.mode, degC, send.fanspeed,
+             send.swingv, send.swingh, send.turbo, send.econo, send.light);
+      break;
+    }
+#endif  // SEND_VOLTAS
 #if SEND_WHIRLPOOL_AC
     case WHIRLPOOL_AC:
     {

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -551,7 +551,7 @@ void IRac::daikin(IRDaikinESP *ac,
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] light Turn on the LED/Display mode.
 /// @param[in] econo Run the device in economical mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 /// @param[in] clock The time in Nr. of mins since midnight. < 0 is ignore.
 void IRac::daikin128(IRDaikin128 *ac,
                   const bool on, const stdAc::opmode_t mode,
@@ -675,7 +675,7 @@ void IRac::daikin176(IRDaikin176 *ac,
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
 /// @param[in] clean Turn on the self-cleaning mode. e.g. Mould, dry filters etc
 /// @param[in] beep Enable/Disable beeps when receiving IR messages.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 /// @param[in] clock The time in Nr. of mins since midnight. < 0 is ignore.
 void IRac::daikin2(IRDaikin2 *ac,
                    const bool on, const stdAc::opmode_t mode,
@@ -744,7 +744,7 @@ void IRac::daikin216(IRDaikin216 *ac,
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] quiet Run the device in quiet/silent mode.
 /// @param[in] turbo Run the device in turbo/powerful mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 /// @param[in] clock The time in Nr. of mins since midnight. < 0 is ignore.
 void IRac::daikin64(IRDaikin64 *ac,
                   const bool on, const stdAc::opmode_t mode,
@@ -1458,7 +1458,7 @@ void IRac::mitsubishiHeavy88(IRMitsubishiHeavy88Ac *ac,
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
 /// @param[in] clean Turn on the self-cleaning mode. e.g. Mould, dry filters etc
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
                               const bool on, const stdAc::opmode_t mode,
                               const float degrees,
@@ -1500,7 +1500,7 @@ void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] light Turn on the LED/Display mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::neoclima(IRNeoclimaAc *ac,
                     const bool on, const stdAc::opmode_t mode,
                     const float degrees, const stdAc::fanspeed_t fan,
@@ -1625,7 +1625,7 @@ void IRac::samsung(IRSamsungAc *ac,
 /// @param[in] fan The speed setting for the fan.
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] beep Enable/Disable beeps when receiving IR messages.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::sanyo(IRSanyoAc *ac,
                  const bool on, const stdAc::opmode_t mode,
                  const float degrees, const stdAc::fanspeed_t fan,
@@ -1755,7 +1755,7 @@ void IRac::tcl112(IRTcl112Ac *ac,
 /// @param[in] fan The speed setting for the fan.
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] light Turn on the LED/Display mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::teco(IRTecoAc *ac,
                 const bool on, const stdAc::opmode_t mode, const float degrees,
                 const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
@@ -1823,7 +1823,7 @@ void IRac::toshiba(IRToshibaAC *ac,
 /// @param[in] mode The operation mode setting.
 /// @param[in] degrees The temperature setting in degrees.
 /// @param[in] fan The speed setting for the fan.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::trotec(IRTrotecESP *ac,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
@@ -1857,7 +1857,7 @@ void IRac::trotec(IRTrotecESP *ac,
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 /// @param[in] clock The time in Nr. of mins since midnight. < 0 is ignore.
 /// @param[in] sendNormal Do we send a Normal settings message at all?
 ///  i.e In addition to the clock/time/timer message
@@ -1902,12 +1902,14 @@ void IRac::vestel(IRVestelAc *ac,
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] light Turn on the LED/Display mode.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::voltas(IRVoltas *ac,
                   const voltas_ac_remote_model_t model,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-                  const bool turbo, const bool econo, const bool light) {
+                  const bool turbo, const bool econo, const bool light,
+                  const int16_t sleep) {
   ac->begin();
   ac->setModel(model);
   ac->setPower(on);
@@ -1923,7 +1925,7 @@ void IRac::voltas(IRVoltas *ac,
   // No Filter setting available.
   // No Clean setting available.
   // No Beep setting available.
-  // No Sleep setting available.
+  ac->setSleep(sleep >= 0);  // Sleep is either on/off, so convert to boolean.
   // No Clock setting available.
   ac->send();
 }
@@ -1940,7 +1942,7 @@ void IRac::voltas(IRVoltas *ac,
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] light Turn on the LED/Display mode.
-/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, > 0 is on.
+/// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 /// @param[in] clock The time in Nr. of mins since midnight. < 0 is ignore.
 void IRac::whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
                      const bool on, const stdAc::opmode_t mode,
@@ -2500,7 +2502,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       IRVoltas ac(_pin, _inverted, _modulation);
       voltas(&ac, (voltas_ac_remote_model_t)send.model, send.power, send.mode,
              degC, send.fanspeed, send.swingv, send.swingh, send.turbo,
-             send.econo, send.light);
+             send.econo, send.light, send.sleep);
       break;
     }
 #endif  // SEND_VOLTAS

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -36,6 +36,7 @@
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
 #include "ir_Vestel.h"
+#include "ir_Voltas.h"
 #include "ir_Whirlpool.h"
 
 // Constants
@@ -405,6 +406,13 @@ void electra(IRElectraAc *ac,
               const int16_t sleep = -1, const int16_t clock = -1,
               const bool sendNormal = true);
 #endif  // SEND_VESTEL_AC
+#if SEND_VOLTAS
+  void voltas(IRVoltas *ac,
+              const bool on, const stdAc::opmode_t mode,
+              const float degrees, const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
+              const bool turbo, const bool econo, const bool light);
+#endif  // SEND_VOLTAS
 #if SEND_WHIRLPOOL_AC
   void whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,
                  const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -407,7 +407,7 @@ void electra(IRElectraAc *ac,
               const bool sendNormal = true);
 #endif  // SEND_VESTEL_AC
 #if SEND_VOLTAS
-  void voltas(IRVoltas *ac,
+  void voltas(IRVoltas *ac, const voltas_ac_remote_model_t model,
               const bool on, const stdAc::opmode_t mode,
               const float degrees, const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -411,7 +411,8 @@ void electra(IRElectraAc *ac,
               const bool on, const stdAc::opmode_t mode,
               const float degrees, const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-              const bool turbo, const bool econo, const bool light);
+              const bool turbo, const bool econo, const bool light,
+              const int16_t sleep = -1);
 #endif  // SEND_VOLTAS
 #if SEND_WHIRLPOOL_AC
   void whirlpool(IRWhirlpoolAc *ac, const whirlpool_ac_remote_model_t model,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -148,6 +148,12 @@ enum panasonic_ac_remote_model_t {
   kPanasonicRkr = 6,
 };
 
+/// Voltas A/C model numbers
+enum voltas_ac_remote_model_t {
+  kVoltasUnknown = 0,  // Full Function
+  kVoltas122LZF = 1,   // (1) 122LZF (No SwingH support) (Default)
+};
+
 /// Whirlpool A/C model numbers
 enum whirlpool_ac_remote_model_t {
   DG11J13A = 1,  // DG11J1-04 too

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -544,6 +544,12 @@ namespace irutils {
           default: return kUnknownStr;
         }
         break;
+      case decode_type_t::VOLTAS:
+        switch (model) {
+          case voltas_ac_remote_model_t::kVoltas122LZF: return F("122LZF");
+          default: return kUnknownStr;
+        }
+        break;
       case decode_type_t::WHIRLPOOL_AC:
         switch (model) {
           case whirlpool_ac_remote_model_t::DG11J13A: return F("DG11J13A");

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -194,9 +194,10 @@ bool IRVoltas::getPower(void) const { return _.Power; }
 /// @param[in] mode The desired operating mode.
 /// @note If we get an unexpected mode, default to AUTO.
 void IRVoltas::setMode(const uint8_t mode) {
+  _.Mode = mode;
   switch (mode) {
     case kVoltasFan:
-      setFan(kVoltasFanHigh);
+      setFan(getFan());  // Force the fan speed to a correct one fo the mode.
       break;
     case kVoltasDry:
       setFan(kVoltasFanLow);
@@ -209,7 +210,6 @@ void IRVoltas::setMode(const uint8_t mode) {
       setMode(kVoltasCool);
       return;
   }
-  _.Mode = mode;
   setEcono(getEcono());  // Reset the econo setting if needed.
 }
 
@@ -257,10 +257,15 @@ uint8_t IRVoltas::getTemp(void) { return _.Temp + kVoltasMinTemp; }
 /// @param[in] fan The desired setting.
 void IRVoltas::setFan(const uint8_t fan) {
   switch (fan) {
+    case kVoltasFanAuto:
+      if (_.Mode == kVoltasFan) {  // Auto speed is not available in fan mode.
+        setFan(kVoltasFanHigh);
+        return;
+      }
+      // FALL-THRU
     case kVoltasFanLow:
     case kVoltasFanMed:
     case kVoltasFanHigh:
-    case kVoltasFanAuto:
       _.FanSpeed = fan;
       break;
     default:

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -404,7 +404,7 @@ uint16_t IRVoltas::getOnTime(void) const {
 /// Is the On Timer enabled?
 /// @return true, A timer is on. false, A timer is off.
 bool IRVoltas::getOnTimerEnabled(void) const {
-  return _.TimerEnable_4 && _.TimerEnable_5 && getOnTime();
+  return _.TimerEnable_4 && _.TimerEnable_5 && _.OnTimerEnable && getOnTime();
 }
 
 /// Set the value of the On Timer time.
@@ -417,9 +417,13 @@ void IRVoltas::setOnTime(const uint16_t nr_of_mins) {
   if (hrs) {  // The timer is to be enabled.
     _.TimerEnable_4 = true;
     _.TimerEnable_5 = true;
-  } else if (!getOffTimerEnabled()) {  // Can we disable the timer(s)?
-    _.TimerEnable_4 = false;
-    _.TimerEnable_5 = false;
+    _.OnTimerEnable = true;
+  } else {
+    _.OnTimerEnable = false;
+    if (!getOffTimerEnabled()) {  // Can we disable the timer(s)?
+      _.TimerEnable_4 = false;
+      _.TimerEnable_5 = false;
+    }
   }
 }
 
@@ -441,16 +445,20 @@ void IRVoltas::setOffTime(const uint16_t nr_of_mins) {
   if (hrs) {  // The timer is to be enabled.
     _.TimerEnable_4 = true;
     _.TimerEnable_5 = true;
-  } else if (!getOnTimerEnabled()) {  // Can we disable the timer(s)?
-    _.TimerEnable_4 = false;
-    _.TimerEnable_5 = false;
+    _.OffTimerEnable = true;
+  } else {
+    _.OffTimerEnable = false;
+    if (!getOnTimerEnabled()) {  // Can we disable the timer(s)?
+      _.TimerEnable_4 = false;
+      _.TimerEnable_5 = false;
+    }
   }
 }
 
 /// Is the Off Timer enabled?
 /// @return true, A timer is on. false, A timer is off.
 bool IRVoltas::getOffTimerEnabled(void) const {
-  return _.TimerEnable_4 && _.TimerEnable_5 && getOffTime();
+  return _.TimerEnable_4 && _.TimerEnable_5 && _.OffTimerEnable && getOffTime();
 }
 
 /// Convert the current internal state into its stdAc::state_t equivilant.

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -410,70 +410,53 @@ void IRVoltas::setSleep(const bool on) {
 bool IRVoltas::getSleep(void) const { return _.Sleep; }
 
 /// Get the value of the On Timer time.
-/// @note Rounded down to the hour mark.
 /// @return Number of minutes before the timer activates.
 uint16_t IRVoltas::getOnTime(void) const {
-  return (12 * _.OnTimer12Hr + _.OnTimerHrs) * 60;
+  return (12 * _.OnTimer12Hr + _.OnTimerHrs) * 60 + _.OnTimerMins;
 }
 
 /// Is the On Timer enabled?
 /// @return true, A timer is on. false, A timer is off.
 bool IRVoltas::getOnTimerEnabled(void) const {
-  return _.TimerEnable_4 && _.TimerEnable_5 && _.OnTimerEnable && getOnTime();
+  return _.OnTimerEnable && getOnTime();
 }
 
 /// Set the value of the On Timer time.
-/// @note Rounded down to the hour mark. Enables timer if >= 60 mins.
 /// @param[in] nr_of_mins Number of minutes before the timer activates.
+/// 0 disables the timer. Max is 23 hrs & 59 mins (1439 mins)
 void IRVoltas::setOnTime(const uint16_t nr_of_mins) {
-  uint16_t hrs = std::min(nr_of_mins / 60, 23);  // Cap to 23 hrs.
+  // Cap the total number of mins.
+  uint16_t mins = std::min(nr_of_mins, (uint16_t)(23 * 60 + 59));
+  uint16_t hrs = mins / 60;
+  _.OnTimerMins = mins % 60;
   _.OnTimer12Hr = hrs >= 12;
   _.OnTimerHrs = hrs % 12;
-  if (hrs) {  // The timer is to be enabled.
-    _.TimerEnable_4 = true;
-    _.TimerEnable_5 = true;
-    _.OnTimerEnable = true;
-  } else {
-    _.OnTimerEnable = false;
-    if (!getOffTimerEnabled()) {  // Can we disable the timer(s)?
-      _.TimerEnable_4 = false;
-      _.TimerEnable_5 = false;
-    }
-  }
+  _.OnTimerEnable = (mins > 0);  // Is the timer is to be enabled?
 }
 
 /// Get the value of the On Timer time.
-/// @note Rounded down to the hour mark.
 /// @return Number of minutes before the timer activates.
 uint16_t IRVoltas::getOffTime(void) const {
-  return (12 * _.OffTimer12Hr + _.OffTimerHrs) * 60;
+  return (12 * _.OffTimer12Hr + _.OffTimerHrs) * 60 + _.OffTimerMins;
 }
 
 /// Set the value of the Off Timer time.
-/// @note Rounded down to the hour mark. Enables timer if >= 60 mins.
 /// @param[in] nr_of_mins Number of minutes before the timer activates.
+/// 0 disables the timer. Max is 23 hrs & 59 mins (1439 mins)
 void IRVoltas::setOffTime(const uint16_t nr_of_mins) {
-  uint16_t hrs = std::min(nr_of_mins / 60, 23);  // Cap to 23 hrs.
-
+  // Cap the total number of mins.
+  uint16_t mins = std::min(nr_of_mins, (uint16_t)(23 * 60 + 59));
+  uint16_t hrs = mins / 60;
+  _.OffTimerMins = mins % 60;
   _.OffTimer12Hr = hrs >= 12;
   _.OffTimerHrs = hrs % 12;
-  if (hrs) {  // The timer is to be enabled.
-    _.TimerEnable_4 = true;
-    _.TimerEnable_5 = true;
-    _.OffTimerEnable = true;
-  } else {
-    _.OffTimerEnable = false;
-    if (!getOnTimerEnabled()) {  // Can we disable the timer(s)?
-      _.TimerEnable_4 = false;
-      _.TimerEnable_5 = false;
-    }
-  }
+  _.OffTimerEnable = (mins > 0);  // Is the timer is to be enabled?
 }
 
 /// Is the Off Timer enabled?
 /// @return true, A timer is on. false, A timer is off.
 bool IRVoltas::getOffTimerEnabled(void) const {
-  return _.TimerEnable_4 && _.TimerEnable_5 && _.OffTimerEnable && getOffTime();
+  return _.OffTimerEnable && getOffTime();
 }
 
 /// Convert the current internal state into its stdAc::state_t equivilant.

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -124,7 +124,7 @@ void IRVoltas::setRaw(const uint8_t new_code[]) {
 
 /// Calculate and set the checksum values for the internal state.
 void IRVoltas::checksum(void) {
-  _.Checksum = calcChecksum(_.raw, kVoltasStateLength - 1);
+  _.Checksum = calcChecksum(_.raw);
 }
 
 /// Verify the checksum is valid for a given state.

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -210,7 +210,10 @@ void IRVoltas::setMode(const uint8_t mode) {
       setMode(kVoltasCool);
       return;
   }
-  setEcono(getEcono());  // Reset the econo setting if needed.
+  // Reset some settings if needed.
+  setEcono(getEcono());
+  setTurbo(getTurbo());
+  setSleep(getSleep());
 }
 
 /// Get the operating mode setting of the A/C.
@@ -358,16 +361,22 @@ bool IRVoltas::getWifi(void) const { return _.Wifi; }
 
 /// Change the Turbo setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
-void IRVoltas::setTurbo(const bool on) { _.Turbo = on; }
+/// @note The Turbo setting is only available in Cool mode.
+void IRVoltas::setTurbo(const bool on) {
+  if (on && _.Mode == kVoltasCool)
+    _.Turbo = true;
+  else
+    _.Turbo = false;
+}
 
 /// Get the value of the current Turbo setting.
 /// @return true, the setting is on. false, the setting is off.
 bool IRVoltas::getTurbo(void) const { return _.Turbo; }
 
-/// Change the Econo setting.
+/// Change the Economy setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
+/// @note The Economy setting is only available in Cool mode.
 void IRVoltas::setEcono(const bool on) {
-  // The econo setting is only available in cool mode.
   if (on && _.Mode == kVoltasCool)
     _.Econo = true;
   else
@@ -388,7 +397,13 @@ bool IRVoltas::getLight(void) const { return _.Light; }
 
 /// Change the Sleep setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
-void IRVoltas::setSleep(const bool on) { _.Sleep = on; }
+/// @note The Sleep setting is only available in Cool mode.
+void IRVoltas::setSleep(const bool on) {
+  if (on && _.Mode == kVoltasCool)
+    _.Sleep = true;
+  else
+    _.Sleep = false;
+}
 
 /// Get the value of the current Sleep setting.
 /// @return true, the setting is on. false, the setting is off.

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -28,7 +28,7 @@ const uint16_t kVoltasFreq = 38000;     ///< Hz.
 
 #if SEND_VOLTAS
 /// Send a Voltas formatted message.
-/// Status: ALPHA / Untested.
+/// Status: STABLE / Working on real device.
 /// @param[in] data An array of bytes containing the IR command.
 ///                 It is assumed to be in MSB order for this code.
 /// e.g.
@@ -51,7 +51,7 @@ void IRsend::sendVoltas(const uint8_t data[], const uint16_t nbytes,
 
 #if DECODE_VOLTAS
 /// Decode the supplied Voltas message.
-/// Status: ALPHA / Untested.
+/// Status: STABLE / Working on real device.
 /// @param[in,out] results Ptr to the data to decode & where to store the decode
 /// @param[in] offset The starting index to use when attempting to decode the
 ///   raw data. Typically/Defaults to kStartOffset.

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -382,6 +382,14 @@ void IRVoltas::setLight(const bool on) { _.Light = on; }
 /// @return true, the setting is on. false, the setting is off.
 bool IRVoltas::getLight(void) const { return _.Light; }
 
+/// Change the Sleep setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRVoltas::setSleep(const bool on) { _.Sleep = on; }
+
+/// Get the value of the current Sleep setting.
+/// @return true, the setting is on. false, the setting is off.
+bool IRVoltas::getSleep(void) const { return _.Sleep; }
+
 /// Convert the current internal state into its stdAc::state_t equivilant.
 /// @param[in] prev Ptr to the previous state if available.
 /// @return The stdAc equivilant of the native settings.
@@ -408,12 +416,12 @@ stdAc::state_t IRVoltas::toCommon(const stdAc::state_t *prev) {
   result.turbo = _.Turbo;
   result.econo = _.Econo;
   result.light = _.Light;
+  result.sleep = _.Sleep ? 0 : -1;
   // Not supported.
   result.quiet = false;
   result.filter = false;
   result.clean = false;
   result.beep = false;
-  result.sleep = -1;
   result.clock = -1;
   return result;
 }
@@ -422,7 +430,7 @@ stdAc::state_t IRVoltas::toCommon(const stdAc::state_t *prev) {
 /// @return A human readable string.
 String IRVoltas::toString() {
   String result = "";
-  result.reserve(120);  // Reserve some heap for the string to reduce fragging.
+  result.reserve(140);  // Reserve some heap for the string to reduce fragging.
   result += addModelToString(decode_type_t::VOLTAS, getModel(), false);
   result += addBoolToString(_.Power, kPowerStr);
   result += addModeToString(_.Mode, 255, kVoltasCool, kVoltasHeat,
@@ -439,5 +447,6 @@ String IRVoltas::toString() {
   result += addBoolToString(_.Econo, kEconoStr);
   result += addBoolToString(_.Wifi, kWifiStr);
   result += addBoolToString(_.Light, kLightStr);
+  result += addBoolToString(_.Sleep, kSleepStr);
   return result;
 }

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -4,12 +4,18 @@
 /// @brief Support for Voltas A/C protocol
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1238
 
-// Supports:
-//   Brand: Voltas,  Model: 122LZF 4011252 Window A/C
-
+#include "ir_Voltas.h"
+#include <cstring>
 #include "IRrecv.h"
 #include "IRsend.h"
+#include "IRtext.h"
 #include "IRutils.h"
+
+using irutils::addBoolToString;
+using irutils::addModeToString;
+using irutils::addFanToString;
+using irutils::addTempToString;
+using irutils::minsToString;
 
 // Constants
 const uint16_t kVoltasBitMark = 1026;   ///< uSeconds.
@@ -61,9 +67,140 @@ bool IRrecv::decodeVoltas(decode_results *results, uint16_t offset,
                     kVoltasBitMark, kVoltasZeroSpace,
                     kVoltasBitMark, kDefaultMessageGap, true)) return false;
 
+  // Compliance
+  if (strict && !IRVoltas::validChecksum(results->state, nbits / 8))
+    return false;
   // Success
   results->decode_type = decode_type_t::VOLTAS;
   results->bits = nbits;
   return true;
 }
 #endif  // DECODE_VOLTAS
+
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+IRVoltas::IRVoltas(const uint16_t pin, const bool inverted,
+                   const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
+  stateReset();
+}
+
+// Reset the internal state to a fixed known good state.
+void IRVoltas::stateReset() {
+  // This resets to a known-good state.
+  std::memset(_.raw, 0, sizeof _.raw);
+}
+
+/// Set up hardware to be able to send a message.
+void IRVoltas::begin() { _irsend.begin(); }
+
+#if SEND_VOLTAS
+/// Send the current internal state as an IR message.
+/// @param[in] repeat Nr. of times the message will be repeated.
+void IRVoltas::send(const uint16_t repeat) {
+  _irsend.sendVoltas(getRaw(), kVoltasStateLength, repeat);
+}
+#endif  // SEND_VOLTAS
+
+/// Get a PTR to the internal state/code for this protocol.
+/// @return PTR to a code for this protocol based on the current internal state.
+uint8_t* IRVoltas::getRaw(void) {
+  checksum();  // Ensure correct settings before sending.
+  return _.raw;
+}
+
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] new_code A valid code for this protocol.
+void IRVoltas::setRaw(const uint8_t new_code[]) {
+  std::memcpy(_.raw, new_code, kVoltasStateLength);
+}
+
+/// Calculate and set the checksum values for the internal state.
+void IRVoltas::checksum(void) {
+  _.Checksum = calcChecksum(_.raw, kVoltasStateLength - 1);
+}
+
+/// Verify the checksum is valid for a given state.
+/// @param[in] state The array to verify the checksum of.
+/// @param[in] length The length of the state array.
+/// @return true, if the state has a valid checksum. Otherwise, false.
+bool IRVoltas::validChecksum(const uint8_t state[], const uint16_t length) {
+  if (length) return state[length - 1] == calcChecksum(state, length);
+  return true;
+}
+
+/// Calculate the checksum is valid for a given state.
+/// @param[in] state The array to calculate the checksum of.
+/// @param[in] length The length of the state array.
+/// @return The valid checksum value for the state.
+uint8_t IRVoltas::calcChecksum(const uint8_t state[], const uint16_t length) {
+  uint8_t result = 0;
+  if (length)
+    result = sumBytes(state, length - 1);
+  return ~result;
+}
+
+/// Change the power setting to On.
+void IRVoltas::on() { setPower(true); }
+
+/// Change the power setting to Off.
+void IRVoltas::off() { setPower(false); }
+
+/// Change the power setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRVoltas::setPower(const bool on) { _.Power = on; }
+
+/// Get the value of the current power setting.
+/// @return true, the setting is on. false, the setting is off.
+bool IRVoltas::getPower(void) const { return _.Power; }
+
+/// Convert the current internal state into its stdAc::state_t equivilant.
+/// @return The stdAc equivilant of the native settings.
+stdAc::state_t IRVoltas::toCommon() {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::VOLTAS;
+  result.power = _.Power;
+  // result.mode = toCommonMode(getMode());
+  result.celsius = true;
+  /*
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  if (getSwingVerticalAuto())
+    result.swingv = stdAc::swingv_t::kAuto;
+  else
+    result.swingv = toCommonSwingV(getSwingVerticalPosition());
+  */
+  result.turbo = _.Turbo;
+  result.econo = _.Econo;
+  result.light = _.Light;
+  /*
+  result.clean = getXFan();
+  result.sleep = getSleep() ? 0 : -1;
+  */
+  // Not supported.
+  result.model = -1;
+  result.swingh = stdAc::swingh_t::kOff;
+  result.quiet = false;
+  result.filter = false;
+  result.beep = false;
+  result.clock = -1;
+  return result;
+}
+
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
+String IRVoltas::toString() {
+  String result = "";
+  result.reserve(80);  // Reserve some heap for the string to reduce fragging.
+  result += addBoolToString(_.Power, kPowerStr, false);
+  /*
+  result += addModeToString(getMode(), kVoltasAuto, kVoltasCool, kVoltasHeat,
+                            kVoltasDry, kVoltasFan);
+  */
+  result += addBoolToString(_.Turbo, kTurboStr);
+  result += addBoolToString(_.Wifi, kWifiStr);
+  result += addBoolToString(_.Light, kLightStr);
+  return result;
+}

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -211,6 +211,7 @@ void IRVoltas::setMode(const uint8_t mode) {
       return;
   }
   _.Mode = mode;
+  setEcono(getEcono());  // Reset the econo setting if needed.
 }
 
 /// Get the operating mode setting of the A/C.
@@ -361,7 +362,13 @@ bool IRVoltas::getTurbo(void) const { return _.Turbo; }
 
 /// Change the Econo setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
-void IRVoltas::setEcono(const bool on) { _.Econo = on; }
+void IRVoltas::setEcono(const bool on) {
+  // The econo setting is only available in cool mode.
+  if (on && _.Mode == kVoltasCool)
+    _.Econo = true;
+  else
+    _.Econo = false;
+}
 
 /// Get the value of the current Econo setting.
 /// @return true, the setting is on. false, the setting is off.

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -30,7 +30,7 @@ union VoltasProtocol {
   struct {
     // Byte 0
     uint8_t SwingH         :1;
-    uint8_t Unknown0       :7;
+    uint8_t SwingHChange   :7;
     // Byte 1
     uint8_t Mode           :4;
     uint8_t                :1;
@@ -81,6 +81,8 @@ const uint8_t kVoltasFanHigh = 0b001;  ///< 1
 const uint8_t kVoltasFanMed =  0b010;  ///< 2
 const uint8_t kVoltasFanLow =  0b100;  ///< 4
 const uint8_t kVoltasFanAuto = 0b111;  ///< 7
+const uint8_t kVoltasSwingHChange =   0b1111100;  ///< 0x7D
+const uint8_t kVoltasSwingHNoChange = 0b0011001;  ///< 0x19
 
 // Classes
 /// Class for handling detailed Voltas A/C messages.
@@ -114,6 +116,8 @@ class IRVoltas {
   uint8_t getMode(void);
   void setSwingH(const bool on);
   bool getSwingH(void) const;
+  void setSwingHChange(const bool on);
+  bool getSwingHChange(void) const;
   void setSwingV(const bool on);
   bool getSwingV(void) const;
   void setEcono(const bool on);
@@ -130,7 +134,7 @@ class IRVoltas {
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void);
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
   String toString(void);
 #ifndef UNIT_TEST
 

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -102,6 +102,8 @@ class IRVoltas {
   void begin();
   static bool validChecksum(const uint8_t state[],
                             const uint16_t length = kVoltasStateLength);
+  void setModel(const voltas_ac_remote_model_t model);
+  voltas_ac_remote_model_t getModel(const bool raw = false) const;
   void setPower(const bool on);
   bool getPower(void) const;
   void on(void);
@@ -146,6 +148,7 @@ class IRVoltas {
   /// @endcond
 #endif
   VoltasProtocol _;  ///< The state of the IR remote.
+  voltas_ac_remote_model_t _model;  ///< Model type.
   void checksum(void);
   static uint8_t calcChecksum(const uint8_t state[],
                               const uint16_t length = kVoltasStateLength);

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -33,7 +33,7 @@ union VoltasProtocol {
     uint8_t SwingHChange   :7;
     // Byte 1
     uint8_t Mode           :4;
-    uint8_t                :1;
+    uint8_t                :1;  // Unknown/Unused
     uint8_t FanSpeed       :3;
     // Byte 2
     uint8_t SwingV         :3;
@@ -44,16 +44,16 @@ union VoltasProtocol {
     uint8_t Power          :1;
     // Byte 3
     uint8_t Temp           :4;
-    uint8_t Unknown3       :2;  // Typically 0b01
+    uint8_t                :2;  // Typically 0b01
     uint8_t Econo          :1;
     uint8_t TempSet        :1;
     // Byte 4
-    uint8_t TimerEnable_4  :1;
-    uint8_t                :6;  // Typically 0b011101
+    uint8_t OnTimerMins    :6;  // 0-59
+    uint8_t                :1;  // Unknown/Unused
     uint8_t OnTimer12Hr    :1;  // 1 if Timer is >= 12 hrs.
     // Byte 5
-    uint8_t TimerEnable_5  :1;
-    uint8_t                :6;  // Typically 0b011101
+    uint8_t OffTimerMins   :6;  // 0-59
+    uint8_t                :1;  // Unknown/Unused
     uint8_t OffTimer12Hr   :1;  // 1 if Timer is >= 12 hrs.
     // Byte 6
     uint8_t                :8;  // Typically 0b00111011(0x3B)

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -75,10 +75,11 @@ const uint8_t kVoltasHeat  = 0b0010;  ///< 2
 const uint8_t kVoltasDry   = 0b0100;  ///< 4
 const uint8_t kVoltasCool  = 0b1000;  ///< 8
 const uint8_t kVoltasMinTemp = 16;  ///< Celsius
+const uint8_t kVoltasDryTemp = 24;  ///< Celsius
 const uint8_t kVoltasMaxTemp = 30;  ///< Celsius
-const uint8_t kVoltasFanLow =  0b001;  ///< 1
+const uint8_t kVoltasFanHigh = 0b001;  ///< 1
 const uint8_t kVoltasFanMed =  0b010;  ///< 2
-const uint8_t kVoltasFanHigh = 0b100;  ///< 4
+const uint8_t kVoltasFanLow =  0b100;  ///< 4
 const uint8_t kVoltasFanAuto = 0b111;  ///< 7
 
 // Classes
@@ -111,6 +112,10 @@ class IRVoltas {
   uint8_t getFan(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
+  void setSwingH(const bool on);
+  bool getSwingH(void) const;
+  void setSwingV(const bool on);
+  bool getSwingV(void) const;
   void setEcono(const bool on);
   bool getEcono(void) const;
   void setLight(const bool on);

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -64,7 +64,7 @@ union VoltasProtocol {
     uint8_t                :5;  // Typically 0b00000
     uint8_t Light          :1;
     uint8_t OffTimerEnable :1;
-    uint8_t                :1;  // Typically 0b0
+    uint8_t OnTimerEnable  :1;
     // Byte 9
     uint8_t Checksum       :8;
   };

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -38,7 +38,7 @@ union VoltasProtocol {
     // Byte 2
     uint8_t SwingV         :3;
     uint8_t Wifi           :1;
-    uint8_t                :1;
+    uint8_t                :1;  // Unknown/Unused
     uint8_t Turbo          :1;
     uint8_t Sleep          :1;
     uint8_t Power          :1;
@@ -128,6 +128,8 @@ class IRVoltas {
   bool getLight(void) const;
   void setTurbo(const bool on);
   bool getTurbo(void) const;
+  void setSleep(const bool on);
+  bool getSleep(void) const;
   void setOffTimer(const uint16_t nr_of_mins);
   uint16_t getOffTimer(void);
   uint8_t* getRaw(void);

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -48,17 +48,18 @@ union VoltasProtocol {
     uint8_t Econo          :1;
     uint8_t TempSet        :1;
     // Byte 4
-    uint8_t OffTimer24h4   :1;
-    uint8_t                :7;  // Typically 0b0011101
-    // Byte 5
-    uint8_t OffTimer24h5   :1;
+    uint8_t TimerEnable_4  :1;
     uint8_t                :6;  // Typically 0b011101
-    uint8_t TimerAdd12Hr   :1;
+    uint8_t OnTimer12Hr    :1;  // 1 if Timer is >= 12 hrs.
+    // Byte 5
+    uint8_t TimerEnable_5  :1;
+    uint8_t                :6;  // Typically 0b011101
+    uint8_t OffTimer12Hr   :1;  // 1 if Timer is >= 12 hrs.
     // Byte 6
     uint8_t                :8;  // Typically 0b00111011(0x3B)
     // Byte 7
-    uint8_t                :4;  // Typically 0b0001
-    uint8_t TimerHrs       :4;  // Nr of Hours.
+    uint8_t OnTimerHrs     :4;  // Nr of Hours.
+    uint8_t OffTimerHrs    :4;  // Nr of Hours.
     // Byte 8
     uint8_t                :5;  // Typically 0b00000
     uint8_t Light          :1;
@@ -130,8 +131,12 @@ class IRVoltas {
   bool getTurbo(void) const;
   void setSleep(const bool on);
   bool getSleep(void) const;
-  void setOffTimer(const uint16_t nr_of_mins);
-  uint16_t getOffTimer(void);
+  uint16_t getOnTime(void) const;
+  void setOnTime(const uint16_t nr_of_mins);
+  bool getOnTimerEnabled(void) const;
+  uint16_t getOffTime(void) const;
+  void setOffTime(const uint16_t nr_of_mins);
+  bool getOffTimerEnabled(void) const;
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[]);
   uint8_t convertMode(const stdAc::opmode_t mode);

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -1,0 +1,128 @@
+// Copyright 2020 David Conran (crankyoldgit)
+// Copyright 2020 manj9501
+/// @file
+/// @brief Support for Voltas A/C protocol
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1238
+
+// Supports:
+//   Brand: Voltas,  Model: 122LZF 4011252 Window A/C
+//
+// Ref: https://docs.google.com/spreadsheets/d/1zzDEUQ52y7MZ7_xCU3pdjdqbRXOwZLsbTGvKWcicqCI/
+// Ref: https://www.corona.co.jp/box/download.php?id=145060636229
+
+#ifndef IR_VOLTAS_H_
+#define IR_VOLTAS_H_
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#ifdef UNIT_TEST
+#include "IRsend_test.h"
+#endif
+
+
+union VoltasProtocol {
+  uint8_t raw[kVoltasStateLength];  ///< The state in native IR code form
+  struct {
+    // Byte 0
+    uint8_t SwingH         :1;
+    uint8_t Unknown0       :7;
+    // Byte 1
+    uint8_t Mode           :4;
+    uint8_t                :1;
+    uint8_t FanSpeed       :3;
+    // Byte 2
+    uint8_t SwingV         :3;
+    uint8_t Wifi           :1;
+    uint8_t                :1;
+    uint8_t Turbo          :1;
+    uint8_t Sleep          :1;
+    uint8_t Power          :1;
+    // Byte 3
+    uint8_t Temp           :4;
+    uint8_t Unknown3       :2;  // Typically 0b01
+    uint8_t Econo          :1;
+    uint8_t TempSet        :1;
+    // Byte 4
+    uint8_t OffTimer24h4   :1;
+    uint8_t                :7;  // Typically 0b0011101
+    // Byte 5
+    uint8_t OffTimer24h5   :1;
+    uint8_t                :6;  // Typically 0b011101
+    uint8_t TimerAdd12Hr   :1;
+    // Byte 6
+    uint8_t                :8;  // Typically 0b00111011(0x3B)
+    // Byte 7
+    uint8_t                :4;  // Typically 0b0001
+    uint8_t TimerHrs       :4;  // Nr of Hours.
+    // Byte 8
+    uint8_t                :5;  // Typically 0b00000
+    uint8_t Light          :1;
+    uint8_t OffTimerEnable :1;
+    uint8_t                :1;  // Typically 0b0
+    // Byte 9
+    uint8_t Checksum       :8;
+  };
+};
+
+// Constants
+
+// Classes
+/// Class for handling detailed Voltas A/C messages.
+class IRVoltas {
+ public:
+  explicit IRVoltas(const uint16_t pin, const bool inverted = false,
+                    const bool use_modulation = true);
+  void stateReset();
+#if SEND_VOLTAS
+  void send(const uint16_t repeat = kNoRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @return The uSec timing offset needed per modulation of the IR Led.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
+  int8_t calibrate(void) { return _irsend.calibrate(); }
+#endif  // SEND_VOLTAS
+  void begin();
+  static bool validChecksum(const uint8_t state[],
+                            const uint16_t length = kVoltasStateLength);
+  void setPower(const bool on);
+  bool getPower(void) const;
+  void on(void);
+  void off(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp(void);
+  void setFan(const uint8_t speed);
+  uint8_t getFan(void);
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void);
+  void setEcono(const bool on);
+  bool getEcono(void);
+  void setOffTimer(const uint16_t nr_of_mins);
+  uint16_t getOffTimer(void);
+  uint8_t* getRaw(void);
+  void setRaw(const uint8_t new_code[]);
+  uint8_t convertMode(const stdAc::opmode_t mode);
+  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::state_t toCommon(void);
+  String toString(void);
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;  ///< Instance of the IR send class
+#else
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif
+  VoltasProtocol _;  ///< The state of the IR remote.
+  void checksum(void);
+  static uint8_t calcChecksum(const uint8_t state[],
+                              const uint16_t length = kVoltasStateLength);
+};
+#endif  // IR_VOLTAS_H_

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -70,6 +70,16 @@ union VoltasProtocol {
 };
 
 // Constants
+const uint8_t kVoltasFan   = 0b0001;  ///< 1
+const uint8_t kVoltasHeat  = 0b0010;  ///< 2
+const uint8_t kVoltasDry   = 0b0100;  ///< 4
+const uint8_t kVoltasCool  = 0b1000;  ///< 8
+const uint8_t kVoltasMinTemp = 16;  ///< Celsius
+const uint8_t kVoltasMaxTemp = 30;  ///< Celsius
+const uint8_t kVoltasFanLow =  0b001;  ///< 1
+const uint8_t kVoltasFanMed =  0b010;  ///< 2
+const uint8_t kVoltasFanHigh = 0b100;  ///< 4
+const uint8_t kVoltasFanAuto = 0b111;  ///< 7
 
 // Classes
 /// Class for handling detailed Voltas A/C messages.
@@ -93,6 +103,8 @@ class IRVoltas {
   bool getPower(void) const;
   void on(void);
   void off(void);
+  void setWifi(const bool on);
+  bool getWifi(void) const;
   void setTemp(const uint8_t temp);
   uint8_t getTemp(void);
   void setFan(const uint8_t speed);
@@ -100,7 +112,11 @@ class IRVoltas {
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
   void setEcono(const bool on);
-  bool getEcono(void);
+  bool getEcono(void) const;
+  void setLight(const bool on);
+  bool getLight(void) const;
+  void setTurbo(const bool on);
+  bool getTurbo(void) const;
   void setOffTimer(const uint16_t nr_of_mins);
   uint16_t getOffTimer(void);
   uint8_t* getRaw(void);

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -50,16 +50,16 @@ union VoltasProtocol {
     // Byte 4
     uint8_t OnTimerMins    :6;  // 0-59
     uint8_t                :1;  // Unknown/Unused
-    uint8_t OnTimer12Hr    :1;  // 1 if Timer is >= 12 hrs.
+    uint8_t OnTimer12Hr    :1;  // (Nr of Hours + 1) % 12.
     // Byte 5
     uint8_t OffTimerMins   :6;  // 0-59
     uint8_t                :1;  // Unknown/Unused
-    uint8_t OffTimer12Hr   :1;  // 1 if Timer is >= 12 hrs.
+    uint8_t OffTimer12Hr   :1;  // (Nr of Hours + 1) % 12.
     // Byte 6
     uint8_t                :8;  // Typically 0b00111011(0x3B)
     // Byte 7
-    uint8_t OnTimerHrs     :4;  // Nr of Hours.
-    uint8_t OffTimerHrs    :4;  // Nr of Hours.
+    uint8_t OnTimerHrs     :4;  // (Nr of Hours + 1) % 12.
+    uint8_t OffTimerHrs    :4;  // (Nr of Hours + 1) % 12.
     // Byte 8
     uint8_t                :5;  // Typically 0b00000
     uint8_t Light          :1;
@@ -133,10 +133,8 @@ class IRVoltas {
   bool getSleep(void) const;
   uint16_t getOnTime(void) const;
   void setOnTime(const uint16_t nr_of_mins);
-  bool getOnTimerEnabled(void) const;
   uint16_t getOffTime(void) const;
   void setOffTime(const uint16_t nr_of_mins);
-  bool getOffTimerEnabled(void) const;
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[]);
   uint8_t convertMode(const stdAc::opmode_t mode);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1585,13 +1585,11 @@ TEST(TestIRac, Voltas) {
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
-/* TODO(crankyoldgit): Fix/enable this.
   ASSERT_EQ(VOLTAS, ac._irsend.capture.decode_type);
   ASSERT_EQ(kVoltasBits, ac._irsend.capture.bits);
   ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
-*/
 }
 
 TEST(TestIRac, Whirlpool) {

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1565,7 +1565,7 @@ TEST(TestIRac, Voltas) {
   char expected_unknown[] =
       "Model: 0 (UNKNOWN), Power: On, Mode: 8 (Cool), Temp: 18C, "
       "Fan: 1 (High), Swing(V): On, Swing(H): On, "
-      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On";
   irac.voltas(&ac,
               voltas_ac_remote_model_t::kVoltasUnknown,  // Model
               true,                                      // Power
@@ -1576,7 +1576,8 @@ TEST(TestIRac, Voltas) {
               stdAc::swingh_t::kAuto,                    // Horizontal Swing
               false,                                     // Turbo
               false,                                     // Econo
-              true);                                     // Light
+              true,                                      // Light
+              3 * 60);                                   // Sleep
   EXPECT_EQ(voltas_ac_remote_model_t::kVoltasUnknown, ac.getModel());
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(kVoltasCool, ac.getMode());
@@ -1585,6 +1586,7 @@ TEST(TestIRac, Voltas) {
   EXPECT_FALSE(ac.getTurbo());
   EXPECT_FALSE(ac.getEcono());
   EXPECT_TRUE(ac.getLight());
+  EXPECT_TRUE(ac.getSleep());
   ASSERT_EQ(expected_unknown, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -1599,7 +1601,7 @@ TEST(TestIRac, Voltas) {
   char expected_122LZF[] =
       "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 18C, "
       "Fan: 1 (High), Swing(V): On, Swing(H): N/A, "
-      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On";
   irac.voltas(&ac,
               voltas_ac_remote_model_t::kVoltas122LZF,   // Model
               true,                                      // Power
@@ -1610,7 +1612,8 @@ TEST(TestIRac, Voltas) {
               stdAc::swingh_t::kAuto,                    // Horizontal Swing
               false,                                     // Turbo
               false,                                     // Econo
-              true);                                     // Light
+              true,                                      // Light
+              3 * 60);                                   // Sleep
   EXPECT_EQ(voltas_ac_remote_model_t::kVoltas122LZF, ac.getModel());
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(kVoltasCool, ac.getMode());
@@ -1619,6 +1622,7 @@ TEST(TestIRac, Voltas) {
   EXPECT_FALSE(ac.getTurbo());
   EXPECT_FALSE(ac.getEcono());
   EXPECT_TRUE(ac.getLight());
+  EXPECT_TRUE(ac.getSleep());
   ASSERT_EQ(expected_122LZF, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -29,6 +29,7 @@
 #include "ir_Toshiba.h"
 #include "ir_Trotec.h"
 #include "ir_Vestel.h"
+#include "ir_Voltas.h"
 #include "ir_Whirlpool.h"
 #include "IRac.h"
 #include "IRrecv.h"
@@ -1554,6 +1555,44 @@ TEST(TestIRac, Vestel) {
       "m520s100000", ac._irsend.outputStr());
 }
 
+TEST(TestIRac, Voltas) {
+  IRVoltas ac(kGpioUnused);
+  IRac irac(kGpioUnused);
+  IRrecv capture(kGpioUnused);
+  char expected[] =
+      "Power: On, Mode: 8 (Cool), Temp: 18C, Fan: 1 (High), "
+      "Swing(V): On, Swing(H): On, "
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
+
+  ac.begin();
+  irac.voltas(&ac,
+              true,                        // Power
+              stdAc::opmode_t::kCool,      // Mode
+              18,                          // Celsius
+              stdAc::fanspeed_t::kHigh,    // Fan speed
+              stdAc::swingv_t::kAuto,      // Vertical Swing
+              stdAc::swingh_t::kAuto,      // Horizontal Swing
+              false,                       // Turbo
+              false,                       // Econo
+              true);                       // Light
+  EXPECT_TRUE(ac.getPower());
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+  EXPECT_EQ(18, ac.getTemp());
+  EXPECT_EQ(kVoltasFanHigh, ac.getFan());
+  EXPECT_FALSE(ac.getTurbo());
+  EXPECT_FALSE(ac.getEcono());
+  EXPECT_TRUE(ac.getLight());
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+/* TODO(crankyoldgit): Fix/enable this.
+  ASSERT_EQ(VOLTAS, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kVoltasBits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+*/
+}
 
 TEST(TestIRac, Whirlpool) {
   IRWhirlpoolAc ac(kGpioUnused);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1565,7 +1565,8 @@ TEST(TestIRac, Voltas) {
   char expected_unknown[] =
       "Model: 0 (UNKNOWN), Power: On, Mode: 8 (Cool), Temp: 18C, "
       "Fan: 1 (High), Swing(V): On, Swing(H): On, "
-      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On";
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On, "
+      "On Timer: Off, Off Timer: Off";
   irac.voltas(&ac,
               voltas_ac_remote_model_t::kVoltasUnknown,  // Model
               true,                                      // Power
@@ -1601,7 +1602,8 @@ TEST(TestIRac, Voltas) {
   char expected_122LZF[] =
       "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 18C, "
       "Fan: 1 (High), Swing(V): On, Swing(H): N/A, "
-      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On";
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On, Sleep: On, "
+      "On Timer: Off, Off Timer: Off";
   irac.voltas(&ac,
               voltas_ac_remote_model_t::kVoltas122LZF,   // Model
               true,                                      // Power

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1559,22 +1559,25 @@ TEST(TestIRac, Voltas) {
   IRVoltas ac(kGpioUnused);
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
-  char expected[] =
-      "Power: On, Mode: 8 (Cool), Temp: 18C, Fan: 1 (High), "
-      "Swing(V): On, Swing(H): On, "
-      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
-
   ac.begin();
+
+  // Test the UNKNOWN model type
+  char expected_unknown[] =
+      "Model: 0 (UNKNOWN), Power: On, Mode: 8 (Cool), Temp: 18C, "
+      "Fan: 1 (High), Swing(V): On, Swing(H): On, "
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
   irac.voltas(&ac,
-              true,                        // Power
-              stdAc::opmode_t::kCool,      // Mode
-              18,                          // Celsius
-              stdAc::fanspeed_t::kHigh,    // Fan speed
-              stdAc::swingv_t::kAuto,      // Vertical Swing
-              stdAc::swingh_t::kAuto,      // Horizontal Swing
-              false,                       // Turbo
-              false,                       // Econo
-              true);                       // Light
+              voltas_ac_remote_model_t::kVoltasUnknown,  // Model
+              true,                                      // Power
+              stdAc::opmode_t::kCool,                    // Mode
+              18,                                        // Celsius
+              stdAc::fanspeed_t::kHigh,                  // Fan speed
+              stdAc::swingv_t::kAuto,                    // Vertical Swing
+              stdAc::swingh_t::kAuto,                    // Horizontal Swing
+              false,                                     // Turbo
+              false,                                     // Econo
+              true);                                     // Light
+  EXPECT_EQ(voltas_ac_remote_model_t::kVoltasUnknown, ac.getModel());
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(kVoltasCool, ac.getMode());
   EXPECT_EQ(18, ac.getTemp());
@@ -1582,14 +1585,46 @@ TEST(TestIRac, Voltas) {
   EXPECT_FALSE(ac.getTurbo());
   EXPECT_FALSE(ac.getEcono());
   EXPECT_TRUE(ac.getLight());
-  ASSERT_EQ(expected, ac.toString());
+  ASSERT_EQ(expected_unknown, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(VOLTAS, ac._irsend.capture.decode_type);
   ASSERT_EQ(kVoltasBits, ac._irsend.capture.bits);
-  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_EQ(expected_unknown, IRAcUtils::resultAcToString(&ac._irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+
+  ac._irsend.reset();
+  // Test the UNKNOWN model type
+  char expected_122LZF[] =
+      "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 18C, "
+      "Fan: 1 (High), Swing(V): On, Swing(H): N/A, "
+      "Turbo: Off, Econo: Off, WiFi: Off, Light: On";
+  irac.voltas(&ac,
+              voltas_ac_remote_model_t::kVoltas122LZF,   // Model
+              true,                                      // Power
+              stdAc::opmode_t::kCool,                    // Mode
+              18,                                        // Celsius
+              stdAc::fanspeed_t::kHigh,                  // Fan speed
+              stdAc::swingv_t::kAuto,                    // Vertical Swing
+              stdAc::swingh_t::kAuto,                    // Horizontal Swing
+              false,                                     // Turbo
+              false,                                     // Econo
+              true);                                     // Light
+  EXPECT_EQ(voltas_ac_remote_model_t::kVoltas122LZF, ac.getModel());
+  EXPECT_TRUE(ac.getPower());
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+  EXPECT_EQ(18, ac.getTemp());
+  EXPECT_EQ(kVoltasFanHigh, ac.getFan());
+  EXPECT_FALSE(ac.getTurbo());
+  EXPECT_FALSE(ac.getEcono());
+  EXPECT_TRUE(ac.getLight());
+  ASSERT_EQ(expected_122LZF, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(VOLTAS, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kVoltasBits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected_122LZF, IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 
 TEST(TestIRac, Whirlpool) {

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -392,7 +392,7 @@ TEST(TestVoltasClass, HumanReadable) {
 
 TEST(TestVoltasClass, Timers) {
   IRVoltas ac(kGpioUnused);
-  const uint8_t off_7hrs[10] = {
+  const uint8_t off_7hrs[10] = {  // Real Data
       0x33, 0x28, 0x80, 0x1B, 0x3B, 0x3B, 0x3B, 0x71, 0x40, 0xA7};
   ac.setRaw(off_7hrs);
   EXPECT_EQ(
@@ -400,7 +400,7 @@ TEST(TestVoltasClass, Timers) {
       "Swing(V): Off, Swing(H): N/A, Turbo: Off, Econo: Off, WiFi: Off, "
       "Light: Off, Sleep: Off, On Timer: Off, Off Timer: 06:59",
       ac.toString());
-  const uint8_t off_16hrs[10] = {
+  const uint8_t off_16hrs[10] = {  // Real Data
       0x33, 0x28, 0x80, 0x1B, 0x3B, 0xBB, 0x3B, 0x41, 0x40, 0x57};
   ac.setRaw(off_16hrs);
   EXPECT_EQ(
@@ -414,7 +414,12 @@ TEST(TestVoltasClass, Timers) {
     "Swing(V): Off, Swing(H): N/A, Turbo: Off, Econo: Off, WiFi: Off, "
     "Light: Off, Sleep: Off, On Timer: Off, Off Timer: 23:59",
     ac.toString());
-  const uint8_t off_24hrs[10] = {  // Guess only
-      0x33, 0x28, 0x80, 0x1B, 0x3B, 0x3B, 0x3B, 0x01, 0x40, 0x17};
-  EXPECT_STATE_EQ(off_24hrs, ac.getRaw(), kVoltasBits);
+  const uint8_t off_24hrs[10] = {  // Real Data
+      0x33, 0x28, 0x80, 0x1B, 0x3A, 0x3A, 0x3B, 0x01, 0x40, 0x19};
+  ac.setRaw(off_24hrs);
+  EXPECT_EQ(
+    "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 27C, Fan: 1 (High), "
+    "Swing(V): Off, Swing(H): N/A, Turbo: Off, Econo: Off, WiFi: Off, "
+    "Light: Off, Sleep: Off, On Timer: Off, Off Timer: 23:58",
+    ac.toString());
 }

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -343,22 +343,25 @@ TEST(TestVoltasClass, HumanReadable) {
       "WiFi: Off, Light: Off, Sleep: Off, On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.on();
-  ac.setMode(kVoltasHeat);
   ac.setTemp(21);
   ac.setFan(kVoltasFanAuto);
   ac.setSwingV(true);
-  ac.setTurbo(true);
   ac.setWifi(true);
   ac.setLight(true);
+  ac.setTurbo(true);
   ac.setSleep(true);
+  ac.setEcono(true);
   ac.setOnTime(2 * 60);
+  ac.setMode(kVoltasHeat);  // Heat mode should cancel Sleep, Turbo, & Econo.
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 2 (Heat), Temp: 21C, "
-      "Fan: 7 (Auto), Swing(V): On, Swing(H): N/A, Turbo: On, Econo: Off, "
-      "WiFi: On, Light: On, Sleep: On, On Timer: 02:00, Off Timer: Off",
+      "Fan: 7 (Auto), Swing(V): On, Swing(H): N/A, Turbo: Off, Econo: Off, "
+      "WiFi: On, Light: On, Sleep: Off, On Timer: 02:00, Off Timer: Off",
       ac.toString());
   ac.setOffTime(13 * 60);
   ac.setMode(kVoltasCool);
+  ac.setTurbo(true);
+  ac.setSleep(true);
   ac.setEcono(true);
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 21C, "

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -41,7 +41,7 @@ TEST(TestDecodeVoltas, RealExample) {
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
-      "Swing(V): Off, Swing(H): On, "
+      "Swing(V): Off, Swing(H): N/A, "
       "Turbo: Off, Econo: Off, WiFi: On, Light: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
@@ -251,13 +251,19 @@ TEST(TestVoltasClass, SwingV) {
 TEST(TestVoltasClass, SwingH) {
   IRVoltas ac(kGpioUnused);
   ac.begin();
+  ac.setSwingHChange(false);
+  EXPECT_FALSE(ac.getSwingHChange());
 
   ac.setSwingH(true);
   EXPECT_TRUE(ac.getSwingH());
+  EXPECT_TRUE(ac.getSwingHChange());
 
+  ac.setSwingHChange(false);
   ac.setSwingH(false);
   EXPECT_EQ(false, ac.getSwingH());
+  EXPECT_TRUE(ac.getSwingHChange());
 
   ac.setSwingH(true);
   EXPECT_TRUE(ac.getSwingH());
+  EXPECT_TRUE(ac.getSwingHChange());
 }

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -43,7 +43,7 @@ TEST(TestDecodeVoltas, RealExample) {
       "Model: 1 (122LZF), Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
       "Swing(V): Off, Swing(H): N/A, "
       "Turbo: Off, Econo: Off, WiFi: On, Light: Off, Sleep: Off, "
-      "On Timer: 01:00, Off Timer: 01:00",
+      "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -351,14 +351,14 @@ TEST(TestVoltasClass, HumanReadable) {
   ac.setTurbo(true);
   ac.setSleep(true);
   ac.setEcono(true);
-  ac.setOnTime(2 * 60);
+  ac.setOnTime(2 * 60 + 17);
   ac.setMode(kVoltasHeat);  // Heat mode should cancel Sleep, Turbo, & Econo.
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 2 (Heat), Temp: 21C, "
       "Fan: 7 (Auto), Swing(V): On, Swing(H): N/A, Turbo: Off, Econo: Off, "
-      "WiFi: On, Light: On, Sleep: Off, On Timer: 02:00, Off Timer: Off",
+      "WiFi: On, Light: On, Sleep: Off, On Timer: 02:17, Off Timer: Off",
       ac.toString());
-  ac.setOffTime(13 * 60);
+  ac.setOffTime(13 * 60 + 37);
   ac.setMode(kVoltasCool);
   ac.setTurbo(true);
   ac.setSleep(true);
@@ -366,21 +366,21 @@ TEST(TestVoltasClass, HumanReadable) {
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 21C, "
       "Fan: 7 (Auto), Swing(V): On, Swing(H): N/A, Turbo: On, Econo: On, "
-      "WiFi: On, Light: On, Sleep: On, On Timer: 02:00, Off Timer: 13:00",
+      "WiFi: On, Light: On, Sleep: On, On Timer: 02:17, Off Timer: 13:37",
       ac.toString());
   ac.setModel(voltas_ac_remote_model_t::kVoltasUnknown);
   ac.setSwingH(true);
   EXPECT_EQ(
       "Model: 0 (UNKNOWN), Power: On, Mode: 8 (Cool), Temp: 21C, "
       "Fan: 7 (Auto), Swing(V): On, Swing(H): On, Turbo: On, Econo: On, "
-      "WiFi: On, Light: On, Sleep: On, On Timer: 02:00, Off Timer: 13:00",
+      "WiFi: On, Light: On, Sleep: On, On Timer: 02:17, Off Timer: 13:37",
       ac.toString());
   ac.setModel(voltas_ac_remote_model_t::kVoltas122LZF);
   ac.setOnTime(0);
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 8 (Cool), Temp: 21C, "
       "Fan: 7 (Auto), Swing(V): On, Swing(H): N/A, Turbo: On, Econo: On, "
-      "WiFi: On, Light: On, Sleep: On, On Timer: Off, Off Timer: 13:00",
+      "WiFi: On, Light: On, Sleep: On, On Timer: Off, Off Timer: 13:37",
       ac.toString());
   ac.setOffTime(0);
   EXPECT_EQ(

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -40,7 +40,8 @@ TEST(TestDecodeVoltas, RealExample) {
   ASSERT_EQ(kVoltasBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Power: On, Turbo: Off, WiFi: On, Light: Off",
+      "Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (High), "
+      "Turbo: Off, Econo: Off, WiFi: On, Light: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -108,4 +109,126 @@ TEST(TestIRVoltasClass, Power) {
 
   ac.setPower(false);
   EXPECT_FALSE(ac.getPower());
+}
+
+TEST(TestIRVoltasClass, Wifi) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setWifi(false);
+  EXPECT_FALSE(ac.getWifi());
+  ac.setWifi(true);
+  EXPECT_TRUE(ac.getWifi());
+  ac.setWifi(false);
+  EXPECT_FALSE(ac.getWifi());
+}
+
+TEST(TestIRVoltasClass, Turbo) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setTurbo(false);
+  EXPECT_FALSE(ac.getTurbo());
+  ac.setTurbo(true);
+  EXPECT_TRUE(ac.getTurbo());
+  ac.setTurbo(false);
+  EXPECT_FALSE(ac.getTurbo());
+}
+
+TEST(TestIRVoltasClass, Econo) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+}
+
+TEST(TestIRVoltasClass, Light) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setLight(false);
+  EXPECT_FALSE(ac.getLight());
+  ac.setLight(true);
+  EXPECT_TRUE(ac.getLight());
+  ac.setLight(false);
+  EXPECT_FALSE(ac.getLight());
+}
+
+TEST(TestVoltasClass, OperatingMode) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setMode(kVoltasCool);
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+  ac.setMode(kVoltasFan);
+  EXPECT_EQ(kVoltasFan, ac.getMode());
+  ac.setMode(kVoltasDry);
+  EXPECT_EQ(kVoltasDry, ac.getMode());
+  ac.setMode(kVoltasHeat);
+  EXPECT_EQ(kVoltasHeat, ac.getMode());
+
+  ac.setMode(kVoltasCool - 1);
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+
+  ac.setMode(kVoltasCool + 1);
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+
+  ac.setMode(255);
+  EXPECT_EQ(kVoltasCool, ac.getMode());
+}
+
+TEST(TestVoltasClass, Temperature) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setTemp(kVoltasMinTemp);
+  EXPECT_EQ(kVoltasMinTemp, ac.getTemp());
+
+  ac.setTemp(kVoltasMinTemp + 1);
+  EXPECT_EQ(kVoltasMinTemp + 1, ac.getTemp());
+
+  ac.setTemp(kVoltasMaxTemp);
+  EXPECT_EQ(kVoltasMaxTemp, ac.getTemp());
+
+  ac.setTemp(kVoltasMinTemp - 1);
+  EXPECT_EQ(kVoltasMinTemp, ac.getTemp());
+
+  ac.setTemp(kVoltasMaxTemp + 1);
+  EXPECT_EQ(kVoltasMaxTemp, ac.getTemp());
+
+  ac.setTemp(23);
+  EXPECT_EQ(23, ac.getTemp());
+
+  ac.setTemp(0);
+  EXPECT_EQ(kVoltasMinTemp, ac.getTemp());
+
+  ac.setTemp(255);
+  EXPECT_EQ(kVoltasMaxTemp, ac.getTemp());
+}
+
+TEST(TestVoltasClass, FanSpeed) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+  ac.setFan(kVoltasFanLow);
+
+  ac.setFan(kVoltasFanAuto);
+  EXPECT_EQ(kVoltasFanAuto, ac.getFan());
+
+  ac.setFan(kVoltasFanLow);
+  EXPECT_EQ(kVoltasFanLow, ac.getFan());
+  ac.setFan(kVoltasFanMed);
+  EXPECT_EQ(kVoltasFanMed, ac.getFan());
+  ac.setFan(kVoltasFanHigh);
+  EXPECT_EQ(kVoltasFanHigh, ac.getFan());
+
+  ac.setFan(0);
+  EXPECT_EQ(kVoltasFanAuto, ac.getFan());
+
+  ac.setFan(255);
+  EXPECT_EQ(kVoltasFanAuto, ac.getFan());
 }

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -80,13 +80,17 @@ TEST(TestIRVoltasClass, Checksums) {
   EXPECT_TRUE(IRVoltas::validChecksum(valid));
   EXPECT_FALSE(IRVoltas::validChecksum(valid, kVoltasStateLength - 1));
   EXPECT_EQ(0xE6, IRVoltas::calcChecksum(valid));
+  const uint8_t badchecksum[kVoltasStateLength] = {
+      0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x00, 0x00};
+  EXPECT_FALSE(IRVoltas::validChecksum(badchecksum));
+  EXPECT_EQ(0xE6, IRVoltas::calcChecksum(badchecksum));
 }
 
 TEST(TestIRVoltasClass, SetandGetRaw) {
   const uint8_t valid[kVoltasStateLength] = {
       0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x00, 0xE6};
   const uint8_t badchecksum[kVoltasStateLength] = {
-      0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x00, 0xE6};
+      0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x00, 0x00};
   IRVoltas ac(kGpioUnused);
 
   ac.setRaw(valid);
@@ -158,6 +162,19 @@ TEST(TestIRVoltasClass, Light) {
   EXPECT_TRUE(ac.getLight());
   ac.setLight(false);
   EXPECT_FALSE(ac.getLight());
+
+  const uint8_t light_off[kVoltasStateLength] = {
+      0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x00, 0xE6};
+  ac.setRaw(light_off);
+  EXPECT_FALSE(ac.getLight());
+  const uint8_t light_on[kVoltasStateLength] = {
+      0x33, 0x84, 0x88, 0x18, 0x3B, 0x3B, 0x3B, 0x11, 0x20, 0xC6};
+  ac.setRaw(light_on);
+  EXPECT_TRUE(ac.getLight());
+  ac.setLight(false);
+  EXPECT_STATE_EQ(light_off, ac.getRaw(), kVoltasBits);
+  ac.setLight(true);
+  EXPECT_STATE_EQ(light_on, ac.getRaw(), kVoltasBits);
 }
 
 TEST(TestVoltasClass, OperatingMode) {

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -40,7 +40,7 @@ TEST(TestDecodeVoltas, RealExample) {
   ASSERT_EQ(kVoltasBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
+      "Model: 1 (122LZF), Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
       "Swing(V): Off, Swing(H): N/A, "
       "Turbo: Off, Econo: Off, WiFi: On, Light: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
@@ -268,6 +268,9 @@ TEST(TestVoltasClass, SwingV) {
 TEST(TestVoltasClass, SwingH) {
   IRVoltas ac(kGpioUnused);
   ac.begin();
+  // This model allows full control.
+  ac.setModel(voltas_ac_remote_model_t::kVoltasUnknown);
+
   ac.setSwingHChange(false);
   EXPECT_FALSE(ac.getSwingHChange());
 
@@ -277,10 +280,21 @@ TEST(TestVoltasClass, SwingH) {
 
   ac.setSwingHChange(false);
   ac.setSwingH(false);
-  EXPECT_EQ(false, ac.getSwingH());
+  EXPECT_FALSE(ac.getSwingH());
   EXPECT_TRUE(ac.getSwingHChange());
 
   ac.setSwingH(true);
   EXPECT_TRUE(ac.getSwingH());
   EXPECT_TRUE(ac.getSwingHChange());
+
+  // Switch to a model that does not allow SwingH control.
+  ac.setModel(voltas_ac_remote_model_t::kVoltas122LZF);
+  EXPECT_FALSE(ac.getSwingHChange());
+  EXPECT_FALSE(ac.getSwingH());
+  ac.setSwingH(true);
+  EXPECT_FALSE(ac.getSwingHChange());
+  EXPECT_FALSE(ac.getSwingH());
+  ac.setSwingH(false);
+  EXPECT_FALSE(ac.getSwingHChange());
+  EXPECT_FALSE(ac.getSwingH());
 }

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -40,7 +40,8 @@ TEST(TestDecodeVoltas, RealExample) {
   ASSERT_EQ(kVoltasBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expected, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (High), "
+      "Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
+      "Swing(V): Off, Swing(H): On, "
       "Turbo: Off, Econo: Off, WiFi: On, Light: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
@@ -68,7 +69,7 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("VOLTAS", typeToString(decode_type_t::VOLTAS));
   ASSERT_EQ(decode_type_t::VOLTAS, strToDecodeType("VOLTAS"));
   ASSERT_TRUE(hasACState(decode_type_t::VOLTAS));
-  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::VOLTAS));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::VOLTAS));
   ASSERT_EQ(kVoltasBits, IRsend::defaultBits(decode_type_t::VOLTAS));
   ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::VOLTAS));
 }
@@ -231,4 +232,32 @@ TEST(TestVoltasClass, FanSpeed) {
 
   ac.setFan(255);
   EXPECT_EQ(kVoltasFanAuto, ac.getFan());
+}
+
+TEST(TestVoltasClass, SwingV) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setSwingV(true);
+  EXPECT_TRUE(ac.getSwingV());
+
+  ac.setSwingV(false);
+  EXPECT_EQ(false, ac.getSwingV());
+
+  ac.setSwingV(true);
+  EXPECT_TRUE(ac.getSwingV());
+}
+
+TEST(TestVoltasClass, SwingH) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setSwingH(true);
+  EXPECT_TRUE(ac.getSwingH());
+
+  ac.setSwingH(false);
+  EXPECT_EQ(false, ac.getSwingH());
+
+  ac.setSwingH(true);
+  EXPECT_TRUE(ac.getSwingH());
 }

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -255,6 +255,7 @@ TEST(TestVoltasClass, Temperature) {
 TEST(TestVoltasClass, FanSpeed) {
   IRVoltas ac(kGpioUnused);
   ac.begin();
+  ac.setMode(kVoltasCool);  // All fan speeds are allowed in cool mode.
   ac.setFan(kVoltasFanLow);
 
   ac.setFan(kVoltasFanAuto);
@@ -272,6 +273,18 @@ TEST(TestVoltasClass, FanSpeed) {
 
   ac.setFan(255);
   EXPECT_EQ(kVoltasFanAuto, ac.getFan());
+
+  // Confirm auto speed isn't operable in Fan mode.
+  ac.setMode(kVoltasFan);
+  EXPECT_NE(kVoltasFanAuto, ac.getFan());
+  ac.setFan(kVoltasFanLow);
+  EXPECT_EQ(kVoltasFanLow, ac.getFan());
+  ac.setFan(kVoltasFanMed);
+  EXPECT_EQ(kVoltasFanMed, ac.getFan());
+  ac.setFan(kVoltasFanHigh);
+  EXPECT_EQ(kVoltasFanHigh, ac.getFan());
+  ac.setFan(kVoltasFanAuto);
+  EXPECT_NE(kVoltasFanAuto, ac.getFan());
 }
 
 TEST(TestVoltasClass, SwingV) {

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -42,7 +42,7 @@ TEST(TestDecodeVoltas, RealExample) {
   EXPECT_EQ(
       "Model: 1 (122LZF), Power: On, Mode: 4 (Dry), Temp: 24C, Fan: 4 (Low), "
       "Swing(V): Off, Swing(H): N/A, "
-      "Turbo: Off, Econo: Off, WiFi: On, Light: Off",
+      "Turbo: Off, Econo: Off, WiFi: On, Light: Off, Sleep: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -138,6 +138,18 @@ TEST(TestIRVoltasClass, Turbo) {
   EXPECT_TRUE(ac.getTurbo());
   ac.setTurbo(false);
   EXPECT_FALSE(ac.getTurbo());
+}
+
+TEST(TestIRVoltasClass, Sleep) {
+  IRVoltas ac(kGpioUnused);
+  ac.begin();
+
+  ac.setSleep(false);
+  EXPECT_FALSE(ac.getSleep());
+  ac.setSleep(true);
+  EXPECT_TRUE(ac.getSleep());
+  ac.setSleep(false);
+  EXPECT_FALSE(ac.getSleep());
 }
 
 TEST(TestIRVoltasClass, Econo) {

--- a/test/ir_Voltas_test.cpp
+++ b/test/ir_Voltas_test.cpp
@@ -143,12 +143,18 @@ TEST(TestIRVoltasClass, Turbo) {
 TEST(TestIRVoltasClass, Econo) {
   IRVoltas ac(kGpioUnused);
   ac.begin();
-
+  // Control of econo mode is only available in cool.
+  ac.setMode(kVoltasCool);
   ac.setEcono(false);
   EXPECT_FALSE(ac.getEcono());
   ac.setEcono(true);
   EXPECT_TRUE(ac.getEcono());
   ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+  ac.setEcono(true);
+  ac.setMode(kVoltasHeat);  // Control of econo mode should now be disabled.
+  EXPECT_FALSE(ac.getEcono());
+  ac.setEcono(true);
   EXPECT_FALSE(ac.getEcono());
 }
 


### PR DESCRIPTION
* Add `IRVoltas` class to handle detailed setting support.
  - Model
  - Power
  - Mode
  - Fan Speed
  - Temperature
  - Turbo (Cool Mode only)
  - Econo (Cool Mode only)
  - Sleep (Cool Mode only)
  - Wifi
  - Light/Lamp
  - SwingV
  - SwingH (Unavailable for Model 122LZF)
  - Off Timer
  - On Timer
* Add support for `VOLTAS` to Common A/C API (`IRac`)
* Unit tests.
* Tested against real received messages, and sending messages to a real device.

Fixes #1238