### PR TITLE
IRac: Fix off-by-one error in Coolix's sleep.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -460,7 +460,7 @@ void IRac::coolix(IRCoolixAC *ac,
     ac->setTurbo();
     ac->send();
   }
-  if (sleep > 0) {
+  if (sleep >= 0) {
     // Sleep has a special command that needs to be sent independently.
     ac->setSleep();
     ac->send();


### PR DESCRIPTION
Use the correct expression to set sleep mode. i.e. `0` or more is supposed to set the sleep mode. See comments for the method.