### PR TITLE
LG2: Better enforce a repeat for LG2 messages.

### DIFF
--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -968,6 +968,7 @@ const uint16_t kLegoPfMinRepeat = kNoRepeat;
 const uint16_t kLgBits = 28;
 const uint16_t kLg32Bits = 32;
 const uint16_t kLgDefaultRepeat = kNoRepeat;
+const uint16_t kLg2DefaultRepeat = kSingleRepeat;
 const uint16_t kLutronBits = 35;
 const uint16_t kMagiquestBits = 56;
 const uint16_t kMetzBits = 19;

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -562,6 +562,7 @@ uint16_t IRsend::minRepeats(const decode_type_t protocol) {
     case COOLIX:
     case GICABLE:
     case INAX:
+    case LG2:
     case MIDEA24:
     case MITSUBISHI:
     case MITSUBISHI2:

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -265,9 +265,9 @@ class IRsend {
 #endif
 #if SEND_LG
   void sendLG(uint64_t data, uint16_t nbits = kLgBits,
-              uint16_t repeat = kNoRepeat);
+              uint16_t repeat = kLgDefaultRepeat);
   void sendLG2(uint64_t data, uint16_t nbits = kLgBits,
-               uint16_t repeat = kNoRepeat);
+               uint16_t repeat = kLg2DefaultRepeat);
   uint32_t encodeLG(uint16_t address, uint16_t command);
 #endif
 #if (SEND_SHARP || SEND_DENON)

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -929,7 +929,7 @@ TEST(TestIRac, LG) {
   IRLgAc ac(kGpioUnused);
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
-  char expected[] =
+  char lg_expected[] =
       "Model: 1 (GE6711AR2853M), "
       "Power: On, Mode: 1 (Dry), Temp: 27C, Fan: 2 (Medium)";
 
@@ -941,14 +941,46 @@ TEST(TestIRac, LG) {
           27,                                   // Degrees C
           stdAc::fanspeed_t::kMedium);          // Fan speed
 
-  ASSERT_EQ(expected, ac.toString());
+  ASSERT_EQ(lg_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(LG, ac._irsend.capture.decode_type);
   ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
-  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_EQ(lg_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+
+  // Tests for the LG2 protocol variant/model.
+  ac._irsend.reset();
+  char lg2_expected[] =
+      "Model: 2 (AKB75215403), "
+      "Power: On, Mode: 0 (Cool), Temp: 26C, Fan: 5 (Auto)";
+  irac.lg(&ac,
+          lg_ac_remote_model_t::AKB75215403,    // Model
+          true,                                 // Power
+          stdAc::opmode_t::kCool,               // Mode
+          26,                                   // Degrees C
+          stdAc::fanspeed_t::kAuto);            // Fan speed
+
+  ASSERT_EQ(lg2_expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(LG2, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kLgBits, ac._irsend.capture.bits);
+  ASSERT_EQ(lg2_expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+  EXPECT_EQ(
+      "f38000d50"
+      "m3200s9850"
+      "m550s1600m550s550m550s550m550s550m550s1600m550s550m550s550m550s550"
+      "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
+      "m550s1600m550s550m550s1600m550s1600m550s550m550s1600m550s550m550s1600"
+      "m550s550m550s550m550s550m550s550"
+      "m550s56300"
+      "m3200s2250"
+      "m550s102050",
+      ac._irsend.outputStr());
+  ac._irsend.reset();
 }
 
 TEST(TestIRac, Midea) {

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -375,7 +375,9 @@ TEST(TestSendLG2, SendDataOnly) {
       "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
       "m550s1600m550s550m550s550m550s1600m550s550m550s1600m550s550m550s550"
       "m550s1600m550s1600m550s550m550s1600"
-      "m550s55250",
+      "m550s55250"
+      "m3200s2250"
+      "m550s102050",
       irsend.outputStr());
 }
 
@@ -658,15 +660,21 @@ TEST(TestIRLgAcClass, calcChecksum) {
 }
 
 TEST(TestUtils, Housekeeping) {
+  // LG 28 bit protocol
   ASSERT_EQ("LG", typeToString(decode_type_t::LG));
   ASSERT_EQ(decode_type_t::LG, strToDecodeType("LG"));
   ASSERT_FALSE(hasACState(decode_type_t::LG));
   ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::LG));
+  ASSERT_EQ(kLgBits, IRsend::defaultBits(decode_type_t::LG));
+  ASSERT_EQ(kLgDefaultRepeat, IRsend::minRepeats(decode_type_t::LG));
 
+  // LG2 28 bit protocol
   ASSERT_EQ("LG2", typeToString(decode_type_t::LG2));
   ASSERT_EQ(decode_type_t::LG2, strToDecodeType("LG2"));
   ASSERT_FALSE(hasACState(decode_type_t::LG2));
   ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::LG2));
+  ASSERT_EQ(kLgBits, IRsend::defaultBits(decode_type_t::LG2));
+  ASSERT_EQ(kLg2DefaultRepeat, IRsend::minRepeats(decode_type_t::LG2));
 }
 
 TEST(TestIRLgAcClass, KnownExamples) {


### PR DESCRIPTION
* Looking at comments for `IRsend::sendLG2()` it seems the repeat is mandatory, but we have no proof it is. So, lets try making it (a minimum of a single repeat for LG2) mandatory in most cases.
* LG should stay the same with "no repeats" as the default.
* Extend existing unit tests to cover these points and to confirm expected operation.

This really needs to verified with hard data to be sure.

Might fix #1298