### PR TITLE
Fix compilation issue when using old 8266 Arduino Frameworks.

### DIFF
--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -95,7 +95,10 @@ String uint64ToString(uint64_t input, uint8_t base) {
 /// @returns A String representation of the integer.
 String int64ToString(int64_t input, uint8_t base) {
   if (input < 0) {
-    return kDashStr + uint64ToString(-input, base);
+    // Using String(kDashStr) to keep compatible with old arduino
+    // frameworks. Not needed with 3.0.2.
+    ///> @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1639#issuecomment-944906016
+    return String(kDashStr) + uint64ToString(-input, base);
   }
   return uint64ToString(input, base);
 }

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -611,7 +611,11 @@ String IRCoolixAC::toString(void) const {
   result += addBoolToString(getZoneFollow(), kZoneFollowStr);
   result += addLabeledString(
       (getSensorTemp() == kCoolixSensorTempIgnoreCode)
-          ? kOffStr : uint64ToString(getSensorTemp()) + 'C', kSensorTempStr);
+          // Encasing with String(blah) to keep compatible with old arduino
+          // frameworks. Not needed with 3.0.2.
+          ///> @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1639#issuecomment-944906016
+          ? kOffStr : String(uint64ToString(getSensorTemp()) + 'C'),
+      kSensorTempStr);
   return result;
 }
 


### PR DESCRIPTION
* Try to add backward compatibility to older 8266 Arduino frameworks
* Add code comments to document why this has been done.
* Doesn't seem to be required as of 3.0.0 of the ESP8266 Arduino Framework/platform code.
  - The fix doesn't seem to hurt either way. 🤷 

Fixes #1639

Co-authored-by: @jimmys01