### PR TITLE
ToshibaAC: Adjust inter-message gap timing to improve matching.

### DIFF
--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 David Conran
+// Copyright 2017-2021 David Conran
 
 /// @file
 /// @brief Support for Toshiba protocols.
@@ -27,7 +27,10 @@ const uint16_t kToshibaAcHdrSpace = 4300;
 const uint16_t kToshibaAcBitMark = 580;
 const uint16_t kToshibaAcOneSpace = 1600;
 const uint16_t kToshibaAcZeroSpace = 490;
-const uint16_t kToshibaAcMinGap = 7400;
+// Some models have a different inter-message gap.
+// See: https://github.com/crankyoldgit/IRremoteESP8266/issues/1420
+const uint16_t kToshibaAcMinGap = 4600;    // WH-UB03NJ remote
+const uint16_t kToshibaAcUsualGap = 7400;  // Others
 
 using irutils::addBoolToString;
 using irutils::addFanToString;
@@ -48,7 +51,7 @@ void IRsend::sendToshibaAC(const uint8_t data[], const uint16_t nbytes,
                            const uint16_t repeat) {
   sendGeneric(kToshibaAcHdrMark, kToshibaAcHdrSpace, kToshibaAcBitMark,
               kToshibaAcOneSpace, kToshibaAcBitMark, kToshibaAcZeroSpace,
-              kToshibaAcBitMark, kToshibaAcMinGap, data, nbytes, 38, true,
+              kToshibaAcBitMark, kToshibaAcUsualGap, data, nbytes, 38, true,
               repeat, 50);
 }
 #endif  // SEND_TOSHIBA_AC

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -16,6 +16,8 @@
 //   Brand: Toshiba,  Model: RAS 18SKP-ES
 //   Brand: Toshiba,  Model: WH-TA04NE
 //   Brand: Toshiba,  Model: WC-L03SE
+//   Brand: Toshiba,  Model: WH-UB03NJ remote
+//   Brand: Toshiba,  Model: RAS-2558V A/C
 //   Brand: Carrier,  Model: 42NQV060M2 / 38NYV060M2 A/C
 //   Brand: Carrier,  Model: 42NQV050M2 / 38NYV050M2 A/C
 //   Brand: Carrier,  Model: 42NQV035M2 / 38NYV035M2 A/C


### PR DESCRIPTION
* Allow for a shorted inter-message gap to handle decoding a WH-UB03NJ remote.
  - A/C does accept the longer inter-message gap. (Confirmed)
* Add unit test to confirm operation.
* Update supported models.

Kudos to @nao-pon for collecting/analysing the data.

Fixes #1420