### PR TITLE
SharpAc: Add model support for A705

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1672,6 +1672,7 @@ void IRac::sanyo(IRSanyoAc *ac,
 /// Send a Sharp A/C message with the supplied settings.
 /// @note Multiple IR messages may be generated & sent.
 /// @param[in, out] ac A Ptr to an IRSharpAc object to use.
+/// @param[in] model The A/C model to use.
 /// @param[in] on The power setting.
 /// @param[in] prev_power The power setting from the previous A/C state.
 /// @param[in] mode The operation mode setting.
@@ -1681,13 +1682,14 @@ void IRac::sanyo(IRSanyoAc *ac,
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
 /// @param[in] clean Turn on the self-cleaning mode. e.g. Mould, dry filters etc
-void IRac::sharp(IRSharpAc *ac,
+void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
                  const bool on, const bool prev_power,
                  const stdAc::opmode_t mode,
                  const float degrees, const stdAc::fanspeed_t fan,
                  const stdAc::swingv_t swingv, const bool turbo,
                  const bool filter, const bool clean) {
   ac->begin();
+  ac->setModel(model);
   ac->setPower(on, prev_power);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -2538,8 +2540,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       IRSharpAc ac(_pin, _inverted, _modulation);
       bool prev_power = !send.power;
       if (prev != NULL) prev_power = prev->power;
-      sharp(&ac, send.power, prev_power, send.mode, degC, send.fanspeed,
-            send.swingv, send.turbo, send.filter, send.clean);
+      sharp(&ac, (sharp_ac_remote_model_t)send.model, send.power, prev_power,
+            send.mode, degC, send.fanspeed, send.swingv, send.turbo,
+            send.filter, send.clean);
       break;
     }
 #endif  // SEND_SHARP_AC

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -370,7 +370,7 @@ void electra(IRElectraAc *ac,
              const bool beep, const int16_t sleep = -1);
 #endif  // SEND_SANYO_AC
 #if SEND_SHARP_AC
-  void sharp(IRSharpAc *ac,
+  void sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
              const bool on, const bool prev_power, const stdAc::opmode_t mode,
              const float degrees, const stdAc::fanspeed_t fan,
              const stdAc::swingv_t swingv, const bool turbo, const bool filter,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -373,8 +373,8 @@ void electra(IRElectraAc *ac,
   void sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
              const bool on, const bool prev_power, const stdAc::opmode_t mode,
              const float degrees, const stdAc::fanspeed_t fan,
-             const stdAc::swingv_t swingv, const bool turbo, const bool filter,
-             const bool clean);
+             const stdAc::swingv_t swingv, const bool turbo, const bool light,
+             const bool filter, const bool clean);
 #endif  // SEND_SHARP_AC
 #if SEND_TCL112AC
   void tcl112(IRTcl112Ac *ac,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -148,6 +148,12 @@ enum panasonic_ac_remote_model_t {
   kPanasonicRkr = 6,
 };
 
+/// Sharp A/C model numbers
+enum sharp_ac_remote_model_t {
+  A907 = 1,  // 802 too.
+  A705 = 2,
+};
+
 /// Voltas A/C model numbers
 enum voltas_ac_remote_model_t {
   kVoltasUnknown = 0,  // Full Function

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -534,6 +534,13 @@ namespace irutils {
           default: return kUnknownStr;
         }
         break;
+      case decode_type_t::SHARP_AC:
+        switch (model) {
+          case sharp_ac_remote_model_t::A907: return F("A907");
+          case sharp_ac_remote_model_t::A705: return F("A705");
+          default: return kUnknownStr;
+        }
+        break;
       case decode_type_t::PANASONIC_AC:
         switch (model) {
           case panasonic_ac_remote_model_t::kPanasonicLke: return F("LKE");

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -44,6 +44,7 @@ using irutils::addFanToString;
 using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
+using irutils::addModelToString;
 using irutils::addTempToString;
 using irutils::minsToString;
 using irutils::setBit;
@@ -243,7 +244,7 @@ void IRsend::sendSharpAc(const unsigned char data[], const uint16_t nbytes,
 /// @param[in] use_modulation Is frequency modulation to be used?
 IRSharpAc::IRSharpAc(const uint16_t pin, const bool inverted,
                      const bool use_modulation)
-    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 /// Set up hardware to be able to send a message.
 void IRSharpAc::begin(void) { _irsend.begin(); }
@@ -279,7 +280,7 @@ bool IRSharpAc::validChecksum(uint8_t state[], const uint16_t length) {
 /// Calculate and set the checksum values for the internal state.
 void IRSharpAc::checksum(void) {
   setBits(&remote[kSharpAcStateLength - 1], kHighNibble, kNibbleSize,
-          this->calcChecksum(remote));
+          calcChecksum(remote));
 }
 
 /// Reset the state of the remote to a known good state/sequence.
@@ -291,12 +292,13 @@ void IRSharpAc::stateReset(void) {
   _temp = getTemp();
   _mode = getMode();
   _fan = getFan();
+  _model = getModel(true);
 }
 
 /// Get a PTR to the internal state/code for this protocol.
 /// @return PTR to a code for this protocol based on the current internal state.
 uint8_t *IRSharpAc::getRaw(void) {
-  this->checksum();  // Ensure correct settings before sending.
+  checksum();  // Ensure correct settings before sending.
   return remote;
 }
 
@@ -305,6 +307,34 @@ uint8_t *IRSharpAc::getRaw(void) {
 /// @param[in] length The length/size of the new_code array.
 void IRSharpAc::setRaw(const uint8_t new_code[], const uint16_t length) {
   memcpy(remote, new_code, std::min(length, kSharpAcStateLength));
+  _model = getModel(true);
+}
+
+/// Set the model of the A/C to emulate.
+/// @param[in] model The enum of the appropriate model.
+void IRSharpAc::setModel(const sharp_ac_remote_model_t model) {
+  switch (model) {
+    case sharp_ac_remote_model_t::A705:
+      _model = model;
+      break;
+    default:
+      _model = sharp_ac_remote_model_t::A907;
+  }
+  setBit(&remote[kSharpAcByteIon], kSharpAcModelBit,
+         _model == sharp_ac_remote_model_t::A705);
+}
+
+/// Get/Detect the model of the A/C.
+/// @param[in] raw Try to determine the model from the raw code only.
+/// @return The enum of the compatible model.
+sharp_ac_remote_model_t IRSharpAc::getModel(const bool raw) {
+  if (raw)
+    return (GETBIT8(remote[kSharpAcByteIon],
+                    kSharpAcModelBit) &&
+            GETBIT8(remote[kSharpAcByteTemp],
+                    kSharpAcModelBit)) ? sharp_ac_remote_model_t::A705
+                                       : sharp_ac_remote_model_t::A907;
+  return _model;
 }
 
 /// Set the value of the Power Special setting without any checks.
@@ -391,14 +421,20 @@ uint8_t IRSharpAc::getSpecial(void) { return remote[kSharpAcByteSpecial]; }
 /// @param[in] temp The temperature in degrees celsius.
 /// @param[in] save Do we save this setting as a user set one?
 void IRSharpAc::setTemp(const uint8_t temp, const bool save) {
-  switch (this->getMode()) {
+  switch (getMode()) {
     // Auto & Dry don't allow temp changes and have a special temp.
     case kSharpAcAuto:
     case kSharpAcDry:
       remote[kSharpAcByteTemp] = 0;
       return;
     default:
-      remote[kSharpAcByteTemp] = 0xC0;
+      switch (getModel()) {
+        case sharp_ac_remote_model_t::A705:
+          remote[kSharpAcByteTemp] = 0xD0;
+          break;
+        default:
+          remote[kSharpAcByteTemp] = 0xC0;
+      }
   }
   uint8_t degrees = std::max(temp, kSharpAcMinTemp);
   degrees = std::min(degrees, kSharpAcMaxTemp);
@@ -430,18 +466,18 @@ void IRSharpAc::setMode(const uint8_t mode, const bool save) {
     case kSharpAcAuto:
     case kSharpAcDry:
       // When Dry or Auto, Fan always 2(Auto)
-      this->setFan(kSharpAcFanAuto, false);
+      setFan(kSharpAcFanAuto, false);
       // FALLTHRU
     case kSharpAcCool:
     case kSharpAcHeat:
       setBits(&remote[kSharpAcByteMode], kLowNibble, kSharpAcModeSize, mode);
       break;
     default:
-      this->setMode(kSharpAcAuto, save);
+      setMode(kSharpAcAuto, save);
       return;
   }
   // Dry/Auto have no temp setting. This step will enforce it.
-  this->setTemp(_temp, false);
+  setTemp(_temp, false);
   // Save the mode in case we need to revert to it. eg. Clean
   if (save) _mode = mode;
 
@@ -463,7 +499,7 @@ void IRSharpAc::setFan(const uint8_t speed, const bool save) {
               speed);
       break;
     default:
-      this->setFan(kSharpAcFanAuto);
+      setFan(kSharpAcFanAuto);
       return;
   }
   if (save) _fan = speed;
@@ -663,18 +699,18 @@ stdAc::fanspeed_t IRSharpAc::toCommonFanSpeed(const uint8_t speed) {
 stdAc::state_t IRSharpAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::SHARP_AC;
-  result.model = -1;  // Not supported.
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
+  result.model = getModel();
+  result.power = getPower();
+  result.mode = toCommonMode(getMode());
   result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFan());
-  result.turbo = this->getTurbo();
-  result.swingv = this->getSwingToggle() ? stdAc::swingv_t::kAuto
-                                         : stdAc::swingv_t::kOff;
-  result.filter = this->getIon();
-  result.econo = this->getEconoToggle();
-  result.clean = this->getClean();
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  result.turbo = getTurbo();
+  result.swingv = getSwingToggle() ? stdAc::swingv_t::kAuto
+                                   : stdAc::swingv_t::kOff;
+  result.filter = getIon();
+  result.econo = getEconoToggle();
+  result.clean = getClean();
   // Not supported.
   result.swingh = stdAc::swingh_t::kOff;
   result.quiet = false;
@@ -689,10 +725,12 @@ stdAc::state_t IRSharpAc::toCommon(void) {
 /// @return A human readable string.
 String IRSharpAc::toString(void) {
   String result = "";
-  result.reserve(135);  // Reserve some heap for the string to reduce fragging.
+  result.reserve(160);  // Reserve some heap for the string to reduce fragging.
+  result += addModelToString(decode_type_t::SHARP_AC, getModel(), false);
+
   result += addLabeledString(isPowerSpecial() ? "-"
                                               : (getPower() ? kOnStr : kOffStr),
-                             kPowerStr, false);
+                             kPowerStr);
   result += addModeToString(getMode(), kSharpAcAuto, kSharpAcCool, kSharpAcHeat,
                             kSharpAcDry, kSharpAcAuto);
   result += addTempToString(getTemp());

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -73,7 +73,9 @@ const uint8_t kSharpAcFanSize = 3;  // Nr. of Bits
 const uint8_t kSharpAcFanAuto =                     0b010;  // 2
 const uint8_t kSharpAcFanMin =                      0b100;  // 4 (FAN1)
 const uint8_t kSharpAcFanMed =                      0b011;  // 3 (FAN2)
+const uint8_t kSharpAcFanA705Low =                  0b011;  // 3
 const uint8_t kSharpAcFanHigh =                     0b101;  // 5 (FAN3)
+const uint8_t kSharpAcFanA705Med =                  0b101;  // 5
 const uint8_t kSharpAcFanMax =                      0b111;  // 7 (FAN4)
 // Byte[7]
 const uint8_t kSharpAcByteTimer = 7;
@@ -160,7 +162,7 @@ class IRSharpAc {
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   stdAc::opmode_t toCommonMode(const uint8_t mode);
-  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   stdAc::state_t toCommon(void);
   String toString(void);
 #ifndef UNIT_TEST

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -143,6 +143,8 @@ class IRSharpAc {
   void setIon(const bool on);
   bool getEconoToggle(void);
   void setEconoToggle(const bool on);
+  bool getLightToggle(void);
+  void setLightToggle(const bool on);
   uint16_t getTimerTime(void);
   bool getTimerEnabled(void);
   bool getTimerType(void);
@@ -181,6 +183,8 @@ class IRSharpAc {
   void setPowerSpecial(const uint8_t value);
   uint8_t getPowerSpecial(void);
   void clearPowerSpecial(void);
+  bool _getEconoToggle(void);
+  void _setEconoToggle(const bool on);
 };
 
 #endif  // IR_SHARP_H_

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -12,11 +12,12 @@
 
 // Supports:
 //   Brand: Sharp,  Model: LC-52D62U TV
-//   Brand: Sharp,  Model: AY-ZP40KR A/C
-//   Brand: Sharp,  Model: AH-AxSAY A/C
-//   Brand: Sharp,  Model: CRMC-A907 JBEZ remote
-//   Brand: Sharp,  Model: AH-XP10NRY A/C
-//   Brand: Sharp,  Model: CRMC-820JBEZ remote
+//   Brand: Sharp,  Model: AY-ZP40KR A/C (A907)
+//   Brand: Sharp,  Model: AH-AxSAY A/C (A907)
+//   Brand: Sharp,  Model: CRMC-A907 JBEZ remote (A907)
+//   Brand: Sharp,  Model: AH-XP10NRY A/C (A907)
+//   Brand: Sharp,  Model: CRMC-820 JBEZ remote (A907)
+//   Brand: Sharp,  Model: CRMC-A705 JBEZ remote (A705)
 
 #ifndef IR_SHARP_H_
 #define IR_SHARP_H_
@@ -41,6 +42,7 @@ const uint16_t kSharpAcOneSpace = 1400;
 const uint32_t kSharpAcGap = kDefaultMessageGap;
 
 // Byte[4]
+const uint8_t kSharpAcModelBit = 4;  // Mask 0b000x0000
 const uint8_t kSharpAcByteTemp = 4;
 const uint8_t kSharpAcMinTemp = 15;  // Celsius
 const uint8_t kSharpAcMaxTemp = 30;  // Celsius
@@ -118,6 +120,8 @@ class IRSharpAc {
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_SHARP_AC
   void begin(void);
+  void setModel(const sharp_ac_remote_model_t model);
+  sharp_ac_remote_model_t getModel(const bool raw = false);
   void on(void);
   void off(void);
   void setPower(const bool on, const bool prev_on = true);
@@ -169,6 +173,7 @@ class IRSharpAc {
   uint8_t _temp;  ///< Saved copy of the desired temp.
   uint8_t _mode;  ///< Saved copy of the desired mode.
   uint8_t _fan;  ///< Saved copy of the desired fan speed.
+  sharp_ac_remote_model_t _model;  ///< Saved copy of the model.
   void stateReset(void);
   void checksum(void);
   static uint8_t calcChecksum(uint8_t state[],

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -60,10 +60,11 @@ const uint8_t kSharpAcPowerTimerSetting = 8;                // 0b1000
 // Byte[6]
 const uint8_t kSharpAcByteMode = 6;
 const uint8_t kSharpAcModeSize = 2;        // Mask 0b000000xx;
-const uint8_t kSharpAcAuto =                             0b00;
+const uint8_t kSharpAcAuto =                             0b00;  // A907 only
+const uint8_t kSharpAcFan =                              0b00;  // A705 only
 const uint8_t kSharpAcDry =                              0b11;
 const uint8_t kSharpAcCool =                             0b10;
-const uint8_t kSharpAcHeat =                             0b01;
+const uint8_t kSharpAcHeat =                             0b01;  // A907 only
 const uint8_t kSharpAcByteClean = kSharpAcByteMode;
 const uint8_t kSharpAcBitCleanOffset = 3;  // Mask 0b0000x000
 const uint8_t kSharpAcByteFan = kSharpAcByteMode;
@@ -158,7 +159,7 @@ class IRSharpAc {
                             const uint16_t length = kSharpAcStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
-  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   stdAc::state_t toCommon(void);
   String toString(void);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1286,20 +1286,21 @@ TEST(TestIRac, Sharp) {
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
   char expected[] =
-      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 3 (Medium), "
+      "Model: 1 (A907), Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 3 (Medium), "
       "Turbo: Off, Swing(V) Toggle: On, Ion: On, Econo: -, Clean: Off";
 
   ac.begin();
   irac.sharp(&ac,
-             true,                         // Power
-             true,                         // Previous Power
-             stdAc::opmode_t::kCool,       // Mode
-             28,                           // Celsius
-             stdAc::fanspeed_t::kMedium,   // Fan speed
-             stdAc::swingv_t::kAuto,       // Vertical swing
-             false,                        // Turbo
-             true,                         // Filter (Ion)
-             false);                       // Clean
+             sharp_ac_remote_model_t::A907,  // Model
+             true,                           // Power
+             true,                           // Previous Power
+             stdAc::opmode_t::kCool,         // Mode
+             28,                             // Celsius
+             stdAc::fanspeed_t::kMedium,     // Fan speed
+             stdAc::swingv_t::kAuto,         // Vertical swing
+             false,                          // Turbo
+             true,                           // Filter (Ion)
+             false);                         // Clean
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1299,6 +1299,7 @@ TEST(TestIRac, Sharp) {
              stdAc::fanspeed_t::kMedium,     // Fan speed
              stdAc::swingv_t::kAuto,         // Vertical swing
              false,                          // Turbo
+             false,                          // Light
              true,                           // Filter (Ion)
              false);                         // Clean
   ASSERT_EQ(expected, ac.toString());

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -1116,7 +1116,7 @@ TEST(TestSharpAcClass, Issue1309) {
   ac.setRaw(issue1309_on);
   EXPECT_EQ(
     "Model: 2 (A705), Power: On, Mode: 2 (Cool), Temp: 16C, Fan: 2 (Auto), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Light: -, Clean: Off",
     ac.toString());
   EXPECT_STATE_EQ(issue1309_on, ac.getRaw(), kSharpAcBits);
 
@@ -1128,7 +1128,7 @@ TEST(TestSharpAcClass, Issue1309) {
   ac.on();
   EXPECT_EQ(
     "Model: 2 (A705), Power: On, Mode: 2 (Cool), Temp: 16C, Fan: 2 (Auto), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Light: -, Clean: Off",
     ac.toString());
 }
 

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -544,6 +544,25 @@ TEST(TestSharpAcClass, OperatingMode) {
 
   ac.setMode(255);
   EXPECT_EQ(kSharpAcAuto, ac.getMode());
+
+  // Tests for A705 models.
+  ac.setMode(kSharpAcHeat);
+  EXPECT_EQ(kSharpAcHeat, ac.getMode());
+  ac.setModel(sharp_ac_remote_model_t::A705);
+  // No heat mode anymore.
+  EXPECT_NE(kSharpAcHeat, ac.getMode());
+  // Even after we set it explicitly.
+  ac.setMode(kSharpAcHeat);
+  EXPECT_NE(kSharpAcHeat, ac.getMode());
+
+  // Has fan mode now. (Note: Fan mode is really Auto mode)
+  ac.setMode(kSharpAcFan);
+  EXPECT_EQ(kSharpAcFan, ac.getMode());
+  // Check toString() says Fan rather than Auto.
+  EXPECT_EQ(
+      "Model: 2 (A705), Power: Off, Mode: 0 (Fan), Temp: 15C, Fan: 2 (Auto), "
+      "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Light: -, Clean: Off",
+      ac.toString());
 }
 
 

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -11,7 +11,7 @@
 // Tests for encodeSharp().
 
 TEST(TestEncodeSharp, NormalEncoding) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   EXPECT_EQ(0x2, irsend.encodeSharp(0, 0));
   EXPECT_EQ(0x4202, irsend.encodeSharp(1, 1));
   EXPECT_EQ(0x4102, irsend.encodeSharp(1, 2));
@@ -22,7 +22,7 @@ TEST(TestEncodeSharp, NormalEncoding) {
 }
 
 TEST(TestEncodeSharp, AdvancedEncoding) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   EXPECT_EQ(0x0, irsend.encodeSharp(0, 0, 0, 0));
   EXPECT_EQ(0x1, irsend.encodeSharp(0, 0, 0, 1));
   EXPECT_EQ(0x2, irsend.encodeSharp(0, 0, 1, 0));
@@ -45,7 +45,7 @@ TEST(TestEncodeSharp, AdvancedEncoding) {
 
 // Test sending typical data only.
 TEST(TestSendSharp, SendDataOnly) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -63,7 +63,7 @@ TEST(TestSendSharp, SendDataOnly) {
 
 // Test sending with different repeats.
 TEST(TestSendSharp, SendWithRepeats) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -87,7 +87,7 @@ TEST(TestSendSharp, SendWithRepeats) {
 
 // Test sending an atypical data size.
 TEST(TestSendSharp, SendUnusualSize) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -117,7 +117,7 @@ TEST(TestSendSharp, SendUnusualSize) {
 
 // Test sending typical data only.
 TEST(TestSendSharpRaw, SendDataOnly) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -135,7 +135,7 @@ TEST(TestSendSharpRaw, SendDataOnly) {
 
 // Test sending with different repeats.
 TEST(TestSendSharpRaw, SendWithRepeats) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -159,7 +159,7 @@ TEST(TestSendSharpRaw, SendWithRepeats) {
 
 // Test sending an atypical data size.
 TEST(TestSendSharpRaw, SendUnusualSize) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -189,8 +189,8 @@ TEST(TestSendSharpRaw, SendUnusualSize) {
 
 // Decode normal Sharp messages.
 TEST(TestDecodeSharp, NormalDecodeWithStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal Sharp 15-bit message.
@@ -235,8 +235,8 @@ TEST(TestDecodeSharp, NormalDecodeWithStrict) {
 
 // Decode normal repeated Sharp messages.
 TEST(TestDecodeSharp, NormalDecodeWithRepeatAndStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal Sharp 15-bit message with 1 repeat.
@@ -261,8 +261,8 @@ TEST(TestDecodeSharp, NormalDecodeWithRepeatAndStrict) {
 
 // Decode unsupported Sharp messages.
 TEST(TestDecodeSharp, DecodeWithNonStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -299,8 +299,8 @@ TEST(TestDecodeSharp, DecodeWithNonStrict) {
 
 // Decode (non-standard) 64-bit messages.
 TEST(TestDecodeSharp, Decode64BitMessages) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -318,8 +318,8 @@ TEST(TestDecodeSharp, Decode64BitMessages) {
 
 // Decode a 'real' example via GlobalCache
 TEST(TestDecodeSharp, DecodeGlobalCacheExample) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -343,8 +343,8 @@ TEST(TestDecodeSharp, DecodeGlobalCacheExample) {
 
 // Fail to decode a non-Sharp example via GlobalCache
 TEST(TestDecodeSharp, FailToDecodeNonSharpExample) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -376,8 +376,8 @@ TEST(TestDecodeSharp, FailToDecodeNonSharpExample) {
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/638#issue-421064165
 TEST(TestDecodeSharpAc, RealExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   // cool-auto-27.txt
   uint16_t rawData[211] = {
       3804, 1892, 466, 486, 466, 1388, 466, 486, 466, 1386, 468, 486, 468, 1388,
@@ -408,17 +408,19 @@ TEST(TestDecodeSharpAc, RealExample) {
   ASSERT_EQ(SHARP_AC, irsend.capture.decode_type);
   ASSERT_EQ(kSharpAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            IRAcUtils::resultAcToString(&irsend.capture));
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // https://github.com/crankyoldgit/IRremoteESP8266/issues/638#issue-421064165
 TEST(TestDecodeSharpAc, SyntheticExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   // cool-auto-27.txt
   uint8_t expectedState[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCC, 0x31, 0x22, 0x00, 0x08, 0x80, 0x04, 0xE0,
@@ -434,16 +436,22 @@ TEST(TestDecodeSharpAc, SyntheticExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
 }
 
-TEST(TestIRUtils, Sharp) {
+TEST(TestIRUtils, Housekeeping_Sharp) {
   ASSERT_EQ("SHARP", typeToString(decode_type_t::SHARP));
   ASSERT_EQ(decode_type_t::SHARP, strToDecodeType("SHARP"));
   ASSERT_FALSE(hasACState(decode_type_t::SHARP));
+  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::SHARP));
+  ASSERT_EQ(kSharpBits, IRsend::defaultBits(decode_type_t::SHARP));
+  ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::SHARP));
 }
 
-TEST(TestIRUtils, SharpAc) {
+TEST(TestIRUtils, Housekeeping_SharpAc) {
   ASSERT_EQ("SHARP_AC", typeToString(decode_type_t::SHARP_AC));
   ASSERT_EQ(decode_type_t::SHARP_AC, strToDecodeType("SHARP_AC"));
   ASSERT_TRUE(hasACState(decode_type_t::SHARP_AC));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::SHARP_AC));
+  ASSERT_EQ(kSharpAcBits, IRsend::defaultBits(decode_type_t::SHARP_AC));
+  ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::SHARP_AC));
 }
 
 // Tests for IRSharpAc class.
@@ -586,9 +594,11 @@ TEST(TestSharpAcClass, ReconstructKnownState) {
   ac.setFan(kSharpAcFanAuto);
   ac.setMode(kSharpAcAuto);
   EXPECT_STATE_EQ(on_auto_auto, ac.getRaw(), kSharpAcBits);
-  EXPECT_EQ("Power: On, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
 
   uint8_t cool_auto_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x22, 0x00, 0x08, 0x80, 0x04, 0xE0,
@@ -598,9 +608,11 @@ TEST(TestSharpAcClass, ReconstructKnownState) {
   ac.setMode(kSharpAcCool);
   ac.setFan(kSharpAcFanAuto);
   ac.setTemp(28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   EXPECT_STATE_EQ(cool_auto_28, ac.getRaw(), kSharpAcBits);
 }
 
@@ -614,65 +626,81 @@ TEST(TestSharpAcClass, KnownStates) {
       0x31};
   ASSERT_TRUE(ac.validChecksum(off_auto_auto));
   ac.setRaw(off_auto_auto);
-  EXPECT_EQ("Power: Off, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: Off, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t on_auto_auto[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0x00, 0x11, 0x20, 0x00, 0x08, 0x80, 0x00, 0xE0,
       0x01};
   ASSERT_TRUE(ac.validChecksum(on_auto_auto));
   ac.setRaw(on_auto_auto);
-  EXPECT_EQ("Power: On, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 0 (Auto), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_auto_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x22, 0x00, 0x08, 0x80, 0x04, 0xE0,
       0x51};
   ASSERT_TRUE(ac.validChecksum(cool_auto_28));
   ac.setRaw(cool_auto_28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_fan1_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x42, 0x00, 0x08, 0x80, 0x05, 0xE0,
       0x21};
   ASSERT_TRUE(ac.validChecksum(cool_fan1_28));
   ac.setRaw(cool_fan1_28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 4 (Low), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 4 (Low), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_fan2_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x32, 0x00, 0x08, 0x80, 0x05, 0xE0,
       0x51};
   ASSERT_TRUE(ac.validChecksum(cool_fan2_28));
   ac.setRaw(cool_fan2_28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 3 (Medium), "
-            "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 3 (Medium), "
+      "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_fan3_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x52, 0x00, 0x08, 0x80, 0x05, 0xE0,
       0x31};
   ASSERT_TRUE(ac.validChecksum(cool_fan3_28));
   ac.setRaw(cool_fan3_28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 5 (UNKNOWN), "
-            "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 5 (UNKNOWN), "
+      "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_fan4_28[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x31, 0x72, 0x00, 0x08, 0x80, 0x05, 0xE0,
       0x11};
   ASSERT_TRUE(ac.validChecksum(cool_fan4_28));
   ac.setRaw(cool_fan4_28);
-  EXPECT_EQ("Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 7 (High), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 2 (Cool), Temp: 28C, Fan: 7 (High), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
   uint8_t cool_fan4_28_ion_on[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x61, 0x72, 0x08, 0x08, 0x80, 0x00, 0xE4,
       0xD1};
   ASSERT_TRUE(ac.validChecksum(cool_fan4_28_ion_on));
   ac.setRaw(cool_fan4_28_ion_on);
-  EXPECT_EQ("Power: -, Mode: 2 (Cool), Temp: 28C, Fan: 7 (High), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: -, Mode: 2 (Cool), Temp: 28C, Fan: 7 (High), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+      ac.toString());
   /* Unsupported / Not yet reverse engineered.
   uint8_t cool_fan4_28_eco1[kSharpAcStateLength] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCD, 0x61, 0x72, 0x18, 0x08, 0x80, 0x00, 0xE8,
@@ -686,13 +714,16 @@ TEST(TestSharpAcClass, KnownStates) {
       0x11};
   ASSERT_TRUE(ac.validChecksum(dry_auto));
   ac.setRaw(dry_auto);
-  EXPECT_EQ("Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-            "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
-            ac.toString());
+  EXPECT_EQ(
+      "Model: 1 (A907), "
+      "Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
+      "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+      ac.toString());
 }
 
 TEST(TestSharpAcClass, toCommon) {
   IRSharpAc ac(kGpioUnused);
+  ac.setModel(sharp_ac_remote_model_t::A705);
   ac.setPower(true);
   ac.setMode(kSharpAcCool);
   ac.setTemp(20);
@@ -704,8 +735,8 @@ TEST(TestSharpAcClass, toCommon) {
   ASSERT_EQ(20, ac.toCommon().degrees);
   ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
   ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
+  ASSERT_EQ(sharp_ac_remote_model_t::A705, ac.toCommon().model);
   // Unsupported.
-  ASSERT_EQ(-1, ac.toCommon().model);
   ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
   ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
   ASSERT_FALSE(ac.toCommon().turbo);
@@ -817,6 +848,7 @@ TEST(TestSharpAcClass, Turbo) {
   EXPECT_TRUE(ac.getTurbo());
   EXPECT_EQ(kSharpAcFanMax, ac.getFan());
   EXPECT_EQ(
+      "Model: 1 (A907), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: On, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
       ac.toString());
@@ -824,6 +856,7 @@ TEST(TestSharpAcClass, Turbo) {
   ac.setRaw(off_state);
   EXPECT_FALSE(ac.getTurbo());
   EXPECT_EQ(
+      "Model: 1 (A907), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
       ac.toString());
@@ -952,6 +985,7 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_EQ(8 * 60 + 30, ac.getTimerTime());
   EXPECT_TRUE(ac.isPowerSpecial());
   EXPECT_EQ(
+      "Model: 1 (A907), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, Off Timer: 08:30",
       ac.toString());
@@ -966,8 +1000,9 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_EQ(12 * 60, ac.getTimerTime());
   EXPECT_TRUE(ac.isPowerSpecial());
   EXPECT_EQ(
-      "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
-      "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, On Timer: 12:00",
+      "Model: 1 (A907), Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), "
+      "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, "
+      "On Timer: 12:00",
       ac.toString());
 }
 
@@ -1003,14 +1038,14 @@ TEST(TestSharpAcClass, Clean) {
   ac.setRaw(clean_on_state);
   EXPECT_TRUE(ac.getClean());
   EXPECT_EQ(
-    "Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
+    "Model: 1 (A907), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
     ac.toString());
   ac.setRaw(clean_off_state);
   EXPECT_FALSE(ac.getClean());
   EXPECT_EQ(
-    "Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Model: 1 (A907), Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
 
   // Try constructing the clean on state.
@@ -1029,39 +1064,89 @@ TEST(TestSharpAcClass, Clean) {
   ac.setFan(7);
   ac.setPower(false);
   EXPECT_EQ(
-    "Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Model: 1 (A907), Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
   // Clean ON
   ac.setClean(true);
   EXPECT_EQ(
-    "Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
+    "Model: 1 (A907), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
     ac.toString());
   // Clean OFF (state is identical to `off_msg`).
   // i.e. It just clears the clean settings & turns off the device.
   ac.setClean(false);
   ac.setPower(false, true);
   EXPECT_EQ(
-    "Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Model: 1 (A907), Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
   // Clean ON
   ac.setClean(true);
   EXPECT_EQ(
-    "Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
+    "Model: 1 (A907), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
     ac.toString());
   // AC OFF
   ac.off();
   EXPECT_EQ(
-    "Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Model: 1 (A907), Power: Off, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
   // AC ON (Mode Cool, Temp 25, Ion OFF, Fan 7)
   ac.on();
   EXPECT_EQ(
-    "Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), Turbo: Off, "
-    "Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Model: 1 (A907), Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
+}
+
+TEST(TestSharpAcClass, Issue1309) {
+  IRSharpAc ac(kGpioUnused);
+  ac.begin();
+  ac.stateReset();
+  EXPECT_EQ(
+    "Model: 1 (A907), Power: Off, Mode: 0 (Auto), Temp: 15C, Fan: 0 (UNKNOWN), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    ac.toString());
+
+  const uint8_t issue1309_on[13] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0xD1, 0x11, 0x22,
+      0x00, 0x08, 0x80, 0x00, 0xF0, 0xF1};
+  ac.setRaw(issue1309_on);
+  EXPECT_EQ(
+    "Model: 2 (A705), Power: On, Mode: 2 (Cool), Temp: 16C, Fan: 2 (Auto), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    ac.toString());
+  EXPECT_STATE_EQ(issue1309_on, ac.getRaw(), kSharpAcBits);
+
+  ac.stateReset();
+  ac.setModel(sharp_ac_remote_model_t::A705);
+  ac.setMode(kSharpAcCool);
+  ac.setTemp(16);
+  ac.setFan(kSharpAcFanAuto);
+  ac.on();
+  EXPECT_EQ(
+    "Model: 2 (A705), Power: On, Mode: 2 (Cool), Temp: 16C, Fan: 2 (Auto), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    ac.toString());
+}
+
+TEST(TestSharpAcClass, Models) {
+  IRSharpAc ac(kGpioUnused);
+  const uint8_t A705_on[13] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0xD1, 0x11, 0x22,
+      0x00, 0x08, 0x80, 0x00, 0xF0, 0xF1};
+  ac.stateReset();
+
+  EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel());
+  EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel(true));
+
+  ac.setRaw(A705_on);
+  EXPECT_EQ(sharp_ac_remote_model_t::A705, ac.getModel());
+  EXPECT_EQ(sharp_ac_remote_model_t::A705, ac.getModel(true));
+
+  ac.setModel(sharp_ac_remote_model_t::A907);
+  EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel());
+  EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel(true));
 }


### PR DESCRIPTION
* Support models `A907` & `A705`
* Remove `this->` from Sharp.
* Update unit tests accordingly.
* Update common A/C api.

Fixes #1309 