### PR TITLE
Reduce download size when using Arduino IDE

### DIFF
--- a/library.json
+++ b/library.json
@@ -44,6 +44,7 @@
       "maintainer": true
     }
   ],
+  "exclude": [".github", "extras", "docs", "assets"],
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"]
 }


### PR DESCRIPTION
Issues with Arduino IDE ( #1451 ) might be related to zip file size. It surpassed 5Meg as of v2.7.16. So remove unneeded items from being included in the zip file, I hope.
This is a Hail Mary