### PR TITLE
Make `IRAc::opmodeToString()` output nicer for humans.

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2875,10 +2875,10 @@ void sendJsonState(const stdAc::state_t state, const String topic,
   json[KEY_PROTOCOL] = typeToString(state.protocol);
   json[KEY_MODEL] = state.model;
   json[KEY_POWER] = IRac::boolToString(state.power);
-  json[KEY_MODE] = IRac::opmodeToString(state.mode);
+  json[KEY_MODE] = IRac::opmodeToString(state.mode, ha_mode);
   // Home Assistant wants mode to be off if power is also off & vice-versa.
   if (ha_mode && (state.mode == stdAc::opmode_t::kOff || !state.power)) {
-    json[KEY_MODE] = IRac::opmodeToString(stdAc::opmode_t::kOff);
+    json[KEY_MODE] = IRac::opmodeToString(stdAc::opmode_t::kOff, ha_mode);
     json[KEY_POWER] = IRac::boolToString(false);
   }
   json[KEY_CELSIUS] = IRac::boolToString(state.celsius);
@@ -3024,7 +3024,7 @@ bool sendClimate(const String topic_prefix, const bool retain,
     diff = true;
     success &= sendInt(topic_prefix + KEY_MODEL, next.model, retain);
   }
-  String mode_str = IRac::opmodeToString(next.mode);
+  String mode_str = IRac::opmodeToString(next.mode, MQTT_CLIMATE_HA_MODE);
   // I don't know why, but the modes need to be lower case to work with
   // Home Assistant & Google Home.
   mode_str.toLowerCase();

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3024,7 +3024,11 @@ bool sendClimate(const String topic_prefix, const bool retain,
     diff = true;
     success &= sendInt(topic_prefix + KEY_MODEL, next.model, retain);
   }
+#ifdef MQTT_CLIMATE_HA_MODE
   String mode_str = IRac::opmodeToString(next.mode, MQTT_CLIMATE_HA_MODE);
+#else  // MQTT_CLIMATE_HA_MODE
+  String mode_str = IRac::opmodeToString(next.mode);
+#endif  // MQTT_CLIMATE_HA_MODE
   // I don't know why, but the modes need to be lower case to work with
   // Home Assistant & Google Home.
   mode_str.toLowerCase();

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3308,8 +3308,9 @@ String IRac::boolToString(const bool value) {
 
 /// Convert the supplied operation mode into the appropriate String.
 /// @param[in] mode The enum to be converted.
+/// @param[in] ha A flag to indicate we want GoogleHome/HomeAssistant output.
 /// @return The equivalent String for the locale.
-String IRac::opmodeToString(const stdAc::opmode_t mode) {
+String IRac::opmodeToString(const stdAc::opmode_t mode, const bool ha) {
   switch (mode) {
     case stdAc::opmode_t::kOff:
       return kOffStr;
@@ -3322,7 +3323,7 @@ String IRac::opmodeToString(const stdAc::opmode_t mode) {
     case stdAc::opmode_t::kDry:
       return kDryStr;
     case stdAc::opmode_t::kFan:
-      return kFanOnlyStr;
+      return ha ? kFanOnlyStr : kFanStr;
     default:
       return kUnknownStr;
   }

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3312,20 +3312,13 @@ String IRac::boolToString(const bool value) {
 /// @return The equivalent String for the locale.
 String IRac::opmodeToString(const stdAc::opmode_t mode, const bool ha) {
   switch (mode) {
-    case stdAc::opmode_t::kOff:
-      return kOffStr;
-    case stdAc::opmode_t::kAuto:
-      return kAutoStr;
-    case stdAc::opmode_t::kCool:
-      return kCoolStr;
-    case stdAc::opmode_t::kHeat:
-      return kHeatStr;
-    case stdAc::opmode_t::kDry:
-      return kDryStr;
-    case stdAc::opmode_t::kFan:
-      return ha ? kFanOnlyStr : kFanStr;
-    default:
-      return kUnknownStr;
+    case stdAc::opmode_t::kOff:  return kOffStr;
+    case stdAc::opmode_t::kAuto: return kAutoStr;
+    case stdAc::opmode_t::kCool: return kCoolStr;
+    case stdAc::opmode_t::kHeat: return kHeatStr;
+    case stdAc::opmode_t::kDry:  return kDryStr;
+    case stdAc::opmode_t::kFan:  return ha ? kFanOnlyStr : kFanStr;
+    default:                     return kUnknownStr;
   }
 }
 
@@ -3334,20 +3327,13 @@ String IRac::opmodeToString(const stdAc::opmode_t mode, const bool ha) {
 /// @return The equivalent String for the locale.
 String IRac::fanspeedToString(const stdAc::fanspeed_t speed) {
   switch (speed) {
-    case stdAc::fanspeed_t::kAuto:
-      return kAutoStr;
-    case stdAc::fanspeed_t::kMax:
-      return kMaxStr;
-    case stdAc::fanspeed_t::kHigh:
-      return kHighStr;
-    case stdAc::fanspeed_t::kMedium:
-      return kMediumStr;
-    case stdAc::fanspeed_t::kLow:
-      return kLowStr;
-    case stdAc::fanspeed_t::kMin:
-      return kMinStr;
-    default:
-      return kUnknownStr;
+    case stdAc::fanspeed_t::kAuto:   return kAutoStr;
+    case stdAc::fanspeed_t::kMax:    return kMaxStr;
+    case stdAc::fanspeed_t::kHigh:   return kHighStr;
+    case stdAc::fanspeed_t::kMedium: return kMediumStr;
+    case stdAc::fanspeed_t::kLow:    return kLowStr;
+    case stdAc::fanspeed_t::kMin:    return kMinStr;
+    default:                         return kUnknownStr;
   }
 }
 
@@ -3356,22 +3342,14 @@ String IRac::fanspeedToString(const stdAc::fanspeed_t speed) {
 /// @return The equivalent String for the locale.
 String IRac::swingvToString(const stdAc::swingv_t swingv) {
   switch (swingv) {
-    case stdAc::swingv_t::kOff:
-      return kOffStr;
-    case stdAc::swingv_t::kAuto:
-      return kAutoStr;
-    case stdAc::swingv_t::kHighest:
-      return kHighestStr;
-    case stdAc::swingv_t::kHigh:
-      return kHighStr;
-    case stdAc::swingv_t::kMiddle:
-      return kMiddleStr;
-    case stdAc::swingv_t::kLow:
-      return kLowStr;
-    case stdAc::swingv_t::kLowest:
-      return kLowestStr;
-    default:
-      return kUnknownStr;
+    case stdAc::swingv_t::kOff:     return kOffStr;
+    case stdAc::swingv_t::kAuto:    return kAutoStr;
+    case stdAc::swingv_t::kHighest: return kHighestStr;
+    case stdAc::swingv_t::kHigh:    return kHighStr;
+    case stdAc::swingv_t::kMiddle:  return kMiddleStr;
+    case stdAc::swingv_t::kLow:     return kLowStr;
+    case stdAc::swingv_t::kLowest:  return kLowestStr;
+    default:                        return kUnknownStr;
   }
 }
 
@@ -3380,24 +3358,15 @@ String IRac::swingvToString(const stdAc::swingv_t swingv) {
 /// @return The equivalent String for the locale.
 String IRac::swinghToString(const stdAc::swingh_t swingh) {
   switch (swingh) {
-    case stdAc::swingh_t::kOff:
-      return kOffStr;
-    case stdAc::swingh_t::kAuto:
-      return kAutoStr;
-    case stdAc::swingh_t::kLeftMax:
-      return kLeftMaxStr;
-    case stdAc::swingh_t::kLeft:
-      return kLeftStr;
-    case stdAc::swingh_t::kMiddle:
-      return kMiddleStr;
-    case stdAc::swingh_t::kRight:
-      return kRightStr;
-    case stdAc::swingh_t::kRightMax:
-      return kRightMaxStr;
-    case stdAc::swingh_t::kWide:
-      return kWideStr;
-    default:
-      return kUnknownStr;
+    case stdAc::swingh_t::kOff:      return kOffStr;
+    case stdAc::swingh_t::kAuto:     return kAutoStr;
+    case stdAc::swingh_t::kLeftMax:  return kLeftMaxStr;
+    case stdAc::swingh_t::kLeft:     return kLeftStr;
+    case stdAc::swingh_t::kMiddle:   return kMiddleStr;
+    case stdAc::swingh_t::kRight:    return kRightStr;
+    case stdAc::swingh_t::kRightMax: return kRightMaxStr;
+    case stdAc::swingh_t::kWide:     return kWideStr;
+    default:                         return kUnknownStr;
   }
 }
 

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -90,7 +90,8 @@ class IRac {
   static stdAc::swingh_t strToSwingH(
       const char *str, const stdAc::swingh_t def = stdAc::swingh_t::kOff);
   static String boolToString(const bool value);
-  static String opmodeToString(const stdAc::opmode_t mode);
+  static String opmodeToString(const stdAc::opmode_t mode,
+                               const bool ha = false);
   static String fanspeedToString(const stdAc::fanspeed_t speed);
   static String swingvToString(const stdAc::swingv_t swingv);
   static String swinghToString(const stdAc::swingh_t swingh);

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -2339,6 +2339,10 @@ TEST(TestIRac, opmodeToString) {
   EXPECT_EQ("Auto", IRac::opmodeToString(stdAc::opmode_t::kAuto));
   EXPECT_EQ("Cool", IRac::opmodeToString(stdAc::opmode_t::kCool));
   EXPECT_EQ("UNKNOWN", IRac::opmodeToString((stdAc::opmode_t)500));
+  // Home Assistant/Google Home differences.
+  EXPECT_EQ("Fan", IRac::opmodeToString(stdAc::opmode_t::kFan, false));
+  EXPECT_EQ("fan-only", IRac::opmodeToString(stdAc::opmode_t::kFan, true));
+  EXPECT_EQ("Fan", IRac::opmodeToString(stdAc::opmode_t::kFan));  // Default
 }
 
 TEST(TestIRac, fanspeedToString) {


### PR DESCRIPTION
* Add two outputs for Fan mode.
Use a nicer & more obvious human mode by default, & a special output which is expected for Home Assistant + Google Home.
* Unit tests
* Pretty up some of the switch statements.

Replaces PR #1612