### PR TITLE
Add some missing Doxygen class/data-type descriptions.

### DIFF
--- a/src/ir_Airwell.h
+++ b/src/ir_Airwell.h
@@ -23,6 +23,7 @@
 #include "IRsend_test.h"
 #endif
 
+/// Native representation of a Airwell A/C message.
 union AirwellProtocol{
   uint64_t raw;  // The state of the IR remote in native IR code form.
   struct {
@@ -35,6 +36,7 @@ union AirwellProtocol{
     uint64_t            :0;
   };
 };
+
 // Constants
 const uint64_t kAirwellKnownGoodState = 0x140500002;  // Mode Fan, Speed 1, 25C
 // Temperature

--- a/src/ir_Amcor.h
+++ b/src/ir_Amcor.h
@@ -24,6 +24,7 @@
 #endif
 
 
+/// Native representation of a Amcor A/C message.
 union AmcorProtocol{
   uint8_t raw[kAmcorStateLength];  // The state of the IR remote.
   struct {

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -20,6 +20,7 @@
 
 //  ARGO Ulisse DCI
 
+/// Native representation of a Argo A/C message.
 union ArgoProtocol {
   uint8_t raw[kArgoStateLength];  ///< The state in native IR code form
   struct {

--- a/src/ir_Carrier.h
+++ b/src/ir_Carrier.h
@@ -26,6 +26,7 @@
 #include "IRsend_test.h"
 #endif
 
+/// Native representation of a Carrier A/C message.
 union CarrierProtocol {
   uint64_t raw;  ///< The state of the IR remote.
   struct {

--- a/src/ir_Corona.h
+++ b/src/ir_Corona.h
@@ -26,6 +26,7 @@
 #include "IRsend_test.h"
 #endif
 
+/// Native representation of a section of a Corona A/C message.
 struct CoronaSection {
   uint8_t Header0;
   uint8_t Header1;
@@ -38,6 +39,7 @@ struct CoronaSection {
 
 const uint8_t kCoronaAcSections = 3;
 
+/// Native representation of a Corona A/C message.
 union CoronaProtocol {
   uint8_t raw[kCoronaAcStateLength];  ///< The state of the IR remote.
   CoronaSection sections[kCoronaAcSections];

--- a/src/ir_Delonghi.h
+++ b/src/ir_Delonghi.h
@@ -22,6 +22,7 @@
 #include "IRsend_test.h"
 #endif
 
+/// Native representation of a Delonghi A/C message.
 union DelonghiProtocol{
   uint64_t raw;  ///< The state of the IR remote.
   struct {

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -28,6 +28,7 @@
 #include "IRsend_test.h"
 #endif
 
+/// Native representation of a Gree A/C message.
 union GreeProtocol{
   uint8_t remote_state[kGreeStateLength];  ///< The state in native IR code form
   struct {

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -26,7 +26,7 @@
 #include "IRsend_test.h"
 #endif
 
-// Haier HSU07-HEA03 remote
+/// Native representation of a Haier HSU07-HEA03 A/C message.
 union HaierProtocol{
   ///< The state in native IR code form
   uint8_t remote_state[kHaierACStateLength];
@@ -131,7 +131,7 @@ const uint8_t kHaierAcSleepBit = 0b01000000;
 #define HAIER_AC_FAN_MED kHaierAcFanMed
 #define HAIER_AC_FAN_HIGH kHaierAcFanHigh
 
-// Haier YRW02 remote
+/// Native representation of a Haier YRW02 A/C message.
 union HaierYRW02Protocol{
   uint8_t raw[kHaierACYRW02StateLength];  ///< The state in native form
   struct {

--- a/src/ir_Midea.h
+++ b/src/ir_Midea.h
@@ -33,6 +33,8 @@
 #if DANBY_DAC
     kSwingVToggleStr = kIonStr;
 #endif
+
+/// Native representation of a Midea A/C message.
 union MideaProtocol{
   uint64_t remote_state;  ///< The state in native IR code form
   // only use 48bits
@@ -57,6 +59,7 @@ union MideaProtocol{
     uint8_t :0;
   };
 };
+
 // Constants
 const uint8_t kMideaACMinTempF = 62;  // Fahrenheit
 const uint8_t kMideaACMaxTempF = 86;  // Fahrenheit

--- a/src/ir_Technibel.h
+++ b/src/ir_Technibel.h
@@ -104,6 +104,7 @@ const uint64_t kTechnibelAcResetState = 0x180101140000EA;  ///<
 
 
 // Classes
+/// Class for handling detailed Technibel A/C messages.
 class IRTechnibelAc {
  public:
   explicit IRTechnibelAc(const uint16_t pin, const bool inverted = false,

--- a/src/ir_Transcold.h
+++ b/src/ir_Transcold.h
@@ -107,6 +107,7 @@ const uint32_t kTranscoldCmdFan = 0b111011110110000101010100;  // NA
 const uint32_t kTranscoldKnownGoodState = 0xE96554;
 
 // Classes
+/// Class for handling detailed Transcold A/C messages.
 class IRTranscoldAc {
  public:
   explicit IRTranscoldAc(const uint16_t pin, const bool inverted = false,

--- a/src/ir_Voltas.h
+++ b/src/ir_Voltas.h
@@ -24,7 +24,7 @@
 #include "IRsend_test.h"
 #endif
 
-
+/// Native representation of a Voltas A/C message.
 union VoltasProtocol {
   uint8_t raw[kVoltasStateLength];  ///< The state in native IR code form
   struct {


### PR DESCRIPTION
I noticed these where missing when I pushed the `gh-pages` documentation branch for the v2.7.11 release.