### PR TITLE
[Bug] Fix crash when IRac::sendAc(state_t, *state_t) called with SAMSUNG_AC & NULL

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -2199,7 +2199,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
   stdAc::state_t send = this->handleToggles(this->cleanState(desired), prev);
   // Some protocols expect a previous state for power.
   // Construct a pointer-safe previous power state incase prev is NULL/NULLPTR.
+#if (SEND_HITACHI_AC1 || SEND_SAMSUNG_AC || SEND_SHARP_AC)
   const bool prev_power = (prev != NULL) ? prev->power : !send.power;
+#endif
   // Per vendor settings & setup.
   switch (send.protocol) {
 #if SEND_AIRWELL

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -2296,3 +2296,19 @@ TEST(TestIRac, Issue1250) {
   // Confirm nothing in the state changed with the send.
   ASSERT_FALSE(IRac::cmpStates(irac.next, copy_of_next_pre_send));
 }
+
+// Ensure Protocols that expect the IRac::sendAC() call to have a prev value set
+// still works when it is NULL. i.e. It doesn't crash.
+// Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/1339
+TEST(TestIRac, Issue1339) {
+  IRac irac(kGpioUnused);
+  stdAc::state_t to_send;
+  IRac::initState(&to_send);
+
+  to_send.protocol = decode_type_t::SAMSUNG_AC;
+  ASSERT_TRUE(irac.sendAc(to_send, NULL));
+  to_send.protocol = decode_type_t::SHARP_AC;
+  ASSERT_TRUE(irac.sendAc(to_send, NULL));
+  to_send.protocol = decode_type_t::HITACHI_AC1;
+  ASSERT_TRUE(irac.sendAc(to_send, NULL));
+}


### PR DESCRIPTION
* Ensure protocols that use the `prev` pointer's power state are okay when it's NULL.
* Add unit test to ensure this doesn't happen again.

Fixes #1339