### PR TITLE
[LG2] Add fan speed, Swing, & Light support for new `AKB74955603` model

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3843,7 +3843,7 @@ namespace IRAcUtils {
         IRLgAc ac(kGpioUnused);
         ac.setRaw(decode->value, decode->decode_type);  // Use value, not state.
         if (!ac.isValidLgAc()) return false;
-        *result = ac.toCommon();
+        *result = ac.toCommon(prev);
         break;
       }
 #endif  // DECODE_LG

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3056,6 +3056,8 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return lg_ac_remote_model_t::GE6711AR2853M;
   } else if (!strcasecmp(str, "AKB75215403")) {
     return lg_ac_remote_model_t::AKB75215403;
+  } else if (!strcasecmp(str, "AKB74955603")) {
+    return lg_ac_remote_model_t::AKB74955603;
   // Panasonic A/C families
   } else if (!strcasecmp(str, "LKE") || !strcasecmp(str, "PANASONICLKE")) {
     return panasonic_ac_remote_model_t::kPanasonicLke;

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1333,20 +1333,23 @@ void IRac::kelvinator(IRKelvinatorAC *ac,
 /// @param[in] mode The operation mode setting.
 /// @param[in] degrees The temperature setting in degrees.
 /// @param[in] fan The speed setting for the fan.
+/// @param[in] swingv The vertical swing setting.
+/// @param[in] light Turn on the LED/Display mode.
 void IRac::lg(IRLgAc *ac, const lg_ac_remote_model_t model,
               const bool on, const stdAc::opmode_t mode,
-              const float degrees, const stdAc::fanspeed_t fan) {
+              const float degrees, const stdAc::fanspeed_t fan,
+              const stdAc::swingv_t swingv, const bool light) {
   ac->begin();
   ac->setModel(model);
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
-  // No Vertical swing setting available.
+  ac->setSwingV(ac->convertSwingV(swingv));
   // No Horizontal swing setting available.
   // No Quiet setting available.
   // No Turbo setting available.
-  // No Light setting available.
+  ac->setLight(light);
   // No Filter setting available.
   // No Clean setting available.
   // No Beep setting available.
@@ -2638,7 +2641,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRLgAc ac(_pin, _inverted, _modulation);
       lg(&ac, (lg_ac_remote_model_t)send.model, send.power, send.mode,
-         send.degrees, send.fanspeed);
+         send.degrees, send.fanspeed, send.swingv, send.light);
       break;
     }
 #endif  // SEND_LG

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3573,14 +3573,7 @@ namespace IRAcUtils {
       case decode_type_t::LG:
       case decode_type_t::LG2: {
         IRLgAc ac(kGpioUnused);
-        ac.setRaw(result->value);  // Like Coolix, use value instead of state.
-        switch (result->decode_type) {
-          case decode_type_t::LG2:
-            ac.setModel(lg_ac_remote_model_t::AKB75215403);
-            break;
-          default:
-            ac.setModel(lg_ac_remote_model_t::GE6711AR2853M);
-        }
+        ac.setRaw(result->value, result->decode_type);  // Use value, not state.
         return ac.isValidLgAc() ? ac.toString() : "";
       }
 #endif  // DECODE_LG
@@ -3845,15 +3838,8 @@ namespace IRAcUtils {
       case decode_type_t::LG:
       case decode_type_t::LG2: {
         IRLgAc ac(kGpioUnused);
-        ac.setRaw(decode->value);  // Uses value instead of state.
+        ac.setRaw(decode->value, decode->decode_type);  // Use value, not state.
         if (!ac.isValidLgAc()) return false;
-        switch (decode->decode_type) {
-          case decode_type_t::LG2:
-            ac.setModel(lg_ac_remote_model_t::AKB75215403);
-            break;
-          default:
-            ac.setModel(lg_ac_remote_model_t::GE6711AR2853M);
-        }
         *result = ac.toCommon();
         break;
       }

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -308,7 +308,8 @@ void electra(IRElectraAc *ac,
   void lg(IRLgAc *ac, const lg_ac_remote_model_t model,
           const bool on, const stdAc::opmode_t mode,
           const float degrees, const stdAc::fanspeed_t fan,
-          const stdAc::swingv_t swingv, const bool light);
+          const stdAc::swingv_t swingv, const stdAc::swingv_t swingv_prev,
+          const bool light);
 #endif  // SEND_LG
 #if SEND_MIDEA
   void midea(IRMideaAC *ac,

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -307,7 +307,8 @@ void electra(IRElectraAc *ac,
 #if SEND_LG
   void lg(IRLgAc *ac, const lg_ac_remote_model_t model,
           const bool on, const stdAc::opmode_t mode,
-          const float degrees, const stdAc::fanspeed_t fan);
+          const float degrees, const stdAc::fanspeed_t fan,
+          const stdAc::swingv_t swingv, const bool light);
 #endif  // SEND_LG
 #if SEND_MIDEA
   void midea(IRMideaAC *ac,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -176,6 +176,7 @@ enum whirlpool_ac_remote_model_t {
 enum lg_ac_remote_model_t {
   GE6711AR2853M = 1,  // (1) LG 28-bit Protocol (default)
   AKB75215403,        // (2) LG2 28-bit Protocol
+  AKB74955603,        // (3) LG2 28-bit Protocol variant
 };
 
 

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -559,6 +559,7 @@ namespace irutils {
         switch (model) {
           case lg_ac_remote_model_t::GE6711AR2853M: return F("GE6711AR2853M");
           case lg_ac_remote_model_t::AKB75215403: return F("AKB75215403");
+          case lg_ac_remote_model_t::AKB74955603: return F("AKB74955603");
           default: return kUnknownStr;
         }
         break;

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -1,6 +1,6 @@
 // Copyright 2015 Darryl Smith
 // Copyright 2015 cheaplin
-// Copyright 2017, 2018 David Conran
+// Copyright 2017-2021 David Conran
 
 /// @file
 /// @brief Support for LG protocols.
@@ -224,7 +224,7 @@ void IRLgAc::stateReset(void) {
   setModel(lg_ac_remote_model_t::GE6711AR2853M);
   _light = true;
   _swingv = kLgAcSwingVOff;
-  _swingv_prev = _swingv;
+  updateSwingVPrev();
 }
 
 /// Set up hardware to be able to send a message.
@@ -242,7 +242,7 @@ void IRLgAc::send(const uint16_t repeat) {
         // Only send the swing setting if we need to.
         if (_swingv != _swingv_prev) {
           _irsend.send(_protocol, _swingv, kLgBits, repeat);
-          _swingv_prev = _swingv;
+          updateSwingVPrev();
         }
         // Any "normal" command sent will always turn the light on, thus we only
         // send it when we want it off. Must be sent last!
@@ -494,6 +494,9 @@ void IRLgAc::setSwingV(const uint32_t position) {
     }
   }
 }
+
+// Copy the previous swingv setting the current one.
+void IRLgAc::updateSwingVPrev(void) { _swingv_prev = _swingv; }
 
 /// Get the Vertical Swing position setting of the A/C.
 /// @return The native position/mode.

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -277,8 +277,22 @@ uint32_t IRLgAc::getRaw(void) {
 
 /// Set the internal state from a valid code for this protocol.
 /// @param[in] new_code A valid code for this protocol.
-void IRLgAc::setRaw(const uint32_t new_code) {
+/// @param[in] protocol A valid decode protocol type to use.
+void IRLgAc::setRaw(const uint32_t new_code, const decode_type_t protocol) {
   _.raw = new_code;
+  // Set the default model for this protocol, if the protocol is supplied.
+  switch (protocol) {
+    case decode_type_t::LG:
+      setModel(lg_ac_remote_model_t::GE6711AR2853M);
+      break;
+    case decode_type_t::LG2:
+      setModel(lg_ac_remote_model_t::AKB75215403);
+      break;
+    default:
+      // Don't change anything if it isn't an expected protocol.
+      break;
+  }
+  // Look for model specific settings/features to improve model detection.
   if (_isAKB74955603()) setModel(lg_ac_remote_model_t::AKB74955603);
   _temp = 15;  // Ensure there is a "sane" previous temp.
   _temp = getTemp();
@@ -509,7 +523,8 @@ String IRLgAc::toString(void) const {
     result += addModeToString(_.Mode, kLgAcAuto, kLgAcCool,
                               kLgAcHeat, kLgAcDry, kLgAcFan);
     result += addTempToString(getTemp());
-    result += addFanToString(_.Fan, kLgAcFanHigh, kLgAcFanLow,
+    result += addFanToString(_.Fan, kLgAcFanHigh,
+                             _isAKB74955603() ? kLgAcFanLowAlt : kLgAcFanLow,
                              kLgAcFanAuto, kLgAcFanLowest, kLgAcFanMedium,
                              kLgAcFanMax);
   }

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -7,6 +7,7 @@
 /// LG decode originally added by Darryl Smith (based on the JVC protocol)
 /// LG send originally added by https://github.com/chaeplin
 /// @see https://github.com/arendst/Tasmota/blob/54c2eb283a02e4287640a4595e506bc6eadbd7f2/sonoff/xdrv_05_irremote.ino#L327-438
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1513
 
 #include "ir_LG.h"
 #include <algorithm>

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -66,7 +66,8 @@ const uint8_t kLgAcPowerOff = 3;  // 0b11
 const uint8_t kLgAcPowerOn = 0;   // 0b00
 const uint8_t kLgAcSignature = 0x88;
 
-const uint32_t kLgAcOffCommand = 0x88C0051;
+const uint32_t kLgAcOffCommand =  0x88C0051;
+const uint32_t kLgAcLightToggle = 0x88C00A6;
 
 // Classes
 /// Class for handling detailed LG A/C messages.
@@ -91,12 +92,16 @@ class IRLgAc {
   void off(void);
   void setPower(const bool on);
   bool getPower(void) const;
+  bool isOffCommand(void) const;
   void setTemp(const uint8_t degrees);
   uint8_t getTemp(void) const;
   void setFan(const uint8_t speed);
   uint8_t getFan(void) const;
   void setMode(const uint8_t mode);
   uint8_t getMode(void) const;
+  void setLight(const bool on);
+  bool getLight(void) const;
+  bool isLightToggle(void) const;
   uint32_t getRaw(void);
   void setRaw(const uint32_t new_code,
               const decode_type_t protocol = decode_type_t::UNKNOWN);
@@ -104,7 +109,7 @@ class IRLgAc {
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
-  stdAc::state_t toCommon(void) const;
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL) const;
   String toString(void) const;
   void setModel(const lg_ac_remote_model_t model);
   lg_ac_remote_model_t getModel(void) const;
@@ -119,11 +124,13 @@ class IRLgAc {
 #endif  // UNIT_TEST
   LGProtocol _;
   uint8_t _temp;
+  bool _light;
   decode_type_t _protocol;  ///< Protocol version
   lg_ac_remote_model_t _model;  ///< Model type
   void checksum(void);
   void _setTemp(const uint8_t value);
   bool _isAKB74955603(void) const;
+  bool _isNormal(void) const;
 };
 
 #endif  // IR_LG_H_

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -1,9 +1,8 @@
-// Copyright 2017, 2019 David Conran
+// Copyright 2017-2021 David Conran
 
 /// @file
 /// @brief Support for LG protocols.
 /// @see https://github.com/arendst/Tasmota/blob/54c2eb283a02e4287640a4595e506bc6eadbd7f2/sonoff/xdrv_05_irremote.ino#L327-438
-
 
 // Supports:
 //   Brand: LG,  Model: 6711A20083V remote (LG)
@@ -125,6 +124,7 @@ class IRLgAc {
   bool isSwingV(void) const;
   void setSwingV(const uint32_t position);
   uint32_t getSwingV(void) const;
+  void updateSwingVPrev(void);
   uint32_t getRaw(void);
   void setRaw(const uint32_t new_code,
               const decode_type_t protocol = decode_type_t::UNKNOWN);

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -98,7 +98,8 @@ class IRLgAc {
   void setMode(const uint8_t mode);
   uint8_t getMode(void) const;
   uint32_t getRaw(void);
-  void setRaw(const uint32_t new_code);
+  void setRaw(const uint32_t new_code,
+              const decode_type_t protocol = decode_type_t::UNKNOWN);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -10,8 +10,11 @@
 //   Brand: LG,  Model: AKB74395308 remote (LG2)
 //   Brand: LG,  Model: S4-W12JA3AA A/C (LG2)
 //   Brand: LG,  Model: AKB75215403 remote (LG2)
-//   Brand: General Electric,  Model: AG1BH09AW101 Split A/C
-//   Brand: General Electric,  Model: 6711AR2853M A/C Remote
+//   Brand: LG,  Model: AKB74955603 remote (LG2 - AKB74955603)
+//   Brand: LG,  Model: A4UW30GFA2 A/C (LG2 - AKB74955603)
+//   Brand: LG,  Model: AMNW09GSJA0 A/C (LG2 - AKB74955603)
+//   Brand: General Electric,  Model: AG1BH09AW101 Split A/C (LG)
+//   Brand: General Electric,  Model: 6711AR2853M A/C Remote (LG)
 
 #ifndef IR_LG_H_
 #define IR_LG_H_
@@ -33,8 +36,7 @@ union LGProtocol{
   uint32_t raw;  ///< The state of the IR remote in IR code form.
   struct {
     uint32_t Sum  :4;
-    uint32_t Fan  :3;
-    uint32_t      :1;
+    uint32_t Fan  :4;
     uint32_t Temp :4;
     uint32_t Mode :3;
     uint32_t      :3;
@@ -43,11 +45,15 @@ union LGProtocol{
   };
 };
 
-const uint8_t kLgAcFanLowest = 0;  // 0b000
-const uint8_t kLgAcFanLow = 1;     // 0b001
-const uint8_t kLgAcFanMedium = 2;  // 0b010
-const uint8_t kLgAcFanHigh = 4;    // 0b100
-const uint8_t kLgAcFanAuto = 5;    // 0b101
+const uint8_t kLgAcFanLowest = 0;  // 0b0000
+const uint8_t kLgAcFanLow = 1;     // 0b0001
+const uint8_t kLgAcFanMedium = 2;  // 0b0010
+const uint8_t kLgAcFanMax = 4;     // 0b0100
+const uint8_t kLgAcFanAuto = 5;    // 0b0101
+const uint8_t kLgAcFanLowAlt = 9;  // 0b1001
+const uint8_t kLgAcFanHigh = 10;   // 0b1010
+// Nr. of slots in the look-up table
+const uint8_t kLgAcFanEntries = kLgAcFanHigh + 1;
 const uint8_t kLgAcTempAdjust = 15;
 const uint8_t kLgAcMinTemp = 16;  // Celsius
 const uint8_t kLgAcMaxTemp = 30;  // Celsius
@@ -112,9 +118,11 @@ class IRLgAc {
 #endif  // UNIT_TEST
   LGProtocol _;
   uint8_t _temp;
-  decode_type_t _protocol;  ///< model
+  decode_type_t _protocol;  ///< Protocol version
+  lg_ac_remote_model_t _model;  ///< Model type
   void checksum(void);
   void _setTemp(const uint8_t value);
+  bool _isAKB74955603(void) const;
 };
 
 #endif  // IR_LG_H_

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -3,6 +3,7 @@
 /// @file
 /// @brief Support for LG protocols.
 /// @see https://github.com/arendst/Tasmota/blob/54c2eb283a02e4287640a4595e506bc6eadbd7f2/sonoff/xdrv_05_irremote.ino#L327-438
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1513
 
 // Supports:
 //   Brand: LG,  Model: 6711A20083V remote (LG)

--- a/src/ir_LG.h
+++ b/src/ir_LG.h
@@ -66,8 +66,28 @@ const uint8_t kLgAcPowerOff = 3;  // 0b11
 const uint8_t kLgAcPowerOn = 0;   // 0b00
 const uint8_t kLgAcSignature = 0x88;
 
-const uint32_t kLgAcOffCommand =  0x88C0051;
-const uint32_t kLgAcLightToggle = 0x88C00A6;
+const uint32_t kLgAcOffCommand          = 0x88C0051;
+const uint32_t kLgAcLightToggle         = 0x88C00A6;
+
+const uint32_t kLgAcSwingSignature      = 0x8813;
+const uint32_t kLgAcSwingVLowest        = 0x8813048;
+const uint32_t kLgAcSwingVLow           = 0x8813059;
+const uint32_t kLgAcSwingVMiddle        = 0x881306A;
+const uint32_t kLgAcSwingVUpperMiddle   = 0x881307B;
+const uint32_t kLgAcSwingVHigh          = 0x881308C;
+const uint32_t kLgAcSwingVHighest       = 0x881309D;
+const uint32_t kLgAcSwingVSwing         = 0x8813149;
+const uint32_t kLgAcSwingVAuto          = kLgAcSwingVSwing;
+const uint32_t kLgAcSwingVOff           = 0x881315A;
+const uint8_t  kLgAcSwingVLowest_Short      = 0x04;
+const uint8_t  kLgAcSwingVLow_Short         = 0x05;
+const uint8_t  kLgAcSwingVMiddle_Short      = 0x06;
+const uint8_t  kLgAcSwingVUpperMiddle_Short = 0x07;
+const uint8_t  kLgAcSwingVHigh_Short        = 0x08;
+const uint8_t  kLgAcSwingVHighest_Short     = 0x09;
+const uint8_t  kLgAcSwingVSwing_Short       = 0x14;
+const uint8_t  kLgAcSwingVAuto_Short        = kLgAcSwingVSwing_Short;
+const uint8_t  kLgAcSwingVOff_Short         = 0x15;
 
 // Classes
 /// Class for handling detailed LG A/C messages.
@@ -102,13 +122,18 @@ class IRLgAc {
   void setLight(const bool on);
   bool getLight(void) const;
   bool isLightToggle(void) const;
+  bool isSwingV(void) const;
+  void setSwingV(const uint32_t position);
+  uint32_t getSwingV(void) const;
   uint32_t getRaw(void);
   void setRaw(const uint32_t new_code,
               const decode_type_t protocol = decode_type_t::UNKNOWN);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
+  static stdAc::swingv_t toCommonSwingV(const uint32_t code);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);
+  static uint32_t convertSwingV(const stdAc::swingv_t swingv);
   stdAc::state_t toCommon(const stdAc::state_t *prev = NULL) const;
   String toString(void) const;
   void setModel(const lg_ac_remote_model_t model);
@@ -125,6 +150,8 @@ class IRLgAc {
   LGProtocol _;
   uint8_t _temp;
   bool _light;
+  uint32_t _swingv;
+  uint32_t _swingv_prev;
   decode_type_t _protocol;  ///< Protocol version
   lg_ac_remote_model_t _model;  ///< Model type
   void checksum(void);

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -518,6 +518,7 @@ TEST(TestIRLgAcClass, SetAndGetMode) {
 
 TEST(TestIRLgAcClass, SetAndGetFan) {
   IRLgAc ac(kGpioUnused);
+  ac.setModel(lg_ac_remote_model_t::AKB74955603);
   ac.setMode(kLgAcCool);
   ac.setFan(kLgAcFanAuto);
   EXPECT_EQ(kLgAcFanAuto, ac.getFan());
@@ -529,6 +530,10 @@ TEST(TestIRLgAcClass, SetAndGetFan) {
   EXPECT_EQ(kLgAcFanAuto, ac.getFan());
   ac.setFan(kLgAcFanLowest - 1);
   EXPECT_EQ(kLgAcFanAuto, ac.getFan());
+  ac.setFan(kLgAcFanMax);
+  EXPECT_EQ(kLgAcFanMax, ac.getFan());
+  ac.setFan(kLgAcFanHigh + 1);
+  EXPECT_EQ(kLgAcFanAuto, ac.getFan());
 }
 
 TEST(TestIRLgAcClass, toCommon) {
@@ -536,7 +541,7 @@ TEST(TestIRLgAcClass, toCommon) {
   ac.setPower(true);
   ac.setMode(kLgAcCool);
   ac.setTemp(20);
-  ac.setFan(kLgAcFanHigh);
+  ac.setFan(kLgAcFanMax);
   // Now test it.
   ASSERT_EQ(decode_type_t::LG, ac.toCommon().protocol);
   ASSERT_EQ(lg_ac_remote_model_t::GE6711AR2853M, ac.toCommon().model);
@@ -576,7 +581,7 @@ TEST(TestIRLgAcClass, HumanReadable) {
   ac.setFan(kLgAcFanHigh);
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 4 (Heat), Temp: 30C, Fan: 4 (High)",
+      "Power: On, Mode: 4 (Heat), Temp: 30C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setMode(kLgAcCool);
   ac.setFan(kLgAcFanLow);
@@ -609,7 +614,7 @@ TEST(TestIRLgAcClass, SetAndGetRaw) {
   ASSERT_EQ(0x8800A4E, ac.getRaw());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 25C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 25C, Fan: 4 (Maximum)",
       ac.toString());
 
   ac.setRaw(0x88C0051);
@@ -630,7 +635,7 @@ TEST(TestIRLgAcClass, MessageConstruction) {
   ASSERT_EQ(0x8800A4E, ac.getRaw());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 25C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 25C, Fan: 4 (Maximum)",
       ac.toString());
 }
 
@@ -734,7 +739,7 @@ TEST(TestIRLgAcClass, KnownExamples) {
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 22C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 22C, Fan: 4 (Maximum)",
       ac.toString());
 
   ac.setRaw(0x8808754);
@@ -748,7 +753,7 @@ TEST(TestIRLgAcClass, KnownExamples) {
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 2 (Fan), Temp: 22C, Fan: 4 (High)",
+      "Power: On, Mode: 2 (Fan), Temp: 22C, Fan: 4 (Maximum)",
       ac.toString());
 
   // https://github.com/crankyoldgit/IRremoteESP8266/issues/1008#issuecomment-570794029
@@ -756,13 +761,13 @@ TEST(TestIRLgAcClass, KnownExamples) {
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setRaw(0x8808440);
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 19C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 19C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setRaw(0x8800459);
   ASSERT_TRUE(ac.isValidLgAc());
@@ -774,19 +779,19 @@ TEST(TestIRLgAcClass, KnownExamples) {
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 1 (Dry), Temp: 24C, Fan: 4 (High)",
+      "Power: On, Mode: 1 (Dry), Temp: 24C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setRaw(0x880A341);
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 2 (Fan), Temp: 18C, Fan: 4 (High)",
+      "Power: On, Mode: 2 (Fan), Temp: 18C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setRaw(0x8810045);
   ASSERT_TRUE(ac.isValidLgAc());
   EXPECT_EQ(
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 15C, Fan: 4 (High)",
+      "Power: On, Mode: 0 (Cool), Temp: 15C, Fan: 4 (Maximum)",
       ac.toString());
   ac.setRaw(0x8810056);
   ASSERT_TRUE(ac.isValidLgAc());
@@ -827,7 +832,7 @@ TEST(TestDecodeLG2, Issue1008) {
 
   char expected[] =
       "Model: 2 (AKB75215403), "
-      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (High)";
+      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (Maximum)";
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -850,7 +855,7 @@ TEST(TestIRLgAcClass, DifferentModels) {
 
   char expected1[] =
       "Model: 1 (GE6711AR2853M), "
-      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (High)";
+      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (Maximum)";
   ASSERT_EQ(expected1, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -866,7 +871,7 @@ TEST(TestIRLgAcClass, DifferentModels) {
 
   char expected2[] =
       "Model: 2 (AKB75215403), "
-      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (High)";
+      "Power: On, Mode: 0 (Cool), Temp: 18C, Fan: 4 (Maximum)";
   ASSERT_EQ(expected2, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -881,6 +886,38 @@ TEST(TestIRLgAcClass, FanSpeedIssue1214) {
   EXPECT_EQ(kLgAcFanLow, IRLgAc::convertFan(stdAc::fanspeed_t::kLow));
   EXPECT_EQ(kLgAcFanMedium, IRLgAc::convertFan(stdAc::fanspeed_t::kMedium));
   EXPECT_EQ(kLgAcFanHigh, IRLgAc::convertFan(stdAc::fanspeed_t::kHigh));
-  EXPECT_EQ(kLgAcFanHigh, IRLgAc::convertFan(stdAc::fanspeed_t::kMax));
+  EXPECT_EQ(kLgAcFanMax, IRLgAc::convertFan(stdAc::fanspeed_t::kMax));
   EXPECT_EQ(kLgAcFanAuto, IRLgAc::convertFan(stdAc::fanspeed_t::kAuto));
+}
+
+TEST(TestIRLgAcClass, FanSpeedIssue1513) {
+  IRLgAc ac(kGpioUnused);
+  // Test for the new model's extra speed.
+  ac.setModel(lg_ac_remote_model_t::AKB74955603);
+  ac.setFan(kLgAcFanHigh);
+  EXPECT_EQ(kLgAcFanHigh, ac.getFan());
+  ac.setFan(kLgAcFanLow);
+  EXPECT_EQ(kLgAcFanLowAlt, ac.getFan());
+  // Check the old model can't do it.
+  ac.setModel(lg_ac_remote_model_t::AKB75215403);
+  ac.setFan(kLgAcFanHigh);
+  EXPECT_EQ(kLgAcFanMax, ac.getFan());
+
+  // Real examples.
+  ac.setRaw(0x880A3A7);
+  EXPECT_EQ(kLgAcFanHigh, ac.getFan());
+  ac.setRaw(0x880A396);
+  EXPECT_EQ(kLgAcFanLowAlt, ac.getFan());
+}
+
+TEST(TestIRLgAcClass, DetectAKB74955603) {
+  IRLgAc ac(kGpioUnused);
+  ac.stateReset();
+  ASSERT_NE(lg_ac_remote_model_t::AKB74955603, ac.getModel());
+  ac.setRaw(0x880A3A7);
+  EXPECT_EQ(lg_ac_remote_model_t::AKB74955603, ac.getModel());
+
+  ac.stateReset();
+  ac.setRaw(0x880A396);
+  EXPECT_EQ(lg_ac_remote_model_t::AKB74955603, ac.getModel());
 }


### PR DESCRIPTION
* Create new `AKB74955603` LG/LG2 model.
* Add support for different fan speed values for the `AKB74955603` model.
* Tweak `IRLgAc::setRaw()` to accept an optional protocol parameter.
* Improve model detection code & unit tests.
* Improve fan speed text output handling.
* Add support for SwingV & Light settings.
  - Because a normal message turns the light on, we can treat it not as a toggle in most cases.
* Misc cleanup and code improvements.
* Unit tests coverage and improvement.
* Update supported devices info.

Fixes #1513