### PR TITLE
Add HTML viewport meta tag to IRServer and IRMQTTServer examples

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1000,7 +1000,8 @@ String htmlHeader(const String title, const String h1_text) {
   html += title;
   html += F("</title><meta http-equiv=\"Content-Type\" "
             "content=\"text/html;charset=utf-8\">"
-            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\">"
+            "<meta name=\"viewport\" content=\"width=device-width,"
+            "initial-scale=1.0,minimum-scale=1.0,maximum-scale=5.0\">"
             "</head><body><center><h1>");
   if (h1_text.length())
     html += h1_text;

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1000,6 +1000,7 @@ String htmlHeader(const String title, const String h1_text) {
   html += title;
   html += F("</title><meta http-equiv=\"Content-Type\" "
             "content=\"text/html;charset=utf-8\">"
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\">"
             "</head><body><center><h1>");
   if (h1_text.length())
     html += h1_text;

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -68,6 +68,7 @@ void handleRoot() {
                 "<head><title>" HOSTNAME " Demo </title>" \
                 "<meta http-equiv=\"Content-Type\" " \
                     "content=\"text/html;charset=utf-8\">" \
+                "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\">" \
                 "</head>" \
                 "<body>" \
                   "<h1>Hello from " HOSTNAME ", you can send NEC encoded IR" \

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -68,7 +68,9 @@ void handleRoot() {
                 "<head><title>" HOSTNAME " Demo </title>" \
                 "<meta http-equiv=\"Content-Type\" " \
                     "content=\"text/html;charset=utf-8\">" \
-                "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\">" \
+                "<meta name=\"viewport\" content=\"width=device-width," \
+                    "initial-scale=1.0,minimum-scale=1.0," \
+                    "maximum-scale=5.0\">" \
                 "</head>" \
                 "<body>" \
                   "<h1>Hello from " HOSTNAME ", you can send NEC encoded IR" \


### PR DESCRIPTION
The IRServer and IRMQTTServer web pages are easier to read with a viewport meta tag when using a phone or tablet in portrait mode.

Fixes #1467.