### PR TITLE
Fix compiler warnings causing Travis failures.

### DIFF
--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -58,4 +58,4 @@ build_flags = -D_IR_LOCALE_=zh-CN  ;  Chinese (Simplified)
 ; Build the library with all protocols disabled to flush out #if/#ifdef issues &
 ; any compiler warnings, by turning them into errors.
 [env:shakedown_no_protocols]
-build_flags = -D_IR_ENABLE_DEFAULT_=false -Werror
+build_flags = -D_IR_ENABLE_DEFAULT_=false -Werror -Wno-error=switch

--- a/examples/SmartIRRepeater/platformio.ini
+++ b/examples/SmartIRRepeater/platformio.ini
@@ -33,4 +33,5 @@ board = nodemcuv2
 build_flags =
   ${env.build_flags}
   -Werror
+  -Wno-error=switch
   -D_IR_ENABLE_DEFAULT_=false

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -285,16 +285,8 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_VOLTAS
     case decode_type_t::VOLTAS:
 #endif
-#if SEND_WHIRLPOOL_AC
     case decode_type_t::WHIRLPOOL_AC:
-#endif
-// Note: Compiler Warning is disabled because someone could disable all
-//       the protocols before this and it is then unreachable.
-//       "-Wswitch-unreachable" not used as it appears to be an unknown option.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wall"
       return true;
-#pragma GCC diagnostic pop
     default:
       return false;
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -293,7 +293,7 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 //       "-Wswitch-unreachable" not used as it appears to be an unknown option.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Werror=switch-unreachable"
+#pragma GCC diagnostic ignored "-Werror"
       return true;
 #pragma GCC diagnostic pop
     default:

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -293,7 +293,6 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 //       "-Wswitch-unreachable" not used as it appears to be an unknown option.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic warning "-Wswitch"
       return true;
 #pragma GCC diagnostic pop
     default:

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -293,7 +293,7 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 //       "-Wswitch-unreachable" not used as it appears to be an unknown option.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Werror"
+#pragma GCC diagnostic warning "-Wswitch"
       return true;
 #pragma GCC diagnostic pop
     default:

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -293,6 +293,7 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 //       "-Wswitch-unreachable" not used as it appears to be an unknown option.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Werror=switch-unreachable"
       return true;
 #pragma GCC diagnostic pop
     default:

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -32,7 +32,7 @@ extern "C" {
 #define USE_IRAM_ATTR IRAM_ATTR
 #else  // IRAM_ATTR
 #define USE_IRAM_ATTR ICACHE_RAM_ATTR
-#endif // IRAM_ATTR
+#endif  // IRAM_ATTR
 #endif  // ESP8266
 #if defined(ESP32)
 #define USE_IRAM_ATTR IRAM_ATTR

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -28,7 +28,11 @@ extern "C" {
 
 #ifndef USE_IRAM_ATTR
 #if defined(ESP8266)
+#if defined(IRAM_ATTR)
+#define USE_IRAM_ATTR IRAM_ATTR
+#else  // IRAM_ATTR
 #define USE_IRAM_ATTR ICACHE_RAM_ATTR
+#endif // IRAM_ATTR
 #endif  // ESP8266
 #if defined(ESP32)
 #define USE_IRAM_ATTR IRAM_ATTR


### PR DESCRIPTION
* Fix ICACHE_RAM_ATTR deprecation warning.
Address compilation issue:
```
/home/travis/build/crankyoldgit/IRremoteESP8266/src/IRrecv.cpp: In member function 'void IRrecv::enableIRIn(bool)':
/home/travis/build/crankyoldgit/IRremoteESP8266/src/IRrecv.cpp:346:62: warning: 'void read_timeout(void*)' is deprecated: Use IRAM_ATTR in place of ICACHE_RAM_ATTR to move functions into IRAM [-Wdeprecated-declarations]
```
* Switch/code unreachable warning.