### PR TITLE
[Bug] IRMQTTServer: Compiler error under PlatformIO on Windows.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -411,6 +411,7 @@ void handleRoot(void);
 String addJsReloadUrl(const String url, const uint16_t timeout_s,
                       const bool notify);
 void handleExamples(void);
+String htmlOptionItem(const String value, const String text, bool selected);
 String htmlSelectBool(const String name, const bool def);
 String htmlSelectClimateProtocol(const String name, const decode_type_t def);
 String htmlSelectAcStateProtocol(const String name, const decode_type_t def,

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -674,6 +674,14 @@ String htmlMenu(void) {
   return html;
 }
 
+String htmlOptionItem(const String value, const String text, bool selected) {
+  String html = F("<option value='");
+  html += value + '\'';
+  if (selected) html += F(" selected='selected'");
+  html += '>' + text + F("</option>");
+  return html;
+}
+
 String htmlSelectAcStateProtocol(const String name, const decode_type_t def,
                                  const bool simple) {
   String html = "<select name='" + name + "'>";
@@ -884,14 +892,6 @@ void handleExamples(void) {
   server.send(200, "text/html", html);
 }
 #endif  // EXAMPLES_ENABLE
-
-String htmlOptionItem(const String value, const String text, bool selected) {
-  String html = F("<option value='");
-  html += value + '\'';
-  if (selected) html += F(" selected='selected'");
-  html += '>' + text + F("</option>");
-  return html;
-}
 
 String htmlSelectBool(const String name, const bool def) {
   String html = "<select name='" + name + "'>";


### PR DESCRIPTION
Moved `htmlOptionItem` function before `htmlSelectAcStateProtocol` in the IRMQTTServer example so it compiles correctly.

Would be a fix for #1353 