### PR TITLE
IRMQTTServer: Change how MQTT packet/buffer size is set.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -1,6 +1,6 @@
 /*
  * Send & receive arbitrary IR codes via a web server or MQTT.
- * Copyright David Conran 2016, 2017, 2018, 2019
+ * Copyright David Conran 2016, 2017, 2018, 2019, 2020
  */
 #ifndef EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 #define EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
@@ -115,6 +115,12 @@ const IPAddress kSubnetMask = IPAddress(255, 255, 255, 0);
 
 // ----------------------- MQTT Related Settings -------------------------------
 #if MQTT_ENABLE
+#ifndef MQTT_BUFFER_SIZE
+// A value of 768 handles most cases easily. Use 1024 or more when using
+// `REPORT_RAW_UNKNOWNS` is recommended.
+#define MQTT_BUFFER_SIZE 768  // Default MQTT packet buffer size.
+#endif  // MQTT_BUFFER_SIZE
+const uint16_t kMqttBufferSize = MQTT_BUFFER_SIZE;  // Packet Buffer size.
 const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 
 #define MQTT_ACK "sent"  // Sub-topic we send back acknowledgements on.
@@ -185,7 +191,7 @@ const uint8_t kCaptureTimeout = 15;  // Milliseconds
 const uint16_t kMinUnknownSize = 2 * 10;
 #define REPORT_UNKNOWNS false  // Report inbound IR messages that we don't know.
 #define REPORT_RAW_UNKNOWNS false  // Report the whole buffer, recommended:
-                                   // MQTT_MAX_PACKET_SIZE of 1024 or more
+                                   // MQTT_BUFFER_SIZE of 1024 or more
 
 // Should we use and report individual A/C settings we capture via IR if we
 // can understand the individual settings of the remote.
@@ -276,7 +282,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.5.1"
+#define _MY_VERSION_ "v1.5.2"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -32,7 +32,7 @@
  * - Arduino IDE:
  *   o Install the following libraries via Library Manager
  *     - ArduinoJson (https://arduinojson.org/) (Version >= 6.0)
- *     - PubSubClient (https://pubsubclient.knolleary.net/) (Version >= 2.7.0)
+ *     - PubSubClient (https://pubsubclient.knolleary.net/) (Version >= 2.8.0)
  *     - WiFiManager (https://github.com/tzapu/WiFiManager)
  *                   (ESP8266: Version >= 0.14, ESP32: 'development' branch.)
  *   o Use the smallest non-zero FILESYSTEM size you can for your board.

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -13,7 +13,7 @@ monitor_speed = 115200
 [common]
 lib_deps_builtin =
 lib_deps_external =
-  PubSubClient@>=2.7.0
+  PubSubClient@>=2.8.0
   ArduinoJson@>=6.0
 
 [common_esp8266]

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -5,7 +5,7 @@ src_dir = .
 lib_extra_dirs = ../../
 lib_ldf_mode = deep+
 lib_ignore = examples
-build_flags = -DMQTT_MAX_PACKET_SIZE=768 ; -D_IR_LOCALE_=en-AU
+build_flags = ; -DMQTT_BUFFER_SIZE=768 -D_IR_LOCALE_=en-AU
 framework = arduino
 platform = espressif8266
 monitor_speed = 115200
@@ -13,7 +13,7 @@ monitor_speed = 115200
 [common]
 lib_deps_builtin =
 lib_deps_external =
-  PubSubClient
+  PubSubClient@>=2.7.0
   ArduinoJson@>=6.0
 
 [common_esp8266]


### PR DESCRIPTION
As of [v2.8.0](https://github.com/knolleary/pubsubclient/releases/tag/v2.8) of the [PubSubClient library](https://github.com/knolleary/pubsubclient), the size of the buffer can be set at runtime rather than the old `MQTT_MAX_PACKET_SIZE` in `PubSubClient.h`, using `PubSubClient::setBufferSize()`.
Move to use this instead of requiring the user to modify their _PubSubClient_ library files when using the Arduino IDE.

* Continue to allow it to be overridden at compile time by passing `-DMQTT_BUFFER_SIZE=nnn` to the compiler.
e.g. See the `platformio.ini` file in this example.
* Size can be set by modifying just the `IRMQTTServer.h` file. Hopefully this will result in less user setup issues.
* Add a requirement for _PubSubClient_ >= 2.8.0 in the `platformio.ini` file.
* Bump IRMQTTServer's version number.

* Tested on a d1_mini. Appears to be working fine.