### PR TITLE
Reduce flash space used.

### DIFF
--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -183,11 +183,12 @@ IRTEXT_CONST_STRING(kSwingVToggleStr, D_STR_SWINGVTOGGLE);  ///<
 ///< "Swing(V) Toggle"
 IRTEXT_CONST_STRING(kTurboToggleStr, D_STR_TURBOTOGGLE);  ///< "Turbo Toggle"
 
-// Separators
+// Separators & Punctuation
 const char kTimeSep = D_CHR_TIME_SEP;  ///< ':'
 IRTEXT_CONST_STRING(kSpaceLBraceStr, D_STR_SPACELBRACE);  ///< " ("
 IRTEXT_CONST_STRING(kCommaSpaceStr, D_STR_COMMASPACE);  ///< ", "
 IRTEXT_CONST_STRING(kColonSpaceStr, D_STR_COLONSPACE);  ///< ": "
+IRTEXT_CONST_STRING(kDashStr, D_STR_DASH);  ///< "-"
 
 // IRutils
 //  - Time

--- a/src/IRtext.h
+++ b/src/IRtext.h
@@ -50,6 +50,7 @@ extern IRTEXT_CONST_PTR(kComfortStr);
 extern IRTEXT_CONST_PTR(kCommandStr);
 extern IRTEXT_CONST_PTR(kCommaSpaceStr);
 extern IRTEXT_CONST_PTR(kCoolStr);
+extern IRTEXT_CONST_PTR(kDashStr);
 extern IRTEXT_CONST_PTR(kDaysStr);
 extern IRTEXT_CONST_PTR(kDayStr);
 extern IRTEXT_CONST_PTR(kDisplayTempStr);

--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -540,7 +540,18 @@ namespace irutils {
   /// @return The resulting String.
   String addBoolToString(const bool value, const String label,
                          const bool precomma) {
-    return addLabeledString((value ? kOnStr : kOffStr), label, precomma);
+    return addLabeledString(value ? kOnStr : kOffStr, label, precomma);
+  }
+
+  /// Create a String with a colon separated toggle flag suitable for Humans.
+  /// e.g. "Light: Toggle", "Light: -"
+  /// @param[in] toggle The value of the toggle to come after the label.
+  /// @param[in] label The label to precede the value.
+  /// @param[in] precomma Should the output string start with ", " or not?
+  /// @return The resulting String.
+  String addToggleToString(const bool toggle, const String label,
+                           const bool precomma) {
+    return addLabeledString(toggle ? kToggleStr : kDashStr, label, precomma);
   }
 
   /// Create a String with a colon separated labeled Integer suitable for

--- a/src/IRutils.h
+++ b/src/IRutils.h
@@ -48,6 +48,8 @@ float fahrenheitToCelsius(const float deg);
 namespace irutils {
   String addBoolToString(const bool value, const String label,
                          const bool precomma = true);
+  String addToggleToString(const bool toggle, const String label,
+                           const bool precomma = true);
   String addIntToString(const uint16_t value, const String label,
                         const bool precomma = true);
   String addSignedIntToString(const int16_t value, const String label,

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -28,6 +28,7 @@ using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addFanToString;
 using irutils::addTempToString;
+using irutils::addToggleToString;
 
 #if SEND_ELECTRA_AC
 /// Send a Electra A/C formatted message.
@@ -351,8 +352,7 @@ String IRElectraAc::toString(void) const {
                            kElectraAcFanMed);
   result += addBoolToString(getSwingV(), kSwingVStr);
   result += addBoolToString(getSwingH(), kSwingHStr);
-  result += addLabeledString(getLightToggle() ? String(kToggleStr)
-                                              : String("-"), kLightStr);
+  result += addToggleToString(getLightToggle(), kLightStr);
   result += addBoolToString(_.Clean, kCleanStr);
   result += addBoolToString(_.Turbo, kTurboStr);
   return result;

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -21,6 +21,7 @@ using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addFanToString;
 using irutils::addTempToString;
+using irutils::addToggleToString;
 
 #if SEND_GOODWEATHER
 /// Send a Goodweather HVAC formatted message.
@@ -347,12 +348,9 @@ String IRGoodweatherAc::toString(void) const {
                            kGoodweatherFanAuto, kGoodweatherFanAuto,
                            kGoodweatherFanMed);
 
-  result += addLabeledString(_.Turbo ? String(kToggleStr)
-                                     : String("-"), kTurboStr);
-  result += addLabeledString(_.Light ? String(kToggleStr)
-                                     : String("-"), kLightStr);
-  result += addLabeledString(_.Sleep ? String(kToggleStr)
-                                     : String("-"), kSleepStr);
+  result += addToggleToString(_.Turbo, kTurboStr);
+  result += addToggleToString(_.Light, kLightStr);
+  result += addToggleToString(_.Sleep, kSleepStr);
   result += addIntToString(_.Swing, kSwingStr);
   result += kSpaceLBraceStr;
   switch (_.Swing) {

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -47,6 +47,7 @@ using irutils::addModeToString;
 using irutils::addModelToString;
 using irutils::addSwingVToString;
 using irutils::addTempToString;
+using irutils::addToggleToString;
 using irutils::minsToString;
 
 // Also used by Denon protocol
@@ -920,14 +921,10 @@ String IRSharpAc::toString(void) const {
   switch (model) {
     case sharp_ac_remote_model_t::A705:
     case sharp_ac_remote_model_t::A903:
-      result += addLabeledString(getLightToggle() ? String(kToggleStr)
-                                                  : String("-"),
-                                 kLightStr);
+      result += addToggleToString(getLightToggle(), kLightStr);
       break;
     default:
-      result += addLabeledString(getEconoToggle() ? String(kToggleStr)
-                                                  : String("-"),
-                                 kEconoStr);
+      result += addToggleToString(getEconoToggle(), kEconoStr);
   }
   result += addBoolToString(_.Clean, kCleanStr);
   if (_.TimerEnabled)

--- a/src/ir_Transcold.cpp
+++ b/src/ir_Transcold.cpp
@@ -29,7 +29,7 @@ using irutils::addIntToString;
 using irutils::addLabeledString;
 using irutils::addModeToString;
 using irutils::addTempToString;
-
+using irutils::addToggleToString;
 
 #if SEND_TRANSCOLD
 /// Send a Transcold message
@@ -391,13 +391,7 @@ String IRTranscoldAc::toString(void) const {
   result += addBoolToString(getPower(), kPowerStr, false);
   if (!getPower()) return result;  // If it's off, there is no other info.
   // Special modes.
-  if (getSwing()) {
-    result += kCommaSpaceStr;
-    result += kSwingStr;
-    result += kColonSpaceStr;
-    result += kToggleStr;
-    return result;
-  }
+  if (getSwing()) return result + addToggleToString(true, kSwingStr);
   result += addModeToString(getMode(), kTranscoldAuto, kTranscoldCool,
                             kTranscoldHeat, kTranscoldDry, kTranscoldFan);
   result += addIntToString(_.Fan, kFanStr);

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -452,6 +452,9 @@
 #ifndef D_STR_COLONSPACE
 #define D_STR_COLONSPACE ": "
 #endif  // D_STR_COLONSPACE
+#ifndef D_STR_DASH
+#define D_STR_DASH "-"
+#endif  // D_STR_DASH
 
 #ifndef D_STR_DAY
 #define D_STR_DAY "Day"


### PR DESCRIPTION
* Add `addToggleToString()` helper routine
Remove duplicate code & strings and replace with new routine.
* Add `__FlashStringHelper*` versions of some string handling methods (ESP8266 Only)
For what ever reason (probably saved `String` conversions) this reduces the Flash usage by ~5K.
e.g.
IRrecvDumpV2:
  - Before:
RAM:   [====      ]  35.5% (used 29072 bytes from 81920 bytes)
Flash: [====      ]  35.8% (used 373421 bytes from 1044464 bytes)
  - After:
RAM:   [====      ]  35.5% (used 29072 bytes from 81920 bytes)
Flash: [====      ]  35.3% (used 368397 bytes from 1044464 bytes)

H/T to @mcspr for the idea.

Confirmed working on a NodeMCU running IRrecvDumpV2.