### PR TITLE
Add `irutils::addSwing[V|H]ToString()` and adjust some constants

### DIFF
--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -674,6 +674,122 @@ namespace irutils {
     return result + ')';
   }
 
+  /// Create a String of human output for the given horizontal swing setting.
+  /// e.g. "Swing(H): 0 (Auto)"
+  /// @param[in] position The numeric position of the swing to display.
+  /// @param[in] automatic The numeric value for Auto position.
+  /// @param[in] maxleft The numeric value for most left position.
+  /// @param[in] left The numeric value for Left position.
+  /// @param[in] middle The numeric value for Middle position.
+  /// @param[in] right The numeric value for Right position.
+  /// @param[in] maxright The numeric value for most right position.
+  /// @param[in] off The numeric value for Off position.
+  /// @param[in] leftright The numeric value for "left right" position.
+  /// @param[in] rightleft The numeric value for "right left" position.
+  /// @param[in] threed The numeric value for 3D setting.
+  /// @param[in] wide The numeric value for Wide position.
+  /// @return The resulting String.
+  String addSwingHToString(const uint8_t position, const uint8_t automatic,
+                           const uint8_t maxleft, const uint8_t left,
+                           const uint8_t middle,
+                           const uint8_t right, const uint8_t maxright,
+                           const uint8_t off,
+                           const uint8_t leftright, const uint8_t rightleft,
+                           const uint8_t threed, const uint8_t wide) {
+    String result = addIntToString(position, kSwingHStr);
+    result += kSpaceLBraceStr;
+    if (position == automatic) {
+      result += kAutoStr;
+    } else if (position == left) {
+      result += kLeftStr;
+    } else if (position == middle) {
+      result += kMiddleStr;
+    } else if (position == right) {
+      result += kRightStr;
+    } else if (position == maxleft) {
+      result += kMaxLeftStr;
+    } else if (position == maxright) {
+      result += kMaxRightStr;
+    } else if (position == off) {
+      result += kOffStr;
+    } else if (position == leftright) {
+      result += kLeftStr;
+      result += ' ';
+      result += kRightStr;
+    } else if (position == rightleft) {
+      result += kRightStr;
+      result += ' ';
+      result += kLeftStr;
+    } else if (position == threed) {
+      result += k3DStr;
+    } else if (position == wide) {
+      result += kWideStr;
+    } else {
+      result += kUnknownStr;
+    }
+    return result + ')';
+  }
+
+  /// Create a String of human output for the given vertical swing setting.
+  /// e.g. "Swing(V): 0 (Auto)"
+  /// @param[in] position The numeric position of the swing to display.
+  /// @param[in] automatic The numeric value for Auto position.
+  /// @param[in] highest The numeric value for Highest position.
+  /// @param[in] high The numeric value for High position.
+  /// @param[in] uppermiddle The numeric value for Upper Middle position.
+  /// @param[in] middle The numeric value for Middle position.
+  /// @param[in] lowermiddle The numeric value for Lower Middle position.
+  /// @param[in] low The numeric value for Low position.
+  /// @param[in] lowest The numeric value for Low position.
+  /// @param[in] off The numeric value for Off position.
+  /// @param[in] swing The numeric value for Swing setting.
+  /// @param[in] breeze The numeric value for Breeze setting.
+  /// @param[in] circulate The numeric value for Circulate setting.
+  /// @return The resulting String.
+  String addSwingVToString(const uint8_t position, const uint8_t automatic,
+                           const uint8_t highest, const uint8_t high,
+                           const uint8_t uppermiddle,
+                           const uint8_t middle,
+                           const uint8_t lowermiddle,
+                           const uint8_t low, const uint8_t lowest,
+                           const uint8_t off, const uint8_t swing,
+                           const uint8_t breeze, const uint8_t circulate) {
+    String result = addIntToString(position, kSwingVStr);
+    result += kSpaceLBraceStr;
+    if (position == automatic) {
+      result += kAutoStr;
+    } else if (position == highest) {
+      result += kHighestStr;
+    } else if (position == high) {
+      result += kHighStr;
+    } else if (position == middle) {
+      result += kMiddleStr;
+    } else if (position == low) {
+      result += kLowStr;
+    } else if (position == lowest) {
+      result += kLowestStr;
+    } else if (position == off) {
+      result += kOffStr;
+    } else if (position == uppermiddle) {
+      result += kUpperStr;
+      result += ' ';
+      result += kMiddleStr;
+    } else if (position == lowermiddle) {
+      result += kLowerStr;
+      result += ' ';
+      result += kMiddleStr;
+    } else if (position == swing) {
+      result += kSwingStr;
+    } else if (position == breeze) {
+      result += kBreezeStr;
+    } else if (position == circulate) {
+      result += kCirculateStr;
+    } else {
+      result += kUnknownStr;
+    }
+    return result + ')';
+  }
+
   /// Escape any special HTML (unsafe) characters in a string. e.g. anti-XSS.
   /// @param[in] unescaped A String containing text to make HTML safe.
   /// @return A string that is HTML safe.

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -63,6 +63,21 @@ namespace irutils {
                         const uint8_t low, const uint8_t automatic,
                         const uint8_t quiet, const uint8_t medium,
                         const uint8_t maximum = 0xFF);
+  String addSwingHToString(const uint8_t position, const uint8_t automatic,
+                           const uint8_t maxleft, const uint8_t left,
+                           const uint8_t middle,
+                           const uint8_t right, const uint8_t maxright,
+                           const uint8_t off,
+                           const uint8_t leftright, const uint8_t rightleft,
+                           const uint8_t threed, const uint8_t wide);
+  String addSwingVToString(const uint8_t position, const uint8_t automatic,
+                           const uint8_t highest, const uint8_t high,
+                           const uint8_t uppermiddle,
+                           const uint8_t middle,
+                           const uint8_t lowermiddle,
+                           const uint8_t low, const uint8_t lowest,
+                           const uint8_t off, const uint8_t swing,
+                           const uint8_t breeze, const uint8_t circulate);
   String addDayToString(const uint8_t day_of_week, const int8_t offset = 0,
                         const bool precomma = true);
   String htmlEscape(const String unescaped);

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -41,6 +41,8 @@ using irutils::addDayToString;
 using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
+using irutils::addSwingHToString;
+using irutils::addSwingVToString;
 using irutils::addTempToString;
 using irutils::addFanToString;
 using irutils::bcdToUint8;
@@ -862,13 +864,13 @@ uint8_t IRDaikin2::getFan(void) const {
 /// @param[in] position The position/mode to set the swing to.
 void IRDaikin2::setSwingVertical(const uint8_t position) {
   switch (position) {
+    case kDaikin2SwingVHighest:
     case kDaikin2SwingVHigh:
-    case 2:
-    case 3:
-    case 4:
-    case 5:
+    case kDaikin2SwingVUpperMiddle:
+    case kDaikin2SwingVLowerMiddle:
     case kDaikin2SwingVLow:
-    case kDaikin2SwingVSwing:
+    case kDaikin2SwingVLowest:
+    case kDaikin2SwingVOff:
     case kDaikin2SwingVBreeze:
     case kDaikin2SwingVCirculate:
     case kDaikin2SwingVAuto:
@@ -892,9 +894,11 @@ uint8_t IRDaikin2::convertSwingV(const stdAc::swingv_t position) {
     case stdAc::swingv_t::kMiddle:
     case stdAc::swingv_t::kLow:
     case stdAc::swingv_t::kLowest:
-      return (uint8_t)position + kDaikin2SwingVHigh;
-    case stdAc::swingv_t::kAuto: return kDaikin2SwingVSwing;
-    default: return kDaikin2SwingVAuto;
+      return (uint8_t)position + kDaikin2SwingVHighest;
+    case stdAc::swingv_t::kOff:
+      return kDaikin2SwingVOff;
+    default:
+      return kDaikin2SwingVAuto;
   }
 }
 
@@ -903,14 +907,14 @@ uint8_t IRDaikin2::convertSwingV(const stdAc::swingv_t position) {
 /// @return The common vertical swing position.
 stdAc::swingv_t IRDaikin2::toCommonSwingV(const uint8_t setting) {
   switch (setting) {
-    case kDaikin2SwingVHigh: return stdAc::swingv_t::kHighest;
-    case kDaikin2SwingVHigh + 1: return stdAc::swingv_t::kHigh;
-    case kDaikin2SwingVHigh + 2:
-    case kDaikin2SwingVHigh + 3: return stdAc::swingv_t::kMiddle;
-    case kDaikin2SwingVLow - 1: return stdAc::swingv_t::kLow;
-    case kDaikin2SwingVLow: return stdAc::swingv_t::kLowest;
-    case kDaikin2SwingVAuto: return stdAc::swingv_t::kOff;
-    default: return stdAc::swingv_t::kAuto;
+    case kDaikin2SwingVHighest:     return stdAc::swingv_t::kHighest;
+    case kDaikin2SwingVHigh:        return stdAc::swingv_t::kHigh;
+    case kDaikin2SwingVUpperMiddle:
+    case kDaikin2SwingVLowerMiddle: return stdAc::swingv_t::kMiddle;
+    case kDaikin2SwingVLow:         return stdAc::swingv_t::kLow;
+    case kDaikin2SwingVLowest:      return stdAc::swingv_t::kLowest;
+    case kDaikin2SwingVOff:         return stdAc::swingv_t::kOff;
+    default:                        return stdAc::swingv_t::kAuto;
   }
 }
 
@@ -1196,14 +1200,14 @@ uint8_t IRDaikin2::convertFan(const stdAc::fanspeed_t speed) {
 /// @return The native equivalent of the enum.
 uint8_t IRDaikin2::convertSwingH(const stdAc::swingh_t position) {
   switch (position) {
-    case stdAc::swingh_t::kAuto: return kDaikin2SwingHSwing;
-    case stdAc::swingh_t::kLeftMax: return kDaikin2SwingHLeftMax;
-    case stdAc::swingh_t::kLeft: return kDaikin2SwingHLeft;
-    case stdAc::swingh_t::kMiddle: return kDaikin2SwingHMiddle;
-    case stdAc::swingh_t::kRight: return kDaikin2SwingHRight;
+    case stdAc::swingh_t::kAuto:     return kDaikin2SwingHSwing;
+    case stdAc::swingh_t::kLeftMax:  return kDaikin2SwingHLeftMax;
+    case stdAc::swingh_t::kLeft:     return kDaikin2SwingHLeft;
+    case stdAc::swingh_t::kMiddle:   return kDaikin2SwingHMiddle;
+    case stdAc::swingh_t::kRight:    return kDaikin2SwingHRight;
     case stdAc::swingh_t::kRightMax: return kDaikin2SwingHRightMax;
-    case stdAc::swingh_t::kWide: return kDaikin2SwingHWide;
-    default: return kDaikin2SwingHAuto;
+    case stdAc::swingh_t::kWide:     return kDaikin2SwingHWide;
+    default:                         return kDaikin2SwingHAuto;
   }
 }
 
@@ -1212,14 +1216,14 @@ uint8_t IRDaikin2::convertSwingH(const stdAc::swingh_t position) {
 /// @return The common horizontal swing position.
 stdAc::swingh_t IRDaikin2::toCommonSwingH(const uint8_t setting) {
   switch (setting) {
-    case kDaikin2SwingHSwing: return stdAc::swingh_t::kAuto;
-    case kDaikin2SwingHLeftMax: return stdAc::swingh_t::kLeftMax;
-    case kDaikin2SwingHLeft: return stdAc::swingh_t::kLeft;
-    case kDaikin2SwingHMiddle: return stdAc::swingh_t::kMiddle;
-    case kDaikin2SwingHRight: return stdAc::swingh_t::kRight;
+    case kDaikin2SwingHSwing:    return stdAc::swingh_t::kAuto;
+    case kDaikin2SwingHLeftMax:  return stdAc::swingh_t::kLeftMax;
+    case kDaikin2SwingHLeft:     return stdAc::swingh_t::kLeft;
+    case kDaikin2SwingHMiddle:   return stdAc::swingh_t::kMiddle;
+    case kDaikin2SwingHRight:    return stdAc::swingh_t::kRight;
     case kDaikin2SwingHRightMax: return stdAc::swingh_t::kRightMax;
-    case kDaikin2SwingHWide: return stdAc::swingh_t::kWide;
-    default: return stdAc::swingh_t::kOff;
+    case kDaikin2SwingHWide:     return stdAc::swingh_t::kWide;
+    default:                     return stdAc::swingh_t::kOff;
   }
 }
 
@@ -1260,57 +1264,26 @@ String IRDaikin2::toString(void) const {
   result += addTempToString(_.Temp);
   result += addFanToString(getFan(), kDaikinFanMax, kDaikinFanMin,
                            kDaikinFanAuto, kDaikinFanQuiet, kDaikinFanMed);
-  result += addIntToString(_.SwingV, kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingV) {
-    case kDaikin2SwingVHigh:
-      result += kHighestStr;
-      break;
-    case 2:
-      result += kHighStr;
-      break;
-    case 3:
-      result += kUpperStr;
-      result += kMiddleStr;
-      break;
-    case 4:
-      result += kLowerStr;
-      result += kMiddleStr;
-      break;
-    case 5:
-      result += kLowStr;
-      break;
-    case kDaikin2SwingVLow:
-      result += kLowestStr;
-      break;
-    case kDaikin2SwingVBreeze:
-      result += kBreezeStr;
-      break;
-    case kDaikin2SwingVCirculate:
-      result += kCirculateStr;
-      break;
-    case kDaikin2SwingVAuto:
-      result += kAutoStr;
-      break;
-    case kDaikin2SwingVSwing:
-      result += kSwingStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
-  result += addIntToString(_.SwingH, kSwingHStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingH) {
-    case kDaikin2SwingHAuto:
-      result += kAutoStr;
-      break;
-    case kDaikin2SwingHSwing:
-      result += kSwingStr;
-      break;
-    default: result += kUnknownStr;
-  }
-  result += ')';
+  result += addSwingVToString(_.SwingV, kDaikin2SwingVAuto,
+                              kDaikin2SwingVHighest, kDaikin2SwingVHigh,
+                              kDaikin2SwingVUpperMiddle,
+                              kDaikin2SwingVAuto,  // Middle is unused.
+                              kDaikin2SwingVLowerMiddle,
+                              kDaikin2SwingVLow, kDaikin2SwingVLowest,
+                              kDaikin2SwingVOff,  // Off is unused
+                              kDaikin2SwingVSwing, kDaikin2SwingVBreeze,
+                              kDaikin2SwingVCirculate);
+  result += addSwingHToString(_.SwingH, kDaikin2SwingHAuto,
+                              kDaikin2SwingHLeftMax,
+                              kDaikin2SwingHLeft,
+                              kDaikin2SwingHMiddle,
+                              kDaikin2SwingHRight,
+                              kDaikin2SwingHRightMax,
+                              kDaikin2SwingHOff,
+                              kDaikin2SwingHAuto,  // Unused
+                              kDaikin2SwingHAuto,  // Unused
+                              kDaikin2SwingHAuto,  // Unused
+                              kDaikin2SwingHWide);
   result += addLabeledString(minsToString(_.CurrentTime), kClockStr);
   result += addLabeledString(
       _.OnTimer ? minsToString(_.OnTime) : kOffStr, kOnTimerStr);
@@ -2471,19 +2444,18 @@ String IRDaikin176::toString(void) const {
   result += addTempToString(getTemp());
   result += addFanToString(_.Fan, kDaikin176FanMax, kDaikinFanMin,
                            kDaikinFanMin, kDaikinFanMin, kDaikinFanMin);
-  result += addIntToString(_.SwingH, kSwingHStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingH) {
-    case kDaikin176SwingHAuto:
-      result += kAutoStr;
-      break;
-    case kDaikin176SwingHOff:
-      result += kOffStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
+  result += addSwingHToString(_.SwingH, kDaikin176SwingHAuto,
+                              kDaikin176SwingHAuto,  // maxleft Unused
+                              kDaikin176SwingHAuto,  // left Unused
+                              kDaikin176SwingHAuto,  // middle Unused
+                              kDaikin176SwingHAuto,  // right Unused
+                              kDaikin176SwingHAuto,  // maxright Unused
+                              kDaikin176SwingHOff,
+                              // Below are unused.
+                              kDaikin176SwingHAuto,
+                              kDaikin176SwingHAuto,
+                              kDaikin176SwingHAuto,
+                              kDaikin176SwingHAuto);
   return result;
 }
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -275,12 +275,18 @@ const uint16_t kDaikin2Sections = 2;
 const uint16_t kDaikin2Section1Length = 20;
 const uint16_t kDaikin2Section2Length = 19;
 const uint8_t kDaikin2Tolerance = 5;  // Extra percentage tolerance
-const uint8_t kDaikin2SwingVHigh = 0x1;
-const uint8_t kDaikin2SwingVLow = 0x6;
-const uint8_t kDaikin2SwingVSwing = 0xF;
-const uint8_t kDaikin2SwingVAuto = 0xE;
-const uint8_t kDaikin2SwingVBreeze = 0xC;
-const uint8_t kDaikin2SwingVCirculate = 0xD;
+const uint8_t kDaikin2SwingVHighest =     0x1;
+const uint8_t kDaikin2SwingVHigh =        0x2;
+const uint8_t kDaikin2SwingVUpperMiddle = 0x3;
+const uint8_t kDaikin2SwingVLowerMiddle = 0x4;
+const uint8_t kDaikin2SwingVLow =         0x5;
+const uint8_t kDaikin2SwingVLowest =      0x6;
+const uint8_t kDaikin2SwingVBreeze =      0xC;
+const uint8_t kDaikin2SwingVCirculate =   0xD;
+const uint8_t kDaikin2SwingVOff =         0xE;
+const uint8_t kDaikin2SwingVAuto =        0xF;  // A.k.a "Swing"
+const uint8_t kDaikin2SwingVSwing =  kDaikin2SwingVAuto;
+
 
 const uint8_t kDaikin2SwingHWide =     0xA3;
 const uint8_t kDaikin2SwingHLeftMax =  0xA8;
@@ -288,8 +294,9 @@ const uint8_t kDaikin2SwingHLeft =     0xA9;
 const uint8_t kDaikin2SwingHMiddle =   0xAA;
 const uint8_t kDaikin2SwingHRight =    0xAB;
 const uint8_t kDaikin2SwingHRightMax = 0xAC;
-const uint8_t kDaikin2SwingHAuto =     0xBE;
-const uint8_t kDaikin2SwingHSwing =    0xBF;
+const uint8_t kDaikin2SwingHAuto =     0xBE;  // A.k.a "Swing"
+const uint8_t kDaikin2SwingHOff =      0xBF;
+const uint8_t kDaikin2SwingHSwing =  kDaikin2SwingHAuto;
 
 const uint8_t kDaikin2MinCoolTemp = 18;  // Min temp (in C) when in Cool mode.
 

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -32,6 +32,8 @@ using irutils::addBoolToString;
 using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
+using irutils::addSwingHToString;
+using irutils::addSwingVToString;
 using irutils::addTempToString;
 using irutils::checkInvertedBytePairs;
 using irutils::invertBytePairs;
@@ -513,72 +515,31 @@ String IRMitsubishiHeavy152Ac::toString(void) const {
       result += kUnknownStr;
   }
   result += ')';
-  result += addIntToString(_.SwingV, kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingV) {
-    case kMitsubishiHeavy152SwingVAuto:
-      result += kAutoStr;
-      break;
-    case kMitsubishiHeavy152SwingVHighest:
-      result += kHighestStr;
-      break;
-    case kMitsubishiHeavy152SwingVHigh:
-      result += kHighStr;
-      break;
-    case kMitsubishiHeavy152SwingVMiddle:
-      result += kMiddleStr;
-      break;
-    case kMitsubishiHeavy152SwingVLow:
-      result += kLowStr;
-      break;
-    case kMitsubishiHeavy152SwingVLowest:
-      result += kLowestStr;
-      break;
-    case kMitsubishiHeavy152SwingVOff:
-      result += kOffStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
-  result += addIntToString(_.SwingH, kSwingHStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingH) {
-    case kMitsubishiHeavy152SwingHAuto:
-      result += kAutoStr;
-      break;
-    case kMitsubishiHeavy152SwingHLeftMax:
-      result += kMaxLeftStr;
-      break;
-    case kMitsubishiHeavy152SwingHLeft:
-      result += kLeftStr;
-      break;
-    case kMitsubishiHeavy152SwingHMiddle:
-      result += kMiddleStr;
-      break;
-    case kMitsubishiHeavy152SwingHRight:
-      result += kRightStr;
-      break;
-    case kMitsubishiHeavy152SwingHRightMax:
-      result += kMaxRightStr;
-      break;
-    case kMitsubishiHeavy152SwingHLeftRight:
-      result += kLeftStr;
-      result += ' ';
-      result += kRightStr;
-      break;
-    case kMitsubishiHeavy152SwingHRightLeft:
-      result += kRightStr;
-      result += ' ';
-      result += kLeftStr;
-      break;
-    case kMitsubishiHeavy152SwingHOff:
-      result += kOffStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
+  result += addSwingVToString(_.SwingV, kMitsubishiHeavy152SwingVAuto,
+                              kMitsubishiHeavy152SwingVHighest,
+                              kMitsubishiHeavy152SwingVHigh,
+                              kMitsubishiHeavy152SwingVAuto,  // UpperMid unused
+                              kMitsubishiHeavy152SwingVMiddle,
+                              kMitsubishiHeavy152SwingVAuto,  // LowerMid unused
+                              kMitsubishiHeavy152SwingVLow,
+                              kMitsubishiHeavy152SwingVLowest,
+                              kMitsubishiHeavy152SwingVOff,
+                              // Below are unused.
+                              kMitsubishiHeavy152SwingVAuto,
+                              kMitsubishiHeavy152SwingVAuto,
+                              kMitsubishiHeavy152SwingVAuto);
+  result += addSwingHToString(_.SwingH, kMitsubishiHeavy152SwingHAuto,
+                              kMitsubishiHeavy152SwingHLeftMax,
+                              kMitsubishiHeavy152SwingHLeft,
+                              kMitsubishiHeavy152SwingHMiddle,
+                              kMitsubishiHeavy152SwingHRight,
+                              kMitsubishiHeavy152SwingHRightMax,
+                              kMitsubishiHeavy152SwingHOff,
+                              kMitsubishiHeavy152SwingHLeftRight,
+                              kMitsubishiHeavy152SwingHRightLeft,
+                              // Below are unused.
+                              kMitsubishiHeavy152SwingHAuto,
+                              kMitsubishiHeavy152SwingHAuto);
   result += addBoolToString(_.Silent, kSilentStr);
   result += addBoolToString(getTurbo(), kTurboStr);
   result += addBoolToString(getEcono(), kEconoStr);
@@ -996,75 +957,32 @@ String IRMitsubishiHeavy88Ac::toString(void) const {
       result += kUnknownStr;
   }
   result += ')';
-  result += addIntToString(getSwingVertical(), kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (getSwingVertical()) {
-    case kMitsubishiHeavy88SwingVAuto:
-      result += kAutoStr;
-      break;
-    case kMitsubishiHeavy88SwingVHighest:
-      result += kHighestStr;
-      break;
-    case kMitsubishiHeavy88SwingVHigh:
-      result += kHighStr;
-      break;
-    case kMitsubishiHeavy88SwingVMiddle:
-      result += kMiddleStr;
-      break;
-    case kMitsubishiHeavy88SwingVLow:
-      result += kLowStr;
-      break;
-    case kMitsubishiHeavy88SwingVLowest:
-      result += kLowestStr;
-      break;
-    case kMitsubishiHeavy88SwingVOff:
-      result += kOffStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
-  result += addIntToString(getSwingHorizontal(), kSwingHStr);
-  result += kSpaceLBraceStr;
-  switch (getSwingHorizontal()) {
-    case kMitsubishiHeavy88SwingHAuto:
-      result += kAutoStr;
-      break;
-    case kMitsubishiHeavy88SwingHLeftMax:
-      result += kMaxLeftStr;
-      break;
-    case kMitsubishiHeavy88SwingHLeft:
-      result += kLeftStr;
-      break;
-    case kMitsubishiHeavy88SwingHMiddle:
-      result += kMiddleStr;
-      break;
-    case kMitsubishiHeavy88SwingHRight:
-      result += kRightStr;
-      break;
-    case kMitsubishiHeavy88SwingHRightMax:
-      result += kMaxRightStr;
-      break;
-    case kMitsubishiHeavy88SwingHLeftRight:
-      result += kLeftStr;
-      result += ' ';
-      result += kRightStr;
-      break;
-    case kMitsubishiHeavy88SwingHRightLeft:
-      result += kRightStr;
-      result += ' ';
-      result += kLeftStr;
-      break;
-    case kMitsubishiHeavy88SwingH3D:
-      result += k3DStr;
-      break;
-    case kMitsubishiHeavy88SwingHOff:
-      result += kOffStr;
-      break;
-    default:
-      result += kUnknownStr;
-  }
-  result += ')';
+  result += addSwingVToString(getSwingVertical(), kMitsubishiHeavy88SwingVAuto,
+                              kMitsubishiHeavy88SwingVHighest,
+                              kMitsubishiHeavy88SwingVHigh,
+                              kMitsubishiHeavy88SwingVAuto,  // UpperMid unused
+                              kMitsubishiHeavy88SwingVMiddle,
+                              kMitsubishiHeavy88SwingVAuto,  // LowerMid unused
+                              kMitsubishiHeavy88SwingVLow,
+                              kMitsubishiHeavy88SwingVLowest,
+                              kMitsubishiHeavy88SwingVOff,
+                              // Below are unused.
+                              kMitsubishiHeavy88SwingVAuto,
+                              kMitsubishiHeavy88SwingVAuto,
+                              kMitsubishiHeavy88SwingVAuto);
+  result += addSwingHToString(getSwingHorizontal(),
+                              kMitsubishiHeavy88SwingHAuto,
+                              kMitsubishiHeavy88SwingHLeftMax,
+                              kMitsubishiHeavy88SwingHLeft,
+                              kMitsubishiHeavy88SwingHMiddle,
+                              kMitsubishiHeavy88SwingHRight,
+                              kMitsubishiHeavy88SwingHRightMax,
+                              kMitsubishiHeavy88SwingHOff,
+                              kMitsubishiHeavy88SwingHLeftRight,
+                              kMitsubishiHeavy88SwingHRightLeft,
+                              kMitsubishiHeavy88SwingH3D,
+                              // Below are unused.
+                              kMitsubishiHeavy88SwingHAuto);
   result += addBoolToString(getTurbo(), kTurboStr);
   result += addBoolToString(getEcono(), kEconoStr);
   result += addBoolToString(get3D(), k3DStr);

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -53,6 +53,8 @@ using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addModelToString;
+using irutils::addSwingHToString;
+using irutils::addSwingVToString;
 using irutils::addTempToString;
 using irutils::minsToString;
 using irutils::setBit;
@@ -792,48 +794,36 @@ String IRPanasonicAc::toString(void) {
   result += addFanToString(getFan(), kPanasonicAcFanMax, kPanasonicAcFanMin,
                            kPanasonicAcFanAuto, kPanasonicAcFanAuto,
                            kPanasonicAcFanMed);
-  result += addIntToString(getSwingVertical(), kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (getSwingVertical()) {
-    case kPanasonicAcSwingVAuto:    result += kAutoStr; break;
-    case kPanasonicAcSwingVHighest: result += kHighestStr; break;
-    case kPanasonicAcSwingVHigh:    result += kHighStr; break;
-    case kPanasonicAcSwingVMiddle:  result += kMiddleStr; break;
-    case kPanasonicAcSwingVLow:     result += kLowStr; break;
-    case kPanasonicAcSwingVLowest:  result += kLowestStr; break;
-    default:                        result += kUnknownStr; break;
-  }
-  result += ')';
+  result += addSwingVToString(getSwingVertical(), kPanasonicAcSwingVAuto,
+                              kPanasonicAcSwingVHighest,
+                              kPanasonicAcSwingVHigh,
+                              kPanasonicAcSwingVAuto,  // Upper Middle is unused
+                              kPanasonicAcSwingVMiddle,
+                              kPanasonicAcSwingVAuto,  // Lower Middle is unused
+                              kPanasonicAcSwingVLow,
+                              kPanasonicAcSwingVLowest,
+                              // Below are unused.
+                              kPanasonicAcSwingVAuto,
+                              kPanasonicAcSwingVAuto,
+                              kPanasonicAcSwingVAuto,
+                              kPanasonicAcSwingVAuto);
   switch (getModel()) {
     case kPanasonicJke:
     case kPanasonicCkp:
       break;  // No Horizontal Swing support.
     default:
-      result += addIntToString(getSwingHorizontal(), kSwingHStr);
-      result += kSpaceLBraceStr;
-      switch (getSwingHorizontal()) {
-        case kPanasonicAcSwingHAuto:
-          result += kAutoStr;
-          break;
-        case kPanasonicAcSwingHFullLeft:
-          result += kMaxLeftStr;
-          break;
-        case kPanasonicAcSwingHLeft:
-          result += kLeftStr;
-          break;
-        case kPanasonicAcSwingHMiddle:
-          result += kMiddleStr;
-          break;
-        case kPanasonicAcSwingHFullRight:
-          result += kMaxRightStr;
-          break;
-        case kPanasonicAcSwingHRight:
-          result += kRightStr;
-          break;
-        default:
-          result += kUnknownStr;
-      }
-      result += ')';
+      result += addSwingHToString(getSwingHorizontal(), kPanasonicAcSwingHAuto,
+                                  kPanasonicAcSwingHFullLeft,
+                                  kPanasonicAcSwingHLeft,
+                                  kPanasonicAcSwingHMiddle,
+                                  kPanasonicAcSwingHRight,
+                                  kPanasonicAcSwingHFullRight,
+                                  // Below are unused.
+                                  kPanasonicAcSwingHAuto,
+                                  kPanasonicAcSwingHAuto,
+                                  kPanasonicAcSwingHAuto,
+                                  kPanasonicAcSwingHAuto,
+                                  kPanasonicAcSwingHAuto);
   }
   result += addBoolToString(getQuiet(), kQuietStr);
   result += addBoolToString(getPowerful(), kPowerfulStr);
@@ -1294,18 +1284,20 @@ String IRPanasonicAc32::toString(void) const {
                            kPanasonicAc32FanAuto, kPanasonicAc32FanMin,
                            kPanasonicAc32FanMed, kPanasonicAc32FanMax);
   result += addBoolToString(_.SwingH, kSwingHStr);
-  result += addIntToString(getSwingVertical(), kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (getSwingVertical()) {
-    case kPanasonicAc32SwingVAuto:  result += kAutoStr; break;
-    case kPanasonicAcSwingVHighest: result += kHighestStr; break;
-    case kPanasonicAcSwingVHigh:    result += kHighStr; break;
-    case kPanasonicAcSwingVMiddle:  result += kMiddleStr; break;
-    case kPanasonicAcSwingVLow:     result += kLowStr; break;
-    case kPanasonicAcSwingVLowest:  result += kLowestStr; break;
-    default:                        result += kUnknownStr; break;
-  }
-  result += ')';
+  result += addSwingVToString(getSwingVertical(),
+                              kPanasonicAc32SwingVAuto,
+                              kPanasonicAcSwingVHighest,
+                              kPanasonicAcSwingVHigh,
+                              kPanasonicAc32SwingVAuto,  // Upper Middle unused
+                              kPanasonicAcSwingVMiddle,
+                              kPanasonicAc32SwingVAuto,  // Lower Middle unused
+                              kPanasonicAcSwingVLow,
+                              kPanasonicAcSwingVLowest,
+                              // Below are unused.
+                              kPanasonicAc32SwingVAuto,
+                              kPanasonicAc32SwingVAuto,
+                              kPanasonicAc32SwingVAuto,
+                              kPanasonicAc32SwingVAuto);
   return result;
 }
 

--- a/src/ir_Sanyo.cpp
+++ b/src/ir_Sanyo.cpp
@@ -27,6 +27,7 @@ using irutils::addFanToString;
 using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
+using irutils::addSwingVToString;
 using irutils::addTempToString;
 using irutils::minsToString;
 using irutils::sumNibbles;
@@ -632,27 +633,17 @@ String IRSanyoAc::toString(void) const {
   result += addFanToString(_.Fan, kSanyoAcFanHigh, kSanyoAcFanLow,
                            kSanyoAcFanAuto, kSanyoAcFanAuto,
                            kSanyoAcFanMedium);
-  result += addIntToString(_.SwingV, kSwingVStr);
-  result += kSpaceLBraceStr;
-  switch (_.SwingV) {
-    case kSanyoAcSwingVHighest: result += kHighestStr; break;
-    case kSanyoAcSwingVHigh:    result += kHighStr; break;
-    case kSanyoAcSwingVUpperMiddle:
-      result += kUpperStr;
-      result += ' ';
-      result += kMiddleStr;
-      break;
-    case kSanyoAcSwingVLowerMiddle:
-      result += kLowerStr;
-      result += ' ';
-      result += kMiddleStr;
-      break;
-    case kSanyoAcSwingVLow:     result += kLowStr; break;
-    case kSanyoAcSwingVLowest:  result += kLowestStr; break;
-    case kSanyoAcSwingVAuto:    result += kAutoStr;   break;
-    default:                    result += kUnknownStr;
-  }
-  result += ')';
+  result += addSwingVToString(_.SwingV, kSanyoAcSwingVAuto,
+                              kSanyoAcSwingVHighest, kSanyoAcSwingVHigh,
+                              kSanyoAcSwingVUpperMiddle,
+                              kSanyoAcSwingVAuto,  // Middle is unused
+                              kSanyoAcSwingVLowerMiddle,
+                              kSanyoAcSwingVLow, kSanyoAcSwingVLowest,
+                              // Below are unused.
+                              kSanyoAcSwingVAuto,
+                              kSanyoAcSwingVAuto,
+                              kSanyoAcSwingVAuto,
+                              kSanyoAcSwingVAuto);
   result += addBoolToString(_.Sleep, kSleepStr);
   result += addBoolToString(_.Beep, kBeepStr);
   result += addLabeledString(_.Sensor ? kRoomStr : kWallStr, kSensorStr);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -394,7 +394,7 @@ TEST(TestIRac, Daikin2) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Power: On, Mode: 3 (Cool), Temp: 19C, Fan: 1 (Low), "
-      "Swing(V): 14 (Auto), Swing(H): 170 (UNKNOWN), Clock: 00:00, "
+      "Swing(V): 14 (Off), Swing(H): 170 (Middle), Clock: 00:00, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 2 (Loud), "
       "Light: 1 (High), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off";

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -1427,7 +1427,7 @@ TEST(TestDaikin2Class, HumanReadable) {
   ac.setTemp(21);
   ac.setFan(kDaikinFanMax);
   ac.setSwingVertical(kDaikin2SwingVAuto);
-  ac.setSwingHorizontal(kDaikin2SwingHSwing);
+  ac.setSwingHorizontal(kDaikin2SwingHAuto);
   ac.setCurrentTime(12 * 60 + 34);  // 12:34
   ac.disableOnTimer();
   ac.enableOffTimer(20 * 60);  // 20:00
@@ -1445,7 +1445,7 @@ TEST(TestDaikin2Class, HumanReadable) {
   ac.setEcono(false);
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 21C, Fan: 5 (High), "
-      "Swing(V): 14 (Auto), Swing(H): 191 (Swing), Clock: 12:34, "
+      "Swing(V): 15 (Auto), Swing(H): 190 (Auto), Clock: 12:34, "
       "On Timer: Off, Off Timer: 20:00, Sleep Timer: 04:00, Beep: 2 (Loud), "
       "Light: 2 (Low), Mould: On, Clean: Off, Fresh: On, Eye: On, "
       "Eye Auto: On, Quiet: Off, Powerful: On, Purify: On, Econo: Off",
@@ -1457,10 +1457,10 @@ TEST(TestDaikin2Class, HumanReadable) {
   ac.setTemp(32);
   ac.setFan(kDaikinFanMin);
   ac.setCurrentTime(23 * 60 + 45);  // 23:45
-  ac.enableOnTimer(9 * 60 + 11);  // 9:11
+  ac.enableOnTimer(9 * 60 + 11);  // 09:11
   EXPECT_EQ(
       "Power: On, Mode: 4 (Heat), Temp: 32C, Fan: 1 (Low), "
-      "Swing(V): 14 (Auto), Swing(H): 191 (Swing), Clock: 23:45, "
+      "Swing(V): 15 (Auto), Swing(H): 190 (Auto), Clock: 23:45, "
       "On Timer: 09:11, Off Timer: 20:00, Sleep Timer: Off, Beep: 1 (Quiet), "
       "Light: 1 (High), Mould: On, Clean: Off, Fresh: On, Eye: On, "
       "Eye Auto: On, Quiet: On, Powerful: Off, Purify: On, Econo: Off",
@@ -1568,7 +1568,7 @@ TEST(TestDecodeDaikin2, Issue582DeepDecodeExample) {
   ASSERT_TRUE(ac.getPurify());
   EXPECT_EQ(
       "Power: On, Mode: 0 (Auto), Temp: 19C, Fan: 10 (Auto), "
-      "Swing(V): 14 (Auto), Swing(H): 190 (Auto), Clock: 09:20, "
+      "Swing(V): 14 (Off), Swing(H): 190 (Auto), Clock: 09:20, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 3 (Off), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: On, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
@@ -1593,7 +1593,7 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
   ASSERT_TRUE(ac.getPowerful());
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 10 (Auto), "
-      "Swing(V): 14 (Auto), Swing(H): 190 (Auto), Clock: 13:46, "
+      "Swing(V): 14 (Off), Swing(H): 190 (Auto), Clock: 13:46, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 3 (Off), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: On, Purify: On, Econo: Off",
@@ -1602,7 +1602,7 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
   ASSERT_FALSE(ac.getPowerful());
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 10 (Auto), "
-      "Swing(V): 14 (Auto), Swing(H): 190 (Auto), Clock: 13:46, "
+      "Swing(V): 14 (Off), Swing(H): 190 (Auto), Clock: 13:46, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 3 (Off), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
@@ -1622,7 +1622,7 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
   ASSERT_TRUE(ac.getEcono());
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 10 (Auto), "
-      "Swing(V): 14 (Auto), Swing(H): 190 (Auto), Clock: 13:47, "
+      "Swing(V): 14 (Off), Swing(H): 190 (Auto), Clock: 13:47, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 3 (Off), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: On",
@@ -1631,7 +1631,7 @@ TEST(TestDecodeDaikin2, Issue582PowerfulEconoFix) {
   ASSERT_FALSE(ac.getEcono());
   EXPECT_EQ(
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 10 (Auto), "
-      "Swing(V): 14 (Auto), Swing(H): 190 (Auto), Clock: 13:47, "
+      "Swing(V): 14 (Off), Swing(H): 190 (Auto), Clock: 13:47, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 3 (Off), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
@@ -1984,7 +1984,7 @@ TEST(TestDaikin2Class, toCommon) {
   ac.setMode(kDaikinCool);
   ac.setTemp(20);
   ac.setFan(kDaikinFanMax);
-  ac.setSwingVertical(kDaikin2SwingVHigh + 3);
+  ac.setSwingVertical(kDaikin2SwingVLowerMiddle);
   ac.setSwingHorizontal(kDaikin2SwingHAuto);
   ac.setQuiet(false);
   ac.setPowerful(true);
@@ -2010,7 +2010,7 @@ TEST(TestDaikin2Class, toCommon) {
   ASSERT_EQ(stdAc::opmode_t::kCool, ac.toCommon().mode);
   ASSERT_EQ(stdAc::fanspeed_t::kMax, ac.toCommon().fanspeed);
   ASSERT_EQ(stdAc::swingv_t::kMiddle, ac.toCommon().swingv);
-  ASSERT_EQ(stdAc::swingh_t::kOff, ac.toCommon().swingh);
+  ASSERT_EQ(stdAc::swingh_t::kAuto, ac.toCommon().swingh);
   ASSERT_EQ(6 * 60, ac.toCommon().sleep);
   // Unsupported.
   ASSERT_EQ(-1, ac.toCommon().clock);
@@ -3030,7 +3030,7 @@ TEST(TestDaikin2ClassNew, Issue908) {
   ac.setRaw(fanMedium);
   EXPECT_EQ(
       "Power: On, Mode: 0 (Auto), Temp: 30C, Fan: 3 (Medium), "
-      "Swing(V): 3 (UpperMiddle), Swing(H): 170 (UNKNOWN), Clock: 09:46, "
+      "Swing(V): 3 (Upper Middle), Swing(H): 170 (Middle), Clock: 09:46, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 2 (Loud), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
@@ -3048,15 +3048,15 @@ TEST(TestDaikin2ClassNew, Issue908) {
   ac.setRaw(swingvMiddle);
   EXPECT_EQ(
       "Power: On, Mode: 0 (Auto), Temp: 30C, Fan: 11 (Quiet), "
-      "Swing(V): 3 (UpperMiddle), Swing(H): 170 (UNKNOWN), Clock: 09:57, "
+      "Swing(V): 3 (Upper Middle), Swing(H): 170 (Middle), Clock: 09:57, "
       "On Timer: Off, Off Timer: Off, Sleep Timer: Off, Beep: 2 (Loud), "
       "Light: 3 (Off), Mould: On, Clean: On, Fresh: Off, Eye: Off, "
       "Eye Auto: Off, Quiet: Off, Powerful: Off, Purify: On, Econo: Off",
       ac.toString());
   ASSERT_EQ(3, ac.getSwingVertical());
   ASSERT_EQ(stdAc::swingv_t::kMiddle, ac.toCommon().swingv);
-  ac.setSwingVertical(4);
-  ASSERT_EQ(4, ac.getSwingVertical());
+  ac.setSwingVertical(kDaikin2SwingVLowerMiddle);
+  ASSERT_EQ(kDaikin2SwingVLowerMiddle, ac.getSwingVertical());
   ASSERT_EQ(stdAc::swingv_t::kMiddle, ac.toCommon().swingv);
   // Either 3 or 4 is fine as they both map to stdAc::swingv_t::kMiddle.
   ASSERT_EQ(4, ac.convertSwingV(stdAc::swingv_t::kMiddle));
@@ -3065,11 +3065,11 @@ TEST(TestDaikin2ClassNew, Issue908) {
   ASSERT_EQ(kDaikin2SwingVSwing, ac.getSwingVertical());
   ASSERT_EQ(stdAc::swingv_t::kAuto, ac.toCommon().swingv);
   ASSERT_EQ(kDaikin2SwingVSwing, ac.convertSwingV(stdAc::swingv_t::kAuto));
-  // Native "auto" should convert to common's "off".
-  ac.setSwingVertical(kDaikin2SwingVAuto);
-  ASSERT_EQ(kDaikin2SwingVAuto, ac.getSwingVertical());
+  // Native "off" should convert to common's "off".
+  ac.setSwingVertical(kDaikin2SwingVOff);
+  ASSERT_EQ(kDaikin2SwingVOff, ac.getSwingVertical());
   ASSERT_EQ(stdAc::swingv_t::kOff, ac.toCommon().swingv);
-  ASSERT_EQ(kDaikin2SwingVAuto, ac.convertSwingV(stdAc::swingv_t::kOff));
+  ASSERT_EQ(kDaikin2SwingVOff, ac.convertSwingV(stdAc::swingv_t::kOff));
 }
 
 // Tests for IRDaikin152 class.


### PR DESCRIPTION
* Use common `irutils::addSwing[V|H]ToString()` functions to reduce duplicate code/strings.
  - Daikin
  - Panasonic
  - Sanyo
  - MistubishHeavy
* Adjust & add some Daikin2 swing constants.
  - Fix some legacy br0k3n or poor constants.
* Improve output of Daikin Swing text output.
* Update unit tests due to change constants & text.

Fixes #1365