### PR TITLE
PANASONIC_AC32: Add limited detailed support.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -241,6 +241,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_PANASONIC_AC
     case decode_type_t::PANASONIC_AC:
 #endif
+#if SEND_PANASONIC_AC32
+    case decode_type_t::PANASONIC_AC32:
+#endif
 #if SEND_SAMSUNG_AC
     case decode_type_t::SAMSUNG_AC:
 #endif
@@ -1583,6 +1586,40 @@ void IRac::panasonic(IRPanasonicAc *ac, const panasonic_ac_remote_model_t model,
 }
 #endif  // SEND_PANASONIC_AC
 
+#if SEND_PANASONIC_AC32
+/// Send a Panasonic A/C message with the supplied settings.
+/// @param[in, out] ac A Ptr to an IRPanasonicAc32 object to use.
+/// @param[in] on The power setting.
+/// @param[in] mode The operation mode setting.
+/// @param[in] degrees The temperature setting in degrees.
+/// @param[in] fan The speed setting for the fan.
+/// @param[in] swingv The vertical swing setting.
+/// @param[in] swingh The horizontal swing setting.
+void IRac::panasonic32(IRPanasonicAc32 *ac,
+                       const bool on, const stdAc::opmode_t mode,
+                       const float degrees, const stdAc::fanspeed_t fan,
+                       const stdAc::swingv_t swingv,
+                       const stdAc::swingh_t swingh) {
+  ac->begin();
+  ac->setPowerToggle(on);
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setSwingVertical(ac->convertSwingV(swingv));
+  ac->setSwingHorizontal(swingh != stdAc::swingh_t::kOff);
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Filter setting available.
+  // No Light setting available.
+  // No Econo setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_PANASONIC_AC32
+
 #if SEND_SAMSUNG_AC
 /// Send a Samsung A/C message with the supplied settings.
 /// @note Multiple IR messages may be generated & sent.
@@ -2137,6 +2174,7 @@ stdAc::state_t IRac::handleToggles(const stdAc::state_t desired,
         break;
       case decode_type_t::AIRWELL:
       case decode_type_t::DAIKIN64:
+      case decode_type_t::PANASONIC_AC32:
       case decode_type_t::WHIRLPOOL_AC:
         result.power = desired.power ^ prev->power;
         break;
@@ -2537,6 +2575,15 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       break;
     }
 #endif  // SEND_PANASONIC_AC
+#if SEND_PANASONIC_AC32
+    case PANASONIC_AC32:
+    {
+      IRPanasonicAc32 ac(_pin, _inverted, _modulation);
+      panasonic32(&ac, send.power, send.mode, degC, send.fanspeed,
+                  send.swingv, send.swingh);
+      break;
+    }
+#endif  // SEND_PANASONIC_AC32
 #if SEND_SAMSUNG_AC
     case SAMSUNG_AC:
     {
@@ -3682,7 +3729,7 @@ namespace IRAcUtils {
         IRPanasonicAc32 ac(kGpioUnused);
         if (decode->bits >= kPanasonicAc32Bits) {
           ac.setRaw(decode->value);  // Uses value instead of state.
-          *result = ac.toCommon();
+          *result = ac.toCommon(prev);
         } else {
           return false;
         }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3266,6 +3266,16 @@ namespace IRAcUtils {
         return "";
       }
 #endif  // DECODE_PANASONIC_AC
+#if DECODE_PANASONIC_AC32
+      case decode_type_t::PANASONIC_AC32: {
+        if (result->bits >= kPanasonicAc32Bits) {
+          IRPanasonicAc32 ac(kGpioUnused);
+          ac.setRaw(result->value);  // Uses value instead of state.
+          return ac.toString();
+        }
+        return "";
+      }
+#endif  // DECODE_PANASONIC_AC
 #if DECODE_HITACHI_AC
       case decode_type_t::HITACHI_AC: {
         IRHitachiAc ac(kGpioUnused);
@@ -3667,6 +3677,18 @@ namespace IRAcUtils {
         break;
       }
 #endif  // DECODE_PANASONIC_AC
+#if DECODE_PANASONIC_AC32
+      case decode_type_t::PANASONIC_AC32: {
+        IRPanasonicAc32 ac(kGpioUnused);
+        if (decode->bits >= kPanasonicAc32Bits) {
+          ac.setRaw(decode->value);  // Uses value instead of state.
+          *result = ac.toCommon();
+        } else {
+          return false;
+        }
+        break;
+      }
+#endif  // DECODE_PANASONIC_AC32
 #if DECODE_SAMSUNG_AC
       case decode_type_t::SAMSUNG_AC: {
         IRSamsungAc ac(kGpioUnused);

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -354,6 +354,12 @@ void electra(IRElectraAc *ac,
                  const bool quiet, const bool turbo, const bool filter,
                  const int16_t clock = -1);
 #endif  // SEND_PANASONIC_AC
+#if SEND_PANASONIC_AC32
+  void panasonic32(IRPanasonicAc32 *ac,
+                   const bool on, const stdAc::opmode_t mode,
+                   const float degrees, const stdAc::fanspeed_t fan,
+                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh);
+#endif  // SEND_PANASONIC_AC32
 #if SEND_SAMSUNG_AC
   void samsung(IRSamsungAc *ac,
                const bool on, const stdAc::opmode_t mode, const float degrees,

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -654,19 +654,22 @@ namespace irutils {
   /// @param[in] automatic The numeric value for Auto speed.
   /// @param[in] quiet The numeric value for Quiet speed.
   /// @param[in] medium The numeric value for Medium speed.
+  /// @param[in] maximum The numeric value for Highest speed. (if > high)
   /// @return The resulting String.
   String addFanToString(const uint8_t speed, const uint8_t high,
                         const uint8_t low, const uint8_t automatic,
-                        const uint8_t quiet, const uint8_t medium) {
+                        const uint8_t quiet, const uint8_t medium,
+                        const uint8_t maximum) {
     String result = addIntToString(speed, kFanStr);
     result += kSpaceLBraceStr;
-    if (speed == high) result += kHighStr;
-    else if (speed == low) result += kLowStr;
+    if (speed == high)           result += kHighStr;
+    else if (speed == low)       result += kLowStr;
     else if (speed == automatic) result += kAutoStr;
-    else if (speed == quiet) result += kQuietStr;
-    else if (speed == medium) result += kMediumStr;
+    else if (speed == quiet)     result += kQuietStr;
+    else if (speed == medium)    result += kMediumStr;
+    else if (speed == maximum)   result += kMaximumStr;
     else
-     result += kUnknownStr;
+      result += kUnknownStr;
     return result + ')';
   }
 

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -61,7 +61,8 @@ namespace irutils {
                          const uint8_t dry, const uint8_t fan);
   String addFanToString(const uint8_t speed, const uint8_t high,
                         const uint8_t low, const uint8_t automatic,
-                        const uint8_t quiet, const uint8_t medium);
+                        const uint8_t quiet, const uint8_t medium,
+                        const uint8_t maximum = 0xFF);
   String addDayToString(const uint8_t day_of_week, const int8_t offset = 0,
                         const bool precomma = true);
   String htmlEscape(const String unescaped);

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -192,7 +192,7 @@ void IRsend::sendPanasonicAC(const uint8_t data[], const uint16_t nbytes,
 /// @param[in] use_modulation Is frequency modulation to be used?
 IRPanasonicAc::IRPanasonicAc(const uint16_t pin, const bool inverted,
                              const bool use_modulation)
-    : _irsend(pin, inverted, use_modulation) { this->stateReset(); }
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
 
 /// Reset the state of the remote to a known good state/sequence.
 void IRPanasonicAc::stateReset(void) {
@@ -226,7 +226,7 @@ uint8_t IRPanasonicAc::calcChecksum(const uint8_t *state,
 /// Calculate and set the checksum values for the internal state.
 /// @param[in] length The size/length of the state.
 void IRPanasonicAc::fixChecksum(const uint16_t length) {
-  remote_state[length - 1] = this->calcChecksum(remote_state, length);
+  remote_state[length - 1] = calcChecksum(remote_state, length);
 }
 
 #if SEND_PANASONIC_AC
@@ -266,7 +266,7 @@ void IRPanasonicAc::setModel(const panasonic_ac_remote_model_t model) {
       remote_state[23] = 0x01;
       remote_state[25] = 0x06;
       // Has to be done last as setSwingHorizontal has model check built-in
-      this->setSwingHorizontal(_swingh);
+      setSwingHorizontal(_swingh);
       break;
     case kPanasonicNke:
       remote_state[17] = 0x06;
@@ -309,7 +309,7 @@ panasonic_ac_remote_model_t IRPanasonicAc::getModel(void) {
 /// Get a PTR to the internal state/code for this protocol.
 /// @return PTR to a code for this protocol based on the current internal state.
 uint8_t *IRPanasonicAc::getRaw(void) {
-  this->fixChecksum();
+  fixChecksum();
   return remote_state;
 }
 
@@ -360,7 +360,7 @@ void IRPanasonicAc::setMode(const uint8_t desired) {
   switch (desired) {
     case kPanasonicAcFan:
       // Allegedly Fan mode has a temperature of 27.
-      this->setTemp(kPanasonicAcFanModeTemp, false);
+      setTemp(kPanasonicAcFanModeTemp, false);
       mode = desired;
       break;
     case kPanasonicAcAuto:
@@ -369,7 +369,7 @@ void IRPanasonicAc::setMode(const uint8_t desired) {
     case kPanasonicAcDry:
       mode = desired;
       // Set the temp to the saved temp, just incase our previous mode was Fan.
-      this->setTemp(_temp);
+      setTemp(_temp);
       break;
   }
   remote_state[13] &= 0x0F;  // Clear the previous mode bits.
@@ -434,7 +434,7 @@ void IRPanasonicAc::setSwingHorizontal(const uint8_t desired_direction) {
   }
   _swingh = desired_direction;  // Store the direction for later.
   uint8_t direction = desired_direction;
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicDke:
     case kPanasonicRkr:
       break;
@@ -473,7 +473,7 @@ uint8_t IRPanasonicAc::getFan(void) {
 /// Get the Quiet setting of the A/C.
 /// @return true, the setting is on. false, the setting is off.
 bool IRPanasonicAc::getQuiet(void) {
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return GETBIT8(remote_state[21], kPanasonicAcQuietCkpOffset);
@@ -486,19 +486,19 @@ bool IRPanasonicAc::getQuiet(void) {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRPanasonicAc::setQuiet(const bool on) {
   uint8_t offset;
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp: offset = kPanasonicAcQuietCkpOffset; break;
     default:            offset = kPanasonicAcQuietOffset;
   }
-  if (on) this->setPowerful(false);  // Powerful is mutually exclusive.
+  if (on) setPowerful(false);  // Powerful is mutually exclusive.
   setBit(&remote_state[21], offset, on);
 }
 
 /// Get the Powerful (Turbo) setting of the A/C.
 /// @return true, the setting is on. false, the setting is off.
 bool IRPanasonicAc::getPowerful(void) {
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp:
       return GETBIT8(remote_state[21], kPanasonicAcPowerfulCkpOffset);
@@ -511,13 +511,13 @@ bool IRPanasonicAc::getPowerful(void) {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRPanasonicAc::setPowerful(const bool on) {
   uint8_t offset;
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicRkr:
     case kPanasonicCkp: offset = kPanasonicAcPowerfulCkpOffset; break;
     default:            offset = kPanasonicAcPowerfulOffset;
   }
 
-  if (on) this->setQuiet(false);  // Quiet is mutually exclusive.
+  if (on) setQuiet(false);  // Quiet is mutually exclusive.
   setBit(&remote_state[21], offset, on);
 }
 
@@ -584,7 +584,7 @@ void IRPanasonicAc::setOnTimer(const uint16_t mins_since_midnight,
 }
 
 /// Cancel the On Timer.
-void IRPanasonicAc::cancelOnTimer(void) { this->setOnTimer(0, false); }
+void IRPanasonicAc::cancelOnTimer(void) { setOnTimer(0, false); }
 
 /// Check if the On Timer is Enabled.
 /// @return true, the setting is on. false, the setting is off.
@@ -619,7 +619,7 @@ void IRPanasonicAc::setOffTimer(const uint16_t mins_since_midnight,
 }
 
 /// Cancel the Off Timer.
-void IRPanasonicAc::cancelOffTimer(void) { this->setOffTimer(0, false); }
+void IRPanasonicAc::cancelOffTimer(void) { setOffTimer(0, false); }
 
 /// Check if the Off Timer is Enabled.
 /// @return true, the setting is on. false, the setting is off.
@@ -630,7 +630,7 @@ bool IRPanasonicAc::isOffTimerEnabled(void) {
 /// Get the Ion (filter) setting of the A/C.
 /// @return true, the setting is on. false, the setting is off.
 bool IRPanasonicAc::getIon(void) {
-  switch (this->getModel()) {
+  switch (getModel()) {
     case kPanasonicDke:
       return GETBIT8(remote_state[kPanasonicAcIonFilterByte],
                      kPanasonicAcIonFilterOffset);
@@ -642,7 +642,7 @@ bool IRPanasonicAc::getIon(void) {
 /// Set the Ion (filter) setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRPanasonicAc::setIon(const bool on) {
-  if (this->getModel() == kPanasonicDke)
+  if (getModel() == kPanasonicDke)
     setBit(&remote_state[kPanasonicAcIonFilterByte],
            kPanasonicAcIonFilterOffset, on);
 }
@@ -758,17 +758,17 @@ stdAc::swingv_t IRPanasonicAc::toCommonSwingV(const uint8_t pos) {
 stdAc::state_t IRPanasonicAc::toCommon(void) {
   stdAc::state_t result;
   result.protocol = decode_type_t::PANASONIC_AC;
-  result.model = this->getModel();
-  result.power = this->getPower();
-  result.mode = this->toCommonMode(this->getMode());
+  result.model = getModel();
+  result.power = getPower();
+  result.mode = toCommonMode(getMode());
   result.celsius = true;
-  result.degrees = this->getTemp();
-  result.fanspeed = this->toCommonFanSpeed(this->getFan());
-  result.swingv = this->toCommonSwingV(this->getSwingVertical());
-  result.swingh = this->toCommonSwingH(this->getSwingHorizontal());
-  result.quiet = this->getQuiet();
-  result.turbo = this->getPowerful();
-  result.filter = this->getIon();
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  result.swingv = toCommonSwingV(getSwingVertical());
+  result.swingh = toCommonSwingH(getSwingHorizontal());
+  result.quiet = getQuiet();
+  result.turbo = getPowerful();
+  result.filter = getIon();
   // Not supported.
   result.econo = false;
   result.clean = false;
@@ -1103,3 +1103,218 @@ bool IRrecv::decodePanasonicAC32(decode_results *results, uint16_t offset,
   return true;
 }
 #endif  // DECODE_PANASONIC_AC32
+
+/// Class constructor
+/// @param[in] pin GPIO to be used when sending.
+/// @param[in] inverted Is the output signal to be inverted?
+/// @param[in] use_modulation Is frequency modulation to be used?
+IRPanasonicAc32::IRPanasonicAc32(const uint16_t pin, const bool inverted,
+                                 const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) { stateReset(); }
+
+/// Set up hardware to be able to send a message.
+void IRPanasonicAc32::begin(void) { _irsend.begin(); }
+
+/// Get a copy of the internal state/code for this protocol.
+/// @return The code for this protocol based on the current internal state.
+uint32_t IRPanasonicAc32::getRaw(void) const { return _.raw; }
+
+/// Set the internal state from a valid code for this protocol.
+/// @param[in] state A valid code for this protocol.
+void IRPanasonicAc32::setRaw(const uint32_t state) {  _.raw = state; }
+
+/// Reset the state of the remote to a known good state/sequence.
+void IRPanasonicAc32::stateReset(void) { setRaw(kPanasonicAc32KnownGood); }
+
+/// Set the desired temperature.
+/// @param[in] degrees The temperature in degrees celsius.
+void IRPanasonicAc32::setTemp(const uint8_t degrees) {
+  uint8_t temp = std::max((uint8_t)kPanasonicAcMinTemp, degrees);
+  temp = std::min((uint8_t)kPanasonicAcMaxTemp, temp);
+  _.Temp = temp - (kPanasonicAcMinTemp - 1);
+}
+
+/// Get the current desired temperature setting.
+/// @return The current setting for temp. in degrees celsius.
+uint8_t IRPanasonicAc32::getTemp(void) const {
+  return _.Temp + (kPanasonicAcMinTemp - 1);
+}
+
+/// Get the operating mode setting of the A/C.
+/// @return The current operating mode setting.
+uint8_t IRPanasonicAc32::getMode(void) const { return _.Mode; }
+
+/// Set the operating mode of the A/C.
+/// @param[in] mode The desired operating mode.
+/// @note If we get an unexpected mode, default to AUTO.
+void IRPanasonicAc32::setMode(const uint8_t mode) {
+  switch (mode) {
+    case kPanasonicAc32Auto:
+    case kPanasonicAc32Cool:
+    case kPanasonicAc32Dry:
+    case kPanasonicAc32Heat:
+    case kPanasonicAc32Fan:
+      _.Mode = mode;
+      break;
+    default: _.Mode = kPanasonicAc32Auto;
+  }
+}
+
+/// Convert a stdAc::opmode_t enum into its native mode.
+/// @param[in] mode The enum to be converted.
+/// @return The native equivalent of the enum.
+uint8_t IRPanasonicAc32::convertMode(const stdAc::opmode_t mode) {
+  switch (mode) {
+    case stdAc::opmode_t::kCool: return kPanasonicAc32Cool;
+    case stdAc::opmode_t::kHeat: return kPanasonicAc32Heat;
+    case stdAc::opmode_t::kDry:  return kPanasonicAc32Dry;
+    case stdAc::opmode_t::kFan:  return kPanasonicAc32Fan;
+    default:                     return kPanasonicAc32Auto;
+  }
+}
+
+/// Convert a native mode into its stdAc equivalent.
+/// @param[in] mode The native setting to be converted.
+/// @return The stdAc equivalent of the native setting.
+stdAc::opmode_t IRPanasonicAc32::toCommonMode(const uint8_t mode) {
+  switch (mode) {
+    case kPanasonicAc32Cool: return stdAc::opmode_t::kCool;
+    case kPanasonicAc32Heat: return stdAc::opmode_t::kHeat;
+    case kPanasonicAc32Dry:  return stdAc::opmode_t::kDry;
+    case kPanasonicAc32Fan:  return stdAc::opmode_t::kFan;
+    default:                 return stdAc::opmode_t::kAuto;
+  }
+}
+
+/// Set the speed of the fan.
+/// @param[in] speed The desired setting.
+void IRPanasonicAc32::setFan(const uint8_t speed) {
+  switch (speed) {
+    case kPanasonicAc32FanMin:
+    case kPanasonicAc32FanLow:
+    case kPanasonicAc32FanMed:
+    case kPanasonicAc32FanHigh:
+    case kPanasonicAc32FanMax:
+    case kPanasonicAc32FanAuto:
+      _.Fan = speed;
+      break;
+    default: _.Fan = kPanasonicAc32FanAuto;
+  }
+}
+
+/// Get the current fan speed setting.
+/// @return The current fan speed.
+uint8_t IRPanasonicAc32::getFan(void) const { return _.Fan; }
+
+/// Convert a native fan speed into its stdAc equivalent.
+/// @param[in] spd The native setting to be converted.
+/// @return The stdAc equivalent of the native setting.
+stdAc::fanspeed_t IRPanasonicAc32::toCommonFanSpeed(const uint8_t spd) {
+  switch (spd) {
+    case kPanasonicAc32FanMax:     return stdAc::fanspeed_t::kMax;
+    case kPanasonicAc32FanHigh:    return stdAc::fanspeed_t::kHigh;
+    case kPanasonicAc32FanMed:     return stdAc::fanspeed_t::kMedium;
+    case kPanasonicAc32FanLow:     return stdAc::fanspeed_t::kLow;
+    case kPanasonicAc32FanMin:     return stdAc::fanspeed_t::kMin;
+    default:                       return stdAc::fanspeed_t::kAuto;
+  }
+}
+
+/// Get the current horizontal swing setting.
+/// @return The current position it is set to.
+bool IRPanasonicAc32::getSwingHorizontal(void) const { return _.SwingH; }
+
+/// Control the horizontal swing setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRPanasonicAc32::setSwingHorizontal(const bool on) { _.SwingH = on; }
+
+/// Get the current vertical swing setting.
+/// @return The current position it is set to.
+uint8_t IRPanasonicAc32::getSwingVertical(void) const { return _.SwingV; }
+
+/// Control the vertical swing setting.
+/// @param[in] pos The position to set the vertical swing to.
+void IRPanasonicAc32::setSwingVertical(const uint8_t pos) {
+  uint8_t elevation = pos;
+  if (elevation != kPanasonicAc32SwingVAuto) {
+    elevation = std::max(elevation, kPanasonicAcSwingVHighest);
+    elevation = std::min(elevation, kPanasonicAcSwingVLowest);
+  }
+  _.SwingV = elevation;
+}
+
+/// Convert a native vertical swing postion to it's common equivalent.
+/// @param[in] pos A native position to convert.
+/// @return The common vertical swing position.
+stdAc::swingv_t IRPanasonicAc32::toCommonSwingV(const uint8_t pos) {
+  return IRPanasonicAc::toCommonSwingV(pos);
+}
+
+/// Convert the current internal state into a human readable string.
+/// @return A human readable string.
+String IRPanasonicAc32::toString(void) const {
+  String result = "";
+  result.reserve(80);
+  result += addTempToString(getTemp(), true, false);
+  result += addModeToString(_.Mode, kPanasonicAc32Auto, kPanasonicAc32Cool,
+                            kPanasonicAc32Heat, kPanasonicAc32Dry,
+                            kPanasonicAc32Fan);
+  result += addFanToString(_.Fan, kPanasonicAc32FanHigh, kPanasonicAc32FanLow,
+                           kPanasonicAc32FanAuto, kPanasonicAc32FanMin,
+                           kPanasonicAc32FanMed);
+  result += addBoolToString(_.SwingH, kSwingHStr);
+  result += addIntToString(getSwingVertical(), kSwingVStr);
+  result += kSpaceLBraceStr;
+  switch (getSwingVertical()) {
+    case kPanasonicAc32SwingVAuto:
+      result += kAutoStr;
+      break;
+    case kPanasonicAcSwingVHighest:
+      result += kHighestStr;
+      break;
+    case kPanasonicAcSwingVHigh:
+      result += kHighStr;
+      break;
+    case kPanasonicAcSwingVMiddle:
+      result += kMiddleStr;
+      break;
+    case kPanasonicAcSwingVLow:
+      result += kLowStr;
+      break;
+    case kPanasonicAcSwingVLowest:
+      result += kLowestStr;
+      break;
+    default:
+      result += kUnknownStr;
+      break;
+  }
+  result += ')';
+  return result;
+}
+
+/// Convert the current internal state into its stdAc::state_t equivalent.
+/// @return The stdAc equivalent of the native settings.
+stdAc::state_t IRPanasonicAc32::toCommon(void) const {
+  stdAc::state_t result;
+  result.protocol = decode_type_t::PANASONIC_AC32;
+  result.model = -1;
+  result.mode = toCommonMode(getMode());
+  result.celsius = true;
+  result.degrees = getTemp();
+  result.fanspeed = toCommonFanSpeed(getFan());
+  result.swingv = toCommonSwingV(getSwingVertical());
+  result.swingh = getSwingHorizontal() ? stdAc::swingh_t::kAuto
+                                       : stdAc::swingh_t::kOff;
+  // Not supported.
+  result.power = true;
+  result.quiet = false;
+  result.turbo = false;
+  result.filter = false;
+  result.econo = false;
+  result.clean = false;
+  result.light = false;
+  result.beep = false;
+  result.sleep = -1;
+  result.clock = -1;
+  return result;
+}

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -795,27 +795,13 @@ String IRPanasonicAc::toString(void) {
   result += addIntToString(getSwingVertical(), kSwingVStr);
   result += kSpaceLBraceStr;
   switch (getSwingVertical()) {
-    case kPanasonicAcSwingVAuto:
-      result += kAutoStr;
-      break;
-    case kPanasonicAcSwingVHighest:
-      result += kHighestStr;
-      break;
-    case kPanasonicAcSwingVHigh:
-      result += kHighStr;
-      break;
-    case kPanasonicAcSwingVMiddle:
-      result += kMiddleStr;
-      break;
-    case kPanasonicAcSwingVLow:
-      result += kLowStr;
-      break;
-    case kPanasonicAcSwingVLowest:
-      result += kLowestStr;
-      break;
-    default:
-      result += kUnknownStr;
-      break;
+    case kPanasonicAcSwingVAuto:    result += kAutoStr; break;
+    case kPanasonicAcSwingVHighest: result += kHighestStr; break;
+    case kPanasonicAcSwingVHigh:    result += kHighStr; break;
+    case kPanasonicAcSwingVMiddle:  result += kMiddleStr; break;
+    case kPanasonicAcSwingVLow:     result += kLowStr; break;
+    case kPanasonicAcSwingVLowest:  result += kLowestStr; break;
+    default:                        result += kUnknownStr; break;
   }
   result += ')';
   switch (getModel()) {
@@ -1306,32 +1292,18 @@ String IRPanasonicAc32::toString(void) const {
   result += addTempToString(getTemp());
   result += addFanToString(_.Fan, kPanasonicAc32FanHigh, kPanasonicAc32FanLow,
                            kPanasonicAc32FanAuto, kPanasonicAc32FanMin,
-                           kPanasonicAc32FanMed);
+                           kPanasonicAc32FanMed, kPanasonicAc32FanMax);
   result += addBoolToString(_.SwingH, kSwingHStr);
   result += addIntToString(getSwingVertical(), kSwingVStr);
   result += kSpaceLBraceStr;
   switch (getSwingVertical()) {
-    case kPanasonicAc32SwingVAuto:
-      result += kAutoStr;
-      break;
-    case kPanasonicAcSwingVHighest:
-      result += kHighestStr;
-      break;
-    case kPanasonicAcSwingVHigh:
-      result += kHighStr;
-      break;
-    case kPanasonicAcSwingVMiddle:
-      result += kMiddleStr;
-      break;
-    case kPanasonicAcSwingVLow:
-      result += kLowStr;
-      break;
-    case kPanasonicAcSwingVLowest:
-      result += kLowestStr;
-      break;
-    default:
-      result += kUnknownStr;
-      break;
+    case kPanasonicAc32SwingVAuto:  result += kAutoStr; break;
+    case kPanasonicAcSwingVHighest: result += kHighestStr; break;
+    case kPanasonicAcSwingVHigh:    result += kHighStr; break;
+    case kPanasonicAcSwingVMiddle:  result += kMiddleStr; break;
+    case kPanasonicAcSwingVLow:     result += kLowStr; break;
+    case kPanasonicAcSwingVLowest:  result += kLowestStr; break;
+    default:                        result += kUnknownStr; break;
   }
   result += ')';
   return result;

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -184,18 +184,19 @@ union PanasonicAc32Protocol {
   uint32_t raw;  ///< The state in IR code form.
   struct {
     // Byte 0
-    uint8_t        :3;
-    uint8_t SwingH :1;
-    uint8_t SwingV :3;
-    uint8_t        :1;  ///< Always appears to be set. (1)
+    uint8_t             :3;
+    uint8_t SwingH      :1;
+    uint8_t SwingV      :3;
+    uint8_t             :1;  ///< Always appears to be set. (1)
     // Byte 1
-    uint8_t :8;  // Always seems to be 0x36.
+    uint8_t             :8;  // Always seems to be 0x36.
     // Byte 2
-    uint8_t Temp   :4;
-    uint8_t Fan    :4;
+    uint8_t Temp        :4;
+    uint8_t Fan         :4;
     // Byte 3
-    uint8_t Mode   :3;
-    uint8_t        :5;
+    uint8_t Mode        :3;
+    uint8_t PowerToggle :1;  // 0 means toggle, 1 = keep the same.
+    uint8_t             :4;
   };
 };
 
@@ -229,6 +230,8 @@ class IRPanasonicAc32 {
   int8_t calibrate(void) { return _irsend.calibrate(); }
 #endif  // SEND_PANASONIC_AC32
   void begin(void);
+  void setPowerToggle(const bool on);
+  bool getPowerToggle(void) const;
   void setTemp(const uint8_t temp);
   uint8_t getTemp(void) const;
   void setFan(const uint8_t fan);
@@ -247,7 +250,7 @@ class IRPanasonicAc32 {
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
-  stdAc::state_t toCommon(void) const;
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL) const;
   String toString(void) const;
 #ifndef UNIT_TEST
 

--- a/src/ir_Panasonic.h
+++ b/src/ir_Panasonic.h
@@ -102,14 +102,14 @@ class IRPanasonicAc {
   explicit IRPanasonicAc(const uint16_t pin, const bool inverted = false,
                          const bool use_modulation = true);
   void stateReset(void);
-#if SEND_PANASONIC
+#if SEND_PANASONIC_AC
   void send(const uint16_t repeat = kPanasonicAcDefaultRepeat);
   /// Run the calibration to calculate uSec timing offsets for this platform.
   /// @return The uSec timing offset needed per modulation of the IR Led.
   /// @note This will produce a 65ms IR signal pulse at 38kHz.
   ///   Only ever needs to be run once per object instantiation, if at all.
   int8_t calibrate(void) { return _irsend.calibrate(); }
-#endif  // SEND_PANASONIC
+#endif  // SEND_PANASONIC_AC
   void begin(void);
   void on(void);
   void off(void);
@@ -177,6 +177,88 @@ class IRPanasonicAc {
   static uint16_t _getTime(const uint8_t ptr[]);
   static void _setTime(uint8_t * const ptr, const uint16_t mins_since_midnight,
                        const bool round_down);
+};
+
+/// Native representation of a Panasonic 32-bit A/C message.
+union PanasonicAc32Protocol {
+  uint32_t raw;  ///< The state in IR code form.
+  struct {
+    // Byte 0
+    uint8_t        :3;
+    uint8_t SwingH :1;
+    uint8_t SwingV :3;
+    uint8_t        :1;  ///< Always appears to be set. (1)
+    // Byte 1
+    uint8_t :8;  // Always seems to be 0x36.
+    // Byte 2
+    uint8_t Temp   :4;
+    uint8_t Fan    :4;
+    // Byte 3
+    uint8_t Mode   :3;
+    uint8_t        :5;
+  };
+};
+
+const uint8_t kPanasonicAc32Fan =  1;  // 0b001
+const uint8_t kPanasonicAc32Cool = 2;  // 0b010
+const uint8_t kPanasonicAc32Dry =  3;  // 0b011
+const uint8_t kPanasonicAc32Heat = 4;  // 0b010
+const uint8_t kPanasonicAc32Auto = 6;  // 0b110
+
+const uint8_t kPanasonicAc32FanMin =  2;
+const uint8_t kPanasonicAc32FanLow =  3;
+const uint8_t kPanasonicAc32FanMed =  4;
+const uint8_t kPanasonicAc32FanHigh = 5;
+const uint8_t kPanasonicAc32FanMax =  6;
+const uint8_t kPanasonicAc32FanAuto = 0xF;
+const uint8_t kPanasonicAc32SwingVAuto = 0x7;   // 0b111
+const uint32_t kPanasonicAc32KnownGood = 0x0AF136FC;  ///< Cool, Auto, 16C
+
+/// Class for handling detailed Panasonic 32bit A/C messages.
+class IRPanasonicAc32 {
+ public:
+  explicit IRPanasonicAc32(const uint16_t pin, const bool inverted = false,
+                           const bool use_modulation = true);
+  void stateReset(void);
+#if SEND_PANASONIC_AC32
+  void send(const uint16_t repeat = kPanasonicAcDefaultRepeat);
+  /// Run the calibration to calculate uSec timing offsets for this platform.
+  /// @return The uSec timing offset needed per modulation of the IR Led.
+  /// @note This will produce a 65ms IR signal pulse at 38kHz.
+  ///   Only ever needs to be run once per object instantiation, if at all.
+  int8_t calibrate(void) { return _irsend.calibrate(); }
+#endif  // SEND_PANASONIC_AC32
+  void begin(void);
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp(void) const;
+  void setFan(const uint8_t fan);
+  uint8_t getFan(void) const;
+  void setMode(const uint8_t mode);
+  uint8_t getMode(void) const;
+  void setRaw(const uint32_t state);
+  uint32_t getRaw(void) const;
+  void setSwingVertical(const uint8_t pos);
+  uint8_t getSwingVertical(void) const;
+  void setSwingHorizontal(const bool on);
+  bool getSwingHorizontal(void) const;
+  static uint8_t convertMode(const stdAc::opmode_t mode);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertSwingV(const stdAc::swingv_t position);
+  static stdAc::opmode_t toCommonMode(const uint8_t mode);
+  static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint8_t pos);
+  stdAc::state_t toCommon(void) const;
+  String toString(void) const;
+#ifndef UNIT_TEST
+
+ private:
+  IRsend _irsend;  ///< Instance of the IR send class
+#else  // UNIT_TEST
+  /// @cond IGNORE
+  IRsendTest _irsend;  ///< Instance of the testing IR send class
+  /// @endcond
+#endif  // UNIT_TEST
+  PanasonicAc32Protocol _;  ///< The state in code form.
 };
 
 #endif  // IR_PANASONIC_H_

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1194,6 +1194,32 @@ TEST(TestIRac, Panasonic) {
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
+TEST(TestIRac, Panasonic32) {
+  IRPanasonicAc32 ac(kGpioUnused);
+  IRac irac(kGpioUnused);
+  IRrecv capture(kGpioUnused);
+  char expected[] =
+      "Power Toggle: On, Mode: 4 (Heat), Temp: 28C, Fan: 4 (Medium), "
+      "Swing(H): On, Swing(V): 7 (Auto)";
+
+  ac.begin();
+  irac.panasonic32(&ac,
+                 true,                        // Power
+                 stdAc::opmode_t::kHeat,      // Mode
+                 28,                          // Celsius
+                 stdAc::fanspeed_t::kMedium,  // Fan speed
+                 stdAc::swingv_t::kAuto,      // Vertical swing
+                 stdAc::swingh_t::kLeft);     // Horizontal swing
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(PANASONIC_AC32, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kPanasonicAc32Bits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+}
+
 TEST(TestIRac, Samsung) {
   IRSamsungAc ac(kGpioUnused);
   IRac irac(kGpioUnused);

--- a/test/ir_Panasonic_test.cpp
+++ b/test/ir_Panasonic_test.cpp
@@ -546,7 +546,7 @@ TEST(TestSendPanasonicAC, SendDataOnly) {
 // Tests for the IRPanasonicAc class.
 
 TEST(TestIRPanasonicAcClass, ChecksumCalculation) {
-  IRPanasonicAc pana(0);
+  IRPanasonicAc ac(kGpioUnused);
 
   const uint8_t originalstate[kPanasonicAcStateLength] = {
       0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06, 0x02,
@@ -563,10 +563,10 @@ TEST(TestIRPanasonicAcClass, ChecksumCalculation) {
   examplestate[kPanasonicAcStateLength - 1] = 0x0;  // Set incorrect checksum.
   EXPECT_FALSE(IRPanasonicAc::validChecksum(examplestate));
   EXPECT_EQ(0x83, IRPanasonicAc::calcChecksum(examplestate));
-  pana.setRaw(examplestate);
+  ac.setRaw(examplestate);
   // Extracting the state from the object should have a correct checksum.
-  EXPECT_TRUE(IRPanasonicAc::validChecksum(pana.getRaw()));
-  EXPECT_STATE_EQ(originalstate, pana.getRaw(), kPanasonicAcBits);
+  EXPECT_TRUE(IRPanasonicAc::validChecksum(ac.getRaw()));
+  EXPECT_STATE_EQ(originalstate, ac.getRaw(), kPanasonicAcBits);
   examplestate[kPanasonicAcStateLength - 1] = 0x83;  // Restore old checksum.
 
   // Change the state to force a different checksum.
@@ -576,181 +576,181 @@ TEST(TestIRPanasonicAcClass, ChecksumCalculation) {
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetPower) {
-  IRPanasonicAc pana(0);
-  pana.on();
-  EXPECT_TRUE(pana.getPower());
-  pana.off();
-  EXPECT_FALSE(pana.getPower());
-  pana.setPower(true);
-  EXPECT_TRUE(pana.getPower());
-  pana.setPower(false);
-  EXPECT_FALSE(pana.getPower());
+  IRPanasonicAc ac(kGpioUnused);
+  ac.on();
+  EXPECT_TRUE(ac.getPower());
+  ac.off();
+  EXPECT_FALSE(ac.getPower());
+  ac.setPower(true);
+  EXPECT_TRUE(ac.getPower());
+  ac.setPower(false);
+  EXPECT_FALSE(ac.getPower());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetModel) {
-  IRPanasonicAc pana(0);
-  EXPECT_EQ(kPanasonicJke, pana.getModel());
-  pana.setModel(kPanasonicDke);
-  EXPECT_EQ(kPanasonicDke, pana.getModel());
-  pana.setModel(kPanasonicLke);
-  EXPECT_EQ(kPanasonicLke, pana.getModel());
-  pana.setModel(kPanasonicNke);
-  EXPECT_EQ(kPanasonicNke, pana.getModel());
-  pana.setModel(kPanasonicUnknown);  // shouldn't change.
-  EXPECT_EQ(kPanasonicNke, pana.getModel());
-  pana.setModel((panasonic_ac_remote_model_t)255);  // shouldn't change.
-  EXPECT_EQ(kPanasonicNke, pana.getModel());
-  pana.setModel(kPanasonicJke);
-  EXPECT_EQ(kPanasonicJke, pana.getModel());
+  IRPanasonicAc ac(kGpioUnused);
+  EXPECT_EQ(kPanasonicJke, ac.getModel());
+  ac.setModel(kPanasonicDke);
+  EXPECT_EQ(kPanasonicDke, ac.getModel());
+  ac.setModel(kPanasonicLke);
+  EXPECT_EQ(kPanasonicLke, ac.getModel());
+  ac.setModel(kPanasonicNke);
+  EXPECT_EQ(kPanasonicNke, ac.getModel());
+  ac.setModel(kPanasonicUnknown);  // shouldn't change.
+  EXPECT_EQ(kPanasonicNke, ac.getModel());
+  ac.setModel((panasonic_ac_remote_model_t)255);  // shouldn't change.
+  EXPECT_EQ(kPanasonicNke, ac.getModel());
+  ac.setModel(kPanasonicJke);
+  EXPECT_EQ(kPanasonicJke, ac.getModel());
 
   // This state tickled a bug in getModel(). Should read as a JKE.
   uint8_t jkeState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06, 0x02,
                           0x20, 0xE0, 0x04, 0x00, 0x32, 0x2E, 0x80, 0xA2, 0x00,
                           0x00, 0x06, 0x60, 0x00, 0x00, 0x80, 0x00, 0x06, 0x74};
-  pana.setModel(kPanasonicDke);  // Make sure it isn't somehow set to JKE
-  pana.setRaw(jkeState);
-  EXPECT_EQ(kPanasonicJke, pana.getModel());
-  EXPECT_STATE_EQ(jkeState, pana.getRaw(), kPanasonicAcBits);
+  ac.setModel(kPanasonicDke);  // Make sure it isn't somehow set to JKE
+  ac.setRaw(jkeState);
+  EXPECT_EQ(kPanasonicJke, ac.getModel());
+  EXPECT_STATE_EQ(jkeState, ac.getRaw(), kPanasonicAcBits);
 
   // This state tickled a bug in getModel(). Should read as CKP.
   uint8_t ckpState[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06, 0x02,
                           0x20, 0xE0, 0x04, 0x00, 0x67, 0x2E, 0x80, 0xAF, 0x00,
                           0xC0, 0x6B, 0x98, 0x10, 0x00, 0x81, 0x64, 0x05, 0x87};
-  pana.setModel(kPanasonicDke);  // Make sure it isn't somehow set to CKP
-  pana.setRaw(ckpState);
-  EXPECT_EQ(kPanasonicCkp, pana.getModel());
-  EXPECT_STATE_EQ(ckpState, pana.getRaw(), kPanasonicAcBits);
+  ac.setModel(kPanasonicDke);  // Make sure it isn't somehow set to CKP
+  ac.setRaw(ckpState);
+  EXPECT_EQ(kPanasonicCkp, ac.getModel());
+  EXPECT_STATE_EQ(ckpState, ac.getRaw(), kPanasonicAcBits);
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetMode) {
-  IRPanasonicAc pana(0);
-  pana.setMode(kPanasonicAcCool);
-  pana.setTemp(21);
-  EXPECT_EQ(kPanasonicAcCool, pana.getMode());
-  pana.setMode(kPanasonicAcHeat);
-  EXPECT_EQ(kPanasonicAcHeat, pana.getMode());
-  pana.setMode(kPanasonicAcAuto);
-  EXPECT_EQ(kPanasonicAcAuto, pana.getMode());
-  pana.setMode(kPanasonicAcDry);
-  EXPECT_EQ(kPanasonicAcDry, pana.getMode());
-  EXPECT_EQ(21, pana.getTemp());  // Temp should be unchanged.
-  pana.setMode(kPanasonicAcFan);
-  EXPECT_EQ(kPanasonicAcFan, pana.getMode());
-  EXPECT_EQ(kPanasonicAcFanModeTemp, pana.getTemp());  // Temp should change.
-  pana.setMode(kPanasonicAcCool);
-  EXPECT_EQ(kPanasonicAcCool, pana.getMode());
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setMode(kPanasonicAcCool);
+  ac.setTemp(21);
+  EXPECT_EQ(kPanasonicAcCool, ac.getMode());
+  ac.setMode(kPanasonicAcHeat);
+  EXPECT_EQ(kPanasonicAcHeat, ac.getMode());
+  ac.setMode(kPanasonicAcAuto);
+  EXPECT_EQ(kPanasonicAcAuto, ac.getMode());
+  ac.setMode(kPanasonicAcDry);
+  EXPECT_EQ(kPanasonicAcDry, ac.getMode());
+  EXPECT_EQ(21, ac.getTemp());  // Temp should be unchanged.
+  ac.setMode(kPanasonicAcFan);
+  EXPECT_EQ(kPanasonicAcFan, ac.getMode());
+  EXPECT_EQ(kPanasonicAcFanModeTemp, ac.getTemp());  // Temp should change.
+  ac.setMode(kPanasonicAcCool);
+  EXPECT_EQ(kPanasonicAcCool, ac.getMode());
   // Temp should be unchanged from the last manual change.
-  EXPECT_EQ(21, pana.getTemp());
+  EXPECT_EQ(21, ac.getTemp());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetTemp) {
-  IRPanasonicAc pana(0);
-  pana.setTemp(25);
-  EXPECT_EQ(25, pana.getTemp());
-  pana.setTemp(kPanasonicAcMinTemp);
-  EXPECT_EQ(kPanasonicAcMinTemp, pana.getTemp());
-  pana.setTemp(kPanasonicAcMinTemp - 1);
-  EXPECT_EQ(kPanasonicAcMinTemp, pana.getTemp());
-  pana.setTemp(kPanasonicAcMaxTemp);
-  EXPECT_EQ(kPanasonicAcMaxTemp, pana.getTemp());
-  pana.setTemp(kPanasonicAcMaxTemp + 1);
-  EXPECT_EQ(kPanasonicAcMaxTemp, pana.getTemp());
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  ac.setTemp(kPanasonicAcMinTemp);
+  EXPECT_EQ(kPanasonicAcMinTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMinTemp - 1);
+  EXPECT_EQ(kPanasonicAcMinTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMaxTemp);
+  EXPECT_EQ(kPanasonicAcMaxTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMaxTemp + 1);
+  EXPECT_EQ(kPanasonicAcMaxTemp, ac.getTemp());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetFan) {
-  IRPanasonicAc pana(0);
-  pana.setFan(kPanasonicAcFanAuto);
-  EXPECT_EQ(kPanasonicAcFanAuto, pana.getFan());
-  pana.setFan(kPanasonicAcFanMin);
-  EXPECT_EQ(kPanasonicAcFanMin, pana.getFan());
-  pana.setFan(kPanasonicAcFanMin - 1);
-  EXPECT_EQ(kPanasonicAcFanAuto, pana.getFan());
-  pana.setFan(kPanasonicAcFanMed);
-  EXPECT_EQ(kPanasonicAcFanMed, pana.getFan());
-  pana.setFan(kPanasonicAcFanMin + 1);
-  EXPECT_EQ(kPanasonicAcFanAuto, pana.getFan());
-  pana.setFan(kPanasonicAcFanMax);
-  EXPECT_EQ(kPanasonicAcFanMax, pana.getFan());
-  pana.setFan(kPanasonicAcFanMax + 1);
-  EXPECT_EQ(kPanasonicAcFanAuto, pana.getFan());
-  pana.setFan(kPanasonicAcFanMax - 1);
-  EXPECT_EQ(kPanasonicAcFanAuto, pana.getFan());
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setFan(kPanasonicAcFanAuto);
+  EXPECT_EQ(kPanasonicAcFanAuto, ac.getFan());
+  ac.setFan(kPanasonicAcFanMin);
+  EXPECT_EQ(kPanasonicAcFanMin, ac.getFan());
+  ac.setFan(kPanasonicAcFanMin - 1);
+  EXPECT_EQ(kPanasonicAcFanAuto, ac.getFan());
+  ac.setFan(kPanasonicAcFanMed);
+  EXPECT_EQ(kPanasonicAcFanMed, ac.getFan());
+  ac.setFan(kPanasonicAcFanMin + 1);
+  EXPECT_EQ(kPanasonicAcFanAuto, ac.getFan());
+  ac.setFan(kPanasonicAcFanMax);
+  EXPECT_EQ(kPanasonicAcFanMax, ac.getFan());
+  ac.setFan(kPanasonicAcFanMax + 1);
+  EXPECT_EQ(kPanasonicAcFanAuto, ac.getFan());
+  ac.setFan(kPanasonicAcFanMax - 1);
+  EXPECT_EQ(kPanasonicAcFanAuto, ac.getFan());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetSwings) {
-  IRPanasonicAc pana(0);
+  IRPanasonicAc ac(kGpioUnused);
 
   // Vertical
-  pana.setSwingVertical(kPanasonicAcSwingVAuto);
-  EXPECT_EQ(kPanasonicAcSwingVAuto, pana.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVAuto);
+  EXPECT_EQ(kPanasonicAcSwingVAuto, ac.getSwingVertical());
 
-  pana.setSwingVertical(kPanasonicAcSwingVHighest);
-  EXPECT_EQ(kPanasonicAcSwingVHighest, pana.getSwingVertical());
-  pana.setSwingVertical(kPanasonicAcSwingVHighest - 1);
-  EXPECT_EQ(kPanasonicAcSwingVHighest, pana.getSwingVertical());
-  pana.setSwingVertical(kPanasonicAcSwingVHighest + 1);
-  EXPECT_EQ(kPanasonicAcSwingVHighest + 1, pana.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVHighest);
+  EXPECT_EQ(kPanasonicAcSwingVHighest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVHighest - 1);
+  EXPECT_EQ(kPanasonicAcSwingVHighest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVHighest + 1);
+  EXPECT_EQ(kPanasonicAcSwingVHighest + 1, ac.getSwingVertical());
 
-  pana.setSwingVertical(kPanasonicAcSwingVLowest);
-  EXPECT_EQ(kPanasonicAcSwingVLowest, pana.getSwingVertical());
-  pana.setSwingVertical(kPanasonicAcSwingVLowest + 1);
-  EXPECT_EQ(kPanasonicAcSwingVLowest, pana.getSwingVertical());
-  pana.setSwingVertical(kPanasonicAcSwingVLowest - 1);
-  EXPECT_EQ(kPanasonicAcSwingVLowest - 1, pana.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVLowest);
+  EXPECT_EQ(kPanasonicAcSwingVLowest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVLowest + 1);
+  EXPECT_EQ(kPanasonicAcSwingVLowest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVLowest - 1);
+  EXPECT_EQ(kPanasonicAcSwingVLowest - 1, ac.getSwingVertical());
 
-  pana.setSwingVertical(kPanasonicAcSwingVAuto);
-  EXPECT_EQ(kPanasonicAcSwingVAuto, pana.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVAuto);
+  EXPECT_EQ(kPanasonicAcSwingVAuto, ac.getSwingVertical());
 
   // Horizontal is model dependant.
-  pana.setModel(kPanasonicNke);  // NKE is always fixed in the middle.
-  EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
-  pana.setSwingHorizontal(kPanasonicAcSwingHAuto);
-  EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
+  ac.setModel(kPanasonicNke);  // NKE is always fixed in the middle.
+  EXPECT_EQ(kPanasonicAcSwingHMiddle, ac.getSwingHorizontal());
+  ac.setSwingHorizontal(kPanasonicAcSwingHAuto);
+  EXPECT_EQ(kPanasonicAcSwingHMiddle, ac.getSwingHorizontal());
 
-  pana.setModel(kPanasonicJke);  // JKE has no H swing.
-  EXPECT_EQ(0, pana.getSwingHorizontal());
-  pana.setSwingHorizontal(kPanasonicAcSwingHMiddle);
-  EXPECT_EQ(0, pana.getSwingHorizontal());
+  ac.setModel(kPanasonicJke);  // JKE has no H swing.
+  EXPECT_EQ(0, ac.getSwingHorizontal());
+  ac.setSwingHorizontal(kPanasonicAcSwingHMiddle);
+  EXPECT_EQ(0, ac.getSwingHorizontal());
 
-  pana.setModel(kPanasonicLke);  // LKE is always fixed in the middle.
-  EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
-  pana.setSwingHorizontal(kPanasonicAcSwingHAuto);
-  EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
+  ac.setModel(kPanasonicLke);  // LKE is always fixed in the middle.
+  EXPECT_EQ(kPanasonicAcSwingHMiddle, ac.getSwingHorizontal());
+  ac.setSwingHorizontal(kPanasonicAcSwingHAuto);
+  EXPECT_EQ(kPanasonicAcSwingHMiddle, ac.getSwingHorizontal());
 
-  pana.setModel(kPanasonicDke);  // DKE has full control.
-  ASSERT_EQ(kPanasonicDke, pana.getModel());
+  ac.setModel(kPanasonicDke);  // DKE has full control.
+  ASSERT_EQ(kPanasonicDke, ac.getModel());
   // Auto was last requested.
-  EXPECT_EQ(kPanasonicAcSwingHAuto, pana.getSwingHorizontal());
-  pana.setSwingHorizontal(kPanasonicAcSwingHLeft);
-  EXPECT_EQ(kPanasonicAcSwingHLeft, pana.getSwingHorizontal());
+  EXPECT_EQ(kPanasonicAcSwingHAuto, ac.getSwingHorizontal());
+  ac.setSwingHorizontal(kPanasonicAcSwingHLeft);
+  EXPECT_EQ(kPanasonicAcSwingHLeft, ac.getSwingHorizontal());
   // Changing models from DKE to something else, then back should not change
   // the intended swing.
-  pana.setModel(kPanasonicLke);
-  EXPECT_EQ(kPanasonicAcSwingHMiddle, pana.getSwingHorizontal());
-  pana.setModel(kPanasonicDke);
-  EXPECT_EQ(kPanasonicAcSwingHLeft, pana.getSwingHorizontal());
+  ac.setModel(kPanasonicLke);
+  EXPECT_EQ(kPanasonicAcSwingHMiddle, ac.getSwingHorizontal());
+  ac.setModel(kPanasonicDke);
+  EXPECT_EQ(kPanasonicAcSwingHLeft, ac.getSwingHorizontal());
 }
 
 TEST(TestIRPanasonicAcClass, QuietAndPowerful) {
-  IRPanasonicAc pana(0);
-  pana.setQuiet(false);
-  EXPECT_FALSE(pana.getQuiet());
-  pana.setQuiet(true);
-  EXPECT_TRUE(pana.getQuiet());
-  EXPECT_FALSE(pana.getPowerful());
-  pana.setPowerful(false);
-  EXPECT_FALSE(pana.getPowerful());
-  EXPECT_TRUE(pana.getQuiet());
-  pana.setPowerful(true);
-  EXPECT_TRUE(pana.getPowerful());
-  EXPECT_FALSE(pana.getQuiet());
-  pana.setPowerful(false);
-  EXPECT_FALSE(pana.getPowerful());
-  EXPECT_FALSE(pana.getQuiet());
-  pana.setPowerful(true);
-  pana.setQuiet(true);
-  EXPECT_TRUE(pana.getQuiet());
-  EXPECT_FALSE(pana.getPowerful());
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setQuiet(false);
+  EXPECT_FALSE(ac.getQuiet());
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
+  EXPECT_FALSE(ac.getPowerful());
+  ac.setPowerful(false);
+  EXPECT_FALSE(ac.getPowerful());
+  EXPECT_TRUE(ac.getQuiet());
+  ac.setPowerful(true);
+  EXPECT_TRUE(ac.getPowerful());
+  EXPECT_FALSE(ac.getQuiet());
+  ac.setPowerful(false);
+  EXPECT_FALSE(ac.getPowerful());
+  EXPECT_FALSE(ac.getQuiet());
+  ac.setPowerful(true);
+  ac.setQuiet(true);
+  EXPECT_TRUE(ac.getQuiet());
+  EXPECT_FALSE(ac.getPowerful());
 }
 
 TEST(TestIRPanasonicAcClass, SetAndGetIon) {
@@ -774,39 +774,39 @@ TEST(TestIRPanasonicAcClass, SetAndGetIon) {
 }
 
 TEST(TestIRPanasonicAcClass, HumanReadable) {
-  IRPanasonicAc pana(0);
+  IRPanasonicAc ac(kGpioUnused);
   EXPECT_EQ(
       "Model: 4 (JKE), Power: Off, Mode: 0 (Auto), Temp: 0C, "
       "Fan: 253 (UNKNOWN), Swing(V): 0 (UNKNOWN), Quiet: Off, "
       "Powerful: Off, Clock: 00:00, On Timer: Off, Off Timer: Off",
-      pana.toString());
-  pana.setPower(true);
-  pana.setTemp(kPanasonicAcMaxTemp);
-  pana.setMode(kPanasonicAcHeat);
-  pana.setFan(kPanasonicAcFanMax);
-  pana.setSwingVertical(kPanasonicAcSwingVAuto);
-  pana.setPowerful(true);
+      ac.toString());
+  ac.setPower(true);
+  ac.setTemp(kPanasonicAcMaxTemp);
+  ac.setMode(kPanasonicAcHeat);
+  ac.setFan(kPanasonicAcFanMax);
+  ac.setSwingVertical(kPanasonicAcSwingVAuto);
+  ac.setPowerful(true);
   EXPECT_EQ(
       "Model: 4 (JKE), Power: On, Mode: 4 (Heat), Temp: 30C, "
       "Fan: 4 (High), Swing(V): 15 (Auto), Quiet: Off, "
       "Powerful: On, Clock: 00:00, On Timer: Off, Off Timer: Off",
-      pana.toString());
-  pana.setQuiet(true);
-  pana.setModel(kPanasonicLke);
+      ac.toString());
+  ac.setQuiet(true);
+  ac.setModel(kPanasonicLke);
   EXPECT_EQ(
       "Model: 1 (LKE), Power: Off, Mode: 4 (Heat), Temp: 30C, "
       "Fan: 4 (High), Swing(V): 15 (Auto), "
       "Swing(H): 6 (Middle), Quiet: On, Powerful: Off, "
       "Clock: 00:00, On Timer: 00:00, Off Timer: Off",
-      pana.toString());
-  pana.setModel(kPanasonicDke);
-  pana.setSwingHorizontal(kPanasonicAcSwingHRight);
+      ac.toString());
+  ac.setModel(kPanasonicDke);
+  ac.setSwingHorizontal(kPanasonicAcSwingHRight);
   EXPECT_EQ(
       "Model: 3 (DKE), Power: Off, Mode: 4 (Heat), Temp: 30C, "
       "Fan: 4 (High), Swing(V): 15 (Auto), "
       "Swing(H): 11 (Right), Quiet: On, Powerful: Off, Ion: Off, "
       "Clock: 00:00, On Timer: Off, Off Timer: Off",
-      pana.toString());
+      ac.toString());
 }
 
 // Tests for decodePanasonicAC().
@@ -969,15 +969,15 @@ TEST(TestDecodePanasonicAC, Issue540) {
   EXPECT_EQ(kPanasonicAcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);
-  IRPanasonicAc pana(0);
-  pana.setRaw(irsend.capture.state);
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setRaw(irsend.capture.state);
   // TODO(crankyoldgit): Try to figure out what model this should be.
   EXPECT_EQ(
       "Model: 0 (UNKNOWN), Power: On, Mode: 3 (Cool), Temp: 26C, "
       "Fan: 7 (Auto), Swing(V): 15 (Auto), "
       "Swing(H): 13 (Auto), Quiet: Off, Powerful: Off, "
       "Clock: 00:00, On Timer: Off, Off Timer: Off",
-      pana.toString());
+      ac.toString());
 }
 
 TEST(TestIRPanasonicAcClass, TimeBasics) {
@@ -993,72 +993,72 @@ TEST(TestIRPanasonicAcClass, TimeBasics) {
 }
 
 TEST(TestIRPanasonicAcClass, TimersAndClock) {
-  IRPanasonicAc pana(0);
+  IRPanasonicAc ac(kGpioUnused);
   // Data from Issue #544
   uint8_t state[27] = {0x02, 0x20, 0xE0, 0x04, 0x00, 0x00, 0x00, 0x06, 0x02,
                        0x20, 0xE0, 0x04, 0x00, 0x4E, 0x2E, 0x80, 0xAF, 0x00,
                        0xCA, 0x6B, 0x98, 0x10, 0x00, 0x01, 0x48, 0x04, 0xDB};
-  pana.setRaw(state);
-  EXPECT_TRUE(pana.isOnTimerEnabled());
-  EXPECT_EQ(0x3CA, pana.getOnTimer());
-  EXPECT_TRUE(pana.isOffTimerEnabled());
-  EXPECT_EQ(0x186, pana.getOffTimer());
-  EXPECT_EQ(0x448, pana.getClock());
+  ac.setRaw(state);
+  EXPECT_TRUE(ac.isOnTimerEnabled());
+  EXPECT_EQ(0x3CA, ac.getOnTimer());
+  EXPECT_TRUE(ac.isOffTimerEnabled());
+  EXPECT_EQ(0x186, ac.getOffTimer());
+  EXPECT_EQ(0x448, ac.getClock());
 
-  pana.cancelOnTimer();
-  EXPECT_FALSE(pana.isOnTimerEnabled());
-  EXPECT_EQ(0, pana.getOnTimer());
-  EXPECT_TRUE(pana.isOffTimerEnabled());
-  EXPECT_EQ(0x186, pana.getOffTimer());
-  EXPECT_EQ(0x448, pana.getClock());
+  ac.cancelOnTimer();
+  EXPECT_FALSE(ac.isOnTimerEnabled());
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_TRUE(ac.isOffTimerEnabled());
+  EXPECT_EQ(0x186, ac.getOffTimer());
+  EXPECT_EQ(0x448, ac.getClock());
 
-  pana.cancelOffTimer();
-  EXPECT_FALSE(pana.isOnTimerEnabled());
-  EXPECT_EQ(0, pana.getOnTimer());
-  EXPECT_FALSE(pana.isOffTimerEnabled());
-  EXPECT_EQ(0, pana.getOffTimer());
-  EXPECT_EQ(0x448, pana.getClock());
+  ac.cancelOffTimer();
+  EXPECT_FALSE(ac.isOnTimerEnabled());
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_FALSE(ac.isOffTimerEnabled());
+  EXPECT_EQ(0, ac.getOffTimer());
+  EXPECT_EQ(0x448, ac.getClock());
 
-  pana.setOnTimer(7 * 60 + 50);
-  EXPECT_TRUE(pana.isOnTimerEnabled());
-  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
-  EXPECT_FALSE(pana.isOffTimerEnabled());
-  EXPECT_EQ(0, pana.getOffTimer());
-  EXPECT_EQ(0x448, pana.getClock());
+  ac.setOnTimer(7 * 60 + 50);
+  EXPECT_TRUE(ac.isOnTimerEnabled());
+  EXPECT_EQ(7 * 60 + 50, ac.getOnTimer());
+  EXPECT_FALSE(ac.isOffTimerEnabled());
+  EXPECT_EQ(0, ac.getOffTimer());
+  EXPECT_EQ(0x448, ac.getClock());
 
-  pana.setOnTimer(7 * 60 + 57);  // It should round down.
-  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
-  pana.setOnTimer(28 * 60);  // It should round down.
-  EXPECT_EQ(kPanasonicAcTimeMax - 9, pana.getOnTimer());
-  pana.setOnTimer(kPanasonicAcTimeSpecial);
-  EXPECT_EQ(0, pana.getOnTimer());
+  ac.setOnTimer(7 * 60 + 57);  // It should round down.
+  EXPECT_EQ(7 * 60 + 50, ac.getOnTimer());
+  ac.setOnTimer(28 * 60);  // It should round down.
+  EXPECT_EQ(kPanasonicAcTimeMax - 9, ac.getOnTimer());
+  ac.setOnTimer(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, ac.getOnTimer());
 
-  pana.setOnTimer(7 * 60 + 50);
-  pana.setOffTimer(19 * 60 + 30);
+  ac.setOnTimer(7 * 60 + 50);
+  ac.setOffTimer(19 * 60 + 30);
 
-  EXPECT_TRUE(pana.isOnTimerEnabled());
-  EXPECT_EQ(7 * 60 + 50, pana.getOnTimer());
-  EXPECT_TRUE(pana.isOffTimerEnabled());
-  EXPECT_EQ(19 * 60 + 30, pana.getOffTimer());
-  EXPECT_EQ(0x448, pana.getClock());
+  EXPECT_TRUE(ac.isOnTimerEnabled());
+  EXPECT_EQ(7 * 60 + 50, ac.getOnTimer());
+  EXPECT_TRUE(ac.isOffTimerEnabled());
+  EXPECT_EQ(19 * 60 + 30, ac.getOffTimer());
+  EXPECT_EQ(0x448, ac.getClock());
 
-  pana.setOffTimer(19 * 60 + 57);  // It should round down.
-  EXPECT_EQ(19 * 60 + 50, pana.getOffTimer());
-  pana.setOffTimer(28 * 60);  // It should round down.
-  EXPECT_EQ(kPanasonicAcTimeMax - 9, pana.getOffTimer());
-  pana.setOffTimer(kPanasonicAcTimeSpecial);
-  EXPECT_EQ(0, pana.getOffTimer());
+  ac.setOffTimer(19 * 60 + 57);  // It should round down.
+  EXPECT_EQ(19 * 60 + 50, ac.getOffTimer());
+  ac.setOffTimer(28 * 60);  // It should round down.
+  EXPECT_EQ(kPanasonicAcTimeMax - 9, ac.getOffTimer());
+  ac.setOffTimer(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, ac.getOffTimer());
 
-  pana.setClock(0);
-  EXPECT_EQ(0, pana.getClock());
-  pana.setClock(kPanasonicAcTimeMax);
-  EXPECT_EQ(kPanasonicAcTimeMax, pana.getClock());
-  pana.setClock(kPanasonicAcTimeMax - 1);
-  EXPECT_EQ(kPanasonicAcTimeMax - 1, pana.getClock());
-  pana.setClock(kPanasonicAcTimeMax + 1);
-  EXPECT_EQ(kPanasonicAcTimeMax, pana.getClock());
-  pana.setClock(kPanasonicAcTimeSpecial);
-  EXPECT_EQ(0, pana.getClock());
+  ac.setClock(0);
+  EXPECT_EQ(0, ac.getClock());
+  ac.setClock(kPanasonicAcTimeMax);
+  EXPECT_EQ(kPanasonicAcTimeMax, ac.getClock());
+  ac.setClock(kPanasonicAcTimeMax - 1);
+  EXPECT_EQ(kPanasonicAcTimeMax - 1, ac.getClock());
+  ac.setClock(kPanasonicAcTimeMax + 1);
+  EXPECT_EQ(kPanasonicAcTimeMax, ac.getClock());
+  ac.setClock(kPanasonicAcTimeSpecial);
+  EXPECT_EQ(0, ac.getClock());
 }
 
 // Decode a real short Panasonic AC message
@@ -1150,25 +1150,25 @@ TEST(TestDecodePanasonicAC, CkpModelSpecifics) {
   EXPECT_STATE_EQ(ckpPowerfulOn, irsend.capture.state, irsend.capture.bits);
   EXPECT_FALSE(irsend.capture.repeat);
 
-  IRPanasonicAc pana(0);
-  pana.setRaw(irsend.capture.state);
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Model: 5 (CKP), Power: Off, Mode: 4 (Heat), Temp: 23C, "
       "Fan: 7 (Auto), Swing(V): 15 (Auto), Quiet: Off, "
       "Powerful: On, Clock: 00:00, On Timer: 00:00, Off Timer: 00:00",
-      pana.toString());
+      ac.toString());
 
-  pana.setQuiet(true);
-  EXPECT_FALSE(pana.getPowerful());
-  EXPECT_TRUE(pana.getQuiet());
-  EXPECT_EQ(kPanasonicCkp, pana.getModel());
-  EXPECT_STATE_EQ(ckpQuietOn, pana.getRaw(), kPanasonicAcBits);
+  ac.setQuiet(true);
+  EXPECT_FALSE(ac.getPowerful());
+  EXPECT_TRUE(ac.getQuiet());
+  EXPECT_EQ(kPanasonicCkp, ac.getModel());
+  EXPECT_STATE_EQ(ckpQuietOn, ac.getRaw(), kPanasonicAcBits);
 
-  pana.setPowerful(true);
-  EXPECT_TRUE(pana.getPowerful());
-  EXPECT_FALSE(pana.getQuiet());
-  EXPECT_EQ(kPanasonicCkp, pana.getModel());
-  EXPECT_STATE_EQ(ckpPowerfulOn, pana.getRaw(), kPanasonicAcBits);
+  ac.setPowerful(true);
+  EXPECT_TRUE(ac.getPowerful());
+  EXPECT_FALSE(ac.getQuiet());
+  EXPECT_EQ(kPanasonicCkp, ac.getModel());
+  EXPECT_STATE_EQ(ckpPowerfulOn, ac.getRaw(), kPanasonicAcBits);
 }
 
 TEST(TestIRPanasonicAcClass, toCommon) {
@@ -1341,9 +1341,11 @@ TEST(TestDecodePanasonicAC32, RealMessage) {
   EXPECT_FALSE(irsend.capture.repeat);
 
   EXPECT_EQ(
-      "", IRAcUtils::resultAcToString(&irsend.capture));
+      "Temp: 17C, Mode: 5 (UNKNOWN), Fan: 15 (Auto), "
+      "Swing(H): On, Swing(V): 7 (Auto)",
+      IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
-  ASSERT_FALSE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
+  ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
 }
 
 // Decode a synthetic Panasonic AC 32 bit message
@@ -1470,4 +1472,102 @@ TEST(TestDecodePanasonicAC32, SyntheticShortMessage) {
       "m3543s3450"
       "m920s13946",
       irsend.outputStr());
+}
+
+TEST(TestIRPanasonicAc32Class, SetAndGetFan) {
+  IRPanasonicAc32 ac(kGpioUnused);
+  ac.setFan(kPanasonicAc32FanAuto);
+  EXPECT_EQ(kPanasonicAc32FanAuto, ac.getFan());
+  ac.setFan(kPanasonicAc32FanMin);
+  EXPECT_EQ(kPanasonicAc32FanMin, ac.getFan());
+  ac.setFan(kPanasonicAc32FanMin - 1);
+  EXPECT_EQ(kPanasonicAc32FanAuto, ac.getFan());
+  ac.setFan(kPanasonicAc32FanMed);
+  EXPECT_EQ(kPanasonicAc32FanMed, ac.getFan());
+  ac.setFan(kPanasonicAc32FanMax);
+  EXPECT_EQ(kPanasonicAc32FanMax, ac.getFan());
+  ac.setFan(kPanasonicAc32FanMax + 1);
+  EXPECT_EQ(kPanasonicAc32FanAuto, ac.getFan());
+}
+
+TEST(TestIRPanasonicAc32Class, SetAndGetMode) {
+  IRPanasonicAc32 ac(kGpioUnused);
+  ac.setMode(kPanasonicAc32Cool);
+  EXPECT_EQ(kPanasonicAc32Cool, ac.getMode());
+  ac.setMode(kPanasonicAc32Heat);
+  EXPECT_EQ(kPanasonicAc32Heat, ac.getMode());
+  ac.setMode(kPanasonicAc32Auto);
+  EXPECT_EQ(kPanasonicAc32Auto, ac.getMode());
+  ac.setMode(kPanasonicAc32Dry);
+  EXPECT_EQ(kPanasonicAc32Dry, ac.getMode());
+  ac.setMode(kPanasonicAcFan);
+  EXPECT_EQ(kPanasonicAcFan, ac.getMode());
+  ac.setMode(255);
+  EXPECT_EQ(kPanasonicAc32Auto, ac.getMode());
+}
+
+TEST(TestIRPanasonicAc32Class, SetAndGetTemp) {
+  IRPanasonicAc ac(kGpioUnused);
+  ac.setTemp(25);
+  EXPECT_EQ(25, ac.getTemp());
+  ac.setTemp(kPanasonicAcMinTemp);
+  EXPECT_EQ(kPanasonicAcMinTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMinTemp - 1);
+  EXPECT_EQ(kPanasonicAcMinTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMaxTemp);
+  EXPECT_EQ(kPanasonicAcMaxTemp, ac.getTemp());
+  ac.setTemp(kPanasonicAcMaxTemp + 1);
+  EXPECT_EQ(kPanasonicAcMaxTemp, ac.getTemp());
+}
+
+TEST(TestIRPanasonicAc32Class, SetAndGetSwings) {
+  IRPanasonicAc32 ac(kGpioUnused);
+
+  // Horizontal
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+  ac.setSwingHorizontal(false);
+  EXPECT_FALSE(ac.getSwingHorizontal());
+  ac.setSwingHorizontal(true);
+  EXPECT_TRUE(ac.getSwingHorizontal());
+
+  // Vertical
+  ac.setSwingVertical(kPanasonicAc32SwingVAuto);
+  EXPECT_EQ(kPanasonicAc32SwingVAuto, ac.getSwingVertical());
+
+  ac.setSwingVertical(kPanasonicAcSwingVHighest);
+  EXPECT_EQ(kPanasonicAcSwingVHighest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVHighest - 1);
+  EXPECT_EQ(kPanasonicAcSwingVHighest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVHighest + 1);
+  EXPECT_EQ(kPanasonicAcSwingVHighest + 1, ac.getSwingVertical());
+
+  ac.setSwingVertical(kPanasonicAcSwingVLowest);
+  EXPECT_EQ(kPanasonicAcSwingVLowest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVLowest + 1);
+  EXPECT_EQ(kPanasonicAcSwingVLowest, ac.getSwingVertical());
+  ac.setSwingVertical(kPanasonicAcSwingVLowest - 1);
+  EXPECT_EQ(kPanasonicAcSwingVLowest - 1, ac.getSwingVertical());
+
+  ac.setSwingVertical(kPanasonicAc32SwingVAuto);
+  EXPECT_EQ(kPanasonicAc32SwingVAuto, ac.getSwingVertical());
+}
+
+TEST(TestIRPanasonicAc32Class, HumanReadable) {
+  IRPanasonicAc32 ac(kGpioUnused);
+
+  EXPECT_EQ(
+      "Temp: 16C, Mode: 2 (Cool), Fan: 15 (Auto), "
+      "Swing(H): On, Swing(V): 7 (Auto)",
+      ac.toString());
+
+  ac.setMode(kPanasonicAc32Heat);
+  ac.setTemp(24);
+  ac.setFan(kPanasonicAc32FanMed);
+  ac.setSwingHorizontal(false);
+  ac.setSwingVertical(kPanasonicAcSwingVLowest);
+  EXPECT_EQ(
+      "Temp: 24C, Mode: 4 (Heat), Fan: 4 (Medium), "
+      "Swing(H): Off, Swing(V): 5 (Lowest)",
+      ac.toString());
 }


### PR DESCRIPTION
* Add set/get support for:
  - Power Toggle
  - Mode
  - Temp
  - Fan Speed
  - Swing V & Swing H
* Add `IRac` class support for new changes.
* Unit test coverage for the above.
* Fix `#if` clause in `IRPanasonicAc` class.
* Extend `irutils::addFanToString()` to have an option for max.
* General code clean-up.

Note: 16 bit message settings are NOT supported.

Fixes #1364
