### PR TITLE
Neoclima: Add Economy & Fahrenheit support

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1493,6 +1493,7 @@ void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
 /// @param[in, out] ac A Ptr to an IRNeoclimaAc object to use.
 /// @param[in] on The power setting.
 /// @param[in] mode The operation mode setting.
+/// @param[in] celsius Temperature units. True is Celsius, False is Fahrenheit.
 /// @param[in] degrees The temperature setting in degrees.
 /// @param[in] fan The speed setting for the fan.
 /// @param[in] swingv The vertical swing setting.
@@ -1504,13 +1505,14 @@ void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
 /// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
 void IRac::neoclima(IRNeoclimaAc *ac,
                     const bool on, const stdAc::opmode_t mode,
-                    const float degrees, const stdAc::fanspeed_t fan,
+                    const bool celsius, const float degrees,
+                    const stdAc::fanspeed_t fan,
                     const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                     const bool turbo, const bool econo, const bool light,
                     const bool filter, const int16_t sleep) {
   ac->begin();
   ac->setMode(ac->convertMode(mode));
-  ac->setTemp(degrees);
+  ac->setTemp(degrees, celsius);
   ac->setFan(ac->convertFan(fan));
   ac->setSwingV(swingv != stdAc::swingv_t::kOff);
   ac->setSwingH(swingh != stdAc::swingh_t::kOff);
@@ -2409,9 +2411,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case NEOCLIMA:
     {
       IRNeoclimaAc ac(_pin, _inverted, _modulation);
-      neoclima(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
-               send.swingh, send.turbo, send.econo, send.light, send.filter,
-               send.sleep);
+      neoclima(&ac, send.power, send.mode, send.celsius, send.degrees,
+               send.fanspeed, send.swingv, send.swingh, send.turbo,
+               send.econo, send.light, send.filter, send.sleep);
       break;
     }
 #endif  // SEND_NEOCLIMA

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1498,6 +1498,7 @@ void IRac::mitsubishiHeavy152(IRMitsubishiHeavy152Ac *ac,
 /// @param[in] swingv The vertical swing setting.
 /// @param[in] swingh The horizontal swing setting.
 /// @param[in] turbo Run the device in turbo/powerful mode.
+/// @param[in] econo Run the device in economical mode.
 /// @param[in] light Turn on the LED/Display mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
 /// @param[in] sleep Nr. of minutes for sleep mode. -1 is Off, >= 0 is on.
@@ -1505,8 +1506,8 @@ void IRac::neoclima(IRNeoclimaAc *ac,
                     const bool on, const stdAc::opmode_t mode,
                     const float degrees, const stdAc::fanspeed_t fan,
                     const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-                    const bool turbo, const bool light, const bool filter,
-                    const int16_t sleep) {
+                    const bool turbo, const bool econo, const bool light,
+                    const bool filter, const int16_t sleep) {
   ac->begin();
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -1516,7 +1517,7 @@ void IRac::neoclima(IRNeoclimaAc *ac,
   // No Quiet setting available.
   ac->setTurbo(turbo);
   ac->setLight(light);
-  // No Econo setting available.
+  ac->setEcono(econo);
   ac->setIon(filter);
   // No Clean setting available.
   // No Beep setting available.
@@ -2409,7 +2410,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRNeoclimaAc ac(_pin, _inverted, _modulation);
       neoclima(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
-               send.swingh, send.turbo, send.light, send.filter, send.sleep);
+               send.swingh, send.turbo, send.econo, send.light, send.filter,
+               send.sleep);
       break;
     }
 #endif  // SEND_NEOCLIMA

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -340,8 +340,8 @@ void electra(IRElectraAc *ac,
   void neoclima(IRNeoclimaAc *ac, const bool on, const stdAc::opmode_t mode,
                 const float degrees, const stdAc::fanspeed_t fan,
                 const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
-                const bool turbo, const bool light, const bool filter,
-                const int16_t sleep = -1);
+                const bool turbo, const bool econo, const bool light,
+                const bool filter, const int16_t sleep = -1);
 #endif  // SEND_NEOCLIMA
 #if SEND_PANASONIC_AC
   void panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -338,7 +338,8 @@ void electra(IRElectraAc *ac,
 #endif  // SEND_MITSUBISHIHEAVY
 #if SEND_NEOCLIMA
   void neoclima(IRNeoclimaAc *ac, const bool on, const stdAc::opmode_t mode,
-                const float degrees, const stdAc::fanspeed_t fan,
+                const bool celsius, const float degrees,
+                const stdAc::fanspeed_t fan,
                 const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                 const bool turbo, const bool econo, const bool light,
                 const bool filter, const int16_t sleep = -1);

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -62,6 +62,8 @@ const PROGMEM char* kSilentStr = D_STR_SILENT;  ///< "Silent"
 const PROGMEM char* kFilterStr = D_STR_FILTER;  ///< "Filter"
 const PROGMEM char* k3DStr = D_STR_3D;  ///< "3D"
 const PROGMEM char* kCelsiusStr = D_STR_CELSIUS;  ///< "Celsius"
+const PROGMEM char* kCelsiusFahrenheitStr = D_STR_CELSIUS_FAHRENHEIT;  ///<
+///< "Celsius/Fahrenheit"
 const PROGMEM char* kTempUpStr = D_STR_TEMPUP;  ///< "Temp Up"
 const PROGMEM char* kTempDownStr = D_STR_TEMPDOWN;  ///< "Temp Down"
 const PROGMEM char* kStartStr = D_STR_START;  ///< "Start"

--- a/src/IRtext.h
+++ b/src/IRtext.h
@@ -27,6 +27,7 @@ extern const char* kBreezeStr;
 extern const char* kButtonStr;
 extern const char* kCancelStr;
 extern const char* kCeilingStr;
+extern const char* kCelsiusFahrenheitStr;
 extern const char* kCelsiusStr;
 extern const char* kCentreStr;
 extern const char* kChangeStr;

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -64,7 +64,7 @@ void IRsend::sendNeoclima(const unsigned char data[], const uint16_t nbytes,
 IRNeoclimaAc::IRNeoclimaAc(const uint16_t pin, const bool inverted,
                            const bool use_modulation)
     : _irsend(pin, inverted, use_modulation) {
-  this->stateReset();
+  stateReset();
 }
 
 /// Reset the state of the remote to a known good state/sequence.
@@ -115,7 +115,7 @@ void IRNeoclimaAc::send(const uint16_t repeat) {
 /// Get a PTR to the internal state/code for this protocol.
 /// @return PTR to a code for this protocol based on the current internal state.
 uint8_t *IRNeoclimaAc::getRaw(void) {
-  this->checksum();
+  checksum();
   return remote_state;
 }
 
@@ -146,11 +146,12 @@ void IRNeoclimaAc::setButton(const uint8_t button) {
     case kNeoclimaButtonFresh:
     case kNeoclimaButton8CHeat:
     case kNeoclimaButtonTurbo:
+    case kNeoclimaButtonEcono:
       setBits(&remote_state[5], kNeoclimaButtonOffset, kNeoclimaButtonSize,
               button);
       break;
     default:
-      this->setButton(kNeoclimaButtonPower);
+      setButton(kNeoclimaButtonPower);
   }
 }
 
@@ -161,15 +162,15 @@ uint8_t IRNeoclimaAc::getButton(void) {
 }
 
 /// Set the requested power state of the A/C to on.
-void IRNeoclimaAc::on(void) { this->setPower(true); }
+void IRNeoclimaAc::on(void) { setPower(true); }
 
 /// Set the requested power state of the A/C to off.
-void IRNeoclimaAc::off(void) { this->setPower(false); }
+void IRNeoclimaAc::off(void) { setPower(false); }
 
 /// Change the power setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setPower(const bool on) {
-  this->setButton(kNeoclimaButtonPower);
+  setButton(kNeoclimaButtonPower);
   setBit(&remote_state[7], kNeoclimaPowerOffset, on);
 }
 
@@ -185,18 +186,18 @@ void IRNeoclimaAc::setMode(const uint8_t mode) {
   switch (mode) {
     case kNeoclimaDry:
       // In this mode fan speed always LOW
-      this->setFan(kNeoclimaFanLow);
+      setFan(kNeoclimaFanLow);
       // FALL THRU
     case kNeoclimaAuto:
     case kNeoclimaCool:
     case kNeoclimaFan:
     case kNeoclimaHeat:
       setBits(&remote_state[9], kNeoclimaModeOffset, kModeBitsSize, mode);
-      this->setButton(kNeoclimaButtonMode);
+      setButton(kNeoclimaButtonMode);
       break;
     default:
       // If we get an unexpected mode, default to AUTO.
-      this->setMode(kNeoclimaAuto);
+      setMode(kNeoclimaAuto);
   }
 }
 
@@ -235,13 +236,13 @@ stdAc::opmode_t IRNeoclimaAc::toCommonMode(const uint8_t mode) {
 /// Set the temperature.
 /// @param[in] temp The temperature in degrees celsius.
 void IRNeoclimaAc::setTemp(const uint8_t temp) {
-  uint8_t oldtemp = this->getTemp();
+  uint8_t oldtemp = getTemp();
   uint8_t newtemp = std::max(kNeoclimaMinTemp, temp);
   newtemp = std::min(kNeoclimaMaxTemp, newtemp);
   if (oldtemp > newtemp)
-    this->setButton(kNeoclimaButtonTempDown);
+    setButton(kNeoclimaButtonTempDown);
   else if (newtemp > oldtemp)
-    this->setButton(kNeoclimaButtonTempUp);
+    setButton(kNeoclimaButtonTempUp);
   setBits(&remote_state[9], kNeoclimaTempOffset, kNeoclimaTempSize,
           newtemp - kNeoclimaMinTemp);
 }
@@ -260,18 +261,18 @@ void IRNeoclimaAc::setFan(const uint8_t speed) {
     case kNeoclimaFanAuto:
     case kNeoclimaFanHigh:
     case kNeoclimaFanMed:
-      if (this->getMode() == kNeoclimaDry) {  // Dry mode only allows low speed.
-        this->setFan(kNeoclimaFanLow);
+      if (getMode() == kNeoclimaDry) {  // Dry mode only allows low speed.
+        setFan(kNeoclimaFanLow);
         return;
       }
       // FALL-THRU
     case kNeoclimaFanLow:
       setBits(&remote_state[7], kNeoclimaFanOffest, kNeoclimaFanSize, speed);
-      this->setButton(kNeoclimaButtonFanSpeed);
+      setButton(kNeoclimaButtonFanSpeed);
       break;
     default:
       // If we get an unexpected speed, default to Auto.
-      this->setFan(kNeoclimaFanAuto);
+      setFan(kNeoclimaFanAuto);
   }
 }
 
@@ -310,7 +311,7 @@ stdAc::fanspeed_t IRNeoclimaAc::toCommonFanSpeed(const uint8_t speed) {
 /// Set the Sleep setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setSleep(const bool on) {
-  this->setButton(kNeoclimaButtonSleep);
+  setButton(kNeoclimaButtonSleep);
   setBit(&remote_state[7], kNeoclimaSleepOffset, on);
 }
 
@@ -323,7 +324,7 @@ bool IRNeoclimaAc::getSleep(void) {
 /// Set the vertical swing setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setSwingV(const bool on) {
-  this->setButton(kNeoclimaButtonSwing);
+  setButton(kNeoclimaButtonSwing);
   setBits(&remote_state[7], kNeoclimaSwingVOffset, kNeoclimaSwingVSize,
           on ? kNeoclimaSwingVOn : kNeoclimaSwingVOff);
 }
@@ -338,7 +339,7 @@ bool IRNeoclimaAc::getSwingV(void) {
 /// Set the horizontal swing setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setSwingH(const bool on) {
-  this->setButton(kNeoclimaButtonAirFlow);
+  setButton(kNeoclimaButtonAirFlow);
   setBit(&remote_state[7], kNeoclimaSwingHOffset, !on);  // Cleared when `on`
 }
 
@@ -351,7 +352,7 @@ bool IRNeoclimaAc::getSwingH(void) {
 /// Set the Turbo setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setTurbo(const bool on) {
-  this->setButton(kNeoclimaButtonTurbo);
+  setButton(kNeoclimaButtonTurbo);
   setBit(&remote_state[3], kNeoclimaTurboOffset, on);
 }
 
@@ -361,10 +362,23 @@ bool IRNeoclimaAc::getTurbo(void) {
   return GETBIT8(remote_state[3], kNeoclimaTurboOffset);
 }
 
+/// Set the Economy (Energy Saver) setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRNeoclimaAc::setEcono(const bool on) {
+  setButton(kNeoclimaButtonEcono);
+  setBit(&remote_state[3], kNeoclimaEconoOffset, on);
+}
+
+/// Get the Economy (Energy Saver) setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
+bool IRNeoclimaAc::getEcono(void) {
+  return GETBIT8(remote_state[3], kNeoclimaEconoOffset);
+}
+
 /// Set the Fresh (air) setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setFresh(const bool on) {
-  this->setButton(kNeoclimaButtonFresh);
+  setButton(kNeoclimaButtonFresh);
   setBit(&remote_state[5], kNeoclimaFreshOffset, on);
 }
 
@@ -377,7 +391,7 @@ bool IRNeoclimaAc::getFresh(void) {
 /// Set the Hold setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setHold(const bool on) {
-  this->setButton(kNeoclimaButtonHold);
+  setButton(kNeoclimaButtonHold);
   setBit(&remote_state[3], kNeoclimaHoldOffset, on);
 }
 
@@ -390,7 +404,7 @@ bool IRNeoclimaAc::getHold(void) {
 /// Set the Ion (filter) setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setIon(const bool on) {
-  this->setButton(kNeoclimaButtonIon);
+  setButton(kNeoclimaButtonIon);
   setBit(&remote_state[1], kNeoclimaIonOffset, on);
 }
 
@@ -403,7 +417,7 @@ bool IRNeoclimaAc::getIon(void) {
 /// Set the Light(LED display) setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setLight(const bool on) {
-  this->setButton(kNeoclimaButtonLight);
+  setButton(kNeoclimaButtonLight);
   setBit(&remote_state[3], kNeoclimaLightOffset, on);
 }
 
@@ -420,7 +434,7 @@ bool IRNeoclimaAc::getLight(void) {
 ///   automatically when nobody is at home over a longer period during severe
 ///   winter.
 void IRNeoclimaAc::set8CHeat(const bool on) {
-  this->setButton(kNeoclimaButton8CHeat);
+  setButton(kNeoclimaButton8CHeat);
   setBit(&remote_state[1], kNeoclima8CHeatOffset, on);
 }
 
@@ -433,7 +447,7 @@ bool IRNeoclimaAc::get8CHeat(void) {
 /// Set the Eye (Sensor) setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRNeoclimaAc::setEye(const bool on) {
-  this->setButton(kNeoclimaButtonEye);
+  setButton(kNeoclimaButtonEye);
   setBit(&remote_state[3], kNeoclimaEyeOffset, on);
 }
 
@@ -446,7 +460,7 @@ bool IRNeoclimaAc::getEye(void) {
 /* DISABLED
    TODO(someone): Work out why "on" is either 0x5D or 0x5F
 void IRNeoclimaAc::setFollow(const bool on) {
-  this->setButton(kNeoclimaButtonFollow);
+  setButton(kNeoclimaButtonFollow);
   if (on)
     remote_state[8] = kNeoclimaFollowMe;
   else
@@ -466,22 +480,22 @@ stdAc::state_t IRNeoclimaAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::NEOCLIMA;
   result.model = -1;  // No models used.
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
+  result.power = getPower();
+  result.mode = toCommonMode(getMode());
   result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFan());
-  result.swingv = this->getSwingV() ? stdAc::swingv_t::kAuto
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  result.swingv = getSwingV() ? stdAc::swingv_t::kAuto
                                     : stdAc::swingv_t::kOff;
-  result.swingh = this->getSwingH() ? stdAc::swingh_t::kAuto
+  result.swingh = getSwingH() ? stdAc::swingh_t::kAuto
                                     : stdAc::swingh_t::kOff;
-  result.turbo = this->getTurbo();
-  result.light = this->getLight();
-  result.filter = this->getIon();
-  result.sleep = this->getSleep() ? 0 : -1;
+  result.turbo = getTurbo();
+  result.econo = getEcono();
+  result.light = getLight();
+  result.filter = getIon();
+  result.sleep = getSleep() ? 0 : -1;
   // Not supported.
   result.quiet = false;
-  result.econo = false;
   result.clean = false;
   result.beep = false;
   result.clock = -1;
@@ -492,7 +506,7 @@ stdAc::state_t IRNeoclimaAc::toCommon(void) {
 /// @return A human readable string.
 String IRNeoclimaAc::toString(void) {
   String result = "";
-  result.reserve(100);  // Reserve some heap for the string to reduce fragging.
+  result.reserve(110);  // Reserve some heap for the string to reduce fragging.
   result += addBoolToString(getPower(), kPowerStr, false);
   result += addModeToString(getMode(), kNeoclimaAuto, kNeoclimaCool,
                             kNeoclimaHeat, kNeoclimaDry, kNeoclimaFan);
@@ -503,6 +517,7 @@ String IRNeoclimaAc::toString(void) {
   result += addBoolToString(getSwingH(), kSwingHStr);
   result += addBoolToString(getSleep(), kSleepStr);
   result += addBoolToString(getTurbo(), kTurboStr);
+  result += addBoolToString(getEcono(), kEconoStr);
   result += addBoolToString(getHold(), kHoldStr);
   result += addBoolToString(getIon(), kIonStr);
   result += addBoolToString(getEye(), kEyeStr);
@@ -512,7 +527,7 @@ String IRNeoclimaAc::toString(void) {
   result += addBoolToString(getFresh(), kFreshStr);
   result += addIntToString(getButton(), kButtonStr);
   result += kSpaceLBraceStr;
-  switch (this->getButton()) {
+  switch (getButton()) {
     case kNeoclimaButtonPower:    result += kPowerStr; break;
     case kNeoclimaButtonMode:     result += kModeStr; break;
     case kNeoclimaButtonTempUp:   result += kTempUpStr; break;
@@ -529,8 +544,8 @@ String IRNeoclimaAc::toString(void) {
     case kNeoclimaButtonFresh:    result += kFreshStr; break;
     case kNeoclimaButton8CHeat:   result += k8CHeatStr; break;
     case kNeoclimaButtonTurbo:    result += kTurboStr; break;
-    default:
-      result += kUnknownStr;
+    case kNeoclimaButtonEcono:    result += kEconoStr; break;
+    default:                      result += kUnknownStr;
   }
   result += ')';
   return result;

--- a/src/ir_Neoclima.h
+++ b/src/ir_Neoclima.h
@@ -9,6 +9,8 @@
 // Supports:
 //   Brand: Neoclima,  Model: NS-09AHTI A/C
 //   Brand: Neoclima,  Model: ZH/TY-01 remote
+//   Brand: Soleus Air,  Model: TTWM1-10-01 A/C
+//   Brand: Soleus Air,  Model: ZCF/TL-05 remote
 
 #ifndef IR_NEOCLIMA_H_
 #define IR_NEOCLIMA_H_

--- a/src/ir_Neoclima.h
+++ b/src/ir_Neoclima.h
@@ -31,14 +31,15 @@
 const uint8_t kNeoclima8CHeatOffset = 1;
 const uint8_t kNeoclimaIonOffset = 2;
 // state[3]
-const uint8_t kNeoclimaLightOffset = 0;
-const uint8_t kNeoclimaHoldOffset = 2;
-const uint8_t kNeoclimaTurboOffset = 3;
-const uint8_t kNeoclimaEyeOffset = 6;
+const uint8_t kNeoclimaLightOffset = 0;   ///< Mask 0b0000000x
+const uint8_t kNeoclimaHoldOffset = 2;    ///< Mask 0b00000x00
+const uint8_t kNeoclimaTurboOffset = 3;   ///< Mask 0b0000x000
+const uint8_t kNeoclimaEconoOffset = 4;   ///< Mask 0b000x0000
+const uint8_t kNeoclimaEyeOffset = 6;     ///< Mask 0b0x000000
 // state[5]
-const uint8_t kNeoclimaFreshOffset = 7;
-const uint8_t kNeoclimaButtonOffset = 0;
-const uint8_t kNeoclimaButtonSize = 5;
+const uint8_t kNeoclimaFreshOffset = 7;   ///< Mask 0bx0000000
+const uint8_t kNeoclimaButtonOffset = 0;  ///< Mask 0b000xxxxx
+const uint8_t kNeoclimaButtonSize = 5;    ///< Mask 0b000xxxxx
 const uint8_t kNeoclimaButtonPower =    0x00;
 const uint8_t kNeoclimaButtonMode =     0x01;
 const uint8_t kNeoclimaButtonTempUp =   0x02;
@@ -50,6 +51,7 @@ const uint8_t kNeoclimaButtonHold =     0x08;
 const uint8_t kNeoclimaButtonSleep =    0x09;
 const uint8_t kNeoclimaButtonTurbo =    0x0A;
 const uint8_t kNeoclimaButtonLight =    0x0B;
+const uint8_t kNeoclimaButtonEcono =    0x0D;
 const uint8_t kNeoclimaButtonEye =      0x0E;
 const uint8_t kNeoclimaButtonFollow =   0x13;
 const uint8_t kNeoclimaButtonIon =      0x14;
@@ -119,6 +121,8 @@ class IRNeoclimaAc {
   bool getSleep(void);
   void setTurbo(const bool on);
   bool getTurbo(void);
+  void setEcono(const bool on);
+  bool getEcono(void);
   void setFresh(const bool on);
   bool getFresh(void);
   void setHold(const bool on);

--- a/src/ir_Neoclima.h
+++ b/src/ir_Neoclima.h
@@ -57,28 +57,32 @@ const uint8_t kNeoclimaButtonFollow =   0x13;
 const uint8_t kNeoclimaButtonIon =      0x14;
 const uint8_t kNeoclimaButtonFresh =    0x15;
 const uint8_t kNeoclimaButton8CHeat =   0x1D;
+const uint8_t kNeoclimaButtonTempUnit = 0x1E;
 // state[7]
-const uint8_t kNeoclimaSleepOffset = 0;
-const uint8_t kNeoclimaPowerOffset = 1;
-const uint8_t kNeoclimaSwingVOffset = 2;
+const uint8_t kNeoclimaSleepOffset = 0;          // Mask 0b0000000x
+const uint8_t kNeoclimaPowerOffset = 1;          // Mask 0b000000x0
+const uint8_t kNeoclimaSwingVOffset = 2;         // Mask 0b0000xx00
 const uint8_t kNeoclimaSwingVSize = 2;  // Bits
-const uint8_t kNeoclimaSwingVOn =   0b01;
-const uint8_t kNeoclimaSwingVOff =  0b10;
-const uint8_t kNeoclimaSwingHOffset = 4;
-const uint8_t kNeoclimaFanOffest = 5;
-const uint8_t kNeoclimaFanSize = 2;
-const uint8_t kNeoclimaFanAuto =     0b00;
-const uint8_t kNeoclimaFanHigh =     0b01;
-const uint8_t kNeoclimaFanMed =      0b10;
-const uint8_t kNeoclimaFanLow =      0b11;
+const uint8_t kNeoclimaSwingVOn =                            0b01;
+const uint8_t kNeoclimaSwingVOff =                           0b10;
+const uint8_t kNeoclimaSwingHOffset = 4;         // Mask 0b000x0000
+const uint8_t kNeoclimaFanOffest = 5;            // Mask 0b0xx00000
+const uint8_t kNeoclimaFanSize = 2;  // Bits
+const uint8_t kNeoclimaFanAuto =                          0b00;
+const uint8_t kNeoclimaFanHigh =                          0b01;
+const uint8_t kNeoclimaFanMed =                           0b10;
+const uint8_t kNeoclimaFanLow =                           0b11;
+const uint8_t kNeoclimaUseFahrenheitOffset = 7;  // Mask 0bx0000000
 // state[8]
 const uint8_t kNeoclimaFollowMe = 0x5D;  // Also 0x5F
 // state[9]
-const uint8_t kNeoclimaTempOffset = 0;
+const uint8_t kNeoclimaTempOffset = 0;  // Mask 0b000xxxxx
 const uint8_t kNeoclimaTempSize = 5;  // Bits
-const uint8_t kNeoclimaMinTemp = 16;   // 16C
-const uint8_t kNeoclimaMaxTemp = 32;   // 32C
-const uint8_t kNeoclimaModeOffset = 5;
+const uint8_t kNeoclimaMinTempC = 16;   // 16C
+const uint8_t kNeoclimaMaxTempC = 32;   // 32C
+const uint8_t kNeoclimaMinTempF = 61;   // 61F
+const uint8_t kNeoclimaMaxTempF = 90;   // 90F
+const uint8_t kNeoclimaModeOffset = 5;  // Mask 0bxxx00000
 const uint8_t kNeoclimaAuto =     0b000;
 const uint8_t kNeoclimaCool =     0b001;
 const uint8_t kNeoclimaDry =      0b010;
@@ -109,7 +113,7 @@ class IRNeoclimaAc {
   bool getPower(void);
   void setMode(const uint8_t mode);
   uint8_t getMode(void);
-  void setTemp(const uint8_t temp);
+  void setTemp(const uint8_t temp, const bool celsius = true);
   uint8_t getTemp(void);
   void setFan(const uint8_t speed);
   uint8_t getFan(void);
@@ -135,6 +139,7 @@ class IRNeoclimaAc {
   bool get8CHeat(void);
   void setEye(const bool on);
   bool getEye(void);
+  bool getTempUnits(void);
   // DISABLED: See TODO in ir_Neoclima.cpp
   // void setFollow(const bool on);
   bool getFollow(void);

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -153,6 +153,12 @@
 #ifndef D_STR_CELSIUS
 #define D_STR_CELSIUS "Celsius"
 #endif  // D_STR_CELSIUS
+#ifndef D_STR_FAHRENHEIT
+#define D_STR_FAHRENHEIT "Fahrenheit"
+#endif  // D_STR_FAHRENHEIT
+#ifndef D_STR_CELSIUS_FAHRENHEIT
+#define D_STR_CELSIUS_FAHRENHEIT D_STR_CELSIUS "/" D_STR_FAHRENHEIT
+#endif  // D_STR_CELSIUS_FAHRENHEIT
 #ifndef D_STR_UP
 #define D_STR_UP "Up"
 #endif  // D_STR_UP

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1102,9 +1102,9 @@ TEST(TestIRac, Neoclima) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 3 (Low), "
-      "Swing(V): Off, Swing(H): On, Sleep: On, Turbo: Off, Hold: Off, Ion: On, "
-      "Eye: Off, Light: On, Follow: Off, 8C Heat: Off, Fresh: Off, "
-      "Button: 0 (Power)";
+      "Swing(V): Off, Swing(H): On, Sleep: On, Turbo: Off, Econo: On, "
+      "Hold: Off, Ion: On, Eye: Off, Light: On, Follow: Off, 8C Heat: Off, "
+      "Fresh: Off, Button: 0 (Power)";
 
   ac.begin();
   irac.neoclima(&ac,
@@ -1115,6 +1115,7 @@ TEST(TestIRac, Neoclima) {
                 stdAc::swingv_t::kOff,       // Veritcal swing
                 stdAc::swingh_t::kAuto,      // Horizontal swing
                 false,                       // Turbo
+                true,                        // Econo
                 true,                        // Light
                 true,                        // Filter
                 8 * 60);                     // Sleep

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1110,7 +1110,8 @@ TEST(TestIRac, Neoclima) {
   irac.neoclima(&ac,
                 true,                        // Power
                 stdAc::opmode_t::kCool,      // Mode
-                20,                          // Celsius
+                true,                        // Celsius
+                20,                          // Degrees
                 stdAc::fanspeed_t::kLow,     // Fan speed
                 stdAc::swingv_t::kOff,       // Veritcal swing
                 stdAc::swingh_t::kAuto,      // Horizontal swing

--- a/test/ir_Neoclima_test.cpp
+++ b/test/ir_Neoclima_test.cpp
@@ -161,20 +161,63 @@ TEST(TestIRNeoclimaAcClass, OperatingMode) {
   EXPECT_EQ(kNeoclimaAuto, ac.getMode());
 }
 
-TEST(TestIRNeoclimaAcClass, SetAndGetTemp) {
+TEST(TestIRNeoclimaAcClass, Temperature) {
   IRNeoclimaAc ac(kGpioUnused);
+  // Celsius
   ac.setTemp(25);
   EXPECT_EQ(25, ac.getTemp());
-  ac.setTemp(kNeoclimaMinTemp);
-  EXPECT_EQ(kNeoclimaMinTemp, ac.getTemp());
+  ac.setTemp(kNeoclimaMinTempC);
+  EXPECT_TRUE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMinTempC, ac.getTemp());
   EXPECT_EQ(kNeoclimaButtonTempDown, ac.getButton());
-  ac.setTemp(kNeoclimaMinTemp - 1);
-  EXPECT_EQ(kNeoclimaMinTemp, ac.getTemp());
-  ac.setTemp(kNeoclimaMaxTemp);
-  EXPECT_EQ(kNeoclimaMaxTemp, ac.getTemp());
+  ac.setTemp(kNeoclimaMinTempC - 1);
+  EXPECT_TRUE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMinTempC, ac.getTemp());
+  ac.setTemp(kNeoclimaMaxTempC);
+  EXPECT_TRUE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMaxTempC, ac.getTemp());
   EXPECT_EQ(kNeoclimaButtonTempUp, ac.getButton());
-  ac.setTemp(kNeoclimaMaxTemp + 1);
-  EXPECT_EQ(kNeoclimaMaxTemp, ac.getTemp());
+  ac.setTemp(kNeoclimaMaxTempC + 1);
+  EXPECT_TRUE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMaxTempC, ac.getTemp());
+  // Fahrenheit
+  ac.setTemp(kNeoclimaMinTempF, false);
+  EXPECT_FALSE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMinTempF, ac.getTemp());
+  ac.setTemp(kNeoclimaMinTempF - 1, false);
+  EXPECT_FALSE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMinTempF, ac.getTemp());
+  ac.setTemp(kNeoclimaMaxTempF, false);
+  EXPECT_FALSE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMaxTempF, ac.getTemp());
+  EXPECT_EQ(kNeoclimaButtonTempUp, ac.getButton());
+  ac.setTemp(kNeoclimaMaxTempF + 1, false);
+  EXPECT_FALSE(ac.getTempUnits());
+  EXPECT_EQ(kNeoclimaMaxTempF, ac.getTemp());
+
+  // Real data
+  // Data from: https://github.com/crankyoldgit/IRremoteESP8266/issues/1260#issuecomment-687235135
+  const uint8_t temp_68F[12] =
+      {0x00, 0x00, 0x00, 0x10, 0x00, 0x1E, 0x00, 0xA2, 0x00, 0x27, 0xA5, 0x9C};
+  ac.setRaw(temp_68F);
+  EXPECT_FALSE(ac.getTempUnits());
+  EXPECT_EQ(68, ac.getTemp());
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Cool), Temp: 68F, Fan: 1 (High), Swing(V): Off, "
+      "Swing(H): On, Sleep: Off, Turbo: Off, Econo: On, Hold: Off, Ion: Off, "
+      "Eye: Off, Light: Off, Follow: Off, 8C Heat: Off, Fresh: Off, "
+      "Button: 30 (Celsius/Fahrenheit)", ac.toString());
+
+  const uint8_t temp_20C[12] =
+      {0x00, 0x00, 0x00, 0x10, 0x00, 0x1E, 0x00, 0x22, 0x00, 0x24, 0xA5, 0x19};
+  ac.setRaw(temp_20C);
+  EXPECT_TRUE(ac.getTempUnits());
+  EXPECT_EQ(20, ac.getTemp());
+  EXPECT_EQ(
+      "Power: On, Mode: 1 (Cool), Temp: 20C, Fan: 1 (High), Swing(V): Off, "
+      "Swing(H): On, Sleep: Off, Turbo: Off, Econo: On, Hold: Off, Ion: Off, "
+      "Eye: Off, Light: Off, Follow: Off, 8C Heat: Off, Fresh: Off, "
+      "Button: 30 (Celsius/Fahrenheit)", ac.toString());
 }
 
 TEST(TestIRNeoclimaAcClass, FanSpeed) {
@@ -326,7 +369,7 @@ TEST(TestIRNeoclimaAcClass, Hold) {
   EXPECT_EQ(kNeoclimaButtonHold, ac.getButton());
 }
 
-TEST(TestIRNeoclimaAcClass, 8CHeat) {
+TEST(TestIRNeoclimaAcClass, _8CHeat) {
   IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.set8CHeat(true);

--- a/test/ir_Neoclima_test.cpp
+++ b/test/ir_Neoclima_test.cpp
@@ -18,7 +18,7 @@ TEST(TestUtils, Housekeeping) {
 
 // Test sending typical data only.
 TEST(TestSendNeoclima, SendDataOnly) {
-  IRsendTest irsend(0);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   uint8_t state[kNeoclimaStateLength] = {
@@ -48,8 +48,8 @@ TEST(TestSendNeoclima, SendDataOnly) {
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/764#issuecomment-503755096
 TEST(TestDecodeNeoclima, RealExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   uint16_t rawData[197] = {
       6112, 7392, 540, 602, 516, 578, 522, 604, 540, 554, 540, 554, 540, 576,
       518, 576, 516, 554, 540, 608, 542, 554, 540, 554, 540, 576, 518, 604, 516,
@@ -78,13 +78,13 @@ TEST(TestDecodeNeoclima, RealExample) {
   ASSERT_EQ(decode_type_t::NEOCLIMA, irsend.capture.decode_type);
   ASSERT_EQ(kNeoclimaBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Power: On, Mode: 1 (Cool), Temp: 26C, Fan: 3 (Low), "
-      "Swing(V): Off, Swing(H): On, Sleep: Off, Turbo: Off, Hold: Off, "
-      "Ion: Off, Eye: Off, Light: Off, Follow: Off, 8C Heat: Off, Fresh: Off, "
-      "Button: 0 (Power)",
+      "Swing(V): Off, Swing(H): On, Sleep: Off, Turbo: Off, Econo: Off, "
+      "Hold: Off, Ion: Off, Eye: Off, Light: Off, Follow: Off, 8C Heat: Off, "
+      "Fresh: Off, Button: 0 (Power)",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -92,8 +92,8 @@ TEST(TestDecodeNeoclima, RealExample) {
 
 // Self decode.
 TEST(TestDecodeNeoclima, SyntheticExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
 
   uint8_t expectedState[kNeoclimaStateLength] = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -110,7 +110,7 @@ TEST(TestDecodeNeoclima, SyntheticExample) {
 }
 
 TEST(TestIRNeoclimaAcClass, Power) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
 
   ac.on();
@@ -129,7 +129,7 @@ TEST(TestIRNeoclimaAcClass, Power) {
 }
 
 TEST(TestIRNeoclimaAcClass, OperatingMode) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
 
   ac.setMode(kNeoclimaAuto);
@@ -162,7 +162,7 @@ TEST(TestIRNeoclimaAcClass, OperatingMode) {
 }
 
 TEST(TestIRNeoclimaAcClass, SetAndGetTemp) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.setTemp(25);
   EXPECT_EQ(25, ac.getTemp());
   ac.setTemp(kNeoclimaMinTemp);
@@ -178,7 +178,7 @@ TEST(TestIRNeoclimaAcClass, SetAndGetTemp) {
 }
 
 TEST(TestIRNeoclimaAcClass, FanSpeed) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
 
   ac.setFan(0);
@@ -231,7 +231,7 @@ TEST(TestIRNeoclimaAcClass, FanSpeed) {
 }
 
 TEST(TestIRNeoclimaAcClass, Sleep) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setSleep(true);
   EXPECT_TRUE(ac.getSleep());
@@ -243,7 +243,7 @@ TEST(TestIRNeoclimaAcClass, Sleep) {
 }
 
 TEST(TestIRNeoclimaAcClass, Turbo) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setTurbo(true);
   EXPECT_TRUE(ac.getTurbo());
@@ -266,8 +266,32 @@ TEST(TestIRNeoclimaAcClass, Turbo) {
   EXPECT_FALSE(ac.getTurbo());
 }
 
+TEST(TestIRNeoclimaAcClass, Econo) {
+  IRNeoclimaAc ac(kGpioUnused);
+  ac.begin();
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+  ac.setEcono(false);
+  EXPECT_FALSE(ac.getEcono());
+  ac.setEcono(true);
+  EXPECT_TRUE(ac.getEcono());
+  EXPECT_EQ(kNeoclimaButtonEcono, ac.getButton());
+  // Data from:
+  //   https://github.com/crankyoldgit/IRremoteESP8266/issues/1260#issuecomment-687235135
+  uint8_t econo_off[12] = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x22, 0x00, 0x20, 0xA5, 0xF4};
+  uint8_t econo_on[12] = {
+      0x00, 0x00, 0x00, 0x10, 0x00, 0x0D, 0x00, 0x22, 0x00, 0x20, 0xA5, 0x04};
+  ac.setRaw(econo_on);
+  EXPECT_TRUE(ac.getEcono());
+  EXPECT_EQ(kNeoclimaButtonEcono, ac.getButton());
+  ac.setRaw(econo_off);
+  EXPECT_EQ(kNeoclimaButtonEcono, ac.getButton());
+  EXPECT_FALSE(ac.getEcono());
+}
+
 TEST(TestIRNeoclimaAcClass, Fresh) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setFresh(true);
   EXPECT_TRUE(ac.getFresh());
@@ -291,7 +315,7 @@ TEST(TestIRNeoclimaAcClass, Fresh) {
 }
 
 TEST(TestIRNeoclimaAcClass, Hold) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setHold(true);
   EXPECT_TRUE(ac.getHold());
@@ -303,7 +327,7 @@ TEST(TestIRNeoclimaAcClass, Hold) {
 }
 
 TEST(TestIRNeoclimaAcClass, 8CHeat) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.set8CHeat(true);
   EXPECT_TRUE(ac.get8CHeat());
@@ -315,7 +339,7 @@ TEST(TestIRNeoclimaAcClass, 8CHeat) {
 }
 
 TEST(TestIRNeoclimaAcClass, Light) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setLight(true);
   EXPECT_TRUE(ac.getLight());
@@ -327,7 +351,7 @@ TEST(TestIRNeoclimaAcClass, Light) {
 }
 
 TEST(TestIRNeoclimaAcClass, Ion) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setIon(true);
   EXPECT_TRUE(ac.getIon());
@@ -339,7 +363,7 @@ TEST(TestIRNeoclimaAcClass, Ion) {
 }
 
 TEST(TestIRNeoclimaAcClass, Eye) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   ac.setEye(true);
   EXPECT_TRUE(ac.getEye());
@@ -351,7 +375,7 @@ TEST(TestIRNeoclimaAcClass, Eye) {
 }
 
 TEST(TestIRNeoclimaAcClass, Follow) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.begin();
   /*  DISABLED: See TODO in ir_Neoclima.cpp
   ac.setFollow(true);
@@ -390,7 +414,7 @@ TEST(TestIRNeoclimaAcClass, ChecksumCalculation) {
   examplestate[11] = 0x12;  // Set an incorrect checksum.
   EXPECT_FALSE(IRNeoclimaAc::validChecksum(examplestate));
   EXPECT_EQ(0x39, IRNeoclimaAc::calcChecksum(examplestate));
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.setRaw(examplestate);
   // Extracting the state from the object should have a correct checksum.
   EXPECT_TRUE(IRNeoclimaAc::validChecksum(ac.getRaw()));
@@ -404,7 +428,7 @@ TEST(TestIRNeoclimaAcClass, ChecksumCalculation) {
 }
 
 TEST(TestIRNeoclimaAcClass, toCommon) {
-  IRNeoclimaAc ac(0);
+  IRNeoclimaAc ac(kGpioUnused);
   ac.setPower(true);
   ac.setMode(kNeoclimaCool);
   ac.setTemp(20);


### PR DESCRIPTION
* Update supported models for this protocol.
* Economy and Fahrenheit support added.
* Unit tests updated/added.
* `IRac` support updated.
* Remove `this->` from `ir_Neoclima.cpp`

Fixes #1260 