### PR TITLE
Daikin64: Add support for Heat mode

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -3610,6 +3610,7 @@ void IRDaikin64::setMode(const uint8_t mode) {
     case kDaikin64Fan:
     case kDaikin64Dry:
     case kDaikin64Cool:
+    case kDaikin64Heat:
       _.Mode = mode;
       break;
     default:
@@ -3624,7 +3625,8 @@ uint8_t IRDaikin64::convertMode(const stdAc::opmode_t mode) {
   switch (mode) {
     case stdAc::opmode_t::kDry: return kDaikin64Dry;
     case stdAc::opmode_t::kFan: return kDaikin64Fan;
-    default: return kDaikinCool;
+    case stdAc::opmode_t::kHeat: return kDaikin64Heat;
+    default: return kDaikin64Cool;
   }
 }
 
@@ -3634,6 +3636,7 @@ uint8_t IRDaikin64::convertMode(const stdAc::opmode_t mode) {
 stdAc::opmode_t IRDaikin64::toCommonMode(const uint8_t mode) {
   switch (mode) {
     case kDaikin64Cool: return stdAc::opmode_t::kCool;
+    case kDaikin64Heat: return stdAc::opmode_t::kHeat;
     case kDaikin64Dry:  return stdAc::opmode_t::kDry;
     case kDaikin64Fan:  return stdAc::opmode_t::kFan;
     default: return stdAc::opmode_t::kAuto;
@@ -3817,7 +3820,7 @@ String IRDaikin64::toString(void) const {
   result.reserve(120);  // Reserve some heap for the string to reduce fragging.
   result += addBoolToString(_.Power, kPowerToggleStr, false);
   result += addModeToString(_.Mode, 0xFF, kDaikin64Cool,
-                            0xFF, kDaikin64Dry, kDaikin64Fan);
+                            kDaikin64Heat, kDaikin64Dry, kDaikin64Fan);
   result += addTempToString(getTemp());
   if (!getTurbo()) {
     result += addFanToString(_.Fan, kDaikin64FanHigh, kDaikin64FanLow,

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -43,6 +43,7 @@
 //   Brand: Daikin,  Model: M Series A/C (DAIKIN)
 //   Brand: Daikin,  Model: FTXM-M A/C (DAIKIN)
 //   Brand: Daikin,  Model: ARC466A33 remote (DAIKIN)
+//   Brand: Daikin,  Model: FTWX35AXV1 A/C (DAIKIN64)
 
 #ifndef IR_DAIKIN_H_
 #define IR_DAIKIN_H_
@@ -627,9 +628,10 @@ const uint8_t kDaikin64Overhead = 9;
 const int8_t  kDaikin64ToleranceDelta = 5;  // +5%
 
 const uint64_t kDaikin64KnownGoodState = 0x7C16161607204216;
-const uint8_t kDaikin64Dry =  0b001;
-const uint8_t kDaikin64Cool = 0b010;
-const uint8_t kDaikin64Fan =  0b100;
+const uint8_t kDaikin64Dry =  0b0001;
+const uint8_t kDaikin64Cool = 0b0010;
+const uint8_t kDaikin64Fan =  0b0100;
+const uint8_t kDaikin64Heat =  0b1000;
 const uint8_t kDaikin64FanAuto =  0b0001;
 const uint8_t kDaikin64FanLow =   0b1000;
 const uint8_t kDaikin64FanMed =   0b0100;

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -3525,6 +3525,9 @@ TEST(TestDaikin64Class, OperatingMode) {
   ac.setMode(kDaikin64Fan);
   EXPECT_EQ(kDaikin64Fan, ac.getMode());
 
+  ac.setMode(kDaikin64Heat);
+  EXPECT_EQ(kDaikin64Heat, ac.getMode());
+
   ac.setMode(kDaikin64Dry);
   EXPECT_EQ(kDaikin64Dry, ac.getMode());
 
@@ -3678,6 +3681,7 @@ TEST(TestDaikin64Class, HumanReadable) {
       "Turbo: On, Quiet: Off, Swing(V): On, Sleep: Off, "
       "Clock: 07:20, On Timer: Off, Off Timer: 23:30",
       ac.toString());
+  ac.setMode(kDaikin64Heat);
   ac.setQuiet(true);
   ac.setSleep(true);
   ac.setClock(12 * 60 + 31);
@@ -3685,7 +3689,7 @@ TEST(TestDaikin64Class, HumanReadable) {
   ac.setOnTime(8 * 60 + 59);
   ac.setOffTimeEnabled(false);
   EXPECT_EQ(
-      "Power Toggle: Off, Mode: 4 (Fan), Temp: 30C, Fan: 9 (Quiet), "
+      "Power Toggle: Off, Mode: 8 (Heat), Temp: 30C, Fan: 9 (Quiet), "
       "Turbo: Off, Quiet: On, Swing(V): On, Sleep: On, "
       "Clock: 12:31, On Timer: 08:30, Off Timer: Off",
       ac.toString());


### PR DESCRIPTION
I noticed the Daikin64 protocol is missing the heat mode. I tested the heat mode, and it worked for me.