### PR TITLE
Removed submodule: googletest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "lib/googletest"]
-	path = lib/googletest
-	url = https://github.com/google/googletest.git
-	branch = v1.8.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ jobs:
       - python cpplint.py --extensions=c,cc,cpp,ino --headers=h,hpp {src,src/locale,test,tools}/*.{h,c,cc,cpp,hpp,ino} examples/*/*.{h,c,cc,cpp,hpp,ino}
       - pylint3 -d F0001 {src,test,tools}/*.py
       - shopt -u nullglob
+      # Install the Google test suite.
+      - (cd test; make install-googletest)
       # Build and run the unit tests.
       - (cd test; make run)
       - (cd tools; make run_tests)

--- a/test/Makefile
+++ b/test/Makefile
@@ -56,6 +56,7 @@ run : all
 run_tests : run
 
 install-googletest :
+	rm -rf ../lib/googletest
 	git clone -b v1.8.x https://github.com/google/googletest.git ../lib/googletest
 
 # Builds gtest.a and gtest_main.a.


### PR DESCRIPTION
Attempt to cleanup any issues found by `arduino-lint --library-manager update --compliance strict`
e.g.
```
Rule LS004 result: fail
WARNING: Git submodule detected. Library Manager installations and installations from GitHub's "Download ZIP" will only contain an empty folder in place of the submodule.
```

It's only a warning, but just being super-safe.

For #1451 