### PR TITLE
SharpAc: Add support for model A903, and improve `IRac` fan & power control.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1730,7 +1730,6 @@ void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
                  const bool light, const bool filter, const bool clean) {
   ac->begin();
   ac->setModel(model);
-  ac->setPower(on, prev_power);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
@@ -1753,6 +1752,7 @@ void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
     ac->send();
   }
   ac->setClean(clean);
+  ac->setPower(on, prev_power);
   if (turbo) {
     ac->send();  // Send the current state.
     // Set up turbo mode as it needs to be sent after everything else.

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1732,7 +1732,7 @@ void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
   ac->setModel(model);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
-  ac->setFan(ac->convertFan(fan));
+  ac->setFan(ac->convertFan(fan, model));
   ac->setSwingToggle(swingv != stdAc::swingv_t::kOff);
   // Econo  deliberately not used as it cycles through 3 modes uncontrollably.
   // ac->setEconoToggle(econo);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -154,8 +154,9 @@ enum panasonic_ac_remote_model_t {
 
 /// Sharp A/C model numbers
 enum sharp_ac_remote_model_t {
-  A907 = 1,  // 802 too.
+  A907 = 1,
   A705 = 2,
+  A903 = 3,  // 820 too
 };
 
 /// Voltas A/C model numbers

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -538,6 +538,7 @@ namespace irutils {
         switch (model) {
           case sharp_ac_remote_model_t::A907: return F("A907");
           case sharp_ac_remote_model_t::A705: return F("A705");
+          case sharp_ac_remote_model_t::A903: return F("A903");
           default: return kUnknownStr;
         }
         break;

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -698,15 +698,29 @@ uint8_t IRSharpAc::convertMode(const stdAc::opmode_t mode) {
 
 /// Convert a stdAc::fanspeed_t enum into it's native speed.
 /// @param[in] speed The enum to be converted.
+/// @param[in] model The enum of the appropriate model.
 /// @return The native equivalent of the enum.
-uint8_t IRSharpAc::convertFan(const stdAc::fanspeed_t speed) {
-  switch (speed) {
-    case stdAc::fanspeed_t::kMin:
-    case stdAc::fanspeed_t::kLow:    return kSharpAcFanMin;
-    case stdAc::fanspeed_t::kMedium: return kSharpAcFanMed;
-    case stdAc::fanspeed_t::kHigh:   return kSharpAcFanHigh;
-    case stdAc::fanspeed_t::kMax:    return kSharpAcFanMax;
-    default:                         return kSharpAcFanAuto;
+uint8_t IRSharpAc::convertFan(const stdAc::fanspeed_t speed,
+                              const sharp_ac_remote_model_t model) {
+  switch (model) {
+    case sharp_ac_remote_model_t::A705:
+    case sharp_ac_remote_model_t::A903:
+      switch (speed) {
+        case stdAc::fanspeed_t::kLow:    return kSharpAcFanA705Low;
+        case stdAc::fanspeed_t::kMedium: return kSharpAcFanA705Med;
+        default: {};  // Fall thru to the next/default clause if not the above
+                      // special cases.
+      }
+    // FALL THRU
+    default:
+      switch (speed) {
+        case stdAc::fanspeed_t::kMin:
+        case stdAc::fanspeed_t::kLow:    return kSharpAcFanMin;
+        case stdAc::fanspeed_t::kMedium: return kSharpAcFanMed;
+        case stdAc::fanspeed_t::kHigh:   return kSharpAcFanHigh;
+        case stdAc::fanspeed_t::kMax:    return kSharpAcFanMax;
+        default:                         return kSharpAcFanAuto;
+      }
   }
 }
 

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -312,12 +312,15 @@ void IRSharpAc::setRaw(const uint8_t new_code[], const uint16_t length) {
 void IRSharpAc::setModel(const sharp_ac_remote_model_t model) {
   switch (model) {
     case sharp_ac_remote_model_t::A705:
+    case sharp_ac_remote_model_t::A903:
       _model = model;
+      _.Model = true;
       break;
     default:
       _model = sharp_ac_remote_model_t::A907;
+      _.Model = false;
   }
-  _.A705 = (_model == sharp_ac_remote_model_t::A705);
+  _.Model2 = (_model != sharp_ac_remote_model_t::A907);
   // Redo the operating mode as some models don't support all modes.
   setMode(_.Mode);
 }
@@ -326,9 +329,16 @@ void IRSharpAc::setModel(const sharp_ac_remote_model_t model) {
 /// @param[in] raw Try to determine the model from the raw code only.
 /// @return The enum of the compatible model.
 sharp_ac_remote_model_t IRSharpAc::getModel(const bool raw) const {
-  if (raw)
-    return (_.A705 && _.Model) ? sharp_ac_remote_model_t::A705
-                               : sharp_ac_remote_model_t::A907;
+  if (raw) {
+    if (_.Model2) {
+      if (_.Model)
+        return sharp_ac_remote_model_t::A705;
+      else
+        return sharp_ac_remote_model_t::A903;
+    } else {
+      return sharp_ac_remote_model_t::A907;
+    }
+  }
   return _model;
 }
 

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -464,9 +464,16 @@ uint8_t IRSharpAc::getMode(void) const {
 /// @param[in] save Do we save this setting as a user set one?
 void IRSharpAc::setMode(const uint8_t mode, const bool save) {
   uint8_t realMode = mode;
-  if (mode == kSharpAcHeat && getModel() == sharp_ac_remote_model_t::A705) {
-    // A705 has no heat mode, use Fan mode instead.
-    realMode = kSharpAcFan;
+  if (mode == kSharpAcHeat) {
+    switch (getModel()) {
+      case sharp_ac_remote_model_t::A705:
+      case sharp_ac_remote_model_t::A903:
+        // These models have no heat mode, use Fan mode instead.
+        realMode = kSharpAcFan;
+        break;
+      default:
+        break;
+    }
   }
 
   switch (realMode) {
@@ -584,16 +591,16 @@ void IRSharpAc::_setEconoToggle(const bool on) {
 /// Set the Economical mode toggle setting of the A/C.
 /// @param[in] on true, the setting is on. false, the setting is off.
 /// @warning Probably incompatible with `setTurbo()`
-/// @note Not available on the A705 model.
+/// @note Available on the A907 models.
 void IRSharpAc::setEconoToggle(const bool on) {
-  if (_model != sharp_ac_remote_model_t::A705) _setEconoToggle(on);
+  if (_model == sharp_ac_remote_model_t::A907) _setEconoToggle(on);
 }
 
 /// Get the Economical mode toggle setting of the A/C.
 /// @return true, the setting is on. false, the setting is off.
-/// @note Not available on the A705 model.
+/// @note Available on the A907 models.
 bool IRSharpAc::getEconoToggle(void) const {
-  return _model != sharp_ac_remote_model_t::A705 && _getEconoToggle();
+  return _model == sharp_ac_remote_model_t::A907 && _getEconoToggle();
 }
 
 /// Set the Light mode toggle setting of the A/C.
@@ -601,7 +608,7 @@ bool IRSharpAc::getEconoToggle(void) const {
 /// @warning Probably incompatible with `setTurbo()`
 /// @note Not available on the A907 model.
 void IRSharpAc::setLightToggle(const bool on) {
-  if (_model != sharp_ac_remote_model_t::A705) _setEconoToggle(on);
+  if (_model != sharp_ac_remote_model_t::A907) _setEconoToggle(on);
 }
 
 /// Get the Light toggle setting of the A/C.
@@ -727,6 +734,7 @@ stdAc::opmode_t IRSharpAc::toCommonMode(const uint8_t mode) const {
 stdAc::fanspeed_t IRSharpAc::toCommonFanSpeed(const uint8_t speed) const {
   switch (getModel()) {
     case sharp_ac_remote_model_t::A705:
+    case sharp_ac_remote_model_t::A903:
       switch (speed) {
         case kSharpAcFanA705Low:  return stdAc::fanspeed_t::kLow;
         case kSharpAcFanA705Med:  return stdAc::fanspeed_t::kMedium;
@@ -784,11 +792,12 @@ String IRSharpAc::toString(void) const {
   result += addModeToString(
       _.Mode,
       // Make the value invalid if the model doesn't support an Auto mode.
-      (model != sharp_ac_remote_model_t::A705) ? kSharpAcAuto : 255,
+      (model == sharp_ac_remote_model_t::A907) ? kSharpAcAuto : 255,
       kSharpAcCool, kSharpAcHeat, kSharpAcDry, kSharpAcFan);
   result += addTempToString(getTemp());
   switch (model) {
     case sharp_ac_remote_model_t::A705:
+    case sharp_ac_remote_model_t::A903:
       result += addFanToString(_.Fan, kSharpAcFanMax, kSharpAcFanA705Low,
                                kSharpAcFanAuto, kSharpAcFanAuto,
                                kSharpAcFanA705Med);
@@ -803,6 +812,7 @@ String IRSharpAc::toString(void) const {
   result += addBoolToString(_.Ion, kIonStr);
   switch (model) {
     case sharp_ac_remote_model_t::A705:
+    case sharp_ac_remote_model_t::A903:
       result += addLabeledString(getLightToggle() ? kToggleStr : "-",
                                  kLightStr);
       break;

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -182,7 +182,9 @@ class IRSharpAc {
   static bool validChecksum(uint8_t state[],
                             const uint16_t length = kSharpAcStateLength);
   static uint8_t convertMode(const stdAc::opmode_t mode);
-  static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint8_t convertFan(const stdAc::fanspeed_t speed,
+                            const sharp_ac_remote_model_t model =
+                                sharp_ac_remote_model_t::A907);
   stdAc::opmode_t toCommonMode(const uint8_t mode) const;
   stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed) const;
   stdAc::state_t toCommon(void) const;

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -9,14 +9,18 @@
 /// @see GlobalCache's IR Control Tower data.
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/638
 /// @see https://github.com/ToniA/arduino-heatpumpir/blob/master/SharpHeatpumpIR.cpp
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1091
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1387
 
 // Supports:
 //   Brand: Sharp,  Model: LC-52D62U TV
 //   Brand: Sharp,  Model: AY-ZP40KR A/C (A907)
 //   Brand: Sharp,  Model: AH-AxSAY A/C (A907)
 //   Brand: Sharp,  Model: CRMC-A907 JBEZ remote (A907)
-//   Brand: Sharp,  Model: AH-XP10NRY A/C (A907)
-//   Brand: Sharp,  Model: CRMC-820 JBEZ remote (A907)
+//   Brand: Sharp,  Model: AH-PR13 A/C (A903)
+//   Brand: Sharp,  Model: CRMC-A903 remote (A903)
+//   Brand: Sharp,  Model: AH-XP10NRY A/C (A903)
+//   Brand: Sharp,  Model: CRMC-820 JBEZ remote (A903)
 //   Brand: Sharp,  Model: CRMC-A705 JBEZ remote (A705)
 
 #ifndef IR_SHARP_H_
@@ -65,11 +69,11 @@ union SharpProtocol{
     // Byte 10
     uint8_t Special :8;
     // Byte 11
-    uint8_t     :2;
-    uint8_t Ion :1;
-    uint8_t     :1;
-    uint8_t A705:1;
-    uint8_t     :3;
+    uint8_t        :2;
+    uint8_t Ion    :1;
+    uint8_t        :1;
+    uint8_t Model2 :1;
+    uint8_t        :3;
     // Byte 12
     uint8_t     :4;
     uint8_t Sum :4;

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -17,8 +17,8 @@
 //   Brand: Sharp,  Model: AY-ZP40KR A/C (A907)
 //   Brand: Sharp,  Model: AH-AxSAY A/C (A907)
 //   Brand: Sharp,  Model: CRMC-A907 JBEZ remote (A907)
-//   Brand: Sharp,  Model: AH-PR13 A/C (A903)
-//   Brand: Sharp,  Model: CRMC-A903 remote (A903)
+//   Brand: Sharp,  Model: AH-PR13-GL A/C (A903)
+//   Brand: Sharp,  Model: CRMC-A903JBEZ remote (A903)
 //   Brand: Sharp,  Model: AH-XP10NRY A/C (A903)
 //   Brand: Sharp,  Model: CRMC-820 JBEZ remote (A903)
 //   Brand: Sharp,  Model: CRMC-A705 JBEZ remote (A705)
@@ -108,9 +108,9 @@ const uint8_t kSharpAcHeat =                             0b01;  // A907 only
 const uint8_t kSharpAcFanAuto =                     0b010;  // 2
 const uint8_t kSharpAcFanMin =                      0b100;  // 4 (FAN1)
 const uint8_t kSharpAcFanMed =                      0b011;  // 3 (FAN2)
-const uint8_t kSharpAcFanA705Low =                  0b011;  // 3
+const uint8_t kSharpAcFanA705Low =                  0b011;  // 3 (A903 too)
 const uint8_t kSharpAcFanHigh =                     0b101;  // 5 (FAN3)
-const uint8_t kSharpAcFanA705Med =                  0b101;  // 5
+const uint8_t kSharpAcFanA705Med =                  0b101;  // 5 (A903 too)
 const uint8_t kSharpAcFanMax =                      0b111;  // 7 (FAN4)
 
 const uint8_t kSharpAcTimerIncrement = 30;  // Mins

--- a/src/ir_Sharp.h
+++ b/src/ir_Sharp.h
@@ -22,6 +22,8 @@
 //   Brand: Sharp,  Model: AH-XP10NRY A/C (A903)
 //   Brand: Sharp,  Model: CRMC-820 JBEZ remote (A903)
 //   Brand: Sharp,  Model: CRMC-A705 JBEZ remote (A705)
+//   Brand: Sharp,  Model: AH-A12REVP-1 A/C (A903)
+//   Brand: Sharp,  Model: CRMC-A863 JBEZ remote (A903)
 
 #ifndef IR_SHARP_H_
 #define IR_SHARP_H_

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -869,7 +869,7 @@ TEST(TestSharpAcClass, Turbo) {
   EXPECT_EQ(
       "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: On, "
-      "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+      "Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off",
       ac.toString());
 
   ac.setRaw(off_state);
@@ -877,7 +877,7 @@ TEST(TestSharpAcClass, Turbo) {
   EXPECT_EQ(
       "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
-      "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+      "Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off",
       ac.toString());
 }
 
@@ -1006,7 +1006,7 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_EQ(
       "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
-      "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, Off Timer: 08:30",
+      "Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off, Off Timer: 08:30",
       ac.toString());
 
   // ref: https://docs.google.com/spreadsheets/d/1otzVFM5_tegrZ4ROCLgQ_jvJaWCDlZs1vC-YuR1FFXM/edit#gid=0&range=E80
@@ -1020,7 +1020,7 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_TRUE(ac.isPowerSpecial());
   EXPECT_EQ(
       "Model: 3 (A903), Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), "
-      "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, "
+      "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off, "
       "On Timer: 12:00",
       ac.toString());
 }
@@ -1058,13 +1058,13 @@ TEST(TestSharpAcClass, Clean) {
   EXPECT_TRUE(ac.getClean());
   EXPECT_EQ(
     "Model: 3 (A903), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Light: -, Clean: On",
     ac.toString());
   ac.setRaw(clean_off_state);
   EXPECT_FALSE(ac.getClean());
   EXPECT_EQ(
     "Model: 3 (A903), Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Light: -, Clean: Off",
     ac.toString());
 
   // Try constructing the clean on state.
@@ -1177,7 +1177,7 @@ TEST(TestSharpAcClass, Models) {
   EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel(true));
 }
 
-TEST(TestSharpAcClass, Issue1387) {
+TEST(TestSharpAcClass, Issue1387Power) {
   IRSharpAc ac(kGpioUnused);
   const uint8_t real_off[13] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xCC, 0x21, 0x32,
@@ -1195,17 +1195,18 @@ TEST(TestSharpAcClass, Issue1387) {
   ac.setIon(true);
   ac.setClean(false);
   ac.setSwingToggle(false);
+  ac.setClean(false);
   ac.setPower(false);
   EXPECT_STATE_EQ(real_off, ac.getRaw(), kSharpAcBits);
   EXPECT_EQ(
-    "Model: 3 (A903), Power: Off, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Medium), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+    "Model: 3 (A903), Power: Off, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Low), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off",
     ac.toString());
   // Create the same off state.
   ac.setPower(true, ac.getPower());
   EXPECT_STATE_EQ(real_on, ac.getRaw(), kSharpAcBits);
   EXPECT_EQ(
-    "Model: 3 (A903), Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Medium), "
-    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+    "Model: 3 (A903), Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Low), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Light: -, Clean: Off",
     ac.toString());
 }

--- a/test/ir_Sharp_test.cpp
+++ b/test/ir_Sharp_test.cpp
@@ -867,7 +867,7 @@ TEST(TestSharpAcClass, Turbo) {
   EXPECT_TRUE(ac.getTurbo());
   EXPECT_EQ(kSharpAcFanMax, ac.getFan());
   EXPECT_EQ(
-      "Model: 1 (A907), "
+      "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: On, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
       ac.toString());
@@ -875,7 +875,7 @@ TEST(TestSharpAcClass, Turbo) {
   ac.setRaw(off_state);
   EXPECT_FALSE(ac.getTurbo());
   EXPECT_EQ(
-      "Model: 1 (A907), "
+      "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
       ac.toString());
@@ -1004,7 +1004,7 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_EQ(8 * 60 + 30, ac.getTimerTime());
   EXPECT_TRUE(ac.isPowerSpecial());
   EXPECT_EQ(
-      "Model: 1 (A907), "
+      "Model: 3 (A903), "
       "Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), Turbo: Off, "
       "Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, Off Timer: 08:30",
       ac.toString());
@@ -1019,7 +1019,7 @@ TEST(TestSharpAcClass, Timers) {
   EXPECT_EQ(12 * 60, ac.getTimerTime());
   EXPECT_TRUE(ac.isPowerSpecial());
   EXPECT_EQ(
-      "Model: 1 (A907), Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), "
+      "Model: 3 (A903), Power: -, Mode: 2 (Cool), Temp: 21C, Fan: 7 (High), "
       "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off, "
       "On Timer: 12:00",
       ac.toString());
@@ -1057,13 +1057,13 @@ TEST(TestSharpAcClass, Clean) {
   ac.setRaw(clean_on_state);
   EXPECT_TRUE(ac.getClean());
   EXPECT_EQ(
-    "Model: 1 (A907), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
+    "Model: 3 (A903), Power: On, Mode: 3 (Dry), Temp: 15C, Fan: 2 (Auto), "
     "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: On",
     ac.toString());
   ac.setRaw(clean_off_state);
   EXPECT_FALSE(ac.getClean());
   EXPECT_EQ(
-    "Model: 1 (A907), Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
+    "Model: 3 (A903), Power: On, Mode: 2 (Cool), Temp: 25C, Fan: 7 (High), "
     "Turbo: Off, Swing(V) Toggle: Off, Ion: Off, Econo: -, Clean: Off",
     ac.toString());
 
@@ -1156,6 +1156,9 @@ TEST(TestSharpAcClass, Models) {
   const uint8_t A705_on[13] = {
       0xAA, 0x5A, 0xCF, 0x10, 0xD1, 0x11, 0x22,
       0x00, 0x08, 0x80, 0x00, 0xF0, 0xF1};
+  const uint8_t A903_on[13] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0xCC, 0x11, 0x32,
+      0x00, 0x08, 0x80, 0x00, 0xF4, 0x61};
   ac.stateReset();
 
   EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel());
@@ -1165,7 +1168,44 @@ TEST(TestSharpAcClass, Models) {
   EXPECT_EQ(sharp_ac_remote_model_t::A705, ac.getModel());
   EXPECT_EQ(sharp_ac_remote_model_t::A705, ac.getModel(true));
 
+  ac.setRaw(A903_on);
+  EXPECT_EQ(sharp_ac_remote_model_t::A903, ac.getModel());
+  EXPECT_EQ(sharp_ac_remote_model_t::A903, ac.getModel(true));
+
   ac.setModel(sharp_ac_remote_model_t::A907);
   EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel());
   EXPECT_EQ(sharp_ac_remote_model_t::A907, ac.getModel(true));
+}
+
+TEST(TestSharpAcClass, Issue1387) {
+  IRSharpAc ac(kGpioUnused);
+  const uint8_t real_off[13] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0xCC, 0x21, 0x32,
+      0x00, 0x08, 0x80, 0x00, 0xF4, 0x51};
+  const uint8_t real_on[13] = {
+      0xAA, 0x5A, 0xCF, 0x10, 0xCC, 0x11, 0x32,
+      0x00, 0x08, 0x80, 0x00, 0xF4, 0x61};
+  // Create the same off state.
+  ac.stateReset();
+  ac.setModel(sharp_ac_remote_model_t::A903);
+  ac.setMode(kSharpAcCool);
+  ac.setTemp(27);
+  ac.setFan(kSharpAcFanMed);
+  ac.setTurbo(false);
+  ac.setIon(true);
+  ac.setClean(false);
+  ac.setSwingToggle(false);
+  ac.setPower(false);
+  EXPECT_STATE_EQ(real_off, ac.getRaw(), kSharpAcBits);
+  EXPECT_EQ(
+    "Model: 3 (A903), Power: Off, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Medium), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+    ac.toString());
+  // Create the same off state.
+  ac.setPower(true, ac.getPower());
+  EXPECT_STATE_EQ(real_on, ac.getRaw(), kSharpAcBits);
+  EXPECT_EQ(
+    "Model: 3 (A903), Power: On, Mode: 2 (Cool), Temp: 27C, Fan: 3 (Medium), "
+    "Turbo: Off, Swing(V) Toggle: Off, Ion: On, Econo: -, Clean: Off",
+    ac.toString());
 }


### PR DESCRIPTION
* Add new model `A903`
  - `A903` appears to be near identical to `A705` model. Make appropriate changes
* Update unit tests accordingly.
* Update supported model info.
* Minor tweaks for this model
* Should allow power control of this model now & improve `IRac` power control of Sharp.
* Fix typo
* Adjust old suggested model for supported devices.
* Enable `IRSharpAc::convertFan()` to report the correct fan speed when passed model info.

Power control (and model detection) confirmed working by users.

Fixes #1387