### PR TITLE
Add support for Lumene Screens

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+RUN pip3 install -U platformio

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+tasks:
+  - command: platformio run -e tasmota
+
+image:
+  file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - ms-vscode.cpptools@0.26.3:u3GsZ5PK12Ddr79vh4TWgQ==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - command: platformio run -e tasmota
+  - command: platformio run
 
 image:
   file: .gitpod.Dockerfile

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -983,6 +983,10 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
     if (decodePanasonicAC32(results, offset, kPanasonicAc32Bits / 2))
       return true;
 #endif  // DECODE_PANASONIC_AC32
+#if DECODE_LUMENE
+    DPRINTLN("Attempting Lumene decode");
+    if (decodeLumene(results, offset)) return true;
+#endif  // DECODE_LUMENE
   // Typically new protocols are added above this line.
   }
 #if DECODE_HASH

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -707,6 +707,12 @@ class IRrecv {
                           const uint16_t nbits = kEliteScreensBits,
                           const bool strict = true);
 #endif  // DECODE_ELITESCREENS
+#if DECODE_LUMENE
+  bool decodeLumene(decode_results *results,
+                    uint16_t offset = kStartOffset,
+                    const uint16_t nbits = kLumeneBits,
+                    const bool strict = true);
+#endif  // DECODE_LUMENE
 };
 
 #endif  // IRRECV_H_

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -719,6 +719,13 @@
 #define SEND_ELITESCREENS      _IR_ENABLE_DEFAULT_
 #endif  // SEND_ELITESCREENS
 
+#ifndef DECODE_LUMENE
+#define DECODE_LUMENE    _IR_ENABLE_DEFAULT_
+#endif  // DECODE_LUMENE
+#ifndef SEND_LUMENE
+#define SEND_LUMENE      _IR_ENABLE_DEFAULT_
+#endif  // SEND_LUMENE
+
 #if (DECODE_ARGO || DECODE_DAIKIN || DECODE_FUJITSU_AC || DECODE_GREE || \
      DECODE_KELVINATOR || DECODE_MITSUBISHI_AC || DECODE_TOSHIBA_AC || \
      DECODE_TROTEC || DECODE_HAIER_AC || DECODE_HITACHI_AC || \
@@ -867,6 +874,7 @@ enum decode_type_t {
   MIRAGE,
   ELITESCREENS,  // 95
   PANASONIC_AC32,
+  LUMENE,
   // Add new entries before this one, and update it to point to the last entry.
   kLastDecodeType = PANASONIC_AC32,
 };
@@ -986,6 +994,8 @@ const uint16_t kLegoPfMinRepeat = kNoRepeat;
 const uint16_t kLgBits = 28;
 const uint16_t kLg32Bits = 32;
 const uint16_t kLgDefaultRepeat = kNoRepeat;
+const uint16_t kLumeneBits = 32;
+const uint16_t kLumeneDefaultRepeat = kSingleRepeat;
 const uint16_t kLutronBits = 35;
 const uint16_t kMagiquestBits = 56;
 const uint16_t kMetzBits = 19;

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -563,6 +563,7 @@ uint16_t IRsend::minRepeats(const decode_type_t protocol) {
     case ELITESCREENS:
     case GICABLE:
     case INAX:
+    case LUMENE:
     case MIDEA24:
     case MITSUBISHI:
     case MITSUBISHI2:
@@ -637,6 +638,7 @@ uint16_t IRsend::defaultBits(const decode_type_t protocol) {
     case CARRIER_AC:
     case ELITESCREENS:
     case EPSON:
+    case LUMENE:
     case NEC:
     case NEC_LIKE:
     case PANASONIC_AC32:
@@ -872,6 +874,11 @@ bool IRsend::send(const decode_type_t type, const uint64_t data,
       sendLG2(data, nbits, min_repeat);
       break;
 #endif
+#if SEND_LUMENE
+    case LUMENE:
+      sendLumene(data, nbits, min_repeat);
+      break;
+#endif  // SEND_LUMENE
 #if SEND_LUTRON
     case LUTRON:
       sendLutron(data, nbits, min_repeat);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -682,6 +682,11 @@ class IRsend {
                         const uint16_t nbits = kEliteScreensBits,
                         const uint16_t repeat = kEliteScreensDefaultRepeat);
 #endif  // SEND_ELITESCREENS
+#if SEND_LUMENE
+  void sendLumene(const uint64_t data,
+                  const uint16_t nbits = kLumeneBits,
+                  const uint16_t repeat = kLumeneDefaultRepeat);
+#endif  // SEND_LUMENE
 
  protected:
 #ifdef UNIT_TEST

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -278,5 +278,6 @@ const PROGMEM char *kAllProtocolNamesStr =
     D_STR_MIRAGE "\x0"
     D_STR_ELITESCREENS "\x0"
     D_STR_PANASONIC_AC32 "\x0"
+    D_STR_LUMENE "\x0"
     ///< New protocol strings should be added just above this line.
     "\x0";  ///< This string requires double null termination.

--- a/src/ir_Lumene.cpp
+++ b/src/ir_Lumene.cpp
@@ -1,0 +1,73 @@
+// Copyright 2020 Fabien G. (AtomBaf)
+/// @file
+/// @brief Support for the Lumene Projector Screen IR protocols.
+/// @see https://en.lumene-screens.com/ecrans-motorises
+
+// Supports:
+//   Brand: Lumene,  Model: Embassy
+
+#include <algorithm>
+#include "IRrecv.h"
+#include "IRsend.h"
+#include "IRutils.h"
+
+// Constants
+const uint16_t kLumeneHdrMark = 400;
+const uint16_t kLumeneHdrSpace = 0;
+const uint16_t kLumeneOneMark = 800;
+const uint16_t kLumeneOneSpace = 0;
+const uint16_t kLumeneZeroMark = 0;
+const uint16_t kLumeneZeroSpace = 800;
+const uint16_t kLumeneFtrMark = 400;
+const uint16_t kLumeneGap = 21000;
+const uint16_t kLumeneFreq = 38000;
+
+#if SEND_LUMENE
+/// Send a Lumene formatted message.
+/// Status: ALPHA / Not tested.
+/// @param[in] data The message to be sent.
+/// @param[in] nbits The number of bits of message to be sent.
+/// @param[in] repeat The number of times the command is to be repeated.
+void IRsend::sendLumene(const uint64_t data, const uint16_t nbits,
+                        const uint16_t repeat) {
+  sendGeneric(kLumeneHdrMark, kLumeneHdrSpace,
+              kLumeneOneMark, kLumeneOneSpace,
+              kLumeneZeroMark, kLumeneZeroSpace,
+              kLumeneFtrMark, kLumeneGap,
+              data, nbits, kLumeneFreq, false, repeat, kDutyDefault);
+}
+
+#endif  // SEND_LUMENE
+
+#if DECODE_LUMENE
+/// Decode the supplied Lumene message.
+/// Status: ALPHA / Not tested.
+/// @param[in,out] results Ptr to the data to decode & where to store the result
+/// @param[in] offset The starting index to use when attempting to decode the
+///   raw data. Typically/Defaults to kStartOffset.
+/// @param[in] nbits The number of data bits to expect.
+/// @param[in] strict Flag indicating if we should perform strict matching.
+/// @return True if it can decode it, false if it can't.
+bool IRrecv::decodeLumene(decode_results *results, uint16_t offset,
+                          const uint16_t nbits, const bool strict) {
+  if (strict && nbits != kLumeneBits)
+    return false;  // We expect Lumene to be a certain sized message.
+
+  uint64_t data = 0;
+
+  // Match Header + Data + Footer
+  if (!matchGeneric(results->rawbuf + offset, &data,
+                    results->rawlen - offset, nbits,
+                    kLumeneHdrMark, kLumeneHdrSpace,
+                    kLumeneOneMark, kLumeneOneSpace,
+                    kLumeneZeroMark, kLumeneZeroSpace,
+                    kLumeneFtrMark, kLumeneGap, false)) return false;
+  // Success
+  results->bits = nbits;
+  results->value = data;
+  results->decode_type = decode_type_t::LUMENE;
+  results->command = 0;
+  results->address = 0;
+  return true;
+}
+#endif  // DECODE_LUMENE

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -613,6 +613,9 @@
 #ifndef D_STR_LG2
 #define D_STR_LG2 "LG2"
 #endif  // D_STR_LG2
+#ifndef D_STR_LUMENE
+#define D_STR_LUMENE "LUMENE"
+#endif  // D_STR_LUMENE
 #ifndef D_STR_LUTRON
 #define D_STR_LUTRON "LUTRON"
 #endif  // D_STR_LUTRON


### PR DESCRIPTION
Hi there

I worked a bit to enable a tasmota device (ESP01S) to pilot a Lumene Screen

Brand: Lumene (https://en.lumene-screens.com/ecrans-motorises)
Model: Embassy
Photo:
![image](https://user-images.githubusercontent.com/5445986/103388623-530c4000-4b0a-11eb-8b43-eb51422bd109.png)

I don't have lot experience with C/Arduino/ESP build tools, so I also added support for gitpod as it was for me the easiest way to add the needed files and compile.

Hope you will find all what you need to merge.

Finally, I saw that there is a recent add for 'Elite Screen' (https://github.com/crankyoldgit/IRremoteESP8266/issues/1306) and as far as I understand this is a very similar protocol. We can discuss further but I think the send method implementation is not okay.
