### PR TITLE
MitsubishiAC: Add support for enabling Weekly Timer.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1334,6 +1334,8 @@ void IRac::mitsubishi(IRMitsubishiAC *ac,
                       const stdAc::swingh_t swingh,
                       const bool quiet, const int16_t clock) {
   ac->begin();
+  // Uncomment next line if you *really* need the weekly timer enabled via IRac.
+  // ac->setWeeklyTimerEnabled(true);  // Weekly Timer is disabled by default.
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -762,6 +762,16 @@ stdAc::state_t IRMitsubishiAC::toCommon(void) const {
   return result;
 }
 
+/// Change the Weekly Timer Enabled setting.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRMitsubishiAC::setWeeklyTimerEnabled(const bool on) {
+  _.WeeklyTimer = on;
+}
+
+/// Get the value of the WeeklyTimer Enabled setting.
+/// @return true, the setting is on. false, the setting is off.
+bool IRMitsubishiAC::getWeeklyTimerEnabled(void) const { return _.WeeklyTimer; }
+
 /// Convert the internal state into a human readable string.
 /// @return A string containing the settings in human-readable form.
 String IRMitsubishiAC::toString(void) const {
@@ -822,6 +832,7 @@ String IRMitsubishiAC::toString(void) const {
       result += _.Timer;
       result += ')';
   }
+  result += addBoolToString(_.WeeklyTimer, kWeeklyTimerStr);
   return result;
 }
 

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -79,8 +79,9 @@ union Mitsubishi144Protocol{
     // Byte 12
     uint8_t StartClock:8;
     // Byte 13
-    uint8_t Timer :3;
-    uint8_t       :5;
+    uint8_t Timer       :3;
+    uint8_t WeeklyTimer :1;
+    uint8_t             :4;
     // Byte 14~16
     uint8_t pad1[3];
     // Byte 17
@@ -277,6 +278,8 @@ class IRMitsubishiAC {
   void setStopClock(const uint8_t clock);
   uint8_t getTimer(void) const;
   void setTimer(const uint8_t timer);
+  bool getWeeklyTimerEnabled(void) const;
+  void setWeeklyTimerEnabled(const bool on);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static uint8_t convertSwingV(const stdAc::swingv_t position);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -991,7 +991,8 @@ TEST(TestIRac, Mitsubishi) {
   char expected[] =
       "Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 2 (Medium), "
       "Swing(V): 0 (Auto), Swing(H): 3 (Middle), "
-      "Clock: 14:30, On Timer: 00:00, Off Timer: 00:00, Timer: -";
+      "Clock: 14:30, On Timer: 00:00, Off Timer: 00:00, Timer: -, "
+      "Weekly Timer: Off";
 
   ac.begin();
   irac.mitsubishi(&ac,


### PR DESCRIPTION
* Add `[s|g]etWeeklyTimerEnabled()`.
* Unit test coverage based on real data.
* Add comment on how to Weekly Timer enabling by default via `IRac` class.

Fixes #1403