### PR TITLE
SamsungAC: Fix power control. Clean-up code & bitmaps from Checksum changes.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -830,8 +830,7 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
     DPRINTLN("Attempting Samsung AC (extended) decode");
     // Check the extended size first, as it should fail fast due to longer
     // length.
-    if (decodeSamsungAC(results, offset, kSamsungAcExtendedBits, false))
-      return true;
+    if (decodeSamsungAC(results, offset, kSamsungAcExtendedBits)) return true;
     // Now check for the more common length.
     DPRINTLN("Attempting Samsung AC decode");
     if (decodeSamsungAC(results, offset, kSamsungAcBits)) return true;

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -447,11 +447,15 @@ void IRSamsungAc::off(void) { setPower(false); }
 
 /// Change the power setting.
 /// @param[in] on true, the setting is on. false, the setting is off.
-void IRSamsungAc::setPower(const bool on) { _.Power = (on ? 0b11 : 0b00); }
+void IRSamsungAc::setPower(const bool on) {
+  _.Power1 = _.Power2 = (on ? 0b11 : 0b00);
+}
 
 /// Get the value of the current power setting.
 /// @return true, the setting is on. false, the setting is off.
-bool IRSamsungAc::getPower(void) const { return _.Power == 0b11; }
+bool IRSamsungAc::getPower(void) const {
+  return _.Power1 == 0b11 && _.Power2 == 0b11;
+}
 
 /// Set the temperature.
 /// @param[in] temp The temperature in degrees celsius.

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -43,36 +43,40 @@ union SamsungProtocol{
   uint8_t raw[kSamsungAcExtendedStateLength];  ///< State in code form.
   struct {
     // Byte 0
-    uint8_t :8;
+    uint8_t         :8;
     // Byte 1
     uint8_t         :4;
-    uint8_t Quiet1  :1;
-    uint8_t Power1  :1;
-    uint8_t         :2;
-    // Byte 2~4
-    uint8_t pad0[3];
+    uint8_t         :4;  // Sum1Lower
+    // Byte 2
+    uint8_t         :4;  // Sum1Upper
+    uint8_t         :4;
+    // Byte 3
+    uint8_t         :8;
+    // Byte 4
+    uint8_t         :8;
     // Byte 5
     uint8_t         :5;
-    uint8_t Quiet5  :1;
+    uint8_t Quiet   :1;
     uint8_t         :2;
     // Byte 6
     uint8_t         :4;
-    uint8_t Power6  :2;
+    uint8_t Power   :2;
     uint8_t         :2;
     // Byte 7
-    uint8_t :8;
+    uint8_t         :8;
     // Byte 8
-    uint8_t Powerful8 :8;
+    uint8_t         :4;
+    uint8_t         :4;  // Sum2Lower
     // Byte 9
-    uint8_t       :4;
-    uint8_t Swing :3;
-    uint8_t       :1;
+    uint8_t         :4;  // Sum1Upper
+    uint8_t Swing   :3;
+    uint8_t         :1;
     // Byte 10
-    uint8_t             :1;
-    uint8_t Powerful10  :3;
-    uint8_t Display     :1;
-    uint8_t             :2;
-    uint8_t Clean10     :1;
+    uint8_t           :1;
+    uint8_t Powerful  :3;
+    uint8_t Display   :1;
+    uint8_t           :2;
+    uint8_t Clean10   :1;
     // Byte 11
     uint8_t Ion     :1;
     uint8_t Clean11 :1;
@@ -146,10 +150,9 @@ union SamsungProtocol{
 };
 
 // Constants
-const uint8_t kSamsungAcPowerfulMask8 = 0b01010000;
 const uint8_t kSamsungAcSwingMove =                0b010;
 const uint8_t kSamsungAcSwingStop =                0b111;
-const uint8_t kSamsungAcPowerful10On =                     0b011;
+const uint8_t kSamsungAcPowerfulOn =                       0b011;
 const uint8_t kSamsungAcBreezeOn =                         0b101;
 const uint8_t kSamsungAcMinTemp  = 16;  // C   Mask 0b11110000
 const uint8_t kSamsungAcMaxTemp  = 30;  // C   Mask 0b11110000

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -60,7 +60,7 @@ union SamsungProtocol{
     uint8_t         :2;
     // Byte 6
     uint8_t         :4;
-    uint8_t Power   :2;
+    uint8_t Power1  :2;
     uint8_t         :2;
     // Byte 7
     uint8_t         :8;
@@ -88,9 +88,11 @@ union SamsungProtocol{
     uint8_t Mode  :3;
     uint8_t       :1;
     // Byte 13
-    uint8_t       :1;
-    uint8_t Beep  :1;
-    uint8_t       :6;
+    uint8_t        :1;
+    uint8_t Beep   :1;
+    uint8_t        :2;
+    uint8_t Power2 :2;
+    uint8_t        :2;
   };
   struct {
     // 1st Section

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -1671,3 +1671,96 @@ TEST(TestIRSamsungAcClass, SectionChecksums) {
   EXPECT_EQ(IRSamsungAc::getSectionChecksum(extended_off + 14),
             IRSamsungAc::calcSectionChecksum(extended_off + 14));
 }
+
+TEST(TestIRSamsungAcClass, Issue1648) {
+  IRSamsungAc ac(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  const uint8_t onState[kSamsungAcExtendedStateLength] = {
+      0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0,
+      0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
+      0x01, 0xC2, 0xFE, 0x71, 0x90, 0x15, 0xF0};
+  const String onText = "Power: On, Mode: 1 (Cool), Temp: 25C, Fan: 2 (Low), "
+                        "Swing: Off, Beep: Off, Clean: Off, Quiet: Off, "
+                        "Powerful: Off, Breeze: Off, Light: On, Ion: Off";
+  const uint8_t extended_offState[kSamsungAcExtendedStateLength] = {
+      0x02, 0xB2, 0x0F, 0x00, 0x00, 0x00, 0xC0,
+      0x01, 0xD2, 0x0F, 0x00, 0x00, 0x00, 0x00,
+      0x01, 0xC2, 0xFE, 0x71, 0x90, 0x15, 0xF0};
+  const uint8_t short_offState[kSamsungAcStateLength] = {
+      0x02, 0xB2, 0x0F, 0x00, 0x00, 0x00, 0xC0,
+      0x01, 0xC2, 0xFE, 0x71, 0x90, 0x15, 0xF0};
+  const String offText = "Power: Off, Mode: 1 (Cool), Temp: 25C, Fan: 2 (Low), "
+                         "Swing: Off, Beep: Off, Clean: Off, Quiet: Off, "
+                         "Powerful: Off, Breeze: Off, Light: On, Ion: Off";
+  const uint8_t coolState[kSamsungAcStateLength] = {
+      0x02, 0x92, 0x0F, 0x00, 0x00, 0x00, 0xF0,
+      0x01, 0xC2, 0xFE, 0x71, 0x90, 0x15, 0xF0};
+
+  // "setup()"" from provided code.
+  ac.begin();  // User code
+  ac.off();  // User code
+  ac.setFan(kSamsungAcFanLow);  // User code
+  ac.setMode(kSamsungAcCool);  // User code
+  ac.setTemp(25);  // User code
+  ac.setSwing(false);  // User code
+
+  // Go through "loop()" from provided code.
+  for (uint8_t i = 0; i < 2; i++) {
+    ac.on();  // User code
+    ac.send();  // User code
+
+    // Verify what was sent.
+    ac._irsend.makeDecodeResult();
+    EXPECT_TRUE(irrecv.decode(&ac._irsend.capture));
+    EXPECT_EQ(SAMSUNG_AC, ac._irsend.capture.decode_type);
+    EXPECT_EQ(kSamsungAcExtendedBits, ac._irsend.capture.bits);
+    EXPECT_STATE_EQ(onState, ac._irsend.capture.state, ac._irsend.capture.bits);
+    EXPECT_EQ(onText, IRAcUtils::resultAcToString(&ac._irsend.capture));
+    EXPECT_TRUE(ac._lastsentpowerstate);
+    ac._irsend.reset();
+
+    ac.setMode(kSamsungAcCool);  // User code
+    ac.send();  // User code
+
+    // Verify what was sent.
+    ac._irsend.makeDecodeResult();
+    EXPECT_TRUE(irrecv.decode(&ac._irsend.capture));
+    EXPECT_EQ(SAMSUNG_AC, ac._irsend.capture.decode_type);
+    EXPECT_EQ(kSamsungAcBits, ac._irsend.capture.bits);
+    EXPECT_STATE_EQ(coolState, ac._irsend.capture.state,
+                   ac._irsend.capture.bits);
+    EXPECT_EQ(onText, IRAcUtils::resultAcToString(&ac._irsend.capture));
+    ac._irsend.reset();
+    EXPECT_TRUE(ac._lastsentpowerstate);
+    EXPECT_FALSE(ac._forcepower);
+
+    ac.off();  // User code
+    ac.send();  // User code
+
+    // Verify what was sent.
+    ac._irsend.makeDecodeResult();
+    EXPECT_TRUE(irrecv.decode(&ac._irsend.capture));
+    EXPECT_EQ(SAMSUNG_AC, ac._irsend.capture.decode_type);
+    EXPECT_EQ(kSamsungAcExtendedBits, ac._irsend.capture.bits);
+    EXPECT_STATE_EQ(extended_offState, ac._irsend.capture.state,
+                    ac._irsend.capture.bits);
+    EXPECT_EQ(offText, IRAcUtils::resultAcToString(&ac._irsend.capture));
+    EXPECT_FALSE(ac._lastsentpowerstate);
+    ac._irsend.reset();
+
+    ac.off();  // User code
+    ac.send();  // User code
+
+    // Verify what was sent.
+    ac._irsend.makeDecodeResult();
+    EXPECT_TRUE(irrecv.decode(&ac._irsend.capture));
+    EXPECT_EQ(SAMSUNG_AC, ac._irsend.capture.decode_type);
+    EXPECT_EQ(kSamsungAcBits, ac._irsend.capture.bits);
+    EXPECT_STATE_EQ(short_offState, ac._irsend.capture.state,
+                    ac._irsend.capture.bits);
+    EXPECT_EQ(offText, IRAcUtils::resultAcToString(&ac._irsend.capture));
+    EXPECT_FALSE(ac._lastsentpowerstate);
+    ac._irsend.reset();
+    // End of "loop()" code.
+  }
+}


### PR DESCRIPTION
* Remove "signature" checks, as they were flat out wrong. We were trying to use the checksum as a fixed signature. This caused some messages to fail to decode on the ESP.
* Add second location for Power setting that was missing.
  - Fixes Power Off problems.
* Streamline some code.
* Clean up some code style formatting.
* Remove bad assumptions of bits that controlled settings that were actually located in the checksum bytes.
* Write a huge unit test to simulate and verify the code in Issue #1648 should do the correct thing.

Fixes #1648
Ref #1277