### PR TITLE
Coolix: Improve Sensor(ZoneFollow) and add Vane Step support.

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -110,7 +110,12 @@ void IRCoolixAC::begin(void) { _irsend.begin(); }
 /// Send the current internal state as an IR message.
 /// @param[in] repeat Nr. of times the message will be repeated.
 void IRCoolixAC::send(const uint16_t repeat) {
-  _irsend.sendCOOLIX(remote_state, kCoolixBits, repeat);
+  // SwingVStep (aka. Direct / Vane step) needs to be sent with `0` repeats.
+  // Typically repeat is `kCoolixDefaultRepeat` which is `1`, so this allows
+  // it to be 0 normally for this command, and allows additional repeats if
+  // requested rather always 0 for that command.
+  _irsend.sendCOOLIX(remote_state, kCoolixBits, repeat - (getSwingVStep() &&
+                                                          repeat > 0) ? 1 : 0);
   // make sure to remove special state from remote_state
   // after command has being transmitted.
   recoverSavedState();

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -79,7 +79,7 @@ void IRsend::sendCOOLIX(uint64_t data, uint16_t nbits, uint16_t repeat) {
   }
   space(kDefaultMessageGap);
 }
-#endif
+#endif  // SEND_COOLIX
 
 /// Class constructor.
 /// @param[in] pin GPIO to be used when sending.
@@ -651,7 +651,7 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t offset,
                           const uint16_t nbits, const bool strict) {
   // The protocol sends the data normal + inverted, alternating on
   // each byte. Hence twice the number of expected data bits.
-  if (results->rawlen <= 2 * 2 * nbits + kHeader + kFooter - 1 + offset)
+  if (results->rawlen < 2 * 2 * nbits + kHeader + kFooter - 1 + offset)
     return false;  // Can't possibly be a valid COOLIX message.
   if (strict && nbits != kCoolixBits)
     return false;      // Not strictly a COOLIX message.
@@ -716,4 +716,4 @@ bool IRrecv::decodeCOOLIX(decode_results *results, uint16_t offset,
   results->command = 0;
   return true;
 }
-#endif
+#endif  // DECODE_COOLIX

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -367,7 +367,8 @@ bool IRCoolixAC::getZoneFollow(void) {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRCoolixAC::setZoneFollow(bool on) {
   zoneFollowFlag = on;
-  setBit(&remote_state, kCoolixZoneFollowMaskOffset, on);
+  setBit(&remote_state, kCoolixZoneFollowMask1Offset, on);
+  setBit(&remote_state, kCoolixZoneFollowMask2Offset, on);
 }
 
 /// Clear the Sensor Temperature setting..

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -239,20 +239,15 @@ uint8_t IRCoolixAC::getTemp(void) const {
 void IRCoolixAC::setSensorTempRaw(const uint8_t code) { _.SensorTemp = code; }
 
 /// Set the sensor temperature.
-/// @param[in] desired The temperature in degrees celsius.
-void IRCoolixAC::setSensorTemp(const uint8_t desired) {
-  uint8_t temp = desired;
-  temp = std::min(temp, kCoolixSensorTempMax);
-  temp = std::max(temp, kCoolixSensorTempMin);
-  setSensorTempRaw(temp - kCoolixSensorTempMin);
+/// @param[in] temp The temperature in degrees celsius.
+void IRCoolixAC::setSensorTemp(const uint8_t temp) {
+  setSensorTempRaw(std::min(temp, kCoolixSensorTempMax));
   setZoneFollow(true);  // Setting a Sensor temp means you want to Zone Follow.
 }
 
 /// Get the sensor temperature setting.
 /// @return The current setting for sensor temp. in degrees celsius.
-uint8_t IRCoolixAC::getSensorTemp(void) const {
-  return _.SensorTemp + kCoolixSensorTempMin;
-}
+uint8_t IRCoolixAC::getSensorTemp(void) const { return _.SensorTemp; }
 
 /// Get the value of the current power setting.
 /// @return true, the setting is on. false, the setting is off.
@@ -608,7 +603,7 @@ String IRCoolixAC::toString(void) const {
   if (getMode() != kCoolixFan) result += addTempToString(getTemp());
   result += addBoolToString(getZoneFollow(), kZoneFollowStr);
   result += addLabeledString(
-      (getSensorTemp() > kCoolixSensorTempMax)
+      (getSensorTemp() == kCoolixSensorTempIgnoreCode)
           ? kOffStr : uint64ToString(getSensorTemp()) + 'C', kSensorTempStr);
   return result;
 }

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -70,9 +70,8 @@ const uint8_t kCoolixTempMap[kCoolixTempRange] = {
     0b1010,  // 29C
     0b1011   // 30C
 };
-const uint8_t kCoolixSensorTempMin = 16;  // Celsius
 const uint8_t kCoolixSensorTempMax = 30;  // Celsius
-const uint8_t kCoolixSensorTempIgnoreCode = 0b1111;
+const uint8_t kCoolixSensorTempIgnoreCode = 0b11111;  // 0x1F / 31 (DEC)
 // kCoolixSensorTempMask = 0b000000000000111100000000;  // 0xF00
 // Fixed states/messages.
 const uint32_t kCoolixOff    = 0b101100100111101111100000;  // 0xB27BE0
@@ -97,8 +96,7 @@ union CoolixProtocol {
     uint32_t Mode       :2;  ///< Operation mode.
     uint32_t Temp       :4;  ///< Desired temperature (Celsius)
     // Byte
-    uint32_t SensorTemp :4;  ///< The temperature sensor in the IR remote.
-    uint32_t            :1;  // Probably part of Sensor Temp.
+    uint32_t SensorTemp :5;  ///< The temperature sensor in the IR remote.
     uint32_t Fan        :3;  ///< Fan speed
     // Byte
     uint32_t            :3;  // Unknown
@@ -131,7 +129,7 @@ class IRCoolixAC {
   bool getPower(void) const;
   void setTemp(const uint8_t temp);
   uint8_t getTemp(void) const;
-  void setSensorTemp(const uint8_t desired);
+  void setSensorTemp(const uint8_t temp);
   uint8_t getSensorTemp(void) const;
   void clearSensorTemp(void);
   void setFan(const uint8_t speed, const bool modecheck = true);

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -42,8 +42,9 @@ const uint8_t kCoolixFan = 0b100;                                 // Synthetic.
 // const uint32_t kCoolixModeMask = 0b000000000000000000001100;  // 0xC
 const uint8_t kCoolixModeOffset = 2;
 const uint8_t kCoolixModeSize = 2;
-// const uint32_t kCoolixZoneFollowMask = 0b000010000000000000000000  0x80000
-const uint8_t kCoolixZoneFollowMaskOffset = 19;
+// const uint32_t kCoolixZoneFollowMask = 0b000010000000000000000010  0x80002
+const uint8_t kCoolixZoneFollowMask1Offset = 19;
+const uint8_t kCoolixZoneFollowMask2Offset = 1;
 // Fan Control
 // const uint32_t kCoolixFanMask = 0b000000001110000000000000;  // 0x00E000
 const uint8_t kCoolixFanOffset = 13;

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -1,6 +1,11 @@
-// Coolix A/C
-//
 // Copyright 2018 David Conran
+/// @file
+/// @brief Support for Coolix A/C protocols.
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/484
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1318
+/// @note Kudos:
+///   Hamper: For the breakdown and mapping of the bit values.
+///   fraschizzato: For additional ZoneFollow & SwingVStep analysis.
 
 // Supports:
 //   Brand: Beko, Model: RG57K7(B)/BGEF Remote
@@ -27,11 +32,6 @@
 #include "IRsend_test.h"
 #endif
 
-// Ref:
-//   https://github.com/crankyoldgit/IRremoteESP8266/issues/484
-// Kudos:
-//   Hamper: For the breakdown and mapping of the bit values.
-
 // Constants
 // Modes
 const uint8_t kCoolixCool = 0b000;
@@ -40,15 +40,8 @@ const uint8_t kCoolixAuto = 0b010;
 const uint8_t kCoolixHeat = 0b011;
 const uint8_t kCoolixFan = 0b100;                                 // Synthetic.
 // const uint32_t kCoolixModeMask = 0b000000000000000000001100;  // 0xC
-const uint8_t kCoolixModeOffset = 2;
-const uint8_t kCoolixModeSize = 2;
 // const uint32_t kCoolixZoneFollowMask = 0b000010000000000000000010  0x80002
-const uint8_t kCoolixZoneFollowMask1Offset = 19;
-const uint8_t kCoolixZoneFollowMask2Offset = 1;
 // Fan Control
-// const uint32_t kCoolixFanMask = 0b000000001110000000000000;  // 0x00E000
-const uint8_t kCoolixFanOffset = 13;
-const uint8_t kCoolixFanSize = 3;
 const uint8_t kCoolixFanMin = 0b100;
 const uint8_t kCoolixFanMed = 0b010;
 const uint8_t kCoolixFanMax = 0b001;
@@ -61,9 +54,6 @@ const uint8_t kCoolixTempMin = 17;  // Celsius
 const uint8_t kCoolixTempMax = 30;  // Celsius
 const uint8_t kCoolixTempRange = kCoolixTempMax - kCoolixTempMin + 1;
 const uint8_t kCoolixFanTempCode = 0b1110;  // Part of Fan Mode.
-// const uint32_t kCoolixTempMask = 0b11110000;
-const uint8_t kCoolixTempOffset = 4;
-const uint8_t kCoolixTempSize = 4;
 const uint8_t kCoolixTempMap[kCoolixTempRange] = {
     0b0000,  // 17C
     0b0001,  // 18c
@@ -84,11 +74,7 @@ const uint8_t kCoolixSensorTempMin = 16;  // Celsius
 const uint8_t kCoolixSensorTempMax = 30;  // Celsius
 const uint8_t kCoolixSensorTempIgnoreCode = 0b1111;
 // kCoolixSensorTempMask = 0b000000000000111100000000;  // 0xF00
-const uint8_t kCoolixSensorTempOffset = 8;
-const uint8_t kCoolixSensorTempSize = 4;
 // Fixed states/messages.
-const uint8_t kCoolixPrefix = 0b1011;  // 0xB
-const uint8_t kCoolixUnknown = 0xFF;
 const uint32_t kCoolixOff    = 0b101100100111101111100000;  // 0xB27BE0
 const uint32_t kCoolixSwing  = 0b101100100110101111100000;  // 0xB26BE0
 const uint32_t kCoolixSwingH = 0b101100101111010110100010;  // 0xB5F5A2
@@ -100,6 +86,26 @@ const uint32_t kCoolixClean  = 0b101101011111010110101010;  // 0xB5F5AA
 const uint32_t kCoolixCmdFan = 0b101100101011111111100100;  // 0xB2BFE4
 // On, 25C, Mode: Auto, Fan: Auto, Zone Follow: Off, Sensor Temp: Ignore.
 const uint32_t kCoolixDefaultState = 0b101100100001111111001000;  // 0xB21FC8
+
+/// Native representation of a Coolix A/C message.
+union CoolixProtocol {
+  uint32_t raw;  ///< The state in IR code form.
+  struct {  // Only 24 bits are used.
+    // Byte
+    uint32_t            :1;  // Unknown
+    uint32_t ZoneFollow1:1;  ///< Control bit for Zone Follow mode.
+    uint32_t Mode       :2;  ///< Operation mode.
+    uint32_t Temp       :4;  ///< Desired temperature (Celsius)
+    // Byte
+    uint32_t SensorTemp :4;  ///< The temperature sensor in the IR remote.
+    uint32_t            :1;  // Probably part of Sensor Temp.
+    uint32_t Fan        :3;  ///< Fan speed
+    // Byte
+    uint32_t            :3;  // Unknown
+    uint32_t ZoneFollow2:1;  ///< Additional control bit for Zone Follow mode.
+    uint32_t            :4;  ///< Fixed value 0b1011 / 0xB.
+  };
+};
 
 // Classes
 
@@ -122,37 +128,37 @@ class IRCoolixAC {
   void on(void);
   void off(void);
   void setPower(const bool on);
-  bool getPower(void);
+  bool getPower(void) const;
   void setTemp(const uint8_t temp);
-  uint8_t getTemp(void);
+  uint8_t getTemp(void) const;
   void setSensorTemp(const uint8_t desired);
-  uint8_t getSensorTemp(void);
+  uint8_t getSensorTemp(void) const;
   void clearSensorTemp(void);
   void setFan(const uint8_t speed, const bool modecheck = true);
-  uint8_t getFan(void);
+  uint8_t getFan(void) const;
   void setMode(const uint8_t mode);
-  uint8_t getMode(void);
+  uint8_t getMode(void) const;
   void setSwing(void);
-  bool getSwing(void);
+  bool getSwing(void) const;
   void setSwingVStep(void);
-  bool getSwingVStep(void);
+  bool getSwingVStep(void) const;
   void setSleep(void);
-  bool getSleep(void);
+  bool getSleep(void) const;
   void setTurbo(void);
-  bool getTurbo(void);
+  bool getTurbo(void) const;
   void setLed(void);
-  bool getLed(void);
+  bool getLed(void) const;
   void setClean(void);
-  bool getClean(void);
-  bool getZoneFollow(void);
-  uint32_t getRaw(void);
+  bool getClean(void) const;
+  bool getZoneFollow(void) const;
+  uint32_t getRaw(void) const;
   void setRaw(const uint32_t new_code);
-  uint8_t convertMode(const stdAc::opmode_t mode);
-  uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
-  String toString(void);
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL) const;
+  String toString(void) const;
 #ifndef UNIT_TEST
 
  private:
@@ -162,26 +168,25 @@ class IRCoolixAC {
   IRsendTest _irsend;  ///< Instance of the testing IR send class
   /// @endcond
 #endif
-  // internal state
-  bool    powerFlag;
-  bool    turboFlag;
-  bool    ledFlag;
-  bool    cleanFlag;
-  bool    sleepFlag;
-  bool    zoneFollowFlag;
-  bool    swingFlag;
-  bool    swingHFlag;
-  bool    swingVFlag;
+  CoolixProtocol _;  ///< The state of the IR remote in IR code form.
+  CoolixProtocol _saved;   ///< Copy of the state if we required a special mode.
 
-  uint32_t remote_state;  ///< The state of the IR remote in IR code form.
-  uint32_t saved_state;   ///< Copy of the state if we required a special mode.
+  // Internal State settings
+  bool powerFlag;
+  bool turboFlag;
+  bool ledFlag;
+  bool cleanFlag;
+  bool sleepFlag;
+  bool zoneFollowFlag;
+  bool swingFlag;
+
   void setTempRaw(const uint8_t code);
-  uint8_t getTempRaw(void);
+  uint8_t getTempRaw(void) const;
   void setSensorTempRaw(const uint8_t code);
   void setZoneFollow(const bool on);
-  bool isSpecialState(void);
+  bool isSpecialState(void) const;
   bool handleSpecialState(const uint32_t data);
-  void updateSavedState(void);
+  void updateAndSaveState(const uint32_t raw_state);
   void recoverSavedState(void);
   uint32_t getNormalState(void);
 };

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -108,7 +108,7 @@ class IRCoolixAC {
  public:
   explicit IRCoolixAC(const uint16_t pin, const bool inverted = false,
                       const bool use_modulation = true);
-  void stateReset();
+  void stateReset(void);
 #if SEND_COOLIX
   void send(const uint16_t repeat = kCoolixDefaultRepeat);
   /// Run the calibration to calculate uSec timing offsets for this platform.
@@ -117,39 +117,41 @@ class IRCoolixAC {
   ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_COOLIX
-  void begin();
-  void on();
-  void off();
-  void setPower(const bool state);
-  bool getPower();
+  void begin(void);
+  void on(void);
+  void off(void);
+  void setPower(const bool on);
+  bool getPower(void);
   void setTemp(const uint8_t temp);
-  uint8_t getTemp();
+  uint8_t getTemp(void);
   void setSensorTemp(const uint8_t desired);
-  uint8_t getSensorTemp();
-  void clearSensorTemp();
+  uint8_t getSensorTemp(void);
+  void clearSensorTemp(void);
   void setFan(const uint8_t speed, const bool modecheck = true);
-  uint8_t getFan();
+  uint8_t getFan(void);
   void setMode(const uint8_t mode);
-  uint8_t getMode();
-  void setSwing();
-  bool getSwing();
-  void setSleep();
-  bool getSleep();
-  void setTurbo();
-  bool getTurbo();
-  void setLed();
-  bool getLed();
-  void setClean();
-  bool getClean();
-  bool getZoneFollow();
-  uint32_t getRaw();
+  uint8_t getMode(void);
+  void setSwing(void);
+  bool getSwing(void);
+  void setSwingVStep(void);
+  bool getSwingVStep(void);
+  void setSleep(void);
+  bool getSleep(void);
+  void setTurbo(void);
+  bool getTurbo(void);
+  void setLed(void);
+  bool getLed(void);
+  void setClean(void);
+  bool getClean(void);
+  bool getZoneFollow(void);
+  uint32_t getRaw(void);
   void setRaw(const uint32_t new_code);
   uint8_t convertMode(const stdAc::opmode_t mode);
   uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
-  String toString();
+  String toString(void);
 #ifndef UNIT_TEST
 
  private:
@@ -173,7 +175,7 @@ class IRCoolixAC {
   uint32_t remote_state;  ///< The state of the IR remote in IR code form.
   uint32_t saved_state;   ///< Copy of the state if we required a special mode.
   void setTempRaw(const uint8_t code);
-  uint8_t getTempRaw();
+  uint8_t getTempRaw(void);
   void setSensorTempRaw(const uint8_t code);
   void setZoneFollow(const bool on);
   bool isSpecialState(void);

--- a/src/ir_Coolix.h
+++ b/src/ir_Coolix.h
@@ -175,8 +175,8 @@ class IRCoolixAC {
   bool ledFlag;
   bool cleanFlag;
   bool sleepFlag;
-  bool zoneFollowFlag;
   bool swingFlag;
+  uint8_t savedFan;
 
   void setTempRaw(const uint8_t code);
   uint8_t getTempRaw(void) const;

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -10,7 +10,7 @@
 
 // Test sending typical data only.
 TEST(TestSendCoolix, SendDataOnly) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -82,7 +82,7 @@ TEST(TestSendCoolix, SendDataOnly) {
 
 // Test sending with different repeats.
 TEST(TestSendCoolix, SendWithRepeats) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -138,7 +138,7 @@ TEST(TestSendCoolix, SendWithRepeats) {
 
 // Test sending an atypical data size.
 TEST(TestSendCoolix, SendUnusualSize) {
-  IRsendTest irsend(4);
+  IRsendTest irsend(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -207,8 +207,8 @@ TEST(TestSendCoolix, SendUnusualSize) {
 
 // Decode normal Coolix messages.
 TEST(TestDecodeCoolix, NormalDecodeWithStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal Coolix 24-bit message.
@@ -253,8 +253,8 @@ TEST(TestDecodeCoolix, NormalDecodeWithStrict) {
 
 // Decode normal repeated Coolix messages.
 TEST(TestDecodeCoolix, NormalDecodeWithRepeatAndStrict) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   // Normal Coolix 16-bit message with 2 repeats.
@@ -285,8 +285,8 @@ TEST(TestDecodeCoolix, NormalDecodeWithRepeatAndStrict) {
 
 // Decode unsupported Coolix messages.
 TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -326,8 +326,8 @@ TEST(TestDecodeCoolix, DecodeWithNonStrictSizes) {
 
 // Decode (non-standard) 64-bit messages.
 TEST(TestDecodeCoolix, Decode64BitMessages) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -343,8 +343,8 @@ TEST(TestDecodeCoolix, Decode64BitMessages) {
 
 // Fail to decode a non-Coolix example via GlobalCache
 TEST(TestDecodeCoolix, FailToDecodeNonCoolixExample) {
-  IRsendTest irsend(4);
-  IRrecv irrecv(4);
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
   irsend.begin();
 
   irsend.reset();
@@ -538,9 +538,9 @@ TEST(TestCoolixACClass, Issue579FanAuto0) {
       ircoolix.toString());
 }
 
-TEST(TestCoolixACClass, RealCaptureExample) {
-  IRsendTest irsend(0);
-  IRrecv irrecv(0);
+TEST(TestDecodeCoolix, RealCaptureExample) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
 
   // From Issue #579
   uint16_t powerOffRawData[199] = {
@@ -580,7 +580,7 @@ TEST(TestCoolixACClass, RealCaptureExample) {
 // Tests to debug/fix:
 //   https://github.com/crankyoldgit/IRremoteESP8266/issues/624
 TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
-  IRCoolixAC ac(0);
+  IRCoolixAC ac(kGpioUnused);
   ac.begin();
   ac.setPower(true);
   // Default
@@ -627,7 +627,7 @@ TEST(TestCoolixACClass, Issue624HandleSpecialStatesBetter) {
 }
 
 TEST(TestCoolixACClass, toCommon) {
-  IRCoolixAC ac(0);
+  IRCoolixAC ac(kGpioUnused);
   ac.begin();
   ac.setPower(true);
   ac.setMode(kCoolixCool);
@@ -657,8 +657,8 @@ TEST(TestCoolixACClass, toCommon) {
 }
 
 TEST(TestCoolixACClass, Issue722) {
-  IRrecv irrecv(0);
-  IRCoolixAC ac(0);
+  IRrecv irrecv(kGpioUnused);
+  IRCoolixAC ac(kGpioUnused);
 
   // Auto 17C ON pressed
   uint32_t on_auto_17c_fan_auto0 = 0xB21F08;
@@ -758,8 +758,8 @@ TEST(TestCoolixACClass, Issue722) {
 }
 
 TEST(TestCoolixACClass, Issue985) {
-  IRrecv irrecv(0);
-  IRCoolixAC ac(0);
+  IRrecv irrecv(kGpioUnused);
+  IRCoolixAC ac(kGpioUnused);
 
   // Test that if we ONLY turn the power off, it only sends a "power off" mesg.
   // i.e. Code from: https://github.com/crankyoldgit/IRremoteESP8266/issues/985#issue-516210106
@@ -853,4 +853,32 @@ TEST(TestCoolixACClass, PowerStateWithSetRaw) {
   ac.setRaw(kCoolixOff);
   ASSERT_FALSE(ac.getPower());
   EXPECT_FALSE(ac.toCommon().power);
+}
+
+TEST(TestDecodeCoolix, Issue1318_DirectMessage) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+
+  // From https://github.com/crankyoldgit/IRremoteESP8266/issues/1318#issuecomment-727611979
+  const uint16_t direct[99] = {
+      4386, 4366, 546, 1622, 520, 522, 548, 1622, 496, 1646, 520, 524, 548, 522,
+      548, 1622, 522, 522, 548, 520, 550, 1620, 520, 522, 548, 522, 546, 1622,
+      496, 1646, 522, 520, 526, 1646, 520, 522, 548, 522, 524, 546, 550, 520,
+      550, 1620, 498, 1644, 520, 1622, 522, 1622, 520, 1620, 522, 1620, 524,
+      1618, 524, 1618, 524, 520, 550, 520, 550, 522, 550, 518, 552, 1618, 524,
+      1618, 524, 1618, 524, 520, 550, 520, 550, 520, 550, 520, 550, 520, 552,
+      516, 552, 518, 550, 522, 550, 1618, 526, 1616, 524, 1618, 524, 1618, 524,
+      1618, 550};  // UNKNOWN B0473CC8
+
+  irsend.begin();
+  irsend.reset();
+
+  irsend.sendRaw(direct, 99, 38000);
+  irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_EQ(COOLIX, irsend.capture.decode_type);
+  EXPECT_EQ(kCoolixBits, irsend.capture.bits);
+  EXPECT_EQ(0xB20FE0, irsend.capture.value);
+  EXPECT_EQ(0x0, irsend.capture.address);
+  EXPECT_EQ(0x0, irsend.capture.command);
 }

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -878,7 +878,10 @@ TEST(TestDecodeCoolix, Issue1318_DirectMessage) {
   ASSERT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(COOLIX, irsend.capture.decode_type);
   EXPECT_EQ(kCoolixBits, irsend.capture.bits);
-  EXPECT_EQ(0xB20FE0, irsend.capture.value);
+  EXPECT_EQ(kCoolixSwingV, irsend.capture.value);
   EXPECT_EQ(0x0, irsend.capture.address);
   EXPECT_EQ(0x0, irsend.capture.command);
+  EXPECT_EQ(
+      "Power: On, Swing(V): Step",
+      IRAcUtils::resultAcToString(&irsend.capture));
 }

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -466,6 +466,13 @@ TEST(TestCoolixACClass, SetGetClearSensorTempAndZoneFollow) {
   ircoolix.clearSensorTemp();
   EXPECT_FALSE(ircoolix.getZoneFollow());
   EXPECT_LT(kCoolixSensorTempMax, ircoolix.getSensorTemp());
+
+  // toString.
+  // For https://github.com/crankyoldgit/IRremoteESP8266/issues/1318#issuecomment-729663834
+  ircoolix.setRaw(0xBAD34E);
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Heat), Fan: 6 (Zone Follow), Temp: 24C, "
+      "Zone Follow: On, Sensor Temp: 19C", ircoolix.toString());
 }
 
 TEST(TestCoolixACClass, SpecialModesAndReset) {

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -363,184 +363,184 @@ TEST(TestDecodeCoolix, FailToDecodeNonCoolixExample) {
 
 // Tests for the IRCoolixAC class.
 TEST(TestCoolixACClass, SetAndGetRaw) {
-  IRCoolixAC ircoolix(0);
+  IRCoolixAC ac(kGpioUnused);
 
-  ircoolix.setRaw(0xB21F28);
-  EXPECT_EQ(0xB21F28, ircoolix.getRaw());
-  ircoolix.setRaw(kCoolixDefaultState);
-  EXPECT_EQ(kCoolixDefaultState, ircoolix.getRaw());
+  ac.setRaw(0xB21F28);
+  EXPECT_EQ(0xB21F28, ac.getRaw());
+  ac.setRaw(kCoolixDefaultState);
+  EXPECT_EQ(kCoolixDefaultState, ac.getRaw());
 }
 
 TEST(TestCoolixACClass, SetAndGetTemp) {
-  IRCoolixAC ircoolix(0);
+  IRCoolixAC ac(kGpioUnused);
 
-  ircoolix.setTemp(25);
-  EXPECT_EQ(25, ircoolix.getTemp());
-  ircoolix.setTemp(kCoolixTempMin);
-  EXPECT_EQ(kCoolixTempMin, ircoolix.getTemp());
-  ircoolix.setTemp(kCoolixTempMax);
-  EXPECT_EQ(kCoolixTempMax, ircoolix.getTemp());
-  ircoolix.setTemp(kCoolixTempMin - 1);
-  EXPECT_EQ(kCoolixTempMin, ircoolix.getTemp());
-  ircoolix.setTemp(kCoolixTempMax + 1);
-  EXPECT_EQ(kCoolixTempMax, ircoolix.getTemp());
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  ac.setTemp(kCoolixTempMin);
+  EXPECT_EQ(kCoolixTempMin, ac.getTemp());
+  ac.setTemp(kCoolixTempMax);
+  EXPECT_EQ(kCoolixTempMax, ac.getTemp());
+  ac.setTemp(kCoolixTempMin - 1);
+  EXPECT_EQ(kCoolixTempMin, ac.getTemp());
+  ac.setTemp(kCoolixTempMax + 1);
+  EXPECT_EQ(kCoolixTempMax, ac.getTemp());
 }
 
 TEST(TestCoolixACClass, SetAndGetMode) {
-  IRCoolixAC ircoolix(0);
+  IRCoolixAC ac(kGpioUnused);
 
-  ircoolix.setMode(kCoolixHeat);
-  EXPECT_EQ(kCoolixHeat, ircoolix.getMode());
-  ircoolix.setMode(kCoolixCool);
-  EXPECT_EQ(kCoolixCool, ircoolix.getMode());
-  ircoolix.setMode(kCoolixDry);
-  EXPECT_EQ(kCoolixDry, ircoolix.getMode());
-  ircoolix.setMode(kCoolixAuto);
-  EXPECT_EQ(kCoolixAuto, ircoolix.getMode());
-  ircoolix.setMode(kCoolixFan);
-  EXPECT_EQ(kCoolixFan, ircoolix.getMode());
+  ac.setMode(kCoolixHeat);
+  EXPECT_EQ(kCoolixHeat, ac.getMode());
+  ac.setMode(kCoolixCool);
+  EXPECT_EQ(kCoolixCool, ac.getMode());
+  ac.setMode(kCoolixDry);
+  EXPECT_EQ(kCoolixDry, ac.getMode());
+  ac.setMode(kCoolixAuto);
+  EXPECT_EQ(kCoolixAuto, ac.getMode());
+  ac.setMode(kCoolixFan);
+  EXPECT_EQ(kCoolixFan, ac.getMode());
 }
 
 TEST(TestCoolixACClass, SetAndGetFan) {
-  IRCoolixAC ircoolix(0);
+  IRCoolixAC ac(kGpioUnused);
 
   // This mode allows pretty much everything except Auto0 speed.
-  ircoolix.setMode(kCoolixCool);
-  ircoolix.setFan(kCoolixFanMax);
-  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanMin);
-  EXPECT_EQ(kCoolixFanMin, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanZoneFollow);
-  EXPECT_EQ(kCoolixFanZoneFollow, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanAuto);
-  EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanAuto0);
-  EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanMax);
-  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
+  ac.setMode(kCoolixCool);
+  ac.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ac.getFan());
+  ac.setFan(kCoolixFanMin);
+  EXPECT_EQ(kCoolixFanMin, ac.getFan());
+  ac.setFan(kCoolixFanZoneFollow);
+  EXPECT_EQ(kCoolixFanZoneFollow, ac.getFan());
+  ac.setFan(kCoolixFanAuto);
+  EXPECT_EQ(kCoolixFanAuto, ac.getFan());
+  ac.setFan(kCoolixFanAuto0);
+  EXPECT_EQ(kCoolixFanAuto, ac.getFan());
+  ac.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ac.getFan());
   ASSERT_NE(3, kCoolixFanAuto);
   // Now try some unexpected value.
-  ircoolix.setFan(3);
-  EXPECT_EQ(kCoolixFanAuto, ircoolix.getFan());
+  ac.setFan(3);
+  EXPECT_EQ(kCoolixFanAuto, ac.getFan());
 
   // These modes allows pretty much everything except Auto speed.
-  ircoolix.setMode(kCoolixDry);
-  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanMax);
-  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanAuto);
-  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
+  ac.setMode(kCoolixDry);
+  EXPECT_EQ(kCoolixFanAuto0, ac.getFan());
+  ac.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ac.getFan());
+  ac.setFan(kCoolixFanAuto);
+  EXPECT_EQ(kCoolixFanAuto0, ac.getFan());
 
-  ircoolix.setMode(kCoolixAuto);
-  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanMax);
-  EXPECT_EQ(kCoolixFanMax, ircoolix.getFan());
-  ircoolix.setFan(kCoolixFanAuto0);
-  EXPECT_EQ(kCoolixFanAuto0, ircoolix.getFan());
+  ac.setMode(kCoolixAuto);
+  EXPECT_EQ(kCoolixFanAuto0, ac.getFan());
+  ac.setFan(kCoolixFanMax);
+  EXPECT_EQ(kCoolixFanMax, ac.getFan());
+  ac.setFan(kCoolixFanAuto0);
+  EXPECT_EQ(kCoolixFanAuto0, ac.getFan());
 }
 
 TEST(TestCoolixACClass, SetGetClearSensorTempAndZoneFollow) {
-  IRCoolixAC ircoolix(0);
+  IRCoolixAC ac(kGpioUnused);
 
-  ircoolix.setRaw(kCoolixDefaultState);
-  EXPECT_FALSE(ircoolix.getZoneFollow());
-  EXPECT_LE(kCoolixSensorTempMax, ircoolix.getSensorTemp());
+  ac.setRaw(kCoolixDefaultState);
+  EXPECT_FALSE(ac.getZoneFollow());
+  EXPECT_LE(kCoolixSensorTempMax, ac.getSensorTemp());
 
-  ircoolix.setSensorTemp(25);
-  EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(25, ircoolix.getSensorTemp());
+  ac.setSensorTemp(25);
+  EXPECT_TRUE(ac.getZoneFollow());
+  EXPECT_EQ(25, ac.getSensorTemp());
 
   // Lower bounds
-  ircoolix.setSensorTemp(0);
-  EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(0, ircoolix.getSensorTemp());
+  ac.setSensorTemp(0);
+  EXPECT_TRUE(ac.getZoneFollow());
+  EXPECT_EQ(0, ac.getSensorTemp());
 
   // Upper bounds
-  ircoolix.setSensorTemp(kCoolixSensorTempMax);
-  EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(kCoolixSensorTempMax, ircoolix.getSensorTemp());
-  ircoolix.setSensorTemp(kCoolixSensorTempMax + 1);
-  EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(kCoolixSensorTempMax, ircoolix.getSensorTemp());
+  ac.setSensorTemp(kCoolixSensorTempMax);
+  EXPECT_TRUE(ac.getZoneFollow());
+  EXPECT_EQ(kCoolixSensorTempMax, ac.getSensorTemp());
+  ac.setSensorTemp(kCoolixSensorTempMax + 1);
+  EXPECT_TRUE(ac.getZoneFollow());
+  EXPECT_EQ(kCoolixSensorTempMax, ac.getSensorTemp());
   // Clearing
-  ircoolix.clearSensorTemp();
-  EXPECT_FALSE(ircoolix.getZoneFollow());
-  EXPECT_LT(kCoolixSensorTempMax, ircoolix.getSensorTemp());
+  ac.clearSensorTemp();
+  EXPECT_FALSE(ac.getZoneFollow());
+  EXPECT_LT(kCoolixSensorTempMax, ac.getSensorTemp());
 
   // toString.
   // For https://github.com/crankyoldgit/IRremoteESP8266/issues/1318#issuecomment-729663834
-  ircoolix.setRaw(0xBAD34E);
+  ac.setRaw(0xBAD34E);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Heat), Fan: 6 (Zone Follow), Temp: 24C, "
-      "Zone Follow: On, Sensor Temp: 19C", ircoolix.toString());
+      "Zone Follow: On, Sensor Temp: 19C", ac.toString());
 }
 
 TEST(TestCoolixACClass, SpecialModesAndReset) {
-  IRCoolixAC ircoolix(0);
-  ASSERT_NE(kCoolixSwing, ircoolix.getRaw());
-  ircoolix.setSwing();
-  ASSERT_EQ(kCoolixSwing, ircoolix.getRaw());
-  ircoolix.setTurbo();
-  ASSERT_EQ(kCoolixTurbo, ircoolix.getRaw());
-  ircoolix.setSleep();
-  ASSERT_EQ(kCoolixSleep, ircoolix.getRaw());
-  ircoolix.setLed();
-  ASSERT_EQ(kCoolixLed, ircoolix.getRaw());
-  ircoolix.setClean();
-  ASSERT_EQ(kCoolixClean, ircoolix.getRaw());
-  ircoolix.stateReset();
-  ASSERT_NE(kCoolixClean, ircoolix.getRaw());
+  IRCoolixAC ac(kGpioUnused);
+  ASSERT_NE(kCoolixSwing, ac.getRaw());
+  ac.setSwing();
+  ASSERT_EQ(kCoolixSwing, ac.getRaw());
+  ac.setTurbo();
+  ASSERT_EQ(kCoolixTurbo, ac.getRaw());
+  ac.setSleep();
+  ASSERT_EQ(kCoolixSleep, ac.getRaw());
+  ac.setLed();
+  ASSERT_EQ(kCoolixLed, ac.getRaw());
+  ac.setClean();
+  ASSERT_EQ(kCoolixClean, ac.getRaw());
+  ac.stateReset();
+  ASSERT_NE(kCoolixClean, ac.getRaw());
 }
 
 TEST(TestCoolixACClass, HumanReadable) {
-  IRCoolixAC ircoolix(0);
-  ircoolix.begin();
-  ircoolix.setPower(true);
+  IRCoolixAC ac(kGpioUnused);
+  ac.begin();
+  ac.setPower(true);
 
   // Initial starting point.
   EXPECT_EQ(
       "Power: On, Mode: 2 (Auto), Fan: 0 (Auto0), Temp: 25C, "
       "Zone Follow: Off, Sensor Temp: Off",
-      ircoolix.toString());
-  ircoolix.setSensorTemp(24);
-  ircoolix.setTemp(22);
-  ircoolix.setMode(kCoolixCool);
-  ircoolix.setFan(kCoolixFanMin);
+      ac.toString());
+  ac.setSensorTemp(24);
+  ac.setTemp(22);
+  ac.setMode(kCoolixCool);
+  ac.setFan(kCoolixFanMin);
   EXPECT_EQ(
       "Power: On, Mode: 0 (Cool), Fan: 4 (Min), Temp: 22C, "
       "Zone Follow: On, Sensor Temp: 24C",
-      ircoolix.toString());
-  ircoolix.setSwing();
-  EXPECT_EQ("Power: On, Swing: Toggle", ircoolix.toString());
-  ircoolix.setPower(false);
-  EXPECT_EQ("Power: Off", ircoolix.toString());
+      ac.toString());
+  ac.setSwing();
+  EXPECT_EQ("Power: On, Swing: Toggle", ac.toString());
+  ac.setPower(false);
+  EXPECT_EQ("Power: Off", ac.toString());
 }
 
 TEST(TestCoolixACClass, KnownExamples) {
-  IRCoolixAC ircoolix(0);
-  ircoolix.begin();
-  ircoolix.setPower(true);
-  ircoolix.setRaw(0b101100101011111111100100);
+  IRCoolixAC ac(kGpioUnused);
+  ac.begin();
+  ac.setPower(true);
+  ac.setRaw(0b101100101011111111100100);
   EXPECT_EQ(
       "Power: On, Mode: 4 (Fan), Fan: 5 (Auto), Zone Follow: Off, "
       "Sensor Temp: Off",
-      ircoolix.toString());
-  ircoolix.setRaw(0b101100101001111100000000);
+      ac.toString());
+  ac.setRaw(0b101100101001111100000000);
   EXPECT_EQ(
       "Power: On, Mode: 0 (Cool), Fan: 4 (Min), Temp: 17C, "
       "Zone Follow: Off, Sensor Temp: Off",
-      ircoolix.toString());
+      ac.toString());
 }
 
 TEST(TestCoolixACClass, Issue579FanAuto0) {
-  IRCoolixAC ircoolix(0);
-  ircoolix.begin();
-  ircoolix.setPower(true);
-  ircoolix.setRaw(0xB21F28);
+  IRCoolixAC ac(kGpioUnused);
+  ac.begin();
+  ac.setPower(true);
+  ac.setRaw(0xB21F28);
   EXPECT_EQ(
       "Power: On, Mode: 2 (Auto), Fan: 0 (Auto0), Temp: 20C, "
       "Zone Follow: Off, Sensor Temp: Off",
-      ircoolix.toString());
+      ac.toString());
 }
 
 TEST(TestDecodeCoolix, RealCaptureExample) {

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -920,3 +920,24 @@ TEST(TestCoolixACClass, SendStep) {
       "m552s105244",
       ac._irsend.outputStr());
 }
+
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1318#issuecomment-731578060
+// Confirm ZoneFollow Fan is being set correctly when SensorTemp is set.
+TEST(TestCoolixACClass, VerifyZoneFollowFan) {
+  IRCoolixAC ac(kGpioUnused);
+  EXPECT_NE(kCoolixFanZoneFollow, ac.getFan());
+  EXPECT_FALSE(ac.getZoneFollow());
+  ac.setPower(true);
+  ac.setMode(kCoolixHeat);
+  ac.setTemp(24);  // C
+  EXPECT_NE(kCoolixFanZoneFollow, ac.getFan());
+  EXPECT_FALSE(ac.getZoneFollow());
+  ac.setSensorTemp(19);  // C
+  EXPECT_EQ(kCoolixFanZoneFollow, ac.getFan());
+  EXPECT_TRUE(ac.getZoneFollow());
+  EXPECT_EQ(0xBAD34E, ac.getRaw());
+  EXPECT_EQ(
+      "Power: On, Mode: 3 (Heat), Fan: 6 (Zone Follow), Temp: 24C, "
+      "Zone Follow: On, Sensor Temp: 19C",
+      ac.toString());
+}

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -885,3 +885,33 @@ TEST(TestDecodeCoolix, Issue1318_DirectMessage) {
       "Power: On, Swing(V): Step",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
+
+TEST(TestCoolixACClass, SendStep) {
+  IRrecv irrecv(kGpioUnused);
+  IRCoolixAC ac(kGpioUnused);
+
+  ac.setSwingVStep();
+  ac.send();
+  ac._irsend.makeDecodeResult();
+  ASSERT_TRUE(irrecv.decode(&ac._irsend.capture));
+  EXPECT_EQ(COOLIX, ac._irsend.capture.decode_type);
+  EXPECT_EQ(kCoolixBits, ac._irsend.capture.bits);
+  EXPECT_EQ(kCoolixSwingV, ac._irsend.capture.value);
+  EXPECT_EQ(
+      "Power: On, Swing(V): Step",
+      IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+  EXPECT_EQ(
+      "f38000d50"
+      "m4692s4416"
+      "m552s1656m552s552m552s1656m552s1656m552s552m552s552m552s1656"
+      "m552s552m552s552m552s1656m552s552m552s552m552s1656m552s1656"
+      "m552s552m552s1656m552s552m552s552m552s552m552s552m552s1656"
+      "m552s1656m552s1656m552s1656m552s1656m552s1656m552s1656m552s1656"
+      "m552s552m552s552m552s552m552s552m552s1656m552s1656m552s1656"
+      "m552s552m552s552m552s552m552s552m552s552m552s552m552s552"
+      "m552s552m552s1656m552s1656m552s1656m552s1656m552s1656"
+      "m552s105244",
+      ac._irsend.outputStr());
+}

--- a/test/ir_Coolix_test.cpp
+++ b/test/ir_Coolix_test.cpp
@@ -444,19 +444,17 @@ TEST(TestCoolixACClass, SetGetClearSensorTempAndZoneFollow) {
 
   ircoolix.setRaw(kCoolixDefaultState);
   EXPECT_FALSE(ircoolix.getZoneFollow());
-  EXPECT_LT(kCoolixSensorTempMax, ircoolix.getSensorTemp());
+  EXPECT_LE(kCoolixSensorTempMax, ircoolix.getSensorTemp());
 
   ircoolix.setSensorTemp(25);
   EXPECT_TRUE(ircoolix.getZoneFollow());
   EXPECT_EQ(25, ircoolix.getSensorTemp());
 
   // Lower bounds
-  ircoolix.setSensorTemp(kCoolixSensorTempMin);
+  ircoolix.setSensorTemp(0);
   EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(kCoolixSensorTempMin, ircoolix.getSensorTemp());
-  ircoolix.setSensorTemp(kCoolixSensorTempMin - 1);
-  EXPECT_TRUE(ircoolix.getZoneFollow());
-  EXPECT_EQ(kCoolixSensorTempMin, ircoolix.getSensorTemp());
+  EXPECT_EQ(0, ircoolix.getSensorTemp());
+
   // Upper bounds
   ircoolix.setSensorTemp(kCoolixSensorTempMax);
   EXPECT_TRUE(ircoolix.getZoneFollow());


### PR DESCRIPTION
* Increase sensor temp range.
* using `setSensorTemp()` now correctly sets up ZoneFollow mode.
* ZoneFollow mode detection.
* Misc code cleanup.
* Refactor code to use bit fields.
* Additional & updated Unit tests.
* Add support for fan vane step commands.

Fixes #1318

* Confirmed working by user in https://github.com/crankyoldgit/IRremoteESP8266/issues/1318#issuecomment-733085483