### PR TITLE
[BUG] Illegal Heap write in rawbuf when the capture has overflowed.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -518,7 +518,9 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
   // interrupt. decode() is not stored in ICACHE_RAM.
   // Another better option would be to zero the entire irparams.rawbuf[] on
   // resume() but that is a much more expensive operation compare to this.
-  params.rawbuf[params.rawlen] = 0;
+  // However, don't do this if rawbuf is already full as we stomp over the heap.
+  // See: https://github.com/crankyoldgit/IRremoteESP8266/issues/1516
+  if (!params.overflow) params.rawbuf[params.rawlen] = 0;
 
   bool resumed = false;  // Flag indicating if we have resumed.
 

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -1884,4 +1884,11 @@ uint16_t IRrecv::matchManchesterData(volatile const uint16_t *data_ptr,
   *result_ptr = GETBITS64(data, 0, nbits);
   return offset;
 }
+
+#if UNIT_TEST
+/// Unit test helper to get access to the params structure.
+volatile irparams_t *IRrecv::_getParamsPtr(void) {
+  return &params;
+}
+#endif  // UNIT_TEST
 // End of IRrecv class -------------------

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -162,6 +162,9 @@ class IRrecv {
 #if DECODE_HASH
   uint16_t _unknown_threshold;
 #endif
+#ifdef UNIT_TEST
+  volatile irparams_t *_getParamsPtr(void);
+#endif  // UNIT_TEST
   // These are called by decode
   uint8_t _validTolerance(const uint8_t percentage);
   void copyIrParams(volatile irparams_t *src, irparams_t *dst);


### PR DESCRIPTION
* Fix an issue where we write past the end of the capture buffer when it is full. Two options to fix this:
  1. Extend all capture buffers by 1 entry. i.e. upto 4 bytes of extra unused heap and some FLASH/PROGMEM bytes. _or_
  2. Skip the memory write when we have overflowed. i.e. Possibly slightly more than 4 bytes of FLASH/PROGMEM used.
  - CPU overhead should be about the same.
  - Given heap & memory is a more critical resource than Flash/PROGMEM, opting for Option 2.
* Add a helper method `IRrecv::_getParamsPtr` to access `params` in Unit tests.
* Unit tests so we can be sure it is fixed, and it doesn't happen again.

Kudos to @davepl for reporting the issue and diagnosing the offending line of code.

Fixes #1516