### PR TITLE
Nicer output IRac::opmodeToString for FanOnly

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3322,7 +3322,7 @@ String IRac::opmodeToString(const stdAc::opmode_t mode) {
     case stdAc::opmode_t::kDry:
       return kDryStr;
     case stdAc::opmode_t::kFan:
-      return kFanOnlyStr;
+      return kFanOnlyNoSpaceStr;
     default:
       return kUnknownStr;
   }


### PR DESCRIPTION
In addition to #1610

For Fan mode return "FanOnly" instead of "fan-only", it is for more nice output to string, i.e. in Tasmota log/

Before:  `..."Vendor":"HAIER_AC_YRW02","Model":-1,"Mode":"fan-only","Power":"On"...`
After:     `..."Vendor":"HAIER_AC_YRW02","Model":-1,"Mode":"FanOnly","Power":"On"...`