### PR TITLE
[Daikin] Add support for `ARC484A4` model.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -524,6 +524,7 @@ void IRac::corona(IRCoronaAc *ac,
 #if SEND_DAIKIN
 /// Send a Daikin A/C message with the supplied settings.
 /// @param[in, out] ac A Ptr to an IRDaikinESP object to use.
+/// @param[in] model The A/C model to use.
 /// @param[in] on The power setting.
 /// @param[in] mode The operation mode setting.
 /// @param[in] degrees The temperature setting in degrees.
@@ -534,13 +535,14 @@ void IRac::corona(IRCoronaAc *ac,
 /// @param[in] turbo Run the device in turbo/powerful mode.
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] clean Turn on the self-cleaning mode. e.g. Mould, dry filters etc
-void IRac::daikin(IRDaikinESP *ac,
+void IRac::daikin(IRDaikinESP *ac, const daikin_ac_remote_model_t model,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                   const bool quiet, const bool turbo, const bool econo,
                   const bool clean) {
   ac->begin();
+  ac->setModel(model);
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
@@ -2443,8 +2445,10 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case DAIKIN:
     {
       IRDaikinESP ac(_pin, _inverted, _modulation);
-      daikin(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
-             send.swingh, send.quiet, send.turbo, send.econo, send.clean);
+      daikin(&ac, (daikin_ac_remote_model_t)send.model,
+             send.power, send.mode, degC, send.fanspeed,
+             send.swingv, send.swingh, send.quiet, send.turbo, send.econo,
+             send.clean);
       break;
     }
 #endif  // SEND_DAIKIN
@@ -3101,6 +3105,11 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return whirlpool_ac_remote_model_t::DG11J13A;
   } else if (!strcasecmp(str, "DG11J191")) {
     return whirlpool_ac_remote_model_t::DG11J191;
+  // Daikin models
+  } else if (!strcasecmp(str, "ARC433XX")) {
+    return daikin_ac_remote_model_t::ARC433XX;
+  } else if (!strcasecmp(str, "ARC484A4")) {
+    return daikin_ac_remote_model_t::ARC484A4;
   } else {
     int16_t number = atoi(str);
     if (number > 0)

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -143,7 +143,7 @@ void carrier64(IRCarrierAc64 *ac,
               const stdAc::swingv_t swingv, const bool econo);
 #endif  // SEND_CORONA_AC
 #if SEND_DAIKIN
-  void daikin(IRDaikinESP *ac,
+  void daikin(IRDaikinESP *ac, const daikin_ac_remote_model_t model,
               const bool on, const stdAc::opmode_t mode, const float degrees,
               const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -180,6 +180,13 @@ enum lg_ac_remote_model_t {
   AKB73757604,        // (4) LG2 Variant of AKB74955603
 };
 
+///< Daikin A/C model numbers
+/// @note Only used by DAIKIN protocol currently. i.e. IRDaikinESP.
+enum daikin_ac_remote_model_t {
+  ARC433XX = 1,  // (1) ARC433**, ARC466A33 (default)
+  ARC484A4,      // (2) ARC484A4 (minor variant of ARC433XX)
+};
+
 
 // Classes
 

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -547,6 +547,13 @@ namespace irutils {
   /// @return The resulting String.
   String modelToStr(const decode_type_t protocol, const int16_t model) {
     switch (protocol) {
+      case decode_type_t::DAIKIN:
+        switch (model) {
+          case daikin_ac_remote_model_t::ARC433XX: return F("ARC433XX");
+          case daikin_ac_remote_model_t::ARC484A4: return F("ARC484A4");
+          default: return kUnknownStr;
+        }
+        break;
       case decode_type_t::FUJITSU_AC:
         switch (model) {
           case fujitsu_ac_remote_model_t::ARRAH2E: return F("ARRAH2E");

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -23,7 +23,7 @@
 /// @see Daikin64 https://github.com/crankyoldgit/IRremoteESP8266/issues/1064
 
 // Supports:
-//   Brand: Daikin,  Model: ARC433** remote (DAIKIN)
+//   Brand: Daikin,  Model: ARC433** remote (DAIKIN, ARC433XX (1))
 //   Brand: Daikin,  Model: ARC477A1 remote (DAIKIN2)
 //   Brand: Daikin,  Model: FTXZ25NV1B A/C (DAIKIN2)
 //   Brand: Daikin,  Model: FTXZ35NV1B A/C (DAIKIN2)
@@ -41,10 +41,12 @@
 //   Brand: Daikin,  Model: ARC480A5 remote (DAIKIN152)
 //   Brand: Daikin,  Model: FFN-C/FCN-F Series A/C (DAIKIN64)
 //   Brand: Daikin,  Model: DGS01 remote (DAIKIN64)
-//   Brand: Daikin,  Model: M Series A/C (DAIKIN)
-//   Brand: Daikin,  Model: FTXM-M A/C (DAIKIN)
-//   Brand: Daikin,  Model: ARC466A33 remote (DAIKIN)
+//   Brand: Daikin,  Model: M Series A/C (DAIKIN, ARC433XX (1))
+//   Brand: Daikin,  Model: FTXM-M A/C (DAIKIN, ARC433XX (1))
+//   Brand: Daikin,  Model: ARC466A33 remote (DAIKIN, ARC433XX (1))
 //   Brand: Daikin,  Model: FTWX35AXV1 A/C (DAIKIN64)
+//   Brand: Daikin,  Model: FTQ60TV16US A/C (DAIKIN, ARC484A4 (2))
+//   Brand: Daikin,  Model: ARC466A33 remote (DAIKIN, ARC484A4 (2))
 
 #ifndef IR_DAIKIN_H_
 #define IR_DAIKIN_H_
@@ -110,9 +112,11 @@ union DaikinESPProtocol{
     uint64_t          :4;
     uint64_t Quiet    :1;
     uint64_t          :2;
-    // Byte 30~31
-    uint64_t          :0;
-
+    // Byte 30
+    uint64_t          :8;
+    // Byte 31
+    uint64_t Arc484a4 :1;  // Always `1` for ARC484A4 models. Ref: Issue#1552
+    uint64_t          :7;
     // Byte 32
     uint8_t             :1;
     uint8_t Sensor      :1;
@@ -706,6 +710,8 @@ class IRDaikinESP {
   void off(void);
   void setPower(const bool on);
   bool getPower(void) const;
+  void setModel(const daikin_ac_remote_model_t model);
+  daikin_ac_remote_model_t getModel(void) const;
   void setTemp(const uint8_t temp);
   uint8_t getTemp(void) const;
   void setFan(const uint8_t fan);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -252,7 +252,8 @@ TEST(TestIRac, Daikin) {
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
   char expected[] =
-      "Power: On, Mode: 3 (Cool), Temp: 19C, Fan: 5 (High), Powerful: Off, "
+      "Model: 2 (ARC484A4), Power: On, Mode: 3 (Cool), Temp: 19C, "
+      "Fan: 5 (High), Powerful: Off, "
       "Quiet: Off, Sensor: Off, Mould: On, Comfort: Off, "
       "Swing(H): Off, Swing(V): Off, "
       "Clock: 00:00, Day: 0 (UNKNOWN), On Timer: Off, "
@@ -260,16 +261,17 @@ TEST(TestIRac, Daikin) {
 
   ac.begin();
   irac.daikin(&ac,
-              true,                        // Power
-              stdAc::opmode_t::kCool,      // Mode
-              19,                          // Celsius
-              stdAc::fanspeed_t::kMax,     // Fan speed
-              stdAc::swingv_t::kOff,       // Vertical swing
-              stdAc::swingh_t::kOff,       // Horizontal swing
-              false,                       // Quiet
-              false,                       // Turbo
-              true,                        // Filter
-              true);                       // Clean
+              daikin_ac_remote_model_t::ARC484A4,  // Model
+              true,                                // Power
+              stdAc::opmode_t::kCool,              // Mode
+              19,                                  // Celsius
+              stdAc::fanspeed_t::kMax,             // Fan speed
+              stdAc::swingv_t::kOff,               // Vertical swing
+              stdAc::swingh_t::kOff,               // Horizontal swing
+              false,                               // Quiet
+              false,                               // Turbo
+              true,                                // Filter
+              true);                               // Clean
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));


### PR DESCRIPTION
* add `set/getModel()` methods to `IRDaikinESP` class.
* Update `toString()` output.
* Update & add unit test coverage.

Fixes #1552