### PR TITLE
Fix Travis-CI build issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: c
 addons:
   apt:
@@ -5,7 +6,7 @@ addons:
     - jq
     - doxygen
     - graphviz
-    - python3
+    - python3.8
     - python3-pip
     - pylint3
     - python3-setuptools

--- a/examples/BlynkIrRemote/platformio.ini
+++ b/examples/BlynkIrRemote/platformio.ini
@@ -13,7 +13,7 @@ build_flags = ; -D_IR_LOCALE_=en-AU
 [common]
 lib_deps_builtin =
 lib_deps_external =
-  Blynk
+  blynkkk/Blynk
 
 [common_esp8266]
 lib_deps_external =

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -34,7 +34,7 @@
  *     - ArduinoJson (https://arduinojson.org/) (Version >= 6.0)
  *     - PubSubClient (https://pubsubclient.knolleary.net/) (Version >= 2.8.0)
  *     - WiFiManager (https://github.com/tzapu/WiFiManager)
- *                   (ESP8266: Version >= 0.14, ESP32: 'development' branch.)
+ *                   (ESP8266: Version >= 0.14, ESP32: Version >= 0.16.)
  *   o Use the smallest non-zero FILESYSTEM size you can for your board.
  *     (See the Tools -> Flash Size menu)
  *

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -26,7 +26,7 @@ lib_deps_external =
 lib_deps_external =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
-  https://github.com/tzapu/WiFiManager.git#development
+  WifiManager@>=0.16
 
 [env:nodemcuv2]
 board = nodemcuv2

--- a/examples/Web-AC-control/platformio.ini
+++ b/examples/Web-AC-control/platformio.ini
@@ -25,7 +25,7 @@ lib_deps_external =
 lib_deps_external =
   ${common.lib_deps_builtin}
   ${common.lib_deps_external}
-  https://github.com/tzapu/WiFiManager.git#development
+  WifiManager@>=0.16
 
 [env:nodemcuv2]
 platform = espressif8266


### PR DESCRIPTION
* Migrate Travis to Python >3.6
  - Use `bionic` dist.
  - PlatformIO has dropped support for Python <3.6
* Update PlatformIO dependencies/requirements based on `bionic` upgrade.
* WifiManager: `development` branch not available. Require >=0.16 for ESP32.

For/Blocking #1395
FYI @siriuslzx