### PR TITLE
Add Mitsubishi AC "fan only" mode

### DIFF
--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -516,6 +516,7 @@ void IRMitsubishiAC::setMode(const uint8_t mode) {
     case kMitsubishiAcCool: _.raw[8] = 0b00110110; break;
     case kMitsubishiAcDry:  _.raw[8] = 0b00110010; break;
     case kMitsubishiAcHeat: _.raw[8] = 0b00110000; break;
+    case kMitsubishiAcFan:  _.raw[8] = 0b00110111; break;
     default:
       _.raw[8] = 0b00110000;
       _.Mode = kMitsubishiAcAuto;

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -613,6 +613,7 @@ uint8_t IRMitsubishiAC::convertMode(const stdAc::opmode_t mode) {
     case stdAc::opmode_t::kCool: return kMitsubishiAcCool;
     case stdAc::opmode_t::kHeat: return kMitsubishiAcHeat;
     case stdAc::opmode_t::kDry:  return kMitsubishiAcDry;
+    case stdAc::opmode_t::kFan:  return kMitsubishiAcFan;
     default:                     return kMitsubishiAcAuto;
   }
 }
@@ -680,6 +681,7 @@ stdAc::opmode_t IRMitsubishiAC::toCommonMode(const uint8_t mode) {
     case kMitsubishiAcCool: return stdAc::opmode_t::kCool;
     case kMitsubishiAcHeat: return stdAc::opmode_t::kHeat;
     case kMitsubishiAcDry:  return stdAc::opmode_t::kDry;
+    case kMitsubishiAcFan:  return stdAc::opmode_t::kFan;
     default:                return stdAc::opmode_t::kAuto;
   }
 }
@@ -781,7 +783,7 @@ String IRMitsubishiAC::toString(void) const {
   result += addBoolToString(_.Power, kPowerStr, false);
   result += addModeToString(_.Mode, kMitsubishiAcAuto, kMitsubishiAcCool,
                             kMitsubishiAcHeat, kMitsubishiAcDry,
-                            kMitsubishiAcAuto);
+                            kMitsubishiAcFan);
   result += addTempFloatToString(getTemp());
   result += addFanToString(getFan(), kMitsubishiAcFanRealMax,
                            kMitsubishiAcFanRealMax - 3,

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -31,6 +31,7 @@
 //   Brand: Mitsubishi Electric,  Model: SG153/M21EDF426 remote (MITSUBISHI_AC)
 //   Brand: Mitsubishi Electric,  Model: MSZ-GV2519 A/C (MITSUBISHI_AC)
 //   Brand: Mitsubishi Electric,  Model: RH151/M21ED6426 remote (MITSUBISHI_AC)
+//   Brand: Mitsubishi Electric,  Model: MSZ-SF25VE3/SG15D remote (MITSUBISHI_AC)
 
 #ifndef IR_MITSUBISHI_H_
 #define IR_MITSUBISHI_H_

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -94,6 +94,7 @@ const uint8_t kMitsubishiAcAuto = 0b100;
 const uint8_t kMitsubishiAcCool = 0b011;
 const uint8_t kMitsubishiAcDry =  0b010;
 const uint8_t kMitsubishiAcHeat = 0b001;
+const uint8_t kMitsubishiAcFan  = 0b111;
 const uint8_t kMitsubishiAcFanAuto = 0;
 const uint8_t kMitsubishiAcFanMax = 5;
 const uint8_t kMitsubishiAcFanRealMax = 4;

--- a/src/ir_Mitsubishi.h
+++ b/src/ir_Mitsubishi.h
@@ -31,7 +31,8 @@
 //   Brand: Mitsubishi Electric,  Model: SG153/M21EDF426 remote (MITSUBISHI_AC)
 //   Brand: Mitsubishi Electric,  Model: MSZ-GV2519 A/C (MITSUBISHI_AC)
 //   Brand: Mitsubishi Electric,  Model: RH151/M21ED6426 remote (MITSUBISHI_AC)
-//   Brand: Mitsubishi Electric,  Model: MSZ-SF25VE3/SG15D remote (MITSUBISHI_AC)
+//   Brand: Mitsubishi Electric,  Model: MSZ-SF25VE3 A/C (MITSUBISHI_AC)
+//   Brand: Mitsubishi Electric,  Model: SG15D remote (MITSUBISHI_AC)
 
 #ifndef IR_MITSUBISHI_H_
 #define IR_MITSUBISHI_H_


### PR DESCRIPTION
This PR adds "fan only" mode for Mitsubishi AC units. I noticed that it was missing previously and always defaulted to "Auto" instead.

The IR code for this was captured from the remote that came with my indoor unit (Mitsubishi MSZ-SF25VE) and the resulting change to the library has been real-world tested with that device as well. I can't say if it will apply to all Mitsubishi AC units, as I only have this type available for testing.

The commits mostly just add the kMitsubishiAcFan constant and raw bitfield data.
No unit tests have been updated, unfortunately.

Quick thanks to everyone for their work on this great little library!