### PR TITLE
[Bug] Fix LG2 timings and refactor `decodeLG()`

### DIFF
--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -26,37 +26,24 @@ using irutils::setBits;
 
 
 // Constants
-const uint16_t kLgTick = 50;
-const uint16_t kLgHdrMarkTicks = 170;
-const uint16_t kLgHdrMark = kLgHdrMarkTicks * kLgTick;  // 8500
-const uint16_t kLgHdrSpaceTicks = 85;
-const uint16_t kLgHdrSpace = kLgHdrSpaceTicks * kLgTick;  // 4250
-const uint16_t kLgBitMarkTicks = 11;
-const uint16_t kLgBitMark = kLgBitMarkTicks * kLgTick;  // 550
-const uint16_t kLgOneSpaceTicks = 32;
-const uint16_t kLgOneSpace = kLgOneSpaceTicks * kLgTick;  // 1600
-const uint16_t kLgZeroSpaceTicks = 11;
-const uint16_t kLgZeroSpace = kLgZeroSpaceTicks * kLgTick;  // 550
-const uint16_t kLgRptSpaceTicks = 45;
-const uint16_t kLgRptSpace = kLgRptSpaceTicks * kLgTick;  // 2250
-const uint16_t kLgMinGapTicks = 795;
-const uint16_t kLgMinGap = kLgMinGapTicks * kLgTick;  // 39750
-const uint16_t kLgMinMessageLengthTicks = 2161;
-const uint32_t kLgMinMessageLength = kLgMinMessageLengthTicks * kLgTick;
-
-const uint16_t kLg32HdrMarkTicks = 90;
-const uint16_t kLg32HdrMark = kLg32HdrMarkTicks * kLgTick;  // 4500
-const uint16_t kLg32HdrSpaceTicks = 89;
-const uint16_t kLg32HdrSpace = kLg32HdrSpaceTicks * kLgTick;  // 4450
-const uint16_t kLg32RptHdrMarkTicks = 179;
-const uint16_t kLg32RptHdrMark = kLg32RptHdrMarkTicks * kLgTick;  // 8950
-
-const uint16_t kLg2HdrMarkTicks = 64;
-const uint16_t kLg2HdrMark = kLg2HdrMarkTicks * kLgTick;  // 3200
-const uint16_t kLg2HdrSpaceTicks = 197;
-const uint16_t kLg2HdrSpace = kLg2HdrSpaceTicks * kLgTick;  // 9850
-const uint16_t kLg2BitMarkTicks = 10;
-const uint16_t kLg2BitMark = kLg2BitMarkTicks * kLgTick;  // 500
+// Common timings
+const uint16_t kLgBitMark = 550;              ///< uSeconds.
+const uint16_t kLgOneSpace = 1600;            ///< uSeconds.
+const uint16_t kLgZeroSpace = 550;            ///< uSeconds.
+const uint16_t kLgRptSpace = 2250;            ///< uSeconds.
+const uint16_t kLgMinGap = 39750;             ///< uSeconds.
+const uint32_t kLgMinMessageLength = 108050;  ///< uSeconds.
+// LG (28 Bit)
+const uint16_t kLgHdrMark = 8500;             ///< uSeconds.
+const uint16_t kLgHdrSpace = 4250;            ///< uSeconds.
+// LG (32 Bit)
+const uint16_t kLg32HdrMark = 4500;           ///< uSeconds.
+const uint16_t kLg32HdrSpace = 4450;          ///< uSeconds.
+const uint16_t kLg32RptHdrMark = 8950;        ///< uSeconds.
+// LG2 (28 Bit)
+const uint16_t kLg2HdrMark = 3200;            ///< uSeconds.
+const uint16_t kLg2HdrSpace = 9900;           ///< uSeconds.
+const uint16_t kLg2BitMark = 480;             ///< uSeconds.
 
 #if SEND_LG
 /// Send an LG formatted message. (LG)
@@ -108,8 +95,8 @@ void IRsend::sendLG2(uint64_t data, uint16_t nbits, uint16_t repeat) {
   }
 
   // LGv2 (28-bit) protocol.
-  sendGeneric(kLg2HdrMark, kLg2HdrSpace, kLgBitMark, kLgOneSpace, kLgBitMark,
-              kLgZeroSpace, kLgBitMark, kLgMinGap, kLgMinMessageLength, data,
+  sendGeneric(kLg2HdrMark, kLg2HdrSpace, kLg2BitMark, kLgOneSpace, kLg2BitMark,
+              kLgZeroSpace, kLg2BitMark, kLgMinGap, kLgMinMessageLength, data,
               nbits, 38, true, 0,  // Repeats are handled later.
               50);
 
@@ -160,85 +147,55 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t offset,
     if (results->rawlen <= 2 * nbits + kHeader - 1 + offset)
       return false;  // Can't possibly be a valid LG message.
   }
+  // Compliance
   if (strict && nbits != kLgBits && nbits != kLg32Bits)
     return false;  // Doesn't comply with expected LG protocol.
+
+  // Header (Mark)
+  uint32_t kHdrSpace;
+  if (matchMark(results->rawbuf[offset], kLgHdrMark))
+    kHdrSpace = kLgHdrSpace;
+  else if (matchMark(results->rawbuf[offset], kLg2HdrMark))
+    kHdrSpace = kLg2HdrSpace;
+  else if (matchMark(results->rawbuf[offset], kLg32HdrMark))
+    kHdrSpace = kLg32HdrSpace;
+  else
+    return false;
+  offset++;
+
+  // Set up the expected data section values.
+  const uint16_t kBitmark = (kHdrSpace == kLg2HdrSpace) ? kLg2BitMark
+                                                        : kLgBitMark;
+  // Header Space + Data + Footer
   uint64_t data = 0;
-  bool isLg2 = false;
-
-  // Header
-  uint32_t m_tick;
-  if (matchMark(results->rawbuf[offset], kLgHdrMark)) {
-    m_tick = results->rawbuf[offset++] * kRawTick / kLgHdrMarkTicks;
-  } else if (matchMark(results->rawbuf[offset], kLg2HdrMark)) {
-    m_tick = results->rawbuf[offset++] * kRawTick / kLg2HdrMarkTicks;
-    isLg2 = true;
-  } else if (matchMark(results->rawbuf[offset], kLg32HdrMark)) {
-    m_tick = results->rawbuf[offset++] * kRawTick / kLg32HdrMarkTicks;
-  } else {
-    return false;
-  }
-  uint32_t s_tick;
-  if (isLg2) {
-    if (matchSpace(results->rawbuf[offset], kLg2HdrSpace))
-      s_tick = results->rawbuf[offset++] * kRawTick / kLg2HdrSpaceTicks;
-    else
-      return false;
-  } else {
-    if (matchSpace(results->rawbuf[offset], kLgHdrSpace))
-      s_tick = results->rawbuf[offset++] * kRawTick / kLgHdrSpaceTicks;
-    else if (matchSpace(results->rawbuf[offset], kLg2HdrSpace))
-      s_tick = results->rawbuf[offset++] * kRawTick / kLg32HdrSpaceTicks;
-    else
-      return false;
-  }
-
-  // Set up the expected tick sizes based on variant.
-  uint16_t bitmarkticks;
-  if (isLg2) {
-    bitmarkticks = kLg2BitMarkTicks;
-  } else {
-    bitmarkticks = kLgBitMarkTicks;
-  }
-
-  // Data
-  match_result_t data_result =
-      matchData(&(results->rawbuf[offset]), nbits, bitmarkticks * m_tick,
-                kLgOneSpaceTicks * s_tick, bitmarkticks * m_tick,
-                kLgZeroSpaceTicks * s_tick, _tolerance, 0);
-  if (data_result.success == false) return false;
-  data = data_result.data;
-  offset += data_result.used;
-
-  // Footer
-  if (!matchMark(results->rawbuf[offset++], bitmarkticks * m_tick))
-    return false;
-  if (offset < results->rawlen &&
-      !matchAtLeast(results->rawbuf[offset], kLgMinGapTicks * s_tick))
-    return false;
+  uint16_t used = matchGeneric(results->rawbuf + offset, &data,
+                               results->rawlen - offset, nbits,
+                               0,  // Already matched the Header mark.
+                               kHdrSpace,
+                               kBitmark, kLgOneSpace, kBitmark, kLgZeroSpace,
+                               kBitmark, kLgMinGap, true, kUseDefTol, 0, true);
+  if (!used) return false;
+  offset += used;
 
   // Repeat
   if (nbits >= kLg32Bits) {
     // If we are expecting the LG 32-bit protocol, there is always
     // a repeat message. So, check for it.
-    offset++;
-    if (!matchMark(results->rawbuf[offset++], kLg32RptHdrMarkTicks * m_tick))
-      return false;
-    if (!matchSpace(results->rawbuf[offset++], kLgRptSpaceTicks * s_tick))
-      return false;
-    if (!matchMark(results->rawbuf[offset++], bitmarkticks * m_tick))
-      return false;
-    if (offset < results->rawlen &&
-        !matchAtLeast(results->rawbuf[offset], kLgMinGapTicks * s_tick))
-      return false;
+    uint64_t unused;
+    if (!matchGeneric(results->rawbuf + offset, &unused,
+                      results->rawlen - offset, 0,  // No Data bits to match.
+                      kLg32RptHdrMark, kLgRptSpace,
+                      kBitmark, kLgOneSpace, kBitmark, kLgZeroSpace,
+                      kBitmark, kLgMinGap, true, kUseDefTol)) return false;
   }
 
   // Compliance
-  uint16_t command = (data >> 4) & 0xFFFF;  // The 16 bits before the checksum.
+  uint16_t command = (data >> 4);  // The 16 bits before the checksum.
 
   if (strict && (data & 0xF) != irutils::sumNibbles(command, 4))
     return false;  // The last 4 bits sent are the expected checksum.
   // Success
-  if (isLg2)
+  if (kHdrSpace == kLg2HdrSpace)  // Was it an LG2 message?
     results->decode_type = LG2;
   else
     results->decode_type = LG;
@@ -248,7 +205,7 @@ bool IRrecv::decodeLG(decode_results *results, uint16_t offset,
   results->address = data >> 20;  // The bits before the command.
   return true;
 }
-#endif
+#endif  // DECODE_LG
 
 // LG A/C Class
 

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -98,7 +98,7 @@ void IRsend::sendLG2(uint64_t data, uint16_t nbits, uint16_t repeat) {
   sendGeneric(kLg2HdrMark, kLg2HdrSpace, kLg2BitMark, kLgOneSpace, kLg2BitMark,
               kLgZeroSpace, kLg2BitMark, kLgMinGap, kLgMinMessageLength, data,
               nbits, 38, true, 0,  // Repeats are handled later.
-              50);
+              33);  // Use a duty cycle of 33% (Testing)
 
   // TODO(crackn): Verify the details of what repeat messages look like.
   // Repeat

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -11,7 +11,7 @@
 
 // Test sending typical data only.
 TEST(TestSendLG, SendDataOnly) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -42,7 +42,7 @@ TEST(TestSendLG, SendDataOnly) {
 
 // Test sending with different repeats.
 TEST(TestSendLG, SendWithRepeats) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -75,7 +75,7 @@ TEST(TestSendLG, SendWithRepeats) {
 
 // Test sending an atypical data size.
 TEST(TestSendLG, SendUnusualSize) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -111,7 +111,7 @@ TEST(TestSendLG, SendUnusualSize) {
 // Tests for encodeLG().
 
 TEST(TestEncodeLG, NormalEncoding) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   EXPECT_EQ(0x0, irsend.encodeLG(0, 0));
   EXPECT_EQ(0x100011, irsend.encodeLG(1, 1));
   EXPECT_EQ(0x100022, irsend.encodeLG(1, 2));
@@ -125,15 +125,15 @@ TEST(TestEncodeLG, NormalEncoding) {
 
 // Decode normal LG messages.
 TEST(TestDecodeLG, NormalDecodeWithStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal LG 28-bit message.
   irsend.reset();
   irsend.sendLG(0x4B4AE51, kLgBits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x4B4AE51, irsend.capture.value);
@@ -145,7 +145,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(0xB4B4AE51, kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, false));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0xB4B4AE51, irsend.capture.value);
@@ -157,7 +157,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99));
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -169,7 +169,7 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x800, 0x8000), kLg32Bits);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0x80080008, irsend.capture.value);
@@ -180,15 +180,15 @@ TEST(TestDecodeLG, NormalDecodeWithStrict) {
 
 // Decode normal repeated LG messages.
 TEST(TestDecodeLG, NormalDecodeWithRepeatAndStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal LG 28-bit message with 2 repeats.
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99), kLgBits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLgBits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -200,7 +200,7 @@ TEST(TestDecodeLG, NormalDecodeWithRepeatAndStrict) {
   irsend.reset();
   irsend.sendLG(irsend.encodeLG(0x07, 0x99), kLg32Bits, 2);
   irsend.makeDecodeResult();
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture, kStartOffset, kLg32Bits, true));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(LG, irsend.capture.decode_type);
   EXPECT_EQ(kLg32Bits, irsend.capture.bits);
   EXPECT_EQ(0x700992, irsend.capture.value);
@@ -211,8 +211,8 @@ TEST(TestDecodeLG, NormalDecodeWithRepeatAndStrict) {
 
 // Decode unsupported LG message values.
 TEST(TestDecodeLG, DecodeWithNonStrictValues) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Illegal values should be rejected when strict is on.
@@ -249,8 +249,8 @@ TEST(TestDecodeLG, DecodeWithNonStrictValues) {
 
 // Decode unsupported LG message sizes.
 TEST(TestDecodeLG, DecodeWithNonStrictSizes) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Illegal sizes should be rejected when strict is on.
@@ -295,8 +295,8 @@ TEST(TestDecodeLG, DecodeWithNonStrictSizes) {
 
 // Decode (non-standard) 64-bit messages.
 TEST(TestDecodeLG, Decode64BitMessages) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -315,8 +315,8 @@ TEST(TestDecodeLG, Decode64BitMessages) {
 
 // Decode a 'real' example via GlobalCache
 TEST(TestDecodeLG, DecodeGlobalCacheExample) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // TODO(anyone): Find a Global Cache example of the LG 28-bit message.
@@ -342,8 +342,8 @@ TEST(TestDecodeLG, DecodeGlobalCacheExample) {
 
 // Fail to decode a non-LG example via GlobalCache
 TEST(TestDecodeLG, FailToDecodeNonLGExample) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -363,32 +363,32 @@ TEST(TestDecodeLG, FailToDecodeNonLGExample) {
 
 // Test sending typical data only.
 TEST(TestSendLG2, SendDataOnly) {
-  IRsendTest irsend(0);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
   irsend.sendLG2(0x880094D);
   EXPECT_EQ(
       "f38000d50"
-      "m3200s9850"
-      "m550s1600m550s550m550s550m550s550m550s1600m550s550m550s550m550s550"
-      "m550s550m550s550m550s550m550s550m550s550m550s550m550s550m550s550"
-      "m550s1600m550s550m550s550m550s1600m550s550m550s1600m550s550m550s550"
-      "m550s1600m550s1600m550s550m550s1600"
-      "m550s55250",
+      "m3200s9900"
+      "m480s1600m480s550m480s550m480s550m480s1600m480s550m480s550m480s550"
+      "m480s550m480s550m480s550m480s550m480s550m480s550m480s550m480s550"
+      "m480s1600m480s550m480s550m480s1600m480s550m480s1600m480s550m480s550"
+      "m480s1600m480s1600m480s550m480s1600"
+      "m480s57230",
       irsend.outputStr());
 }
 
 TEST(TestDecodeLG2, SyntheticExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
   irsend.sendLG2(0x880094D);
   irsend.makeDecodeResult();
 
-  ASSERT_TRUE(irrecv.decodeLG(&irsend.capture));
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(LG2, irsend.capture.decode_type);
   EXPECT_EQ(kLgBits, irsend.capture.bits);
   EXPECT_EQ(0x880094D, irsend.capture.value);
@@ -396,8 +396,8 @@ TEST(TestDecodeLG2, SyntheticExample) {
 
 // Verify decoding of LG variant 2 messages.
 TEST(TestDecodeLG2, RealLG2Example) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -421,8 +421,8 @@ TEST(TestDecodeLG2, RealLG2Example) {
 // Tests for issue reported in
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/620
 TEST(TestDecodeLG, Issue620) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Raw data as reported in initial comment of Issue #620
@@ -662,11 +662,15 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ(decode_type_t::LG, strToDecodeType("LG"));
   ASSERT_FALSE(hasACState(decode_type_t::LG));
   ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::LG));
+  ASSERT_EQ(kLgBits, IRsendTest::defaultBits(decode_type_t::LG));
+  ASSERT_EQ(kLgDefaultRepeat, IRsendTest::minRepeats(decode_type_t::LG));
 
   ASSERT_EQ("LG2", typeToString(decode_type_t::LG2));
   ASSERT_EQ(decode_type_t::LG2, strToDecodeType("LG2"));
   ASSERT_FALSE(hasACState(decode_type_t::LG2));
   ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::LG2));
+  ASSERT_EQ(kLgBits, IRsendTest::defaultBits(decode_type_t::LG2));
+  ASSERT_EQ(kLgDefaultRepeat, IRsendTest::minRepeats(decode_type_t::LG2));
 }
 
 TEST(TestIRLgAcClass, KnownExamples) {
@@ -794,8 +798,8 @@ TEST(TestIRLgAcClass, KnownExamples) {
 
 // Verify decoding of LG2 message.
 TEST(TestDecodeLG2, Issue1008) {
-  IRsendTest irsend(0);
-  IRrecv capture(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv capture(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -836,7 +840,7 @@ TEST(TestDecodeLG2, Issue1008) {
 
 TEST(TestIRLgAcClass, DifferentModels) {
   IRLgAc ac(kGpioUnused);
-  IRrecv capture(0);
+  IRrecv capture(kGpioUnused);
 
   ac.setRaw(0x8800347);
 
@@ -855,7 +859,6 @@ TEST(TestIRLgAcClass, DifferentModels) {
   ASSERT_EQ(expected1, IRAcUtils::resultAcToString(&ac._irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
-
 
   ac.setModel(lg_ac_remote_model_t::AKB75215403);  // aka. 2
   ac._irsend.reset();

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -369,7 +369,7 @@ TEST(TestSendLG2, SendDataOnly) {
   irsend.reset();
   irsend.sendLG2(0x880094D);
   EXPECT_EQ(
-      "f38000d50"
+      "f38000d33"
       "m3200s9900"
       "m480s1600m480s550m480s550m480s550m480s1600m480s550m480s550m480s550"
       "m480s550m480s550m480s550m480s550m480s550m480s550m480s550m480s550"


### PR DESCRIPTION
* [BUG] LG2 was incorrectly using the Bitmark timings of the LG protocol.
  - Tweak the timings some more to match reported working LG2 data.
* While here, re-write the mess that is `decodeLG()` to use generic routines and clean it up.
* Remove all `tick` calculations to simplify things.
* Fix a number of style issues.
* Misc improvements to Unit tests.

For #1298