### PR TITLE
TCL112AC/TEKNOPOINT: Add support for `GZ055BE1` model

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1942,6 +1942,7 @@ void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
 #if SEND_TCL112AC
 /// Send a TCL 112-bit A/C message with the supplied settings.
 /// @param[in, out] ac A Ptr to an IRTcl112Ac object to use.
+/// @param[in] model The A/C model to use.
 /// @param[in] on The power setting.
 /// @param[in] mode The operation mode setting.
 /// @param[in] degrees The temperature setting in degrees.
@@ -1953,18 +1954,19 @@ void IRac::sharp(IRSharpAc *ac, const sharp_ac_remote_model_t model,
 /// @param[in] light Turn on the LED/Display mode.
 /// @param[in] econo Run the device in economical mode.
 /// @param[in] filter Turn on the (ion/pollen/etc) filter mode.
-void IRac::tcl112(IRTcl112Ac *ac,
+void IRac::tcl112(IRTcl112Ac *ac, const tcl_ac_remote_model_t model,
                   const bool on, const stdAc::opmode_t mode,
                   const float degrees, const stdAc::fanspeed_t fan,
                   const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                   const bool quiet, const bool turbo, const bool light,
                   const bool econo, const bool filter) {
   ac->begin();
+  ac->setModel(model);
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
-  ac->setSwingVertical(swingv != stdAc::swingv_t::kOff);
+  ac->setSwingVertical(ac->convertSwingV(swingv));
   ac->setSwingHorizontal(swingh != stdAc::swingh_t::kOff);
   ac->setQuiet(quiet);
   ac->setTurbo(turbo);
@@ -2910,9 +2912,9 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case TCL112AC:
     {
       IRTcl112Ac ac(_pin, _inverted, _modulation);
-      tcl112(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
-             send.swingh, send.quiet, send.turbo, send.light, send.econo,
-             send.filter);
+      tcl112(&ac, (tcl_ac_remote_model_t)send.model, send.power, send.mode,
+             degC, send.fanspeed, send.swingv, send.swingh, send.quiet,
+             send.turbo, send.light, send.econo, send.filter);
       break;
     }
 #endif  // SEND_TCL112AC
@@ -3235,6 +3237,18 @@ int16_t IRac::strToModel(const char *str, const int16_t def) {
     return panasonic_ac_remote_model_t::kPanasonicCkp;
   } else if (!strcasecmp(str, "RKR") || !strcasecmp(str, "PANASONICRKR")) {
     return panasonic_ac_remote_model_t::kPanasonicRkr;
+  // Sharp A/C Models
+  } else if (!strcasecmp(str, "A907")) {
+    return sharp_ac_remote_model_t::A907;
+  } else if (!strcasecmp(str, "A705")) {
+    return sharp_ac_remote_model_t::A705;
+  } else if (!strcasecmp(str, "A903")) {
+    return sharp_ac_remote_model_t::A903;
+  // TCL A/C Models
+  } else if (!strcasecmp(str, "TAC09CHSD")) {
+    return tcl_ac_remote_model_t::TAC09CHSD;
+  } else if (!strcasecmp(str, "GZ055BE1")) {
+    return tcl_ac_remote_model_t::GZ055BE1;
   // Voltas A/C models
   } else if (!strcasecmp(str, "122LZF")) {
     return voltas_ac_remote_model_t::kVoltas122LZF;

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -418,7 +418,7 @@ void electra(IRElectraAc *ac,
              const bool filter, const bool clean);
 #endif  // SEND_SHARP_AC
 #if SEND_TCL112AC
-  void tcl112(IRTcl112Ac *ac,
+  void tcl112(IRTcl112Ac *ac, const tcl_ac_remote_model_t model,
               const bool on, const stdAc::opmode_t mode, const float degrees,
               const stdAc::fanspeed_t fan,
               const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -160,6 +160,12 @@ enum sharp_ac_remote_model_t {
   A903 = 3,  // 820 too
 };
 
+/// TCL A/C model numbers
+enum tcl_ac_remote_model_t {
+  TAC09CHSD = 1,
+  GZ055BE1 = 2,
+};
+
 /// Voltas A/C model numbers
 enum voltas_ac_remote_model_t {
   kVoltasUnknown = 0,  // Full Function

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -586,14 +586,6 @@ namespace irutils {
           default: return kUnknownStr;
         }
         break;
-      case decode_type_t::SHARP_AC:
-        switch (model) {
-          case sharp_ac_remote_model_t::A907: return F("A907");
-          case sharp_ac_remote_model_t::A705: return F("A705");
-          case sharp_ac_remote_model_t::A903: return F("A903");
-          default: return kUnknownStr;
-        }
-        break;
       case decode_type_t::PANASONIC_AC:
         switch (model) {
           case panasonic_ac_remote_model_t::kPanasonicLke: return F("LKE");
@@ -602,6 +594,21 @@ namespace irutils {
           case panasonic_ac_remote_model_t::kPanasonicJke: return F("JKE");
           case panasonic_ac_remote_model_t::kPanasonicCkp: return F("CKP");
           case panasonic_ac_remote_model_t::kPanasonicRkr: return F("RKR");
+          default: return kUnknownStr;
+        }
+        break;
+      case decode_type_t::SHARP_AC:
+        switch (model) {
+          case sharp_ac_remote_model_t::A907: return F("A907");
+          case sharp_ac_remote_model_t::A705: return F("A705");
+          case sharp_ac_remote_model_t::A903: return F("A903");
+          default: return kUnknownStr;
+        }
+        break;
+      case decode_type_t::TCL112AC:
+        switch (model) {
+          case tcl_ac_remote_model_t::TAC09CHSD: return F("TAC09CHSD");
+          case tcl_ac_remote_model_t::GZ055BE1:  return F("GZ055BE1");
           default: return kUnknownStr;
         }
         break;

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -1166,7 +1166,7 @@ void IRsend::sendMitsubishi112(const unsigned char data[],
 }
 #endif  // SEND_MITSUBISHI112
 
-#if DECODE_MITSUBISHI112 || DECODE_TCL112AC
+#if (DECODE_MITSUBISHI112 || DECODE_TCL112AC)
 /// Decode the supplied Mitsubishi/TCL 112-bit A/C message.
 ///   (MITSUBISHI112, TCL112AC)
 /// Status: STABLE / Reported as working.
@@ -1212,7 +1212,7 @@ bool IRrecv::decodeMitsubishi112(decode_results *results, uint16_t offset,
     gap = kMitsubishi112Gap;
   }
 #endif  // DECODE_MITSUBISHI112
-#if DECODE_TCL112AC
+#if (DECODE_TCL112AC || DECODE_TEKNOPOINT)
   if (typeguess == decode_type_t::UNKNOWN &&  // We didn't match Mitsubishi112
       matchMark(results->rawbuf[offset], kTcl112AcHdrMark,
                 kTcl112AcHdrMarkTolerance, 0)) {
@@ -1224,7 +1224,7 @@ bool IRrecv::decodeMitsubishi112(decode_results *results, uint16_t offset,
     gap = kTcl112AcGap;
     tolerance += kTcl112AcTolerance;
   }
-#endif  // DECODE_TCL112AC
+#endif  // (DECODE_TCL112AC || DECODE_TEKNOPOINT)
   if (typeguess == decode_type_t::UNKNOWN) return false;  // No header matched.
   offset++;
 

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -477,7 +477,8 @@ stdAc::state_t IRTcl112Ac::toCommon(const stdAc::state_t *prev) const {
 String IRTcl112Ac::toString(void) const {
   String result = "";
   result.reserve(220);  // Reserve some heap for the string to reduce fragging.
-  result += addModelToString(decode_type_t::TCL112AC, getModel(), false);
+  tcl_ac_remote_model_t model = getModel();
+  result += addModelToString(decode_type_t::TCL112AC, model, false);
   result += addIntToString(_.MsgType, D_STR_TYPE);
   switch (_.MsgType) {
     case kTcl112AcNormal:
@@ -486,11 +487,8 @@ String IRTcl112Ac::toString(void) const {
                                 kTcl112AcHeat, kTcl112AcDry, kTcl112AcFan);
       result += addTempFloatToString(getTemp());
       result += addFanToString(_.Fan, kTcl112AcFanHigh, kTcl112AcFanLow,
-                               kTcl112AcFanAuto, kTcl112AcFanAuto,
+                               kTcl112AcFanAuto, kTcl112AcFanMin,
                                kTcl112AcFanMed);
-      result += addBoolToString(_.Econo, kEconoStr);
-      result += addBoolToString(_.Health, kHealthStr);
-      result += addBoolToString(_.Turbo, kTurboStr);
       result += addBoolToString(_.SwingH, kSwingHStr);
       result += addSwingVToString(_.SwingV, kTcl112AcSwingVOff,
                                             kTcl112AcSwingVHighest,
@@ -503,7 +501,12 @@ String IRTcl112Ac::toString(void) const {
                                             kTcl112AcSwingVOff,
                                             kTcl112AcSwingVOn,  // Swing
                                             0xFF, 0xFF);  // Both Unused
-      result += addBoolToString(getLight(), kLightStr);
+      if (model != tcl_ac_remote_model_t::GZ055BE1) {
+        result += addBoolToString(_.Econo, kEconoStr);
+        result += addBoolToString(_.Health, kHealthStr);
+        result += addBoolToString(_.Turbo, kTurboStr);
+        result += addBoolToString(getLight(), kLightStr);
+      }
       result += addLabeledString(
           _.OnTimerEnabled ? minsToString(getOnTimer()) : kOffStr,
           kOnTimerStr);

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -489,7 +489,6 @@ String IRTcl112Ac::toString(void) const {
       result += addFanToString(_.Fan, kTcl112AcFanHigh, kTcl112AcFanLow,
                                kTcl112AcFanAuto, kTcl112AcFanMin,
                                kTcl112AcFanMed);
-      result += addBoolToString(_.SwingH, kSwingHStr);
       result += addSwingVToString(_.SwingV, kTcl112AcSwingVOff,
                                             kTcl112AcSwingVHighest,
                                             kTcl112AcSwingVHigh,
@@ -502,6 +501,7 @@ String IRTcl112Ac::toString(void) const {
                                             kTcl112AcSwingVOn,  // Swing
                                             0xFF, 0xFF);  // Both Unused
       if (model != tcl_ac_remote_model_t::GZ055BE1) {
+        result += addBoolToString(_.SwingH, kSwingHStr);
         result += addBoolToString(_.Econo, kEconoStr);
         result += addBoolToString(_.Health, kHealthStr);
         result += addBoolToString(_.Turbo, kTurboStr);

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -287,6 +287,11 @@ bool IRTcl112Ac::getSwingHorizontal(void) const { return _.SwingH; }
 void IRTcl112Ac::setSwingVertical(const uint8_t setting) {
   switch (setting) {
     case kTcl112AcSwingVOff:
+    case kTcl112AcSwingVHighest:
+    case kTcl112AcSwingVHigh:
+    case kTcl112AcSwingVMiddle:
+    case kTcl112AcSwingVLow:
+    case kTcl112AcSwingVLowest:
     case kTcl112AcSwingVOn:
      _.SwingV = setting;
   }
@@ -403,8 +408,13 @@ stdAc::opmode_t IRTcl112Ac::toCommonMode(const uint8_t mode) {
 /// @return The native equivalent of the enum.
 uint8_t IRTcl112Ac::convertSwingV(const stdAc::swingv_t position) {
   switch (position) {
-    case stdAc::swingv_t::kOff: return kTcl112AcSwingVOff;
-    default:                    return kTcl112AcSwingVOn;
+    case stdAc::swingv_t::kOff:     return kTcl112AcSwingVOff;
+    case stdAc::swingv_t::kHighest: return kTcl112AcSwingVHighest;
+    case stdAc::swingv_t::kHigh:    return kTcl112AcSwingVHigh;
+    case stdAc::swingv_t::kMiddle:  return kTcl112AcSwingVMiddle;
+    case stdAc::swingv_t::kLow:     return kTcl112AcSwingVLow;
+    case stdAc::swingv_t::kLowest:  return kTcl112AcSwingVLowest;
+    default:                        return kTcl112AcSwingVOn;
   }
 }
 
@@ -483,10 +493,16 @@ String IRTcl112Ac::toString(void) const {
       result += addBoolToString(_.Turbo, kTurboStr);
       result += addBoolToString(_.SwingH, kSwingHStr);
       result += addSwingVToString(_.SwingV, kTcl112AcSwingVOff,
-                                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                                            0xFF, 0xFF,  // Unused
+                                            kTcl112AcSwingVHighest,
+                                            kTcl112AcSwingVHigh,
+                                            0xFF,  // unused
+                                            kTcl112AcSwingVMiddle,
+                                            0xFF,  // unused
+                                            kTcl112AcSwingVLow,
+                                            kTcl112AcSwingVLowest,
+                                            kTcl112AcSwingVOff,
                                             kTcl112AcSwingVOn,  // Swing
-                                            0xFF, 0xFF);  // Unused
+                                            0xFF, 0xFF);  // Both Unused
       result += addBoolToString(getLight(), kLightStr);
       result += addLabeledString(
           _.OnTimerEnabled ? minsToString(getOnTimer()) : kOffStr,

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -103,8 +103,13 @@ const uint8_t kTcl112AcFanNight = kTcl112AcFanMin;
 const float   kTcl112AcTempMax    = 31.0;
 const float   kTcl112AcTempMin    = 16.0;
 
-const uint8_t kTcl112AcSwingVOn =    0b111;
-const uint8_t kTcl112AcSwingVOff =   0b000;
+const uint8_t kTcl112AcSwingVOff =     0b000;
+const uint8_t kTcl112AcSwingVHighest = 0b001;
+const uint8_t kTcl112AcSwingVHigh =    0b010;
+const uint8_t kTcl112AcSwingVMiddle =  0b011;
+const uint8_t kTcl112AcSwingVLow =     0b100;
+const uint8_t kTcl112AcSwingVLowest =  0b101;
+const uint8_t kTcl112AcSwingVOn =      0b111;
 // MsgType
 const uint8_t kTcl112AcNormal  = 0b01;
 const uint8_t kTcl112AcSpecial = 0b10;

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -25,54 +25,54 @@ union Tcl112Protocol{
   uint8_t raw[kTcl112AcStateLength];  ///< The State in IR code form.
   struct {
     // Byte 0~2
-    uint8_t            :8;
-    uint8_t            :8;
-    uint8_t            :8;
+    uint8_t                 :8;
+    uint8_t                 :8;
+    uint8_t                 :8;
     // Byte 3
-    uint8_t MsgType    :2;
-    uint8_t            :6;
+    uint8_t MsgType         :2;
+    uint8_t                 :6;
     // Byte 4
-    uint8_t            :8;
+    uint8_t                 :8;
     // Byte 5
-    uint8_t            :2;
-    uint8_t Power      :1;
-    uint8_t OnTimerEnabled  :1;
+    uint8_t                 :2;
+    uint8_t Power           :1;
     uint8_t OffTimerEnabled :1;
-    uint8_t Quiet      :1;
-    uint8_t Light      :1;
-    uint8_t Econo      :1;
+    uint8_t OnTimerEnabled  :1;
+    uint8_t Quiet           :1;
+    uint8_t Light           :1;
+    uint8_t Econo           :1;
     // Byte 6
-    uint8_t Mode       :4;
-    uint8_t Health     :1;
-    uint8_t Turbo      :1;
-    uint8_t            :2;
+    uint8_t Mode            :4;
+    uint8_t Health          :1;
+    uint8_t Turbo           :1;
+    uint8_t                 :2;
     // Byte 7
-    uint8_t Temp       :4;
-    uint8_t            :4;
+    uint8_t Temp            :4;
+    uint8_t                 :4;
     // Byte 8
-    uint8_t Fan        :3;
-    uint8_t SwingV     :3;
-    uint8_t TimerIndicator :1;
-    uint8_t            :1;
+    uint8_t Fan             :3;
+    uint8_t SwingV          :3;
+    uint8_t TimerIndicator  :1;
+    uint8_t                 :1;
     // Byte 9
-    uint8_t            :1;  // 0
-    uint8_t OnTimer   :6;
-    uint8_t            :1;  // 0
+    uint8_t                 :1;  // 0
+    uint8_t OffTimer        :6;
+    uint8_t                 :1;  // 0
     // Byte 10
-    uint8_t            :1;  // 0
-    uint8_t OffTimer    :6;
-    uint8_t            :1;  // 0
+    uint8_t                 :1;  // 0
+    uint8_t OnTimer         :6;
+    uint8_t                 :1;  // 0
     // Byte 11
-    uint8_t            :8;  // 00000000
+    uint8_t                 :8;  // 00000000
     // Byte 12
-    uint8_t            :3;
-    uint8_t SwingH     :1;
-    uint8_t            :1;
-    uint8_t HalfDegree :1;
-    uint8_t            :1;
-    uint8_t isTcl      :1;
+    uint8_t                 :3;
+    uint8_t SwingH          :1;
+    uint8_t                 :1;
+    uint8_t HalfDegree      :1;
+    uint8_t                 :1;
+    uint8_t isTcl           :1;
     // Byte 13
-    uint8_t Sum :8;
+    uint8_t Sum             :8;
   };
 };
 

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -36,7 +36,8 @@ union Tcl112Protocol{
     // Byte 5
     uint8_t            :2;
     uint8_t Power      :1;
-    uint8_t TimerType  :2;
+    uint8_t OnTimerEnabled  :1;
+    uint8_t OffTimerEnabled :1;
     uint8_t Quiet      :1;
     uint8_t Light      :1;
     uint8_t Econo      :1;
@@ -51,7 +52,8 @@ union Tcl112Protocol{
     // Byte 8
     uint8_t Fan        :3;
     uint8_t SwingV     :3;
-    uint8_t            :2;
+    uint8_t TimerIndicator :1;
+    uint8_t            :1;
     // Byte 9
     uint8_t            :1;  // 0
     uint8_t OffTimer   :6;
@@ -74,58 +76,6 @@ union Tcl112Protocol{
   };
 };
 
-/// Native representation of a Teknopoint 112bit A/C message.
-union TeknopointProtocol{
-  uint8_t raw[kTeknopointStateLength];  ///< The State in IR code form.
-  struct {
-    // Bytes 0-4
-    uint8_t            :8;  // constant 0010001111001011001001100000000100000000
-    uint8_t            :8;
-    uint8_t            :8;
-    uint8_t            :8;
-    uint8_t            :8;
-    // Byte 5
-    uint8_t            :2;  // 0b00
-    uint8_t Power      :1;
-    uint8_t TimerType  :2;
-    uint8_t Quiet      :1;  // 1
-    uint8_t Light      :1;  // 0 - 0 =? Light on?
-    uint8_t Econo      :1;  // 0
-    // Byte  6
-    uint8_t Mode       :4;
-    uint8_t Health     :1;  // 0
-    uint8_t Turbo      :1;  // 0
-    uint8_t            :2;  // 0b00
-    // Byte 7
-    uint8_t Temp       :4;
-    uint8_t            :4;  // 0b0000
-    // Byte 8
-    uint8_t Fan_and_Night  :3;
-    uint8_t SwingV         :3;
-    uint8_t TimerIndicator :1;
-    uint8_t                :1;  // 0
-
-    // Byte 9
-    uint8_t          :1;  // 0
-    uint8_t OffTimer :6;
-    uint8_t          :1;  // 0
-    // Byte 10
-    uint8_t          :1;  // 0
-    uint8_t OnTimer  :6;
-    uint8_t          :1;  // 0
-    // Byte 11
-    uint8_t          :8;  // 00000000
-    // Byte 12
-    uint8_t            :3;  // 000
-    uint8_t SwingH     :1;  // 0
-    uint8_t            :1;  // 0
-    uint8_t HalfDegree :1;  // 0
-    uint8_t            :2;  // 00
-      // Byte 13
-    uint8_t CheckSum   :8;
-  };
-};
-
 // Constants
 const uint16_t kTcl112AcHdrMark = 3000;
 const uint16_t kTcl112AcHdrSpace = 1650;
@@ -144,9 +94,11 @@ const uint8_t kTcl112AcFan =  7;
 const uint8_t kTcl112AcAuto = 8;
 
 const uint8_t kTcl112AcFanAuto = 0b000;
+const uint8_t kTcl112AcFanMin  = 0b001;  // Aka. "Night"
 const uint8_t kTcl112AcFanLow  = 0b010;
 const uint8_t kTcl112AcFanMed  = 0b011;
 const uint8_t kTcl112AcFanHigh = 0b101;
+const uint8_t kTcl112AcFanNight = kTcl112AcFanMin;
 
 const float   kTcl112AcTempMax    = 31.0;
 const float   kTcl112AcTempMin    = 16.0;
@@ -206,6 +158,10 @@ class IRTcl112Ac {
   bool getTurbo(void) const;
   void setQuiet(const bool on);
   bool getQuiet(const bool def = false) const;
+  uint16_t getOnTimer(void) const;
+  void setOnTimer(const uint16_t mins);
+  uint16_t getOffTimer(void) const;
+  void setOffTimer(const uint16_t mins);
   static bool isTcl(const uint8_t state[]);
   static uint8_t convertMode(const stdAc::opmode_t mode);
   static uint8_t convertFan(const stdAc::fanspeed_t speed);

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -4,8 +4,10 @@
 /// @brief Support for TCL protocols.
 
 // Supports:
-//   Brand: Leberg,  Model: LBS-TOR07 A/C
-//   Brand: TCL,  Model: TAC-09CHSD/XA31I A/C
+//   Brand: Leberg,  Model: LBS-TOR07 A/C (TAC09CHSD)
+//   Brand: TCL,  Model: TAC-09CHSD/XA31I A/C (TAC09CHSD)
+//   Brand: Teknopoint,  Model: Allegro SSA-09H A/C (GZ055BE1)
+//   Brand: Teknopoint,  Model: GZ-055B-E1 remote (GZ055BE1)
 
 #ifndef IR_TCL_H_
 #define IR_TCL_H_
@@ -99,6 +101,7 @@ const uint8_t kTcl112AcFanLow  = 0b010;
 const uint8_t kTcl112AcFanMed  = 0b011;
 const uint8_t kTcl112AcFanHigh = 0b101;
 const uint8_t kTcl112AcFanNight = kTcl112AcFanMin;
+const uint8_t kTcl112AcFanQuiet = kTcl112AcFanMin;
 
 const float   kTcl112AcTempMax    = 31.0;
 const float   kTcl112AcTempMin    = 16.0;

--- a/src/ir_Tcl.h
+++ b/src/ir_Tcl.h
@@ -56,11 +56,11 @@ union Tcl112Protocol{
     uint8_t            :1;
     // Byte 9
     uint8_t            :1;  // 0
-    uint8_t OffTimer   :6;
+    uint8_t OnTimer   :6;
     uint8_t            :1;  // 0
     // Byte 10
     uint8_t            :1;  // 0
-    uint8_t OnTimer    :6;
+    uint8_t OffTimer    :6;
     uint8_t            :1;  // 0
     // Byte 11
     uint8_t            :8;  // 00000000

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1643,7 +1643,8 @@ TEST(TestIRac, Tcl112) {
   char expected[] =
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 20C, "
       "Fan: 3 (Medium), Econo: On, Health: On, Turbo: Off, "
-      "Swing(H): On, Swing(V): 0 (Auto), Light: On";
+      "Swing(H): On, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off";
 
   ac.begin();
   irac.tcl112(&ac,

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1642,8 +1642,8 @@ TEST(TestIRac, Tcl112) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 20C, "
-      "Fan: 3 (Medium), Econo: On, Health: On, Turbo: Off, "
-      "Swing(H): On, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 3 (Medium), Swing(H): On, Swing(V): 0 (Auto), "
+      "Econo: On, Health: On, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off";
 
   ac.begin();

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1642,7 +1642,7 @@ TEST(TestIRac, Tcl112) {
   IRrecv capture(kGpioUnused);
   char expected[] =
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 20C, "
-      "Fan: 3 (Medium), Swing(H): On, Swing(V): 0 (Auto), "
+      "Fan: 3 (Medium), Swing(V): 0 (Auto), Swing(H): On, "
       "Econo: On, Health: On, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off";
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -1641,23 +1641,24 @@ TEST(TestIRac, Tcl112) {
   IRac irac(kGpioUnused);
   IRrecv capture(kGpioUnused);
   char expected[] =
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 20C, Fan: 3 (Medium), "
-      "Econo: On, Health: On, Turbo: Off, Swing(H): On, Swing(V): Off, "
-      "Light: On";
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 20C, "
+      "Fan: 3 (Medium), Econo: On, Health: On, Turbo: Off, "
+      "Swing(H): On, Swing(V): 0 (Auto), Light: On";
 
   ac.begin();
   irac.tcl112(&ac,
-              true,                        // Power
-              stdAc::opmode_t::kCool,      // Mode
-              20,                          // Celsius
-              stdAc::fanspeed_t::kMedium,  // Fan speed
-              stdAc::swingv_t::kOff,       // Vertical swing
-              stdAc::swingh_t::kAuto,      // Horizontal swing
-              false,                       // Quiet (aka. Mute)
-              false,                       // Turbo
-              true,                        // Light
-              true,                        // Econo
-              true);                       // Filter (aka. Health)
+              tcl_ac_remote_model_t::TAC09CHSD,  // Model
+              true,                              // Power
+              stdAc::opmode_t::kCool,            // Mode
+              20,                                // Celsius
+              stdAc::fanspeed_t::kMedium,        // Fan speed
+              stdAc::swingv_t::kOff,             // Vertical swing
+              stdAc::swingh_t::kAuto,            // Horizontal swing
+              false,                             // Quiet (aka. Mute)
+              false,                             // Turbo
+              true,                              // Light
+              true,                              // Econo
+              true);                             // Filter (aka. Health)
   ASSERT_EQ(expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -1669,23 +1670,24 @@ TEST(TestIRac, Tcl112) {
   // Test the quiet mode, which should generate two messages.
   ac._irsend.reset();
   irac.tcl112(&ac,
-              true,                        // Power
-              stdAc::opmode_t::kCool,      // Mode
-              20,                          // Celsius
-              stdAc::fanspeed_t::kMedium,  // Fan speed
-              stdAc::swingv_t::kOff,       // Vertical swing
-              stdAc::swingh_t::kAuto,      // Horizontal swing
-              true,                        // Quiet (aka. Mute)
-              false,                       // Turbo
-              true,                        // Light
-              true,                        // Econo
-              true);                       // Filter (aka. Health)
+              tcl_ac_remote_model_t::TAC09CHSD,  // Model
+              true,                              // Power
+              stdAc::opmode_t::kCool,            // Mode
+              20,                                // Celsius
+              stdAc::fanspeed_t::kMedium,        // Fan speed
+              stdAc::swingv_t::kOff,             // Vertical swing
+              stdAc::swingh_t::kAuto,            // Horizontal swing
+              true,                              // Quiet (aka. Mute)
+              false,                             // Turbo
+              true,                              // Light
+              true,                              // Econo
+              true);                             // Filter (aka. Health)
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
   ASSERT_EQ(TCL112AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(
-      "Type: 2, Quiet: On",
+      "Model: 1 (TAC09CHSD), Type: 2, Quiet: On",
       IRAcUtils::resultAcToString(&ac._irsend.capture));
   // TCL112 uses the Mitsubishi112 decoder.
   // Skip first message.

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -10,8 +10,18 @@
 
 // General housekeeping
 TEST(TestTcl112Ac, Housekeeping) {
-  ASSERT_EQ("TCL112AC", typeToString(TCL112AC));
-  ASSERT_TRUE(hasACState(TCL112AC));
+  ASSERT_EQ("TCL112AC", typeToString(decode_type_t::TCL112AC));
+  ASSERT_EQ(decode_type_t::TCL112AC, strToDecodeType("TCL112AC"));
+  ASSERT_TRUE(hasACState(decode_type_t::TCL112AC));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::TCL112AC));
+  ASSERT_EQ(kTcl112AcBits, IRsend::defaultBits(decode_type_t::TCL112AC));
+  ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::TCL112AC));
+  ASSERT_EQ(tcl_ac_remote_model_t::TAC09CHSD, IRac::strToModel("TAC09CHSD"));
+  ASSERT_EQ(irutils::modelToStr(decode_type_t::TCL112AC,
+                                tcl_ac_remote_model_t::TAC09CHSD), "TAC09CHSD");
+  ASSERT_EQ(tcl_ac_remote_model_t::GZ055BE1, IRac::strToModel("GZ055BE1"));
+  ASSERT_EQ(irutils::modelToStr(decode_type_t::TCL112AC,
+                                tcl_ac_remote_model_t::GZ055BE1), "GZ055BE1");
 }
 
 // Tests for decodeTcl112Ac().
@@ -63,9 +73,9 @@ TEST(TestDecodeTcl112Ac, DecodeRealExample) {
   EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -106,27 +116,27 @@ TEST(TestTcl112AcClass, Temperature) {
   IRTcl112Ac ac(kGpioUnused);
   ac.setRaw(temp16C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
   ac.setRaw(temp16point5C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 16.5C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16.5C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
   ac.setRaw(temp19point5C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 19.5C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 19.5C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
 
   ac.setTemp(kTcl112AcTempMin);
@@ -206,9 +216,9 @@ TEST(TestTcl112AcClass, OperatingMode) {
       0x07, 0x00, 0x00, 0x00, 0x00, 0x80, 0x48};
   ac.setRaw(automode);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
 }
 
@@ -236,9 +246,9 @@ TEST(TestTcl112AcClass, Power) {
       0x0F, 0x00, 0x00, 0x00, 0x00, 0x80, 0xCB};
   ac.setRaw(on);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
 
   const uint8_t off[kTcl112AcStateLength] = {
@@ -246,9 +256,9 @@ TEST(TestTcl112AcClass, Power) {
       0x07, 0x40, 0x00, 0x00, 0x00, 0x80, 0xCB};
   ac.setRaw(off);
   EXPECT_EQ(
-      "Type: 1, Power: Off, Mode: 3 (Cool), Temp: 24C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: Off, Mode: 3 (Cool), Temp: 24C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
 }
 
@@ -263,15 +273,15 @@ TEST(TestTcl112AcClass, Checksum) {
   EXPECT_EQ(0xCB, ac.calcChecksum(temp16C));
   ac.setRaw(temp16C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
   EXPECT_EQ(0xBC, ac.calcChecksum(temp31C));
 
@@ -337,12 +347,12 @@ TEST(TestTcl112AcClass, SwingVertical) {
   IRTcl112Ac ac(kGpioUnused);
   ac.begin();
 
-  ac.setSwingVertical(true);
-  EXPECT_TRUE(ac.getSwingVertical());
-  ac.setSwingVertical(false);
-  EXPECT_EQ(false, ac.getSwingVertical());
-  ac.setSwingVertical(true);
-  EXPECT_TRUE(ac.getSwingVertical());
+  ac.setSwingVertical(kTcl112AcSwingVOff);
+  EXPECT_EQ(kTcl112AcSwingVOff, ac.getSwingVertical());
+  ac.setSwingVertical(kTcl112AcSwingVOn);
+  EXPECT_EQ(kTcl112AcSwingVOn, ac.getSwingVertical());
+  ac.setSwingVertical(kTcl112AcSwingVOff);
+  EXPECT_EQ(kTcl112AcSwingVOff, ac.getSwingVertical());
 }
 
 TEST(TestTcl112AcClass, Turbo) {
@@ -405,6 +415,7 @@ TEST(TestTcl112AcClass, Quiet_Mute) {
 
 TEST(TestTcl112AcClass, toCommon) {
   IRTcl112Ac ac(kGpioUnused);
+  ac.setModel(tcl_ac_remote_model_t::TAC09CHSD);
   ac.setPower(true);
   ac.setMode(kTcl112AcCool);
   ac.setTemp(20);
@@ -418,7 +429,7 @@ TEST(TestTcl112AcClass, toCommon) {
   ac.setQuiet(false);
   // Now test it.
   ASSERT_EQ(decode_type_t::TCL112AC, ac.toCommon().protocol);
-  ASSERT_EQ(-1, ac.toCommon().model);
+  ASSERT_EQ(1, ac.toCommon().model);
   ASSERT_TRUE(ac.toCommon().power);
   ASSERT_TRUE(ac.toCommon().celsius);
   ASSERT_EQ(20, ac.toCommon().degrees);
@@ -485,9 +496,9 @@ TEST(TestDecodeTcl112Ac, Issue744) {
   IRTcl112Ac ac(kGpioUnused);
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 23C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: On",
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 23C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
       ac.toString());
 }
 
@@ -527,7 +538,7 @@ TEST(TestDecodeTcl112Ac, Issue1528) {
   EXPECT_EQ(kTcl112AcBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Type: 2, Quiet: On",
+      "Model: 1 (TAC09CHSD), Type: 2, Quiet: On",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -535,7 +546,6 @@ TEST(TestDecodeTcl112Ac, Issue1528) {
 TEST(TestTcl112AcClass, SendingQuiet) {
   IRTcl112Ac ac(kGpioUnused);
   IRrecv capture(kGpioUnused);
-
 
   ac.begin();
   ac.on();
@@ -559,16 +569,37 @@ TEST(TestTcl112AcClass, SendingQuiet) {
   ASSERT_EQ(TCL112AC, ac._irsend.capture.decode_type);
   ASSERT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(
-      "Type: 2, Quiet: On",
+      "Model: 1 (TAC09CHSD), Type: 2, Quiet: On",
       IRAcUtils::resultAcToString(&ac._irsend.capture));
   // Second message.
   // TCL112 uses the Mitsubishi112 decoder.
   // Skip first message.
   EXPECT_TRUE(capture.decodeMitsubishi112(&ac._irsend.capture, 229));
-  ASSERT_EQ(TCL112AC, ac._irsend.capture.decode_type);
-  ASSERT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
+  EXPECT_EQ(TCL112AC, ac._irsend.capture.decode_type);
+  EXPECT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(
-      "Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, Fan: 0 (Auto), "
-      "Econo: Off, Health: Off, Turbo: Off, Swing(H): Off, Swing(V): Off, "
-      "Light: Off", IRAcUtils::resultAcToString(&ac._irsend.capture));
+      "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: Off",
+      IRAcUtils::resultAcToString(&ac._irsend.capture));
+}
+
+TEST(TestTcl112AcClass, isTcl) {
+  const uint8_t tcl_temp16C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0F, 0x00, 0x00, 0x00, 0x00, 0x80, 0xCB};
+  EXPECT_TRUE(IRTcl112Ac::isTcl(tcl_temp16C));
+  const uint8_t tcl_temp31C[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xBC};
+  EXPECT_TRUE(IRTcl112Ac::isTcl(tcl_temp31C));
+  const uint8_t issue1528[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x02, 0x00, 0x60, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x85};
+  EXPECT_TRUE(IRTcl112Ac::isTcl(issue1528));
+  // Ref: https://cociweb.info/container/hvac_ir_recapture_2719.log
+  const uint8_t teknopoint[14] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0F, 0x38, 0x00, 0x00, 0x00, 0x00, 0x83};
+  EXPECT_FALSE(IRTcl112Ac::isTcl(teknopoint));
 }

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -361,8 +361,18 @@ TEST(TestTcl112AcClass, SwingVertical) {
   EXPECT_EQ(kTcl112AcSwingVOff, ac.getSwingVertical());
   ac.setSwingVertical(kTcl112AcSwingVOn);
   EXPECT_EQ(kTcl112AcSwingVOn, ac.getSwingVertical());
+  ac.setSwingVertical(kTcl112AcSwingVHigh);
+  EXPECT_EQ(kTcl112AcSwingVHigh, ac.getSwingVertical());
   ac.setSwingVertical(kTcl112AcSwingVOff);
   EXPECT_EQ(kTcl112AcSwingVOff, ac.getSwingVertical());
+  ac.setSwingVertical(0xFF);  // Unused value so shouldn't change from previous.
+  EXPECT_EQ(kTcl112AcSwingVOff, ac.getSwingVertical());
+
+  const uint8_t highest[kTcl112AcStateLength] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
+      0x0F, 0x08, 0x00, 0x00, 0x00, 0x00, 0x53};
+  ac.setRaw(highest);
+  EXPECT_EQ(kTcl112AcSwingVHighest, ac.getSwingVertical());
 }
 
 TEST(TestTcl112AcClass, Turbo) {

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -661,4 +661,30 @@ TEST(TestTcl112AcClass, Timers) {
   EXPECT_FALSE(ac._.TimerIndicator);
   EXPECT_FALSE(ac._.OnTimerEnabled);
   EXPECT_FALSE(ac._.OffTimerEnabled);
+
+  // Real messages/states
+  // Per https://github.com/crankyoldgit/IRremoteESP8266/issues/1486#issuecomment-917545485
+
+  const uint8_t offtimer_1h[14] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x34, 0x03,
+      0x00, 0x78, 0x00, 0x06, 0x00, 0x00, 0xCA};
+  ac.setRaw(offtimer_1h);
+  EXPECT_EQ(60, ac.getOffTimer());
+  EXPECT_TRUE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_TRUE(ac._.OffTimerEnabled);
+
+  const uint8_t offtimer_4h[14] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x34, 0x03,
+      0x00, 0x78, 0x00, 0x18, 0x00, 0x00, 0xDC};
+  ac.setRaw(offtimer_4h);
+  EXPECT_EQ(240, ac.getOffTimer());
+  EXPECT_TRUE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_TRUE(ac._.OffTimerEnabled);
+  EXPECT_EQ(
+      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 7 (Swing), "
+      "On Timer: Off, Off Timer: 04:00",
+      ac.toString());
 }

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -75,7 +75,8 @@ TEST(TestDecodeTcl112Ac, DecodeRealExample) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -118,25 +119,29 @@ TEST(TestTcl112AcClass, Temperature) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp16point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16.5C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp19point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 19.5C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
 
   ac.setTemp(kTcl112AcTempMin);
@@ -218,7 +223,8 @@ TEST(TestTcl112AcClass, OperatingMode) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
 
@@ -248,7 +254,8 @@ TEST(TestTcl112AcClass, Power) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
 
   const uint8_t off[kTcl112AcStateLength] = {
@@ -258,7 +265,8 @@ TEST(TestTcl112AcClass, Power) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: Off, Mode: 3 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
 
@@ -275,13 +283,15 @@ TEST(TestTcl112AcClass, Checksum) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
   EXPECT_EQ(0xBC, ac.calcChecksum(temp31C));
 
@@ -498,7 +508,8 @@ TEST(TestDecodeTcl112Ac, Issue744) {
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 23C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
 
@@ -580,7 +591,8 @@ TEST(TestTcl112AcClass, SendingQuiet) {
   ASSERT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: Off",
+      "Swing(H): Off, Swing(V): 0 (Auto), Light: Off, "
+      "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&ac._irsend.capture));
 }
 
@@ -602,4 +614,41 @@ TEST(TestTcl112AcClass, isTcl) {
       0x23, 0xCB, 0x26, 0x01, 0x00, 0x24, 0x03,
       0x0F, 0x38, 0x00, 0x00, 0x00, 0x00, 0x83};
   EXPECT_FALSE(IRTcl112Ac::isTcl(teknopoint));
+}
+
+TEST(TestTcl112AcClass, Timers) {
+  IRTcl112Ac ac(kGpioUnused);
+
+  ac.stateReset();
+  ac.setOnTimer(0);
+  ac.setOffTimer(0);
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_EQ(0, ac.getOffTimer());
+  EXPECT_FALSE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
+
+  ac.setOnTimer(7 * 60);
+  EXPECT_EQ(7 * 60, ac.getOnTimer());
+  EXPECT_TRUE(ac._.TimerIndicator);
+  EXPECT_TRUE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
+
+  ac.setOnTimer(0);
+  EXPECT_EQ(0, ac.getOnTimer());
+  EXPECT_FALSE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
+
+  ac.setOffTimer(13 * 60);  // Beyond max.
+  EXPECT_EQ(12 * 60, ac.getOffTimer());
+  EXPECT_TRUE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_TRUE(ac._.OffTimerEnabled);
+
+  ac.setOffTimer(0);
+  EXPECT_EQ(0, ac.getOffTimer());
+  EXPECT_FALSE(ac._.TimerIndicator);
+  EXPECT_FALSE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
 }

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -74,8 +74,8 @@ TEST(TestDecodeTcl112Ac, DecodeRealExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
@@ -118,29 +118,29 @@ TEST(TestTcl112AcClass, Temperature) {
   ac.setRaw(temp16C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp16point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16.5C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp19point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 19.5C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
 
@@ -222,8 +222,8 @@ TEST(TestTcl112AcClass, OperatingMode) {
   ac.setRaw(automode);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
@@ -253,8 +253,8 @@ TEST(TestTcl112AcClass, Power) {
   ac.setRaw(on);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
 
@@ -264,8 +264,8 @@ TEST(TestTcl112AcClass, Power) {
   ac.setRaw(off);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: Off, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
@@ -282,15 +282,15 @@ TEST(TestTcl112AcClass, Checksum) {
   ac.setRaw(temp16C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   EXPECT_EQ(0xBC, ac.calcChecksum(temp31C));
@@ -517,8 +517,8 @@ TEST(TestDecodeTcl112Ac, Issue744) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 23C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
 }
@@ -600,8 +600,8 @@ TEST(TestTcl112AcClass, SendingQuiet) {
   EXPECT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 0 (Auto), Light: Off, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Econo: Off, Health: Off, Turbo: Off, Light: Off, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&ac._irsend.capture));
 }

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -74,7 +74,7 @@ TEST(TestDecodeTcl112Ac, DecodeRealExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
@@ -118,28 +118,28 @@ TEST(TestTcl112AcClass, Temperature) {
   ac.setRaw(temp16C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp16point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16.5C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp19point5C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 19.5C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -222,7 +222,7 @@ TEST(TestTcl112AcClass, OperatingMode) {
   ac.setRaw(automode);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -253,7 +253,7 @@ TEST(TestTcl112AcClass, Power) {
   ac.setRaw(on);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -264,7 +264,7 @@ TEST(TestTcl112AcClass, Power) {
   ac.setRaw(off);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: Off, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -282,14 +282,14 @@ TEST(TestTcl112AcClass, Checksum) {
   ac.setRaw(temp16C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(temp31C);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -517,7 +517,7 @@ TEST(TestDecodeTcl112Ac, Issue744) {
   ac.setRaw(irsend.capture.state);
   EXPECT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 23C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: On, "
       "On Timer: Off, Off Timer: Off",
       ac.toString());
@@ -600,7 +600,7 @@ TEST(TestTcl112AcClass, SendingQuiet) {
   EXPECT_EQ(kTcl112AcBits, ac._irsend.capture.bits);
   ASSERT_EQ(
       "Model: 1 (TAC09CHSD), Type: 1, Power: On, Mode: 3 (Cool), Temp: 24C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 0 (Auto), "
+      "Fan: 0 (Auto), Swing(V): 0 (Auto), Swing(H): Off, "
       "Econo: Off, Health: Off, Turbo: Off, Light: Off, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&ac._irsend.capture));
@@ -684,7 +684,7 @@ TEST(TestTcl112AcClass, Timers) {
   EXPECT_FALSE(ac._.OffTimerEnabled);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 7 (Swing), "
+      "Fan: 0 (Auto), Swing(V): 7 (Swing), "
       "On Timer: 04:00, Off Timer: Off",
       ac.toString());
 
@@ -699,7 +699,7 @@ TEST(TestTcl112AcClass, Timers) {
   EXPECT_TRUE(ac._.OffTimerEnabled);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 7 (Swing), "
+      "Fan: 0 (Auto), Swing(V): 7 (Swing), "
       "On Timer: Off, Off Timer: 02:00",
       ac.toString());
 }

--- a/test/ir_Tcl_test.cpp
+++ b/test/ir_Tcl_test.cpp
@@ -665,26 +665,41 @@ TEST(TestTcl112AcClass, Timers) {
   // Real messages/states
   // Per https://github.com/crankyoldgit/IRremoteESP8266/issues/1486#issuecomment-917545485
 
-  const uint8_t offtimer_1h[14] = {
+  const uint8_t ontimer_1h[14] = {
       0x23, 0xCB, 0x26, 0x01, 0x00, 0x34, 0x03,
       0x00, 0x78, 0x00, 0x06, 0x00, 0x00, 0xCA};
-  ac.setRaw(offtimer_1h);
-  EXPECT_EQ(60, ac.getOffTimer());
+  ac.setRaw(ontimer_1h);
+  EXPECT_EQ(60, ac.getOnTimer());
   EXPECT_TRUE(ac._.TimerIndicator);
-  EXPECT_FALSE(ac._.OnTimerEnabled);
-  EXPECT_TRUE(ac._.OffTimerEnabled);
+  EXPECT_TRUE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
 
-  const uint8_t offtimer_4h[14] = {
+  const uint8_t ontimer_4h[14] = {
       0x23, 0xCB, 0x26, 0x01, 0x00, 0x34, 0x03,
       0x00, 0x78, 0x00, 0x18, 0x00, 0x00, 0xDC};
-  ac.setRaw(offtimer_4h);
-  EXPECT_EQ(240, ac.getOffTimer());
+  ac.setRaw(ontimer_4h);
+  EXPECT_EQ(240, ac.getOnTimer());
+  EXPECT_TRUE(ac._.TimerIndicator);
+  EXPECT_TRUE(ac._.OnTimerEnabled);
+  EXPECT_FALSE(ac._.OffTimerEnabled);
+  EXPECT_EQ(
+      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 7 (Swing), "
+      "On Timer: 04:00, Off Timer: Off",
+      ac.toString());
+
+  const uint8_t offtimer_2h[14] = {
+      0x23, 0xCB, 0x26, 0x01, 0x00, 0x2C, 0x08,
+      0x07, 0x78, 0x0C, 0x00, 0x00, 0x00, 0xD4};
+
+  ac.setRaw(offtimer_2h);
+  EXPECT_EQ(120, ac.getOffTimer());
   EXPECT_TRUE(ac._.TimerIndicator);
   EXPECT_FALSE(ac._.OnTimerEnabled);
   EXPECT_TRUE(ac._.OffTimerEnabled);
   EXPECT_EQ(
-      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 31C, "
+      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 8 (Auto), Temp: 24C, "
       "Fan: 0 (Auto), Swing(H): Off, Swing(V): 7 (Swing), "
-      "On Timer: Off, Off Timer: 04:00",
+      "On Timer: Off, Off Timer: 02:00",
       ac.toString());
 }

--- a/test/ir_Teknopoint_test.cpp
+++ b/test/ir_Teknopoint_test.cpp
@@ -46,7 +46,8 @@ TEST(TestDecodeTeknopoint, RealExample) {
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On",
+      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -71,7 +72,8 @@ TEST(TestDecodeTeknopoint, SyntheticExample) {
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On",
+      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On, "
+      "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 
   EXPECT_EQ(

--- a/test/ir_Teknopoint_test.cpp
+++ b/test/ir_Teknopoint_test.cpp
@@ -45,8 +45,7 @@ TEST(TestDecodeTeknopoint, RealExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (Highest), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 1 (Highest), "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
@@ -71,8 +70,7 @@ TEST(TestDecodeTeknopoint, SyntheticExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (Highest), Light: On, "
+      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 1 (Highest), "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 

--- a/test/ir_Teknopoint_test.cpp
+++ b/test/ir_Teknopoint_test.cpp
@@ -45,7 +45,7 @@ TEST(TestDecodeTeknopoint, RealExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 1 (Highest), "
+      "Fan: 0 (Auto), Swing(V): 1 (Highest), "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
@@ -70,7 +70,7 @@ TEST(TestDecodeTeknopoint, SyntheticExample) {
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
-      "Fan: 0 (Auto), Swing(H): Off, Swing(V): 1 (Highest), "
+      "Fan: 0 (Auto), Swing(V): 1 (Highest), "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 

--- a/test/ir_Teknopoint_test.cpp
+++ b/test/ir_Teknopoint_test.cpp
@@ -46,7 +46,7 @@ TEST(TestDecodeTeknopoint, RealExample) {
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On, "
+      "Swing(H): Off, Swing(V): 1 (Highest), Light: On, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
@@ -72,7 +72,7 @@ TEST(TestDecodeTeknopoint, SyntheticExample) {
   EXPECT_EQ(
       "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
       "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
-      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On, "
+      "Swing(H): Off, Swing(V): 1 (Highest), Light: On, "
       "On Timer: Off, Off Timer: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
 

--- a/test/ir_Teknopoint_test.cpp
+++ b/test/ir_Teknopoint_test.cpp
@@ -44,7 +44,9 @@ TEST(TestDecodeTeknopoint, RealExample) {
   ASSERT_EQ(kTeknopointBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "",
+      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On",
       IRAcUtils::resultAcToString(&irsend.capture));
 }
 
@@ -67,7 +69,9 @@ TEST(TestDecodeTeknopoint, SyntheticExample) {
   ASSERT_EQ(kTeknopointBits, irsend.capture.bits);
   EXPECT_STATE_EQ(expectedState, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "",
+      "Model: 2 (GZ055BE1), Type: 1, Power: On, Mode: 3 (Cool), Temp: 16C, "
+      "Fan: 0 (Auto), Econo: Off, Health: Off, Turbo: Off, "
+      "Swing(H): Off, Swing(V): 1 (UNKNOWN), Light: On",
       IRAcUtils::resultAcToString(&irsend.capture));
 
   EXPECT_EQ(
@@ -95,7 +99,7 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_EQ("TEKNOPOINT", typeToString(decode_type_t::TEKNOPOINT));
   ASSERT_EQ(decode_type_t::TEKNOPOINT, strToDecodeType("TEKNOPOINT"));
   ASSERT_TRUE(hasACState(decode_type_t::TEKNOPOINT));
-  ASSERT_FALSE(IRac::isProtocolSupported(decode_type_t::TEKNOPOINT));
+  ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::TEKNOPOINT));
   ASSERT_EQ(kTeknopointBits, IRsend::defaultBits(decode_type_t::TEKNOPOINT));
   ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::TEKNOPOINT));
 }


### PR DESCRIPTION
* Add `model` support for `TCL112AC` protocol.
* Hack `TEKNOPOINT` decoding to use `TCL112AC` model `GZ055BE1`
* Change Vertical Swing to have multiple positions.
* Add On & Off timer support.
* Add "Night" (aka. Quiet/min fan speed)
* Plenty of Unit Test additions, updates, & improvements.

Fixes #1486