### PR TITLE
ToshibaAC: Swing handling and `setRaw()` improvements.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3866,7 +3866,7 @@ namespace IRAcUtils {
       case decode_type_t::TOSHIBA_AC: {
         IRToshibaAC ac(kGpioUnused);
         ac.setRaw(decode->state);
-        *result = ac.toCommon();
+        *result = ac.toCommon(prev);
         break;
       }
 #endif  // DECODE_TOSHIBA_AC

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3287,7 +3287,7 @@ namespace IRAcUtils {
 #if DECODE_TOSHIBA_AC
       case decode_type_t::TOSHIBA_AC: {
         IRToshibaAC ac(kGpioUnused);
-        ac.setRaw(result->state);
+        ac.setRaw(result->state, result->bits / 8);
         return ac.toString();
       }
 #endif  // DECODE_TOSHIBA_AC
@@ -3865,7 +3865,7 @@ namespace IRAcUtils {
 #if DECODE_TOSHIBA_AC
       case decode_type_t::TOSHIBA_AC: {
         IRToshibaAC ac(kGpioUnused);
-        ac.setRaw(decode->state);
+        ac.setRaw(decode->state, decode->bits / 8);
         *result = ac.toCommon(prev);
         break;
       }

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -141,8 +141,9 @@ uint8_t* IRToshibaAC::getRaw(void) {
 
 /// Set the internal state from a valid code for this protocol.
 /// @param[in] newState A valid code for this protocol.
-void IRToshibaAC::setRaw(const uint8_t newState[]) {
-  memcpy(_.raw, newState, kToshibaACStateLength);
+/// @param[in] length The length/size of the array.
+void IRToshibaAC::setRaw(const uint8_t newState[], const uint16_t length) {
+  memcpy(_.raw, newState, length);
   _prev_mode = getMode();
   _send_swing = true;
 }

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -409,11 +409,18 @@ stdAc::state_t IRToshibaAC::toCommon(const stdAc::state_t *prev) const {
   }
   result.protocol = decode_type_t::TOSHIBA_AC;
   result.model = -1;  // Not supported.
-  result.power = getPower();
-  result.mode = toCommonMode(getMode());
-  result.celsius = true;
-  result.degrees = getTemp();
-  result.fanspeed = toCommonFanSpeed(getFan());
+  // Do we have enough current state info to override any previous state?
+  // i.e. Was the class just setRaw()'ed with a short "swing" message.
+  // This should enables us to also ignore the Swing msg's special 17C setting.
+  if (getStateLength() != kToshibaACStateLengthShort) {
+    result.power = getPower();
+    result.mode = toCommonMode(getMode());
+    result.celsius = true;
+    result.degrees = getTemp();
+    result.fanspeed = toCommonFanSpeed(getFan());
+    result.turbo = getTurbo();
+    result.econo = getEcono();
+  }
   switch (getSwing()) {
     case kToshibaAcSwingOn:
       result.swingv = stdAc::swingv_t::kAuto;
@@ -426,8 +433,6 @@ stdAc::state_t IRToshibaAC::toCommon(const stdAc::state_t *prev) const {
       break;
     default: result.swingv = stdAc::swingv_t::kOff;
   }
-  result.turbo = getTurbo();
-  result.econo = getEcono();
   // Not supported.
   result.light = false;
   result.filter = false;

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -60,8 +60,8 @@ union ToshibaProtocol{
     uint8_t ShortMsg:1;
     uint8_t         :2;
     // Byte[5]
-    uint8_t Swing :2;
-    uint8_t       :2;
+    uint8_t Swing :3;
+    uint8_t       :1;
     uint8_t Temp  :4;
     // Byte[6]
     uint8_t Mode  :3;
@@ -83,9 +83,10 @@ const uint8_t kToshibaAcMinLength = 6;  ///< Min Nr. of bytes in a message.
 const uint16_t kToshibaAcInvertedLength = 4;  ///< Nr. of leading bytes in
                                               ///< inverted pairs.
 
-const uint8_t kToshibaAcSwingStep = 0;       ///<            0b00
-const uint8_t kToshibaAcSwingOn = 1;         ///<            0b01
-const uint8_t kToshibaAcSwingOff = 2;        ///<            0b10
+const uint8_t kToshibaAcSwingStep = 0;       ///<            0b000
+const uint8_t kToshibaAcSwingOn = 1;         ///<            0b001
+const uint8_t kToshibaAcSwingOff = 2;        ///<            0b010
+const uint8_t kToshibaAcSwingToggle = 4;     ///<            0b100
 
 const uint8_t kToshibaAcMinTemp = 17;  ///< 17C
 const uint8_t kToshibaAcMaxTemp = 30;  ///< 30C
@@ -158,7 +159,7 @@ class IRToshibaAC {
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void) const;
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL) const;
   String toString(void) const;
 #ifndef UNIT_TEST
 

--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -146,7 +146,8 @@ class IRToshibaAC {
   bool getEcono(void) const;
   void setMode(const uint8_t mode);
   uint8_t getMode(const bool raw = false) const;
-  void setRaw(const uint8_t newState[]);
+  void setRaw(const uint8_t newState[],
+              const uint16_t length = kToshibaACStateLength);
   uint8_t* getRaw(void);
   static uint16_t getInternalStateLength(const uint8_t state[],
                                          const uint16_t size);

--- a/test/ir_Toshiba_test.cpp
+++ b/test/ir_Toshiba_test.cpp
@@ -426,7 +426,7 @@ TEST(TestDecodeToshibaAC, RealExamples) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(TOSHIBA_AC, irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, irsend.capture.bits);
-  ac.setRaw(irsend.capture.state);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(23, ac.getTemp());
   EXPECT_EQ(kToshibaAcFanAuto, ac.getFan());
@@ -465,7 +465,7 @@ TEST(TestDecodeToshibaAC, RealExamples) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(TOSHIBA_AC, irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, irsend.capture.bits);
-  ac.setRaw(irsend.capture.state);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(17, ac.getTemp());
   EXPECT_EQ(3, ac.getFan());
@@ -504,7 +504,7 @@ TEST(TestDecodeToshibaAC, RealExamples) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(TOSHIBA_AC, irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, irsend.capture.bits);
-  ac.setRaw(irsend.capture.state);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_TRUE(ac.getPower());
   EXPECT_EQ(24, ac.getTemp());
   EXPECT_EQ(kToshibaAcFanMax, ac.getFan());
@@ -543,7 +543,7 @@ TEST(TestDecodeToshibaAC, RealExamples) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   ASSERT_EQ(TOSHIBA_AC, irsend.capture.decode_type);
   ASSERT_EQ(kToshibaACBits, irsend.capture.bits);
-  ac.setRaw(irsend.capture.state);
+  ac.setRaw(irsend.capture.state, irsend.capture.bits / 8);
   EXPECT_FALSE(ac.getPower());
   EXPECT_EQ(22, ac.getTemp());
   EXPECT_EQ(4, ac.getFan());
@@ -822,7 +822,7 @@ TEST(TestToshibaACClass, SwingCodes) {
 
   const uint8_t swingToggleState[kToshibaACStateLengthShort] = {
         0xF2, 0x0D, 0x01, 0xFE, 0x21, 0x04, 0x25};
-  ac.setRaw(swingToggleState);
+  ac.setRaw(swingToggleState, kToshibaACStateLengthShort);
   EXPECT_EQ(kToshibaAcSwingToggle, ac.getSwing());
   EXPECT_EQ(
       "Temp: 17C, Swing(V): 4 (Toggle)",

--- a/test/ir_Toshiba_test.cpp
+++ b/test/ir_Toshiba_test.cpp
@@ -793,3 +793,38 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ(kToshibaACBits, IRsend::defaultBits(decode_type_t::TOSHIBA_AC));
   ASSERT_EQ(kSingleRepeat, IRsend::minRepeats(decode_type_t::TOSHIBA_AC));
 }
+
+// For https://github.com/crankyoldgit/IRremoteESP8266/issues/1423
+TEST(TestToshibaACClass, SwingCodes) {
+  IRToshibaAC ac(kGpioUnused);
+  ac.setStateLength(kToshibaACStateLengthShort);
+  ac.setTemp(kToshibaAcMinTemp);
+  ac.setSwing(kToshibaAcSwingOn);
+
+  EXPECT_EQ(
+      "Temp: 17C, Swing(V): 1 (On)",
+      ac.toString());
+  EXPECT_EQ(kToshibaACStateLengthShort, ac.getStateLength());
+  const uint8_t swingOnState[kToshibaACStateLengthShort] = {
+        0xF2, 0x0D, 0x01, 0xFE, 0x21, 0x01, 0x20};
+  EXPECT_STATE_EQ(swingOnState, ac.getRaw(), kToshibaACBitsShort);
+  EXPECT_EQ(kToshibaACStateLengthShort, ac.getStateLength());
+
+  ac.setSwing(kToshibaAcSwingOff);
+  EXPECT_EQ(
+      "Temp: 17C, Swing(V): 2 (Off)",
+      ac.toString());
+  EXPECT_EQ(kToshibaACStateLengthShort, ac.getStateLength());
+  const uint8_t swingOffState[kToshibaACStateLengthShort] = {
+        0xF2, 0x0D, 0x01, 0xFE, 0x21, 0x02, 0x23};
+  EXPECT_STATE_EQ(swingOffState, ac.getRaw(), kToshibaACBitsShort);
+  EXPECT_EQ(kToshibaACStateLengthShort, ac.getStateLength());
+
+  const uint8_t swingToggleState[kToshibaACStateLengthShort] = {
+        0xF2, 0x0D, 0x01, 0xFE, 0x21, 0x04, 0x25};
+  ac.setRaw(swingToggleState);
+  EXPECT_EQ(kToshibaAcSwingToggle, ac.getSwing());
+  EXPECT_EQ(
+      "Temp: 17C, Swing(V): 4 (Toggle)",
+      ac.toString());
+}


### PR DESCRIPTION
* Add support for the Swing Toggle setting.
  - Turns out there is another setting for swing. This means it needs to grow from 2 bits to 3 bits. Adjustments as needed.
* Fix potential memory crash issue with `setRaw()`
  - Make `setRaw()` memory safer by passing a length arg.
  - Update calls to `IRToshibaAC::setRaw()`
* Unit test coverage.

Fixes #1423 

* Try to ignore changing the `IRac` class temp when we get an inbound swing IR command.
* May fix some upstream implementations & setups. e.g. Tasmota & Home Assistant.
  - Can't hurt at least. (Famous last words)

Fixes #1424 