### PR TITLE
[BUG] Fix `IRAcUtils::decodeToState()` for different length Samsung msgs

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3817,7 +3817,7 @@ namespace IRAcUtils {
 #if DECODE_SAMSUNG_AC
       case decode_type_t::SAMSUNG_AC: {
         IRSamsungAc ac(kGpioUnused);
-        ac.setRaw(decode->state);
+        ac.setRaw(decode->state, decode->bits / 8);
         *result = ac.toCommon();
         break;
       }


### PR DESCRIPTION
Need to pass byte length to `IRSamsungAc::setRaw()` to handle normal & **extended** messages.

Kudos to @yaroshd81 for finding the bug, and offering the solution.

Fixes #1447