### PR TITLE
Yamaha protocol

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -731,6 +731,12 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
       return true;
 #endif
   */
+#if DECODE_YAMAHA
+	// Yamaha utilises a modified NEC spec for some of its commands.
+	// These special cases can be caught before hitting the general NEC-like decoder.
+	DPRINTLN("Attempting Yamaha decode");
+	if (decodeYamaha(results, offset)) return true;
+#endif  // DECODE_YAMAHA
 #if DECODE_NEC
     // Some devices send NEC-like codes that don't follow the true NEC spec.
     // This should detect those. e.g. Apple TV remote etc.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -707,6 +707,10 @@ class IRrecv {
                           const uint16_t nbits = kEliteScreensBits,
                           const bool strict = true);
 #endif  // DECODE_ELITESCREENS
+#if DECODE_YAMAHA
+bool decodeYamaha(decode_results *results, uint16_t offset,
+                  const uint16_t nbits = kYamahaBits, const bool strict = true);
+#endif  // DECODE_YAMAHA
 };
 
 #endif  // IRRECV_H_

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -37,6 +37,7 @@
  * Vestel AC code by Erdem U. Altınyurt
  * Teco AC code by Fabien Valthier (hcoohb)
  * Mitsubishi 112 AC Code by kuchel77
+ * Yamaha extension to NEC code by DragRedSim
  *
  *  GPL license, all text above must be included in any redistribution
  ****************************************************/
@@ -719,6 +720,13 @@
 #define SEND_ELITESCREENS      _IR_ENABLE_DEFAULT_
 #endif  // SEND_ELITESCREENS
 
+#ifndef DECODE_YAMAHA
+#define DECODE_YAMAHA            _IR_ENABLE_DEFAULT_
+#endif  // DECODE_YAMAHA
+#ifndef SEND_YAMAHA
+#define SEND_YAMAHA               _IR_ENABLE_DEFAULT_
+#endif  // SEND_YAMAHA
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
@@ -867,8 +875,10 @@ enum decode_type_t {
   MIRAGE,
   ELITESCREENS,  // 95
   PANASONIC_AC32,
+  YAMAHA,
   // Add new entries before this one, and update it to point to the last entry.
-  kLastDecodeType = PANASONIC_AC32,
+  kLastDecodeType = YAMAHA,
+
 };
 
 // Message lengths & required repeat values
@@ -1092,6 +1102,7 @@ const uint16_t kWhynterBits = 32;
 const uint8_t  kVestelAcBits = 56;
 const uint16_t kZepealBits = 16;
 const uint16_t kZepealMinRepeat = 4;
+const uint16_t kYamahaBits = 32;
 const uint16_t kVoltasBits = 80;
 const uint16_t kVoltasStateLength = 10;
 

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -643,6 +643,7 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
     case SAMSUNG:
     case SHERWOOD:
     case WHYNTER:
+	case YAMAHA:
       return 32;
     case AIRWELL:
       return 34;
@@ -1011,12 +1012,17 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
     case VESTEL_AC:
       sendVestelAc(data, nbits, min_repeat);
       break;
-#endif
+#endif  // SEND_VESTEL_AC
 #if SEND_WHYNTER
     case WHYNTER:
       sendWhynter(data, nbits, min_repeat);
       break;
-#endif
+#endif  // SEND_WHYNTER
+#if SEND_YAMAHA
+	case YAMAHA:
+	  sendYamaha(data, nbits, min_repeat);
+	  break;
+#endif  // SEND_YAMAHA
 #if SEND_ZEPEAL
     case ZEPEAL:
       sendZepeal(data, nbits, min_repeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -682,6 +682,13 @@ class IRsend {
                         const uint16_t nbits = kEliteScreensBits,
                         const uint16_t repeat = kEliteScreensDefaultRepeat);
 #endif  // SEND_ELITESCREENS
+#if SEND_YAMAHA
+  void sendYamaha(uint64_t data, uint16_t nbits = kYamahaBits,
+               uint16_t repeat = kNoRepeat);
+  uint32_t encodeYamaha(uint16_t address, uint16_t command);
+  uint32_t encodeYamaha(uint32_t yamahaCode);
+  uint32_t encodeYamaha(uint16_t address, uint8_t command, bool altCommand, bool remoteID);
+#endif  // SEND_YAMAHA  
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -278,5 +278,6 @@ const PROGMEM char *kAllProtocolNamesStr =
     D_STR_MIRAGE "\x0"
     D_STR_ELITESCREENS "\x0"
     D_STR_PANASONIC_AC32 "\x0"
+	D_STR_YAMAHA "\x0"
     ///< New protocol strings should be added just above this line.
     "\x0";  ///< This string requires double null termination.

--- a/src/ir_Yamaha.cpp
+++ b/src/ir_Yamaha.cpp
@@ -1,0 +1,192 @@
+// Copyright 2009 Ken Shirriff
+// Copyright 2017 David Conran
+
+/// @file
+/// @brief Support for Yamaha extensions to (Renesas) protocols.
+/// NEC originally added from https://github.com/shirriff/Arduino-IRremote/
+/// @see http://www.sbprojects.com/knowledge/ir/nec.php
+
+//Requires SEND_NEC to be available as an upstream capability for broadcasting.
+#define __STDC_LIMIT_MACROS
+#include "ir_NEC.h"
+#include <stdint.h>
+#include <algorithm>
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRutils.h"
+
+
+#if (SEND_YAMAHA)
+
+/// Send a raw Yamaha formatted message.
+/// This simply calls the sendNEC(), as the format is identical; only the actual code sent differs, in that it uses modified inversions in the final byte to add extra commands.
+/// Status: STABLE / Known working.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+/// @note This protocol appears to have no header.
+/// @see http://www.sbprojects.com/knowledge/ir/nec.php
+void IRsend::sendYamaha(uint64_t data, uint16_t nbits, uint16_t repeat) {
+  sendNEC(data, nbits, repeat)
+}
+
+/// Calculate the raw Yamaha data based on address and command.
+/// Status: STABLE / Expected to work.
+/// @param[in] address An address value. Yamaha utilises normal NEC address values.
+/// @param[in] command A 16-bit command value, as defined by the published Yamaha codes. This includes the modified inversion of the command code; the modifications include a further inverted 0x1 for the second remote control, and a further inverted 0x80 for the alternate task.
+/// @return A raw 32-bit NEC message suitable for use with `sendNEC()`.
+/// @see http://www.sbprojects.com/knowledge/ir/nec.php
+uint32_t IRsend::encodeYamaha(uint16_t address, uint16_t command) {
+  command &= 0xFFFF;  // Yamaha commands are two bytes, with the second byte being a potentially modified inversion of the first.
+  // sendNEC() sends MSB first, but protocol says this is LSB first.
+  uint16_t commandHigh = (command>>8) & 0xFF;
+  commandHigh = reverseBits(commandHigh, 8);
+  uint16_t commandLow = command & 0xFF;
+  commandLow = reverseBits(commandLow, 8);
+
+  if (address > 0xFF) {                         // Is it Extended NEC?
+    address = reverseBits(address, 16);
+    return ((address << 16) + (commandHigh << 8) + commandLow);  // Extended.
+  } else {
+    address = reverseBits(address, 8);
+    return (address << 24) + ((address ^ 0xFF) << 16) + (commandHigh << 8) + commandLow;  // Normal.
+  }
+}
+
+/// Calculate the raw Yamaha data based on a code in the published Yamaha format.
+/// Status: STABLE / Expected to work.
+/// @param[in] yamahaCode A code as documented by Yamaha. This includes the address and command, along with any modifications in the lower byte.
+/// @return A raw 32-bit NEC message suitable for use with `sendNEC()`.
+uint32_t IRsend::encodeYamaha(uint32_t yamahaCode) {
+	uint16_t addressHigh = (yamahaCode >> 24) & 0xFF; //high 16 bytes are an NEC address. Parity is not checked or calculated, as the low byte is defined as part of the code.
+	addressHigh = reverseBits(addressHigh, 8)
+	uint16_t addressLow = (yamahaCode >> 16) & 0xFF;
+	addressLow = reverseBits(addressLow, 8)
+	uint32_t command = yamahaCode & 0xFFFF; // low 16 bits are the command, including address bit flip and command bit flip.
+	uint16_t commandHigh = (command >> 8) & 0xFF;
+	commandHigh = reverseBits(commandHigh, 8);
+	uint16_t commandLow = command & 0xFF;
+	commandLow = reverseBits(commandLow, 8);
+	
+	return (addressHigh << 24) + (addressLow << 16) + (commandHigh << 8) + commandLow;
+}
+
+/// Calculate the raw Yamaha data based on a command
+/// Status: BETA / Expected to work, but could be incorrect per testing.
+/// @param[in] address An address value. Yamaha utilises normal NEC address values.
+/// @param[in] command A one-byte command
+/// @param[in] altCommand Whether to use the alternate command option; certain commands utilise this
+/// @param[in] remoteID The remote ID to emulate; determines part of the breaks in parity. Set false to use ID 1; set true to use ID 2. 
+/// @return A raw 32-bit message suitable for use with `sendYamaha()`.
+uint32_t IRsend::encodeYamaha(uint16_t address, uint8_t command, bool altCommand, bool remoteID) {
+	//All extra commands act upon the low byte of the command
+	uint16_t commandHigh = command & 0xFF;
+	commandHigh = reverseBits(commandHigh, 8);
+	uint16_t commandLow = commandHigh ^ 0xFF; //true parity at this point
+	if (remoteID == true) {
+		commandLow = commandLow ^ 0x80; // alter high bit for remote ID, since we've already gone to LSB order
+	}
+	if (altCommand == true) {
+		commandLow = commandLow ^ 0x01; //alter low bit, since we've already gone to LSB order
+	}
+	
+  if (address > 0xFF) {                         // Is it Extended NEC?
+    address = reverseBits(address, 16);
+    return ((address << 16) + (commandHigh << 8) + commandLow);  // Extended.
+  } else {
+    address = reverseBits(address, 8);
+    return (address << 24) + ((address ^ 0xFF) << 16) + (commandHigh << 8) + commandLow;  // Normal.
+  }
+}
+#endif  // (SEND_YAMAHA)
+
+#if (DECODE_YAMAHA)
+/// Decode the supplied Yamaha message.
+/// Status: STABLE / Known good.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
+/// @note NEC protocol has three variants/forms.
+///   Normal:   an 8 bit address & an 8 bit command in 32 bit data form.
+///             i.e. address + inverted(address) + command + inverted(command)
+///   Extended: a 16 bit address & an 8 bit command in 32 bit data form.
+///             i.e. address + command + inverted(command)
+///   Yamaha:   an address (either normal or extended) and an 8-bit command, with potentially incorrect parity.
+///             i.e. address + command + alteredinverted(command)
+///   Repeat:   a 0-bit code. i.e. No data bits. Just the header + footer.
+/// @see http://www.sbprojects.com/knowledge/ir/nec.php
+bool IRrecv::decodeYamaha(decode_results *results, uint16_t offset,
+                       const uint16_t nbits, const bool strict) {
+  if (results->rawlen < kNecRptLength + offset - 1)
+    return false;  // Can't possibly be a valid NEC message.
+  if (strict && nbits != kNECBits)
+    return false;  // Not strictly an NEC message.
+
+  uint64_t data = 0;
+
+  // Header - All NEC messages have this Header Mark.
+  if (!matchMark(results->rawbuf[offset++], kNecHdrMark)) return false;
+  // Check if it is a repeat code.
+  if (matchSpace(results->rawbuf[offset], kNecRptSpace) &&
+      matchMark(results->rawbuf[offset + 1], kNecBitMark) &&
+      (offset + 2 <= results->rawlen ||
+       matchAtLeast(results->rawbuf[offset + 2], kNecMinGap))) {
+    results->value = kRepeat;
+    results->decode_type = YAMAHA;
+    results->bits = 0;
+    results->address = 0;
+    results->command = 0;
+    results->repeat = true;
+    return true;
+  }
+
+  // Match Header (cont.) + Data + Footer
+  if (!matchGeneric(results->rawbuf + offset, &data,
+                    results->rawlen - offset, nbits,
+                    0, kNecHdrSpace,
+                    kNecBitMark, kNecOneSpace,
+                    kNecBitMark, kNecZeroSpace,
+                    kNecBitMark, kNecMinGap, true)) return false;
+  // Compliance
+  // Calculate command and optionally enforce integrity checking.
+  uint8_t command = (data & 0xFF00) >> 8;
+  uint8_t command2 = data & 0xFF;
+  // Command is sent twice, once as plain and then inverted.
+  if ((command ^ 0xFF) != (command2)) { 
+	  if (command ^ 0xFF) = ((command2) ^ 0x01) { // alternate command
+	    command2 = ((command2) ^ 0x01);
+	  }
+	  else if (command ^ 0xFF) = ((command2) ^ 0x80) { // remoteID = 2
+	    command2 = ((command2) ^ 0x80);
+	  }
+	  else if (command ^ 0xFF) = ((command2) ^ 0x81) { // alternate command and remoteID = 2
+	    command2 = ((command2) ^ 0x81);
+	  }
+	  else {
+        if (strict) return false;  // Command integrity failed in a way that is not known as being deliberate.
+        command = 0;  // The command value isn't valid, so default to zero.
+		command2 = 0;
+	  }
+  }
+
+  // Success
+  results->bits = nbits;
+  results->value = data;
+  results->decode_type = YAMAHA;
+  // NEC command and address are technically in LSB first order so the
+  // final versions have to be reversed.
+  results->command = reverseBits(command, 8)<<8 + reverseBits(command2, 8);
+  // Normal NEC protocol has an 8 bit address sent, followed by it inverted.
+  uint8_t address = (data & 0xFF000000) >> 24;
+  uint8_t address_inverted = (data & 0x00FF0000) >> 16;
+  if (address == (address_inverted ^ 0xFF))
+    // Inverted, so it is normal NEC protocol.
+    results->address = reverseBits(address, 8);
+  else  // Not inverted, so must be Extended NEC protocol, thus 16 bit address.
+    results->address = reverseBits((data >> 16) & UINT16_MAX, 16);
+  return true;
+}
+#endif  // (DECODE_YAMAHA)

--- a/src/ir_Yamaha.cpp
+++ b/src/ir_Yamaha.cpp
@@ -80,10 +80,10 @@ uint32_t IRsend::encodeYamaha(uint32_t yamahaCode) {
 		addressHigh = reverseBits(addressHigh, 8);
 		//the second byte could be either address or command
 		uint8_t unknownValue = (yamahaCode >> 8) & 0xFF;
+		unknownValue = reverseBits(unknownValue, 8);
 		if(addressHigh + unknownValue == 0xFF) {
 			//in this case, the unknown value is a match for an inverse address, so we have a 2-byte address, 1-byte command
 			uint8_t addressLow = unknownValue;
-			addressLow = reverseBits(addressLow, 8);
 			uint8_t command = yamahaCode & 0xFF;
 			uint8_t commandHigh = command;
 			commandHigh = reverseBits(commandHigh, 8);
@@ -116,6 +116,7 @@ uint32_t IRsend::encodeYamaha(uint32_t yamahaCode) {
 /// @param[in] altCommand Whether to use the alternate command option; certain commands utilise this. Defaults to false.
 /// @param[in] remoteID The remote ID to emulate; determines part of the breaks in parity. Set false to use ID 1; set true to use ID 2. Defaults to false (ID 1).
 /// @return A raw 32-bit message suitable for use with `sendYamaha()`.
+/// @note How to determine if a command requires the altCommand value: looking at a remote code, the fifth and seventh values should add to hex F. Therefore, a code 7F01-609F makes 0 plus F equals F; altCommand is false. Code 7F01-611E: 6 + 1 = 7, not F. altCommand is true.
 uint32_t IRsend::encodeYamaha(uint16_t address, uint8_t command, bool altCommand = false, bool remoteID = false) {
 	//All extra commands act upon the low byte of the command
 	uint8_t commandHigh = command & 0xFF;
@@ -140,7 +141,7 @@ uint32_t IRsend::encodeYamaha(uint16_t address, uint8_t command, bool altCommand
 
 #if (DECODE_YAMAHA)
 /// Decode the supplied Yamaha message.
-/// Status: STABLE / Known good.
+/// Status: BETA / All known good, except for the effects of disabling the checking for a repeat code. If all goes to plan, repeats should show as being on the NEC protocol.
 /// @param[in,out] results Ptr to the data to decode & where to store the result
 /// @param[in] offset The starting index to use when attempting to decode the
 ///   raw data. Typically/Defaults to kStartOffset.

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -772,6 +772,9 @@
 #ifndef D_STR_WHYNTER
 #define D_STR_WHYNTER "WHYNTER"
 #endif  // D_STR_WHYNTER
+#ifndef D_STR_YAMAHA
+#define D_STR_YAMAHA "YAMAHA"
+#endif  // D_STR_YAMAHA
 #ifndef D_STR_ZEPEAL
 #define D_STR_ZEPEAL "ZEPEAL"
 #endif  // D_STR_ZEPEAL


### PR DESCRIPTION
This is effectively an extension to the current NEC protocol, and relies on it for broadcasting messages. Yamaha utilises a proprietary form of expressing the infrared codes in text; this unit allows the submission of these text codes as-is, as a singular input. Along with this, it can also encode a regular address/command pair, along with an alternate address/command pairing that also accepts two Booleans; one alters the remote ID, the other provides a bit which is flipped on certain commands to allow overloading. However, the use of these Booleans breaks the NEC standard, in that the final byte of the command is no longer the direct binary inverse of the instruction byte. Hence, the original need for a protocol extension in the first place.

I've been operating a pre-release on my own IR blaster for the last few months, however it has not had massive testing. The addition of handling Yamaha-format 24-bit and 16-bit commands is a new addition, and untested, as none of the commands I have found are actually applicable to my model of reciever.