### PR TITLE
Fujitsu: Add support for timers.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -845,12 +845,13 @@ void IRac::electra(IRElectraAc *ac,
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
 /// @param[in] clean Turn on the self-cleaning mode. e.g. Mould, dry filters etc
+/// @param[in] sleep Nr. of minutes for sleep mode. <= 0 is Off, > 0 is on.
 void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
                    const bool on, const stdAc::opmode_t mode,
                    const float degrees, const stdAc::fanspeed_t fan,
                    const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                    const bool quiet, const bool turbo, const bool econo,
-                   const bool filter, const bool clean) {
+                   const bool filter, const bool clean, const int16_t sleep) {
   ac->begin();
   ac->setModel(model);
   if (on) {
@@ -886,6 +887,7 @@ void IRac::fujitsu(IRFujitsuAC *ac, const fujitsu_ac_remote_model_t model,
     ac->setFilter(filter);
     ac->setClean(clean);
     // No Beep setting available.
+    ac->setSleepTimer(sleep > 0 ? sleep : 0);
     // No Sleep setting available.
     // No Clock setting available.
     ac->on();  // Ref: Issue #860
@@ -1005,7 +1007,7 @@ void IRac::haier(IRHaierAC *ac,
   // No Clean setting available.
   // No Beep setting available.
   ac->setSleep(sleep >= 0);  // Sleep on this A/C is either on or off.
-  if (clock >=0) ac->setCurrTime(clock);
+  if (clock >= 0) ac->setCurrTime(clock);
   if (on)
     ac->setCommand(kHaierAcCmdOn);
   else

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -218,7 +218,7 @@ void electra(IRElectraAc *ac,
                const stdAc::fanspeed_t fan,
                const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                const bool quiet, const bool turbo, const bool econo,
-               const bool filter, const bool clean);
+               const bool filter, const bool clean, const int16_t sleep = -1);
 #endif  // SEND_FUJITSU_AC
 #if SEND_GOODWEATHER
   void goodweather(IRGoodweatherAc *ac,

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -30,6 +30,7 @@ using irutils::addModeToString;
 using irutils::addModelToString;
 using irutils::addFanToString;
 using irutils::addTempToString;
+using irutils::minsToString;
 using irutils::setBit;
 using irutils::setBits;
 
@@ -64,8 +65,8 @@ IRFujitsuAC::IRFujitsuAC(const uint16_t pin,
                          const fujitsu_ac_remote_model_t model,
                          const bool inverted, const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) {
-  this->setModel(model);
-  this->stateReset();
+  setModel(model);
+  stateReset();
 }
 
 /// Set the currently emulated model of the A/C.
@@ -100,7 +101,10 @@ void IRFujitsuAC::stateReset(void) {
   _cmd = kFujitsuAcCmdTurnOn;
   _filter = false;
   _clean = false;
-  this->buildState();
+  _timertype = kFujitsuAcStopTimers;
+  _ontimer = 0;
+  _offtimer = 0;
+  buildState();
 }
 
 /// Set up hardware to be able to send a message.
@@ -110,7 +114,7 @@ void IRFujitsuAC::begin(void) { _irsend.begin(); }
 /// Send the current internal state as an IR message.
 /// @param[in] repeat Nr. of times the message will be repeated.
 void IRFujitsuAC::send(const uint16_t repeat) {
-  this->buildState();
+  buildState();
   _irsend.sendFujitsuAC(remote_state, getStateLength(), repeat);
 }
 #endif  // SEND_FUJITSU_AC
@@ -155,11 +159,19 @@ void IRFujitsuAC::buildState(void) {
 
     remote_state[7] = 0x30;
     remote_state[8] = (_cmd == kFujitsuAcCmdTurnOn) | (tempByte << 4);
-    remote_state[9] = _mode | 0 << 4;  // timer off
+    remote_state[9] = _mode | (getTimerType() << 4);
     remote_state[10] = _fanSpeed;
-    remote_state[11] = 0;  // timerOff values
-    remote_state[12] = 0;  // timerOff/On values
-    remote_state[13] = 0;  // timerOn values
+
+    // Set the On/Off/Sleep timer Nr of mins.
+    remote_state[11] = getOffSleepTimer();
+    remote_state[12] = ((getOnTimer() & 0x0F) << 4) |
+        ((getOffSleepTimer() >> 8) & 0x07);
+    remote_state[13] = getOnTimer() >> 4;
+    // Enable bit for the Off/Sleep timer
+    setBit(&remote_state[12], 3, getOffSleepTimer());
+    // Enable bit for the On timer
+    setBit(&remote_state[13], 7, getOnTimer());
+
     switch (_model) {
       case fujitsu_ac_remote_model_t::ARRY4:
         remote_state[14] = _filter << 3;
@@ -212,7 +224,7 @@ void IRFujitsuAC::buildState(void) {
 /// Get the length (size) of the state code for the current configuration.
 /// @return The length of the state array required for this config.
 uint8_t IRFujitsuAC::getStateLength(void) {
-  this->buildState();  // Force an update of the internal state.
+  buildState();  // Force an update of the internal state.
   if (((_model == fujitsu_ac_remote_model_t::ARRAH2E ||
         _model == fujitsu_ac_remote_model_t::ARREB1E ||
         _model == fujitsu_ac_remote_model_t::ARRY4) &&
@@ -227,7 +239,7 @@ uint8_t IRFujitsuAC::getStateLength(void) {
 /// Get a PTR to the internal state/code for this protocol.
 /// @return PTR to a code for this protocol based on the current internal state.
 uint8_t* IRFujitsuAC::getRaw(void) {
-  this->buildState();
+  buildState();
   return remote_state;
 }
 
@@ -237,29 +249,29 @@ void IRFujitsuAC::buildFromState(const uint16_t length) {
   switch (length) {
     case kFujitsuAcStateLength - 1:
     case kFujitsuAcStateLengthShort - 1:
-      this->setModel(fujitsu_ac_remote_model_t::ARDB1);
+      setModel(fujitsu_ac_remote_model_t::ARDB1);
       // ARJW2 has horizontal swing.
-      if (this->getSwing(true) > kFujitsuAcSwingVert)
-        this->setModel(fujitsu_ac_remote_model_t::ARJW2);
+      if (getSwing(true) > kFujitsuAcSwingVert)
+        setModel(fujitsu_ac_remote_model_t::ARJW2);
       break;
     default:
-      switch (this->getCmd(true)) {
+      switch (getCmd(true)) {
         case kFujitsuAcCmdEcono:
         case kFujitsuAcCmdPowerful:
-          this->setModel(fujitsu_ac_remote_model_t::ARREB1E);
+          setModel(fujitsu_ac_remote_model_t::ARREB1E);
           break;
         default:
-          this->setModel(fujitsu_ac_remote_model_t::ARRAH2E);
+          setModel(fujitsu_ac_remote_model_t::ARRAH2E);
       }
   }
   switch (remote_state[6]) {
     case 8:
-      if (this->getModel() != fujitsu_ac_remote_model_t::ARJW2)
-        this->setModel(fujitsu_ac_remote_model_t::ARDB1);
+      if (getModel() != fujitsu_ac_remote_model_t::ARJW2)
+        setModel(fujitsu_ac_remote_model_t::ARDB1);
       break;
     case 9:
-      if (this->getModel() != fujitsu_ac_remote_model_t::ARREB1E)
-        this->setModel(fujitsu_ac_remote_model_t::ARRAH2E);
+      if (getModel() != fujitsu_ac_remote_model_t::ARREB1E)
+        setModel(fujitsu_ac_remote_model_t::ARRAH2E);
       break;
   }
   setTemp((remote_state[8] >> 4) + kFujitsuAcMinTemp);
@@ -288,7 +300,17 @@ void IRFujitsuAC::buildFromState(const uint16_t length) {
       setCmd(remote_state[5]);
       break;
   }
-  _outsideQuiet = this->getOutsideQuiet(true);
+  _outsideQuiet = getOutsideQuiet(true);
+  // Timers
+  switch (getModel()) {
+    // These models seem to have timer support.
+    case fujitsu_ac_remote_model_t::ARRAH2E:
+    case fujitsu_ac_remote_model_t::ARREB1E:
+      _offtimer = getOffSleepTimer(true);
+      _ontimer = getOnTimer(true);
+      _timertype = getTimerType(true);
+    default: break;
+  }
 }
 
 /// Set the internal state from a valid code for this protocol.
@@ -308,27 +330,27 @@ bool IRFujitsuAC::setRaw(const uint8_t newState[], const uint16_t length) {
 }
 
 /// Request the A/C to step the Horizontal Swing.
-void IRFujitsuAC::stepHoriz(void) { this->setCmd(kFujitsuAcCmdStepHoriz); }
+void IRFujitsuAC::stepHoriz(void) { setCmd(kFujitsuAcCmdStepHoriz); }
 
 /// Request the A/C to toggle the Horizontal Swing mode.
 /// @param[in] update Do we need to update the general swing config?
 void IRFujitsuAC::toggleSwingHoriz(const bool update) {
   // Toggle the current setting.
-  if (update) this->setSwing(this->getSwing() ^ kFujitsuAcSwingHoriz);
+  if (update) setSwing(getSwing() ^ kFujitsuAcSwingHoriz);
   // and set the appropriate special command.
-  this->setCmd(kFujitsuAcCmdToggleSwingHoriz);
+  setCmd(kFujitsuAcCmdToggleSwingHoriz);
 }
 
 /// Request the A/C to step the Vertical Swing.
-void IRFujitsuAC::stepVert(void) { this->setCmd(kFujitsuAcCmdStepVert); }
+void IRFujitsuAC::stepVert(void) { setCmd(kFujitsuAcCmdStepVert); }
 
 /// Request the A/C to toggle the Vertical Swing mode.
 /// @param[in] update Do we need to update the general swing config?
 void IRFujitsuAC::toggleSwingVert(const bool update) {
   // Toggle the current setting.
-  if (update) this->setSwing(this->getSwing() ^ kFujitsuAcSwingVert);
+  if (update) setSwing(getSwing() ^ kFujitsuAcSwingVert);
   // and set the appropriate special command.
-  this->setCmd(kFujitsuAcCmdToggleSwingVert);
+  setCmd(kFujitsuAcCmdToggleSwingVert);
 }
 
 /// Set the requested (special) command part for the A/C message.
@@ -381,14 +403,14 @@ uint8_t IRFujitsuAC::getCmd(const bool raw) {
 /// Change the power setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRFujitsuAC::setPower(const bool on) {
-  this->setCmd(on ? kFujitsuAcCmdTurnOn : kFujitsuAcCmdTurnOff);
+  setCmd(on ? kFujitsuAcCmdTurnOn : kFujitsuAcCmdTurnOff);
 }
 
 /// Set the requested power state of the A/C to off.
-void IRFujitsuAC::off(void) { this->setPower(false); }
+void IRFujitsuAC::off(void) { setPower(false); }
 
 /// Set the requested power state of the A/C to on.
-void IRFujitsuAC::on(void) { this->setPower(true); }
+void IRFujitsuAC::on(void) { setPower(true); }
 
 /// Get the value of the current power setting.
 /// @return true, the setting is on. false, the setting is off.
@@ -398,17 +420,17 @@ bool IRFujitsuAC::getPower(void) { return _cmd != kFujitsuAcCmdTurnOff; }
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRFujitsuAC::setOutsideQuiet(const bool on) {
   _outsideQuiet = on;
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the Outside Quiet mode status of the A/C.
 /// @param[in] raw Do we get the result from base data?
 /// @return true, the setting is on. false, the setting is off.
 bool IRFujitsuAC::getOutsideQuiet(const bool raw) {
-  if (_state_length == kFujitsuAcStateLength && raw) {
+  if ((_state_length == kFujitsuAcStateLength) && raw) {
     _outsideQuiet = GETBIT8(remote_state[14], kFujitsuAcOutsideQuietOffset);
     // Only ARREB1E seems to have this mode.
-    if (_outsideQuiet) this->setModel(fujitsu_ac_remote_model_t::ARREB1E);
+    if (_outsideQuiet) setModel(fujitsu_ac_remote_model_t::ARREB1E);
   }
   return _outsideQuiet;
 }
@@ -418,7 +440,7 @@ bool IRFujitsuAC::getOutsideQuiet(const bool raw) {
 void IRFujitsuAC::setTemp(const uint8_t temp) {
   _temp = std::max((uint8_t)kFujitsuAcMinTemp, temp);
   _temp = std::min((uint8_t)kFujitsuAcMaxTemp, _temp);
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the current temperature setting.
@@ -432,7 +454,7 @@ void IRFujitsuAC::setFanSpeed(const uint8_t fanSpeed) {
     _fanSpeed = kFujitsuAcFanHigh;  // Set the fan to maximum if out of range.
   else
     _fanSpeed = fanSpeed;
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the current fan speed setting.
@@ -446,7 +468,7 @@ void IRFujitsuAC::setMode(const uint8_t mode) {
     _mode = kFujitsuAcModeHeat;  // Set the mode to maximum if out of range.
   else
     _mode = mode;
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the operating mode setting of the A/C.
@@ -474,7 +496,7 @@ void IRFujitsuAC::setSwing(const uint8_t swingMode) {
       // Set the mode to max if out of range
       if (swingMode > kFujitsuAcSwingBoth) _swingMode = kFujitsuAcSwingBoth;
   }
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the requested swing operation mode of the A/C unit.
@@ -490,7 +512,7 @@ uint8_t IRFujitsuAC::getSwing(const bool raw) {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRFujitsuAC::setClean(const bool on) {
   _clean = on;
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the Clean mode status of the A/C.
@@ -511,7 +533,7 @@ bool IRFujitsuAC::getClean(const bool raw) {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRFujitsuAC::setFilter(const bool on) {
   _filter = on;
-  this->setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
+  setCmd(kFujitsuAcCmdStayOn);  // No special command involved.
 }
 
 /// Get the Filter mode status of the A/C.
@@ -526,6 +548,106 @@ bool IRFujitsuAC::getFilter(const bool raw) {
       default: return false;
     }
   }
+}
+
+/// Get the Timer type of the A/C message.
+/// @param[in] raw Do we get the result from base data?
+/// @return The current timer type in numeric form.
+uint8_t IRFujitsuAC::getTimerType(const bool raw) {
+  switch (getModel()) {
+    // These models seem to have timer support.
+    case fujitsu_ac_remote_model_t::ARRAH2E:
+    case fujitsu_ac_remote_model_t::ARREB1E:
+      if (raw)
+        return GETBITS8(remote_state[kFujitsuAcTimerTypeByte],
+                        kFujitsuAcTimerTypeOffset, kFujitsuAcTimerTypeSize);
+      else
+        return _timertype;
+    default: return kFujitsuAcStopTimers;
+  }
+}
+
+/// Set the Timer type of the A/C message.
+/// @param[in] timertype The kind of timer to use for the message.
+void IRFujitsuAC::setTimerType(const uint8_t timertype) {
+  switch (timertype) {
+    case kFujitsuAcSleepTimer:
+    case kFujitsuAcOnTimer:
+    case kFujitsuAcOffTimer:
+    case kFujitsuAcStopTimers:
+      _timertype = timertype;
+      break;
+    default: setTimerType(kFujitsuAcStopTimers);
+  }
+}
+
+/// Get the On Timer setting of the A/C.
+/// @param[in] raw Do we get the result from base data?
+/// @return nr of minutes left on the timer. 0 means disabled/not supported.
+uint16_t IRFujitsuAC::getOnTimer(const bool raw) {
+  if (getTimerType(raw) == kFujitsuAcOnTimer) {
+    if (raw)
+      return (GETBITS8(remote_state[13], 0, 7) << 4) +
+          GETBITS8(remote_state[12], 4, 4);
+    else
+      return _ontimer;
+  } else {
+    return 0;
+  }
+}
+
+/// Set the On Timer setting of the A/C.
+/// @param[in] nr_mins Nr. of minutes to set the timer to. 0 means disabled.
+void IRFujitsuAC::setOnTimer(const uint16_t nr_mins) {
+  _ontimer = std::min(kFujitsuAcTimerMax, nr_mins);  // Bounds check.
+  if (_ontimer) {
+    setTimerType(kFujitsuAcOnTimer);
+  } else {
+    if (getTimerType() == kFujitsuAcOnTimer) setTimerType(kFujitsuAcStopTimers);
+  }
+}
+
+/// Get the Off/Sleep Timer setting of the A/C.
+/// @param[in] raw Do we get the result from base data?
+/// @return nr of minutes left on the timer. 0 means disabled/not supported.
+uint16_t IRFujitsuAC::getOffSleepTimer(const bool raw) {
+  switch (getTimerType(raw)) {
+    case kFujitsuAcOffTimer:
+    case kFujitsuAcSleepTimer:
+      if (raw)
+        return (GETBITS8(remote_state[12], 0, 3) << 8) +
+            remote_state[11];
+      else
+        return _offtimer;
+    default:
+      return 0;
+  }
+}
+
+/// Set the Off/Sleep Timer time for the A/C.
+/// @param[in] nr_mins Nr. of minutes to set the timer to. 0 means disabled.
+void IRFujitsuAC::setOffSleepTimer(const uint16_t nr_mins) {
+  _offtimer = std::min(kFujitsuAcTimerMax, nr_mins);  // Bounds check.
+}
+
+/// Set the Off Timer time for the A/C.
+/// @param[in] nr_mins Nr. of minutes to set the timer to. 0 means disabled.
+void IRFujitsuAC::setOffTimer(const uint16_t nr_mins) {
+  setOffSleepTimer(nr_mins);
+  if (nr_mins)
+    setTimerType(kFujitsuAcOffTimer);
+  else
+    if (getTimerType() != kFujitsuAcOnTimer) setTimerType(kFujitsuAcStopTimers);
+}
+
+/// Set the Sleep Timer time for the A/C.
+/// @param[in] nr_mins Nr. of minutes to set the timer to. 0 means disabled.
+void IRFujitsuAC::setSleepTimer(const uint16_t nr_mins) {
+  setOffSleepTimer(nr_mins);
+  if (nr_mins)
+    setTimerType(kFujitsuAcSleepTimer);
+  else
+    if (getTimerType() != kFujitsuAcOnTimer) setTimerType(kFujitsuAcStopTimers);
 }
 
 /// Verify the checksum is valid for a given state.
@@ -611,13 +733,13 @@ stdAc::fanspeed_t IRFujitsuAC::toCommonFanSpeed(const uint8_t speed) {
 stdAc::state_t IRFujitsuAC::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::FUJITSU_AC;
-  result.model = this->getModel();
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
+  result.model = getModel();
+  result.power = getPower();
+  result.mode = toCommonMode(getMode());
   result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFanSpeed());
-  uint8_t swing = this->getSwing();
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFanSpeed());
+  uint8_t swing = getSwing();
   switch (result.model) {
     case fujitsu_ac_remote_model_t::ARREB1E:
     case fujitsu_ac_remote_model_t::ARRAH2E:
@@ -636,9 +758,9 @@ stdAc::state_t IRFujitsuAC::toCommon(void) {
       result.swingh = stdAc::swingh_t::kOff;
   }
 
-  result.quiet = (this->getFanSpeed() == kFujitsuAcFanQuiet);
-  result.turbo = this->getCmd() == kFujitsuAcCmdPowerful;
-  result.econo = this->getCmd() == kFujitsuAcCmdEcono;
+  result.quiet = (getFanSpeed() == kFujitsuAcFanQuiet);
+  result.turbo = getCmd() == kFujitsuAcCmdPowerful;
+  result.econo = getCmd() == kFujitsuAcCmdEcono;
   // Not supported.
   result.light = false;
   result.filter = false;
@@ -654,7 +776,7 @@ stdAc::state_t IRFujitsuAC::toCommon(void) {
 String IRFujitsuAC::toString(void) {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  fujitsu_ac_remote_model_t model = this->getModel();
+  fujitsu_ac_remote_model_t model = getModel();
   result += addModelToString(decode_type_t::FUJITSU_AC, model, false);
   result += addBoolToString(getPower(), kPowerStr);
   result += addModeToString(getMode(), kFujitsuAcModeAuto, kFujitsuAcModeCool,
@@ -672,9 +794,9 @@ String IRFujitsuAC::toString(void) {
     default:  // Assume everything else does.
       result += addBoolToString(getClean(), kCleanStr);
       result += addBoolToString(getFilter(), kFilterStr);
-      result += addIntToString(this->getSwing(), kSwingStr);
+      result += addIntToString(getSwing(), kSwingStr);
       result += kSpaceLBraceStr;
-      switch (this->getSwing()) {
+      switch (getSwing()) {
         case kFujitsuAcSwingOff:
           result += kOffStr;
           break;
@@ -697,7 +819,7 @@ String IRFujitsuAC::toString(void) {
   result += kCommaSpaceStr;
   result += kCommandStr;
   result += kColonSpaceStr;
-  switch (this->getCmd()) {
+  switch (getCmd()) {
     case kFujitsuAcCmdStepHoriz:
       result += kStepStr;
       result += ' ';
@@ -727,8 +849,33 @@ String IRFujitsuAC::toString(void) {
     default:
       result += kNAStr;
   }
-  if (this->getModel() == fujitsu_ac_remote_model_t::ARREB1E)
-    result += addBoolToString(getOutsideQuiet(), kOutsideQuietStr);
+  uint16_t mins = 0;
+  String type_str = kTimerStr;
+  switch (model) {
+    case fujitsu_ac_remote_model_t::ARREB1E:
+      result += addBoolToString(getOutsideQuiet(), kOutsideQuietStr);
+      // FALL-THRU
+    // These models seem to have timer support.
+    case fujitsu_ac_remote_model_t::ARRAH2E:
+      switch (getTimerType()) {
+        case kFujitsuAcOnTimer:
+          type_str = kOnTimerStr;
+          mins = getOnTimer();
+          break;
+        case kFujitsuAcOffTimer:
+          type_str = kOffTimerStr;
+          mins = getOffSleepTimer();
+          break;
+        case kFujitsuAcSleepTimer:
+          type_str = kSleepTimerStr;
+          mins = getOffSleepTimer();
+          break;
+      }
+      result += addLabeledString(mins ? minsToString(mins) : kOffStr, type_str);
+      break;
+    default:
+      break;
+  }
   return result;
 }
 

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -77,6 +77,15 @@ const uint8_t kFujitsuAcOutsideQuietOffset = 7;
 const uint8_t kFujitsuAcCleanOffset = 3;
 const uint8_t kFujitsuAcFilterOffset = 3;
 
+const uint8_t kFujitsuAcTimerTypeByte = 9;
+const uint8_t kFujitsuAcTimerTypeOffset = 4;  ///< Mask: 0b00xx0000
+const uint8_t kFujitsuAcTimerTypeSize = 2;    ///< Mask: 0b00xx0000
+const uint8_t kFujitsuAcStopTimers =                       0b00;  // 0
+const uint8_t kFujitsuAcSleepTimer =                       0b01;  // 1
+const uint8_t kFujitsuAcOffTimer =                         0b10;  // 2
+const uint8_t kFujitsuAcOnTimer =                          0b11;  // 3
+const uint16_t kFujitsuAcTimerMax = 12 * 60;  ///< Minutes.
+
 // Legacy defines.
 #define FUJITSU_AC_MODE_AUTO kFujitsuAcModeAuto
 #define FUJITSU_AC_MODE_COOL kFujitsuAcModeCool
@@ -146,9 +155,14 @@ class IRFujitsuAC {
   void setFilter(const bool on);
   bool getFilter(const bool raw = false);
   void setOutsideQuiet(const bool on);
-
   bool getOutsideQuiet(const bool raw = false);
-
+  uint8_t getTimerType(const bool raw = false);
+  void setTimerType(const uint8_t timertype);
+  uint16_t getOnTimer(const bool raw = false);
+  void setOnTimer(const uint16_t nr_mins);
+  uint16_t getOffSleepTimer(const bool raw = false);
+  void setOffTimer(const uint16_t nr_mins);
+  void setSleepTimer(const uint16_t nr_mins);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
@@ -176,8 +190,12 @@ class IRFujitsuAC {
   bool _outsideQuiet;
   bool _clean;
   bool _filter;
+  uint16_t _ontimer;
+  uint16_t _offtimer;  // Also is the sleep timer value
+  uint8_t _timertype;
   void buildState(void);
   void buildFromState(const uint16_t length);
+  void setOffSleepTimer(const uint16_t nr_mins);
 };
 
 #endif  // IR_FUJITSU_H_

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -544,7 +544,8 @@ TEST(TestIRac, Fujitsu) {
       "Fan: 2 (Medium), Command: N/A";
   std::string arrah2e_expected =
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 19C, "
-      "Fan: 2 (Medium), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A";
+      "Fan: 2 (Medium), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Sleep Timer: 03:00";
   std::string arry4_expected =
       "Model: 5 (ARRY4), Power: On, Mode: 1 (Cool), Temp: 19C, "
       "Fan: 2 (Medium), Clean: On, Filter: On, Swing: 0 (Off), Command: N/A";
@@ -584,7 +585,8 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Turbo (Powerful)
                false,                       // Econo
                true,                        // Filter
-               true);                       // Clean
+               true,                        // Clean
+               3 * 60);                     // Sleep
   ASSERT_EQ(arrah2e_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -23,7 +23,7 @@ TEST(TestIRFujitsuACClass, GetRawDefault) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 24C, "
             "Fan: 1 (High), Clean: Off, Filter: Off, "
-            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A",
+            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A, Timer: Off",
             ac.toString());
 
   uint8_t expected_ardb1[15] = {
@@ -46,7 +46,7 @@ TEST(TestIRFujitsuACClass, GetRawTurnOff) {
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: Off, Mode: 1 (Cool), Temp: 24C, "
             "Fan: 1 (High), Clean: Off, Filter: Off, "
-            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A",
+            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A, Timer: Off",
             ac.toString());
 
   ac.setModel(ARDB1);
@@ -67,7 +67,7 @@ TEST(TestIRFujitsuACClass, GetRawStepHoriz) {
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 24C, "
       "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 3 (Swing(V)+Swing(H)), "
-      "Command: Step Swing(H)",
+      "Command: Step Swing(H), Timer: Off",
       ac.toString());
 }
 
@@ -81,7 +81,7 @@ TEST(TestIRFujitsuACClass, GetRawStepVert) {
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 24C, "
       "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 3 (Swing(V)+Swing(H)), "
-      "Command: Step Swing(V)",
+      "Command: Step Swing(V), Timer: Off",
       ac.toString());
 
   ac.setModel(ARDB1);
@@ -107,7 +107,7 @@ TEST(TestIRFujitsuACClass, GetRawWithSwingHoriz) {
   EXPECT_STATE_EQ(expected, ac.getRaw(), 16 * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 25C, "
             "Fan: 4 (Quiet), Clean: Off, Filter: Off, "
-            "Swing: 2 (Swing(H)), Command: N/A",
+            "Swing: 2 (Swing(H)), Command: N/A, Timer: Off",
             ac.toString());
 }
 
@@ -127,7 +127,7 @@ TEST(TestIRFujitsuACClass, GetRawWithFan) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 3 (Fan), Temp: 20C, "
             "Fan: 2 (Medium), Clean: Off, Filter: Off, "
-            "Swing: 2 (Swing(H)), Command: N/A",
+            "Swing: 2 (Swing(H)), Command: N/A, Timer: Off",
             ac.toString());
 
   ac.setModel(ARDB1);
@@ -150,7 +150,8 @@ TEST(TestIRFujitsuACClass, SetRaw) {
                   ac.getStateLength() * 8);
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 24C, "
             "Fan: 1 (High), Clean: Off, Filter: Off, "
-            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A",
+            "Swing: 3 (Swing(V)+Swing(H)), Command: N/A, "
+            "Timer: Off",
             ac.toString());
   // Now set a new state via setRaw();
   // This state is a real state from an AR-DB1 remote.
@@ -318,7 +319,8 @@ TEST(TestDecodeFujitsuAC, SyntheticShortMessages) {
   EXPECT_STATE_EQ(expected_arrah2e, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: Off, Mode: 0 (Auto), Temp: 16C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -364,7 +366,8 @@ TEST(TestDecodeFujitsuAC, SyntheticLongMessages) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ("Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 18C, "
             "Fan: 4 (Quiet), Clean: Off, Filter: Off, "
-            "Swing: 1 (Swing(V)), Command: N/A",
+            "Swing: 1 (Swing(V)), Command: N/A, "
+            "Timer: Off",
             ac.toString());
 
   irsend.reset();
@@ -538,7 +541,8 @@ TEST(TestDecodeFujitsuAC, Issue414) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 4 (Heat), Temp: 24C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
 
   // Resend it using the state this time.
@@ -614,7 +618,8 @@ TEST(TestIRFujitsuACClass, toCommon) {
   // Now test it.
   EXPECT_EQ(    // Off mode technically has no temp, mode, fan, etc.
       "Model: 1 (ARRAH2E), Power: Off, Mode: 0 (Auto), Temp: 16C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
   ASSERT_EQ(decode_type_t::FUJITSU_AC, ac.toCommon().protocol);
   ASSERT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.toCommon().model);
@@ -670,7 +675,8 @@ TEST(TestDecodeFujitsuAC, Issue716) {
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 3 (ARREB1E), Power: On, Mode: 0 (Auto), Temp: 16C, "
             "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), "
-            "Command: Powerful, Outside Quiet: Off",
+            "Command: Powerful, Outside Quiet: Off, "
+            "Timer: Off",
             ac.toString());
 
   // Economy (just from the state)
@@ -685,7 +691,8 @@ TEST(TestDecodeFujitsuAC, Issue716) {
   EXPECT_EQ(kFujitsuAcStateLengthShort, ac.getStateLength());
   EXPECT_EQ("Model: 3 (ARREB1E), Power: On, Mode: 0 (Auto), Temp: 16C, "
             "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), "
-            "Command: Econo, Outside Quiet: Off",
+            "Command: Econo, Outside Quiet: Off, "
+            "Timer: Off",
             ac.toString());
 }
 
@@ -717,12 +724,12 @@ TEST(TestIRFujitsuACClass, OutsideQuiet) {
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 1 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), "
-      "Command: N/A", ac.toString());
+      "Command: N/A, Timer: Off", ac.toString());
   ac.setModel(fujitsu_ac_remote_model_t::ARREB1E);
   EXPECT_EQ(
       "Model: 3 (ARREB1E), Power: On, Mode: 1 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), "
-      "Command: N/A, Outside Quiet: Off",
+      "Command: N/A, Outside Quiet: Off, Timer: Off",
       ac.toString());
 
   // Make sure we can't accidentally inherit the correct model.
@@ -734,7 +741,7 @@ TEST(TestIRFujitsuACClass, OutsideQuiet) {
   EXPECT_EQ(
       "Model: 3 (ARREB1E), Power: On, Mode: 1 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), "
-      "Command: N/A, Outside Quiet: On",
+      "Command: N/A, Outside Quiet: On, Timer: Off",
       ac.toString());
 
   ac.setOutsideQuiet(false);
@@ -819,7 +826,8 @@ TEST(TestDecodeFujitsuAC, Issue726) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 24C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
 }
 
@@ -851,14 +859,16 @@ TEST(TestIRFujitsuACClass, Clean) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
   // Now it is in ARRAH2E model mode, it shouldn't accept setting it on.
   ac.setClean(true);
   EXPECT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.getModel());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
   // But ARRY4 does.
   ac.setModel(fujitsu_ac_remote_model_t::ARRY4);
@@ -895,7 +905,8 @@ TEST(TestIRFujitsuACClass, Filter) {
   EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
   EXPECT_EQ(
       "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A",
+      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Timer: Off",
       ac.toString());
   // Now it is in ARRAH2E model mode, it shouldn't accept setting it on.
   ac.setFilter(true);
@@ -907,4 +918,124 @@ TEST(TestIRFujitsuACClass, Filter) {
       "Model: 5 (ARRY4), Power: On, Mode: 0 (Auto), Temp: 26C, "
       "Fan: 0 (Auto), Clean: Off, Filter: On, Swing: 0 (Off), Command: N/A",
       ac.toString());
+}
+
+TEST(TestIRFujitsuACClass, Timers) {
+  IRFujitsuAC ac(kGpioUnused);
+  // Data from:
+  //  https://github.com/crankyoldgit/IRremoteESP8266/issues/1255#issuecomment-686445720
+  const uint8_t timer_on_12h[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x30, 0x01, 0x00, 0x00, 0xAD, 0x20, 0x32};
+  ac.setRaw(timer_on_12h, kFujitsuAcStateLength);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(kFujitsuAcOnTimer, ac.getTimerType());
+  EXPECT_EQ(12 * 60, ac.getOnTimer());
+  EXPECT_EQ(0, ac.getOffSleepTimer());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "On Timer: 12:00",
+      ac.toString());
+
+  const uint8_t timer_on_8h30m[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x30, 0x01, 0x00, 0xE0, 0x9F, 0x20, 0x60};
+  ac.setRaw(timer_on_8h30m, kFujitsuAcStateLength);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(kFujitsuAcOnTimer, ac.getTimerType());
+  EXPECT_EQ(8 * 60 + 30, ac.getOnTimer());
+  EXPECT_EQ(0, ac.getOffSleepTimer());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "On Timer: 08:30",
+      ac.toString());
+
+  // TIMER OFF 11H
+  const uint8_t timer_off_11h[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x20, 0x01, 0x94, 0x0A, 0x00, 0x20, 0x51};
+  ac.setRaw(timer_off_11h, kFujitsuAcStateLength);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(kFujitsuAcOffTimer, ac.getTimerType());
+  EXPECT_EQ(11 * 60, ac.getOffSleepTimer());
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Off Timer: 11:00",
+      ac.toString());
+
+  // TIMER OFF 0.5H
+  const uint8_t timer_off_30m[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x20, 0x01, 0x1E, 0x08, 0x00, 0x20, 0xC9};
+  ac.setRaw(timer_off_30m, kFujitsuAcStateLength);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(kFujitsuAcOffTimer, ac.getTimerType());
+  EXPECT_EQ(30, ac.getOffSleepTimer());
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Off Timer: 00:30",
+      ac.toString());
+
+  // TIMER SLEEP 3H
+  const uint8_t timer_sleep_3h[kFujitsuAcStateLength] = {
+      0x14, 0x63, 0x00, 0x10, 0x10, 0xFE, 0x09, 0x30,
+      0xA0, 0x10, 0x01, 0xB4, 0x08, 0x00, 0x20, 0x43};
+  ac.setRaw(timer_sleep_3h, kFujitsuAcStateLength);
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(kFujitsuAcSleepTimer, ac.getTimerType());
+  EXPECT_EQ(3 * 60, ac.getOffSleepTimer());
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Sleep Timer: 03:00",
+      ac.toString());
+
+  // Re-construct a known timer state from scratch.
+  ac.stateReset();
+  ac.setModel(fujitsu_ac_remote_model_t::ARRAH2E);
+  ac.setPower(true);
+  ac.setMode(kFujitsuAcModeAuto);
+  ac.setTemp(26);
+  ac.setFanSpeed(1);
+  ac.setClean(false);
+  ac.setFilter(false);
+  ac.setSwing(0);
+
+  ac.setOffTimer(30);
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Off Timer: 00:30",
+      ac.toString());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_STATE_EQ(timer_off_30m, ac.getRaw(), ac.getStateLength() * 8);
+
+  ac.setOnTimer(12 * 60);
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "On Timer: 12:00",
+      ac.toString());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_EQ(12 * 60, ac.getOnTimer());
+  EXPECT_TRUE(ac.getOnTimer());
+  EXPECT_STATE_EQ(timer_on_12h, ac.getRaw(), ac.getStateLength() * 8);
+  EXPECT_EQ(12 * 60, ac.getOnTimer());
+  EXPECT_TRUE(ac.getOnTimer());
+
+  ac.setSleepTimer(3 * 60);
+  EXPECT_EQ(
+      "Model: 1 (ARRAH2E), Power: On, Mode: 0 (Auto), Temp: 26C, "
+      "Fan: 1 (High), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
+      "Sleep Timer: 03:00",
+      ac.toString());
+  EXPECT_EQ(kFujitsuAcStateLength, ac.getStateLength());
+  EXPECT_STATE_EQ(timer_sleep_3h, ac.getRaw(), ac.getStateLength() * 8);
 }


### PR DESCRIPTION
* Add Sleep, On, & Off timer support.
* Remove `this->` from Fujitsu code base.
* Add unit test coverage for Timers.
* Update existing Unit tests.
* Misc other code style cleanup.

Fixes #1261
Fixes #1255