### PR TITLE
Fix `addApbChangeCallback(): duplicate func` kernel msgs

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -360,6 +360,7 @@ void IRrecv::disableIRIn(void) {
 #endif  // ESP8266
 #if defined(ESP32)
   timerAlarmDisable(timer);
+  timerEnd(timer);
 #endif  // ESP32
   detachInterrupt(params.recvpin);
 #endif  // UNIT_TEST


### PR DESCRIPTION
When `IRrecv::enableIRn()` was called after a `IRrecv::disableIRn()` call the ESP32 would produce a kernel message/warning on the serial port. e.g.:
```
[E][esp32-hal-cpu.c:93] addApbChangeCallback(): duplicate func=400814C4 arg=3FFBDFC4
```
if the ESP32 IDF 3.3 (v1.0.5) was used.

Fix the issue by ensuring a `timerEnd()` call is made in the `disableIRIn()` call to properly clean up the timer.

Tested on an ESP32dev board. Confirmed the message no longer appears.

Fixes #1434