### PR TITLE
LG A/C: Potential fix for A/C power off issue.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1254,7 +1254,6 @@ void IRac::lg(IRLgAc *ac, const lg_ac_remote_model_t model,
               const float degrees, const stdAc::fanspeed_t fan) {
   ac->begin();
   ac->setModel(model);
-  ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
@@ -1268,6 +1267,7 @@ void IRac::lg(IRLgAc *ac, const lg_ac_remote_model_t model,
   // No Beep setting available.
   // No Sleep setting available.
   // No Clock setting available.
+  ac->setPower(on);  // Power off affects temp, so do after setting the temp.
   ac->send();
 }
 #endif  // SEND_LG


### PR DESCRIPTION
LG's A/C power off sets the temp to a special value. So move the `setPower()` call to last in `IRac::lg()` so it happens after any temp changes.

Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1298#issuecomment-708579459
Fixes #1298