### PR TITLE
Fix MDNS in IRServer and IRMQTTServer

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2143,8 +2143,8 @@ void setup(void) {
   if (mdns.begin(Hostname)) {
 #endif  // ESP8266
     debug("MDNS responder started");
-    // Announce esp tcp service on port 8080
-    mdns.addService("esp", "tcp", 8080);
+    // Announce http tcp service on kHttpPort
+    mdns.addService("http", "tcp", kHttpPort);
   }
 #endif  // MDNS_ENABLE
 
@@ -2593,9 +2593,9 @@ void sendMQTTDiscovery(const char *topic) {
 #endif  // MQTT_ENABLE
 
 void loop(void) {
-#if MDNS_ENABLE
+#if MDNS_ENABLE && defined(ESP8266)
   mdns.update();
-#endif  // MDNS_ENABLE
+#endif  // MDNS_ENABLE and ESP8266
   server.handleClient();  // Handle any web activity
 
 #if MQTT_ENABLE

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2593,7 +2593,9 @@ void sendMQTTDiscovery(const char *topic) {
 #endif  // MQTT_ENABLE
 
 void loop(void) {
+#if MDNS_ENABLE
   mdns.update();
+#endif  // MDNS_ENABLE
   server.handleClient();  // Handle any web activity
 
 #if MQTT_ENABLE

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2143,6 +2143,8 @@ void setup(void) {
   if (mdns.begin(Hostname)) {
 #endif  // ESP8266
     debug("MDNS responder started");
+    // Announce esp tcp service on port 8080
+    mdns.addService("esp", "tcp", 8080);
   }
 #endif  // MDNS_ENABLE
 
@@ -2591,6 +2593,7 @@ void sendMQTTDiscovery(const char *topic) {
 #endif  // MQTT_ENABLE
 
 void loop(void) {
+  mdns.update();
   server.handleClient();  // Handle any web activity
 
 #if MQTT_ENABLE

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -132,8 +132,8 @@ void setup(void) {
   if (mdns.begin(HOSTNAME)) {
 #endif  // ESP8266
     Serial.println("MDNS responder started");
-    // Announce esp tcp service on port 8080
-    mdns.addService("esp", "tcp", 8080);
+    // Announce http tcp service on port 80
+    mdns.addService("http", "tcp", 80);
   }
 
   server.on("/", handleRoot);
@@ -150,6 +150,8 @@ void setup(void) {
 }
 
 void loop(void) {
+#if defined(ESP8266)
   mdns.update();
+#endif
   server.handleClient();
 }

--- a/examples/IRServer/IRServer.ino
+++ b/examples/IRServer/IRServer.ino
@@ -132,6 +132,8 @@ void setup(void) {
   if (mdns.begin(HOSTNAME)) {
 #endif  // ESP8266
     Serial.println("MDNS responder started");
+    // Announce esp tcp service on port 8080
+    mdns.addService("esp", "tcp", 8080);
   }
 
   server.on("/", handleRoot);
@@ -148,5 +150,6 @@ void setup(void) {
 }
 
 void loop(void) {
+  mdns.update();
   server.handleClient();
 }


### PR DESCRIPTION
Fix MDNS service in IRServer and IRMQTTServer examples

In the examples IRServer and IRMQTTServer, Chromium and Firefox running on Ubuntu fail to connect to the ESP8266 using the MDNS hostname. For example, esp8266.local and ir_server.local do not resolve.

Based on the MDNS examples included with the ESP8266 board package, adding calls to mdns.addService() and mdns.update() fixes the problems.

Fixes #1498