### PR TITLE
IRMQTTServer: Build a minimal OTA image via PlatformIO.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -1,6 +1,6 @@
 /*
  * Send & receive arbitrary IR codes via a web server or MQTT.
- * Copyright David Conran 2016, 2017, 2018, 2019, 2020
+ * Copyright David Conran 2016-2021
  */
 #ifndef EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
 #define EXAMPLES_IRMQTTSERVER_IRMQTTSERVER_H_
@@ -101,8 +101,9 @@ const IPAddress kSubnetMask = IPAddress(255, 255, 255, 0);
                                    // The unset default is 8%.
                                    // (Uncomment to enable)
 // Do you want/need mdns enabled? (https://en.wikipedia.org/wiki/Multicast_DNS)
+#ifndef MDNS_ENABLE
 #define MDNS_ENABLE true  // `false` to disable and save ~21k of program space.
-
+#endif  // MDNS_ENABLE
 // ----------------------- HTTP Related Settings -------------------------------
 #define FIRMWARE_OTA true  // Allow remote update of the firmware via http.
                            // Less secure if enabled.
@@ -197,7 +198,9 @@ const uint16_t kMinUnknownSize = 2 * 10;
 // can understand the individual settings of the remote.
 // e.g. Aquire the A/C settings from an actual A/C IR remote and override
 //      any local settings set via MQTT/HTTP etc.
+#ifndef USE_DECODED_AC_SETTINGS
 #define USE_DECODED_AC_SETTINGS true  // `false` to disable. `true` to enable.
+#endif  // USE_DECODED_AC_SETTINGS
 // Should we allow or ignore an A/C IR remote to override the A/C protocol/model
 // as set via MQTT or HTTP?
 // e.g. If `true`, you can use any fully supported A/C remote to control

--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -50,7 +50,21 @@ lib_deps = ${common_esp32.lib_deps_external}
 
 [env:esp01_1m]
 board = esp01_1m
+board_build.ldscript = eagle.flash.1m64.ld
+lib_deps = ${common_esp8266.lib_deps_external}
+
+; This is just to help enable swapping IRMQTTServer via OTA on platforms with
+; limited flash space. It doesn't do *ANY* IR stuff. It has almost everything
+; turned off except OTA over http.
+; Produces a ".bin" file of ~380k.
+[env:esp8266_1m_OTA_minimal]
+board = esp01_1m
+board_build.ldscript = eagle.flash.1m64.ld
 build_flags =
   ${env.build_flags}
-  -Wl,-Teagle.flash.1m64.ld
+  -DMQTT_ENABLE=false
+  -D_IR_ENABLE_DEFAULT_=false
+  -DEXAMPLES_ENABLE=false
+  -DMDNS_ENABLE=false
+  -DUSE_DECODED_AC_SETTINGS=false
 lib_deps = ${common_esp8266.lib_deps_external}

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -58,10 +58,10 @@ const uint8_t kDefaultESP32Timer = 3;
 #if DECODE_AC
 // Hitachi AC is the current largest state size.
 const uint16_t kStateSizeMax = kHitachiAc2StateLength;
-#else
-// Just define something
-const uint16_t kStateSizeMax = 0;
-#endif
+#else  // DECODE_AC
+// Just define something (a uint64_t)
+const uint16_t kStateSizeMax = sizeof(uint64_t);
+#endif  // DECODE_AC
 
 // Types
 


### PR DESCRIPTION
* Allow some flags to be set by compiler flags.
* Fix a build issue when _**all**_ protocols are disabled.
* Upgrade from deprecated build flag `-Wl,-Teagle.flash.1m64.ld` to `board_build.ldscript`

For #1513