### PR TITLE
rewrite ir_Argo by using bit field

### DIFF
--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -28,8 +28,6 @@ using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addTempToString;
-using irutils::setBit;
-using irutils::setBits;
 
 #if SEND_ARGO
 /// Send a Argo A/C formatted message.
@@ -54,7 +52,7 @@ void IRsend::sendArgo(const unsigned char data[], const uint16_t nbytes,
 /// @param[in] use_modulation Is frequency modulation to be used?
 IRArgoAC::IRArgoAC(const uint16_t pin, const bool inverted,
                    const bool use_modulation)
-      : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
+      : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 /// Set up hardware to be able to send a message.
 void IRArgoAC::begin(void) { _irsend.begin(); }
@@ -89,45 +87,44 @@ bool IRArgoAC::validChecksum(const uint8_t state[], const uint16_t length) {
 
 /// Update the checksum for the internal state.
 void IRArgoAC::checksum(void) {
-  uint8_t sum = IRArgoAC::calcChecksum(argo, kArgoStateLength);
+  uint8_t sum = IRArgoAC::calcChecksum(_.raw, kArgoStateLength);
   // Append sum to end of array
   // Set const part of checksum bit 10
-  argo[10] = 0b00000010;
-  argo[10] += sum << 2;  // Shift up 2 bits and append to byte 10
-  argo[11] = sum >> 6;   // Shift down 6 bits and add in two LSBs of bit 11
+  _.raw[10] = 0b00000010;
+  _.Sum = sum;
 }
 
 /// Reset the internals of the object to a known good state.
 void IRArgoAC::stateReset(void) {
-  for (uint8_t i = 0; i < kArgoStateLength; i++) argo[i] = 0x0;
+  for (uint8_t i = 0; i < kArgoStateLength; i++) _.raw[i] = 0x0;
 
   // Argo Message. Store MSB left.
   // Default message:
-  argo[0] = 0b10101100;  // LSB first (as sent) 0b00110101; //const preamble
-  argo[1] = 0b11110101;  // LSB first: 0b10101111; //const preamble
+  _.raw[0] = 0b10101100;  // LSB first (as sent) 0b00110101; //const preamble
+  _.raw[1] = 0b11110101;  // LSB first: 0b10101111; //const preamble
   // Keep payload 2-9 at zero
-  argo[10] = 0b00000010;  // Const 01, checksum 6bit
-  argo[11] = 0b00000000;  // Checksum 2bit
+  _.raw[10] = 0b00000010;  // Const 01
+  _.Sum = 0;
 
-  this->off();
-  this->setTemp(20);
-  this->setRoomTemp(25);
-  this->setMode(kArgoAuto);
-  this->setFan(kArgoFanAuto);
+  off();
+  setTemp(20);
+  setRoomTemp(25);
+  setMode(kArgoAuto);
+  setFan(kArgoFanAuto);
 }
 
 /// Get the raw state of the object, suitable to be sent with the appropriate
 /// IRsend object method.
 /// @return A PTR to the internal state.
 uint8_t* IRArgoAC::getRaw(void) {
-  this->checksum();  // Ensure correct bit array before returning
-  return argo;
+  checksum();  // Ensure correct bit array before returning
+  return _.raw;
 }
 
 /// Set the raw state of the object.
 /// @param[in] state The raw state from the native IR message.
 void IRArgoAC::setRaw(const uint8_t state[]) {
-  memcpy(argo, state, kArgoStateLength);
+  std::memcpy(_.raw, state, kArgoStateLength);
 }
 
 /// Set the internal state to have the power on.
@@ -139,22 +136,22 @@ void IRArgoAC::off(void) { setPower(false); }
 /// Set the internal state to have the desired power.
 /// @param[in] on The desired power state.
 void IRArgoAC::setPower(const bool on) {
-  setBit(&argo[9], kArgoPowerBitOffset, on);
+  _.Power = on;
 }
 
 /// Get the power setting from the internal state.
 /// @return A boolean indicating the power setting.
-bool IRArgoAC::getPower(void) { return GETBIT8(argo[9], kArgoPowerBitOffset); }
+bool IRArgoAC::getPower(void) const { return _.Power; }
 
 /// Control the current Max setting. (i.e. Turbo)
 /// @param[in] on The desired setting.
 void IRArgoAC::setMax(const bool on) {
-  setBit(&argo[9], kArgoMaxBitOffset, on);
+  _.Max = on;
 }
 
 /// Is the Max (i.e. Turbo) setting on?
 /// @return The current value.
-bool IRArgoAC::getMax(void) { return GETBIT8(argo[9], kArgoMaxBitOffset); }
+bool IRArgoAC::getMax(void) const { return _.Max; }
 
 /// Set the temperature.
 /// @param[in] degrees The temperature in degrees celsius.
@@ -163,33 +160,27 @@ void IRArgoAC::setTemp(const uint8_t degrees) {
   uint8_t temp = std::max(kArgoMinTemp, degrees);
   // delta 4 degrees. "If I want 12 degrees, I need to send 8"
   temp = std::min(kArgoMaxTemp, temp) - kArgoTempDelta;
-  // Settemp = Bit 6,7 of byte 2, and bit 0-2 of byte 3
   // mask out bits
   // argo[13] & 0x00000100;  // mask out ON/OFF Bit
-  setBits(&argo[2], kArgoTempLowOffset, kArgoTempLowSize, temp);
-  setBits(&argo[3], kArgoTempHighOffset, kArgoTempHighSize,
-          temp >> kArgoTempLowSize);
+  _.Temp = temp;
 }
 
 /// Get the current temperature setting.
 /// @return The current setting for temp. in degrees celsius.
-uint8_t IRArgoAC::getTemp(void) {
-  return ((GETBITS8(argo[3], kArgoTempHighOffset,
-                    kArgoTempHighSize) << kArgoTempLowSize) |
-           GETBITS8(argo[2], kArgoTempLowOffset, kArgoTempLowSize)) +
-      kArgoTempDelta;
+uint8_t IRArgoAC::getTemp(void) const {
+  return _.Temp + kArgoTempDelta;
 }
 
 /// Set the speed of the fan.
 /// @param[in] fan The desired setting.
 void IRArgoAC::setFan(const uint8_t fan) {
-  setBits(&argo[3], kArgoFanOffset, kArgoFanSize, std::min(fan, kArgoFan3));
+  _.Fan = std::min(fan, kArgoFan3);
 }
 
 /// Get the current fan speed setting.
 /// @return The current fan speed.
-uint8_t IRArgoAC::getFan(void) {
-  return GETBITS8(argo[3], kArgoFanOffset, kArgoFanSize);
+uint8_t IRArgoAC::getFan(void) const {
+  return _.Fan;
 }
 
 /// Set the flap position. i.e. Swing.
@@ -203,12 +194,12 @@ void IRArgoAC::setFlap(const uint8_t flap) {
 /// Get the flap position. i.e. Swing.
 /// @warning Not yet working!
 /// @return The current flap setting.
-uint8_t IRArgoAC::getFlap(void) { return flap_mode; }
+uint8_t IRArgoAC::getFlap(void) const { return flap_mode; }
 
 /// Get the current operation mode setting.
 /// @return The current operation mode.
-uint8_t IRArgoAC::getMode(void) {
-  return GETBITS8(argo[2], kArgoModeOffset, kArgoModeSize);
+uint8_t IRArgoAC::getMode(void) const {
+  return _.Mode;
 }
 
 /// Set the desired operation mode.
@@ -221,32 +212,32 @@ void IRArgoAC::setMode(const uint8_t mode) {
     case kArgoOff:
     case kArgoHeat:
     case kArgoHeatAuto:
-      setBits(&argo[2], kArgoModeOffset, kArgoModeSize, mode);
+      _.Mode = mode;
       return;
     default:
-      this->setMode(kArgoAuto);
+      _.Mode = kArgoAuto;
   }
 }
 
 /// Turn on/off the Night mode. i.e. Sleep.
 /// @param[in] on The desired setting.
 void IRArgoAC::setNight(const bool on) {
-  setBit(&argo[9], kArgoNightBitOffset, on);
+  _.Night = on;
 }
 
 /// Get the status of Night mode. i.e. Sleep.
 /// @return true if on, false if off.
-bool IRArgoAC::getNight(void) { return GETBIT8(argo[9], kArgoNightBitOffset); }
+bool IRArgoAC::getNight(void) const { return _.Night; }
 
 /// Turn on/off the iFeel mode.
 /// @param[in] on The desired setting.
 void IRArgoAC::setiFeel(const bool on) {
-  setBit(&argo[9], kArgoIFeelBitOffset, on);
+  _.iFeel = on;
 }
 
 /// Get the status of iFeel mode.
 /// @return true if on, false if off.
-bool IRArgoAC::getiFeel(void) { return GETBIT8(argo[9], kArgoIFeelBitOffset); }
+bool IRArgoAC::getiFeel(void) const { return _.iFeel; }
 
 /// Set the time for the A/C
 /// @warning Not yet working!
@@ -259,18 +250,13 @@ void IRArgoAC::setTime(void) {
 void IRArgoAC::setRoomTemp(const uint8_t degrees) {
   uint8_t temp = std::min(degrees, kArgoMaxRoomTemp);
   temp = std::max(temp, kArgoTempDelta) - kArgoTempDelta;
-  setBits(&argo[3], kArgoRoomTempLowOffset, kArgoRoomTempLowSize, temp);
-  setBits(&argo[4], kArgoRoomTempHighOffset, kArgoRoomTempHighSize,
-          temp >> kArgoRoomTempLowSize);
+  _.RoomTemp = temp;
 }
 
 /// Get the currently stored value for the room temperature setting.
 /// @return The current setting for the room temp. in degrees celsius.
-uint8_t IRArgoAC::getRoomTemp(void) {
-  return ((GETBITS8(argo[4], kArgoRoomTempHighOffset,
-                   kArgoRoomTempHighSize) << kArgoRoomTempLowSize) |
-           GETBITS8(argo[3], kArgoRoomTempLowOffset, kArgoRoomTempLowSize)) +
-      kArgoTempDelta;
+uint8_t IRArgoAC::getRoomTemp(void) const {
+  return _.RoomTemp + kArgoTempDelta;
 }
 
 /// Convert a stdAc::opmode_t enum into its native mode.
@@ -357,16 +343,16 @@ stdAc::fanspeed_t IRArgoAC::toCommonFanSpeed(const uint8_t speed) {
 
 /// Convert the current internal state into its stdAc::state_t equivilant.
 /// @return The stdAc equivilant of the native settings.
-stdAc::state_t IRArgoAC::toCommon(void) {
+stdAc::state_t IRArgoAC::toCommon(void) const {
   stdAc::state_t result;
   result.protocol = decode_type_t::ARGO;
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
+  result.power = _.Power;
+  result.mode = toCommonMode(_.Mode);
   result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFan());
-  result.turbo = this->getMax();
-  result.sleep = this->getNight() ? 0 : -1;
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(_.Fan);
+  result.turbo = _.Max;
+  result.sleep = _.Night ? 0 : -1;
   // Not supported.
   result.model = -1;  // Not supported.
   result.swingv = stdAc::swingv_t::kOff;
@@ -383,13 +369,13 @@ stdAc::state_t IRArgoAC::toCommon(void) {
 
 /// Convert the current internal state into a human readable string.
 /// @return A human readable string.
-String IRArgoAC::toString(void) {
+String IRArgoAC::toString(void) const {
   String result = "";
   result.reserve(100);  // Reserve some heap for the string to reduce fragging.
-  result += addBoolToString(getPower(), kPowerStr, false);
-  result += addIntToString(getMode(), kModeStr);
+  result += addBoolToString(_.Power, kPowerStr, false);
+  result += addIntToString(_.Mode, kModeStr);
   result += kSpaceLBraceStr;
-  switch (getMode()) {
+  switch (_.Mode) {
     case kArgoAuto:
       result += kAutoStr;
       break;
@@ -414,9 +400,9 @@ String IRArgoAC::toString(void) {
       result += kUnknownStr;
   }
   result += ')';
-  result += addIntToString(getFan(), kFanStr);
+  result += addIntToString(_.Fan, kFanStr);
   result += kSpaceLBraceStr;
-  switch (getFan()) {
+  switch (_.Fan) {
     case kArgoFanAuto:
       result += kAutoStr;
       break;
@@ -438,9 +424,9 @@ String IRArgoAC::toString(void) {
   result += kRoomStr;
   result += ' ';
   result += addTempToString(getRoomTemp(), true, false);
-  result += addBoolToString(getMax(), kMaxStr);
-  result += addBoolToString(getiFeel(), kIFeelStr);
-  result += addBoolToString(getNight(), kNightStr);
+  result += addBoolToString(_.Max, kMaxStr);
+  result += addBoolToString(_.iFeel, kIFeelStr);
+  result += addBoolToString(_.Night, kNightStr);
   return result;
 }
 

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -43,22 +43,22 @@ union ArgoProtocol {
     uint64_t          :3;  // OffTimer, maybe hours
     uint64_t          :5;  // Time
     // Byte 8
-    uint8_t           :6;  // Time
-    uint8_t           :1;  // Timer On/Off
-    uint8_t           :1;  // Timer Program
+    uint32_t          :6;  // Time
+    uint32_t          :1;  // Timer On/Off
+    uint32_t          :1;  // Timer Program
     // Byte 9
-    uint8_t           :1;  // Timer Program
-    uint8_t           :1;  // Timer 1h
-    uint8_t Night     :1;
-    uint8_t Max       :1;
-    uint8_t           :1;  // Filter
-    uint8_t Power     :1;
-    uint8_t           :1;  // const 0
-    uint8_t iFeel     :1;
+    uint32_t          :1;  // Timer Program
+    uint32_t          :1;  // Timer 1h
+    uint32_t Night    :1;
+    uint32_t Max      :1;
+    uint32_t          :1;  // Filter
+    uint32_t Power    :1;
+    uint32_t          :1;  // const 0
+    uint32_t iFeel    :1;
     // Byte 10~11
-    uint16_t          :2;  // const 01
-    uint16_t Sum      :8;
-    uint16_t          :6;
+    uint32_t          :2;  // const 01
+    uint32_t Sum      :8;  // straddle byte 10 and 11
+    uint32_t          :6;
   };
 };
 

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -20,35 +20,53 @@
 
 //  ARGO Ulisse DCI
 
-/*
-	Protocol Description:
-  All in LSB first as it is sent. argo message array will be stored MSB first!
-  do LSB-MSB conversion in sendData
-  Byte 0: const 0	0	1	1	0	1	0	1
-  Byte 1: const 1	0	1	0	1	1	1	1
-  Byte 2: 0 0 0, 3bit Cool/Heat Mode, 2bit start SetTemp LSB first
-  Byte 3: 3bit End SetTemp, 2bit Fan Mode, 3bit RoomTemp LSB first
-  Byte 4: 2bit RoomTemp, 3bit Flap Mode, 3bit OnTimer
-  Byte 5: 8bit OnTimer
-  Byte 6: 8Bit OffTimer
-  Byte 7: 3bit OffTimer, 5bit Time
-  Byte 8: 6bit Time, 1bit Timer On/Off, 1bit Timer Program
-  Byte 9: 1bit Timer Program, 1bit Timer 1h, 1 bit Night Mode, 1bit Max Mode, 1bit Filter, 1bit on/off, 1bit const 0, 1bit iFeel
-  Byte 10: 2bit const 0 1, 6bit Checksum
-  Byte 11: 2bit Checksum
-*/
+union ArgoProtocol {
+  uint8_t raw[kArgoStateLength];  ///< The state in native IR code form
+  struct {
+    // Byte 0
+    uint64_t          :8;  // Typically 0b00110101
+    // Byte 1
+    uint64_t          :8;  // Typically 0b10101111
+    // Byte 2~4
+    uint64_t          :3;
+    uint64_t Mode     :3;
+    uint64_t Temp     :5;  // straddle byte 2 and 3
+    uint64_t Fan      :2;
+    uint64_t RoomTemp :5;  // straddle byte 3 and 4
+    uint64_t Flap     :3;  // SwingV
+    uint64_t          :3;  // OnTimer, maybe hours
+    // Byte 5
+    uint64_t          :8;  // OnTimer, maybe minutes
+    // Byte 6
+    uint64_t          :8;  // OffTimer, maybe minutes
+    // Byte 7
+    uint64_t          :3;  // OffTimer, maybe hours
+    uint64_t          :5;  // Time
+    // Byte 8
+    uint8_t           :6;  // Time
+    uint8_t           :1;  // Timer On/Off
+    uint8_t           :1;  // Timer Program
+    // Byte 9
+    uint8_t           :1;  // Timer Program
+    uint8_t           :1;  // Timer 1h
+    uint8_t Night     :1;
+    uint8_t Max       :1;
+    uint8_t           :1;  // Filter
+    uint8_t Power     :1;
+    uint8_t           :1;  // const 0
+    uint8_t iFeel     :1;
+    // Byte 10~11
+    uint16_t          :2;  // const 01
+    uint16_t Sum      :8;
+    uint16_t          :6;
+  };
+};
 
 // Constants. Store MSB left.
 
-// byte[2]
 const uint8_t kArgoHeatBit =      0b00100000;
-//            kArgoTempLowMask =  0b11000000;
-const uint8_t kArgoTempLowOffset = 5;
-const uint8_t kArgoTempLowSize = 2;
 
 // Mode                           0b00111000
-const uint8_t kArgoModeOffset = 3;
-const uint8_t kArgoModeSize = 3;
 const uint8_t kArgoCool =           0b000;
 const uint8_t kArgoDry =            0b001;
 const uint8_t kArgoAuto =           0b010;
@@ -58,40 +76,19 @@ const uint8_t kArgoHeatAuto =       0b101;
 // ?no idea what mode that is
 const uint8_t kArgoHeatBlink =      0b110;
 
-// byte[3]
-//            kArgoTempHighMask =    0b00000111;
-const uint8_t kArgoTempHighOffset = 0;
-const uint8_t kArgoTempHighSize = 3;
 // Fan                               0b00011000
-const uint8_t kArgoFanOffset = 3;
-const uint8_t kArgoFanSize = 2;
 const uint8_t kArgoFanAuto = 0;      // 0b00
 const uint8_t kArgoFan1 = 1;         // 0b01
 const uint8_t kArgoFan2 = 2;         // 0b10
 const uint8_t kArgoFan3 = 3;         // 0b11
-//            kArgoRoomTempLowMask = 0b11100000;
-const uint8_t kArgoRoomTempLowOffset = 5;
-const uint8_t kArgoRoomTempLowSize = 3;
 
-// byte[4]
-//            kArgoRoomTempHighMask = 0b00000011;
-const uint8_t kArgoRoomTempHighOffset = 0;
-const uint8_t kArgoRoomTempHighSize = 2;
-
+// Temp
 const uint8_t kArgoTempDelta = 4;
-const uint8_t kArgoMaxRoomTemp =
-    ((1 << (kArgoRoomTempHighSize + kArgoRoomTempLowSize)) - 1) +
-    kArgoTempDelta;  // 35C
-
-// byte[9]
-const uint8_t kArgoNightBitOffset = 2;
-const uint8_t kArgoMaxBitOffset = 3;
-const uint8_t kArgoPowerBitOffset = 5;
-const uint8_t kArgoIFeelBitOffset = 7;
-
+const uint8_t kArgoMaxRoomTemp = 35;  // Celsius
 const uint8_t kArgoMinTemp = 10;  // Celsius delta +4
 const uint8_t kArgoMaxTemp = 32;  // Celsius
 
+// Flap/SwingV
 const uint8_t kArgoFlapAuto = 0;
 const uint8_t kArgoFlap1 = 1;
 const uint8_t kArgoFlap2 = 2;
@@ -144,32 +141,32 @@ class IRArgoAC {
   void off(void);
 
   void setPower(const bool on);
-  bool getPower(void);
+  bool getPower(void) const;
 
   void setTemp(const uint8_t degrees);
-  uint8_t getTemp(void);
+  uint8_t getTemp(void) const;
 
   void setFan(const uint8_t fan);
-  uint8_t getFan(void);
+  uint8_t getFan(void) const;
 
   void setFlap(const uint8_t flap);
-  uint8_t getFlap(void);
+  uint8_t getFlap(void) const;
 
   void setMode(const uint8_t mode);
-  uint8_t getMode(void);
+  uint8_t getMode(void) const;
 
   void setMax(const bool on);
-  bool getMax(void);
+  bool getMax(void) const;
 
   void setNight(const bool on);
-  bool getNight(void);
+  bool getNight(void) const;
 
   void setiFeel(const bool on);
-  bool getiFeel(void);
+  bool getiFeel(void) const;
 
   void setTime(void);
   void setRoomTemp(const uint8_t degrees);
-  uint8_t getRoomTemp(void);
+  uint8_t getRoomTemp(void) const;
 
   uint8_t* getRaw(void);
   void setRaw(const uint8_t state[]);
@@ -182,8 +179,8 @@ class IRArgoAC {
   static uint8_t convertSwingV(const stdAc::swingv_t position);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void);
-  String toString();
+  stdAc::state_t toCommon(void) const;
+  String toString(void) const;
 #ifndef UNIT_TEST
 
  private:
@@ -194,7 +191,7 @@ class IRArgoAC {
   /// @endcond
 #endif
   // # of bytes per command
-  uint8_t argo[kArgoStateLength];  // Defined in IRremoteESP8266.h
+  ArgoProtocol _;
   void stateReset(void);
   void checksum(void);
 


### PR DESCRIPTION
I think it must meet 3 conditions when using bit field:

1. Don't straddle bytes unless necessary;
2. Don't exceed the width of the underlying type;
3. Follow the Object's alignment requirement
see [https://en.cppreference.com/w/cpp/language/bit_field#Notes](https://en.cppreference.com/w/cpp/language/bit_field#Notes)
[https://en.cppreference.com/w/cpp/language/object#Alignment](https://en.cppreference.com/w/cpp/language/object#Alignment)

for example:
```
    // Byte 2~4
    uint64_t          :3;
    uint64_t Mode     :3;
    uint64_t Temp     :5;  // straddle byte 2 and 3
    uint64_t Fan      :2;
    uint64_t RoomTemp :5;  // straddle byte 3 and 4
    uint64_t Flap     :3;  // SwingV
    uint64_t          :3;  // OnTimer, maybe hours
```
The field "Temp" straddle byte 2 and 3 and "RoomTemp" straddle byte 3 and 4, it means the bytes 2~4  should be taken as a whole, so you can't use uint8_t or uint16_t to hold them. If you use uint32_t, it's size is 4 and it's alignment must  >=4, so you can't place it at byte 2. Finally, I use uint64_t start at byte 0.