### PR TITLE
[HAIER_AC176/HAIER_AC_YRW02] Add support `Lock` function

### DIFF
--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -123,6 +123,7 @@ IRTEXT_CONST_STRING(kTypeStr, D_STR_TYPE);  ///< "Type"
 IRTEXT_CONST_STRING(kSpecialStr, D_STR_SPECIAL);  ///< "Special"
 IRTEXT_CONST_STRING(kIdStr, D_STR_ID);  ///< "Id" / Device Identifier
 IRTEXT_CONST_STRING(kVaneStr, D_STR_VANE);  ///< "Vane"
+IRTEXT_CONST_STRING(kLockStr, D_STR_LOCK);  ///< "Lock"
 
 IRTEXT_CONST_STRING(kAutoStr, D_STR_AUTO);  ///< "Auto"
 IRTEXT_CONST_STRING(kAutomaticStr, D_STR_AUTOMATIC);  ///< "Automatic"

--- a/src/IRtext.h
+++ b/src/IRtext.h
@@ -119,6 +119,7 @@ extern IRTEXT_CONST_PTR(kLightStr);
 extern IRTEXT_CONST_PTR(kLightToggleStr);
 extern IRTEXT_CONST_PTR(kLkeStr);
 extern IRTEXT_CONST_PTR(kLoStr);
+extern IRTEXT_CONST_PTR(kLockStr);
 extern IRTEXT_CONST_PTR(kLoudStr);
 extern IRTEXT_CONST_PTR(kLowerStr);
 extern IRTEXT_CONST_PTR(kLowestStr);

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -1084,6 +1084,9 @@ String IRHaierAC176::toString(void) const {
     case kHaierAcYrw02ButtonTurbo:
       result += kTurboStr;
       break;
+    case kHaierAcYrw02ButtonTimer:
+      result += kTimerStr;
+      break;
     default:
       result += kUnknownStr;
   }

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -618,6 +618,7 @@ void IRHaierAC176::setButton(uint8_t button) {
     case kHaierAcYrw02ButtonHealth:
     case kHaierAcYrw02ButtonTurbo:
     case kHaierAcYrw02ButtonSleep:
+    case kHaierAcYrw02ButtonLock:
       _.Button = button;
   }
 }
@@ -907,6 +908,17 @@ uint16_t IRHaierAC176::getOffTimer(void) const {
   return _.OffTimerHrs * 60 + _.OffTimerMins;
 }
 
+/// Get the Lock setting of the A/C.
+/// @return true, the setting is on. false, the setting is off.
+bool IRHaierAC176::getLock(void) const { return _.Lock; }
+
+/// Set the Lock setting of the A/C.
+/// @param[in] on true, the setting is on. false, the setting is off.
+void IRHaierAC176::setLock(const bool on) {
+  _.Button = kHaierAcYrw02ButtonLock;
+  _.Lock = on;
+}
+
 /// Convert a stdAc::opmode_t enum into its native mode.
 /// @param[in] mode The enum to be converted.
 /// @return The native equivalent of the enum.
@@ -1048,7 +1060,7 @@ stdAc::state_t IRHaierAC176::toCommon(void) const {
 /// @return A human readable string.
 String IRHaierAC176::toString(void) const {
   String result = "";
-  result.reserve(250);  // Reserve some heap for the string to reduce fragging.
+  result.reserve(260);  // Reserve some heap for the string to reduce fragging.
   result += addBoolToString(_.Power, kPowerStr, false);
   uint8_t cmd = _.Button;
   result += addIntToString(cmd, kButtonStr);
@@ -1086,6 +1098,9 @@ String IRHaierAC176::toString(void) const {
       break;
     case kHaierAcYrw02ButtonTimer:
       result += kTimerStr;
+      break;
+    case kHaierAcYrw02ButtonLock:
+      result += kLockStr;
       break;
     default:
       result += kUnknownStr;
@@ -1172,6 +1187,7 @@ String IRHaierAC176::toString(void) const {
   result += addLabeledString((tmode != kHaierAcYrw02NoTimers &&
                               tmode != kHaierAcYrw02OnTimer) ?
       minsToString(getOffTimer()) : kOffStr, kOffTimerStr);
+  result += addBoolToString(_.Lock, kLockStr);
   return result;
 }
 // End of IRHaierAC176 class.

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -406,6 +406,9 @@ class IRHaierAC176 {
   void setOffTimer(const uint16_t mins);
   uint16_t getOffTimer(void) const;
 
+  bool getLock(void) const;
+  void setLock(const bool on);
+
   uint8_t* getRaw(void);
   virtual void setRaw(const uint8_t new_code[]);
   static bool validChecksum(const uint8_t state[],

--- a/src/ir_Haier.h
+++ b/src/ir_Haier.h
@@ -161,16 +161,18 @@ const uint8_t kHaierAcYrw02Dry =  0b010;  // 2
 const uint8_t kHaierAcYrw02Heat = 0b100;  // 4
 const uint8_t kHaierAcYrw02Fan =  0b110;  // 5
 
-const uint8_t kHaierAcYrw02ButtonTempUp = 0x0;
-const uint8_t kHaierAcYrw02ButtonTempDown = 0x1;
-const uint8_t kHaierAcYrw02ButtonSwingV = 0x2;
-const uint8_t kHaierAcYrw02ButtonSwingH = 0x3;
-const uint8_t kHaierAcYrw02ButtonFan = 0x4;
-const uint8_t kHaierAcYrw02ButtonPower = 0x5;
-const uint8_t kHaierAcYrw02ButtonMode = 0x6;
-const uint8_t kHaierAcYrw02ButtonHealth = 0x7;
-const uint8_t kHaierAcYrw02ButtonTurbo = 0x8;
-const uint8_t kHaierAcYrw02ButtonSleep = 0xB;
+const uint8_t kHaierAcYrw02ButtonTempUp =   0b00000;
+const uint8_t kHaierAcYrw02ButtonTempDown = 0b00001;
+const uint8_t kHaierAcYrw02ButtonSwingV =   0b00010;
+const uint8_t kHaierAcYrw02ButtonSwingH =   0b00011;
+const uint8_t kHaierAcYrw02ButtonFan =      0b00100;
+const uint8_t kHaierAcYrw02ButtonPower =    0b00101;
+const uint8_t kHaierAcYrw02ButtonMode =     0b00110;
+const uint8_t kHaierAcYrw02ButtonHealth =   0b00111;
+const uint8_t kHaierAcYrw02ButtonTurbo =    0b01000;
+const uint8_t kHaierAcYrw02ButtonSleep =    0b01011;
+const uint8_t kHaierAcYrw02ButtonTimer =    0b10000;
+const uint8_t kHaierAcYrw02ButtonLock =     0b10100;
 
 const uint8_t kHaierAcYrw02NoTimers       = 0b000;
 const uint8_t kHaierAcYrw02OffTimer       = 0b001;
@@ -220,8 +222,9 @@ union HaierAc176Protocol{
     // Byte 11
     uint8_t             :8;
     // Byte 12
-    uint8_t Button      :4;
-    uint8_t             :4;
+    uint8_t Button      :5;
+    uint8_t Lock        :1;
+    uint8_t             :2;
     // Byte 13
     uint8_t Sum         :8;
     // Byte 14

--- a/src/locale/defaults.h
+++ b/src/locale/defaults.h
@@ -291,6 +291,9 @@
 #ifndef D_STR_VANE
 #define D_STR_VANE "Vane"
 #endif  // D_STR_VANE
+#ifndef D_STR_LOCK
+#define D_STR_LOCK "Lock"
+#endif  // D_STR_LOCK
 
 #ifndef D_STR_AUTO
 #define D_STR_AUTO "Auto"

--- a/src/locale/ru-RU.h
+++ b/src/locale/ru-RU.h
@@ -84,6 +84,7 @@
 #define D_STR_SPECIAL "Специальный"
 #define D_STR_RECYCLE "Рециркуляция"
 #define D_STR_VANE "Жалюзи"
+#define D_STR_LOCK "Блокировка"
 #define D_STR_AUTO "Авто"
 #define D_STR_AUTOMATIC "Автоматический"
 #define D_STR_MANUAL "Ручной"

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -793,7 +793,7 @@ TEST(TestIRac, Haier176) {
       "Power: On, Button: 5 (Power), Mode: 1 (Cool), Temp: 23C, "
       "Fan: 2 (Medium), Turbo: On, Quiet: Off, Swing(V): 1 (Highest), "
       "Swing(H): 0 (Middle), Sleep: On, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off";
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off";
   ac.begin();
   irac.haier176(&ac,
                 true,                        // Power
@@ -824,7 +824,7 @@ TEST(TestIRac, HaierYrwo2) {
       "Power: On, Button: 5 (Power), Mode: 1 (Cool), Temp: 23C, "
       "Fan: 2 (Medium), Turbo: Off, Quiet: On, Swing(V): 1 (Highest), "
       "Swing(H): 7 (Auto), Sleep: On, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off";
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off";
 
   ac.begin();
   irac.haierYrwo2(&ac,

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -723,6 +723,24 @@ TEST(TestHaierACYRW02Class, SwingH) {
   EXPECT_EQ(kHaierAcYrw02ButtonTempUp, ac.getButton());
 }
 
+TEST(TestHaierACYRW02Class, Lock) {
+  IRHaierACYRW02 ac(kGpioUnused);
+  ac.begin();
+
+  ac.setLock(true);
+  EXPECT_TRUE(ac.getLock());
+  EXPECT_EQ(kHaierAcYrw02ButtonLock, ac.getButton());
+
+  ac.setButton(kHaierAcYrw02ButtonTempUp);
+  ac.setLock(false);
+  EXPECT_FALSE(ac.getLock());
+  EXPECT_EQ(kHaierAcYrw02ButtonLock, ac.getButton());
+
+  ac.setLock(true);
+  EXPECT_TRUE(ac.getLock());
+  EXPECT_EQ(kHaierAcYrw02ButtonLock, ac.getButton());
+}
+
 TEST(TestHaierACYRW02Class, MessageConstuction) {
   IRHaierACYRW02 ac(kGpioUnused);
 
@@ -730,7 +748,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
       "Power: On, Button: 5 (Power), Mode: 0 (Auto), Temp: 25C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 0 (Off), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
   ac.setMode(kHaierAcYrw02Cool);
   ac.setTemp(21);
@@ -739,7 +757,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
       "Power: On, Button: 4 (Fan), Mode: 1 (Cool), Temp: 21C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 0 (Off), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 
   ac.setSwingV(kHaierAcYrw02SwingVMiddle);
@@ -750,7 +768,7 @@ TEST(TestHaierACYRW02Class, MessageConstuction) {
       "Power: On, Button: 8 (Turbo), Mode: 1 (Cool), Temp: 21C, "
       "Fan: 1 (High), Turbo: On, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: On, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 }
 
@@ -766,7 +784,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       "Power: On, Button: 7 (Health), Mode: 4 (Heat), Temp: 30C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 1 (Highest), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 
   uint8_t expectedState2[kHaierACYRW02StateLength] = {
@@ -777,7 +795,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       "Power: Off, Button: 5 (Power), Mode: 4 (Heat), Temp: 30C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 0 (Off), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 
   uint8_t expectedState3[kHaierACYRW02StateLength] = {
@@ -788,7 +806,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       "Power: On, Button: 1 (Temp Down), Mode: 1 (Cool), Temp: 16C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 
   // cool 25, health, fan auto, vertical swing auto,  sleep on
@@ -800,7 +818,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       "Power: On, Button: 11 (Sleep), Mode: 1 (Cool), Temp: 25C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 12 (Auto), "
       "Swing(H): 0 (Middle), Sleep: On, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 
   // cool 25, health, fan 3, vertical swing auto,  sleep on
@@ -812,7 +830,7 @@ TEST(TestHaierACYRW02Class, RealStates) {
       "Power: On, Button: 4 (Fan), Mode: 1 (Cool), Temp: 25C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 12 (Auto), "
       "Swing(H): 0 (Middle), Sleep: On, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 }
 
@@ -1044,7 +1062,7 @@ TEST(TestDecodeHaierAC_YRW02, RealExample) {
       "Power: On, Button: 5 (Power), Mode: 1 (Cool), Temp: 17C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 }
 
@@ -1270,7 +1288,7 @@ TEST(TestDecodeHaierAC176, SyntheticDecode) {
       "Power: On, Button: 5 (Power), Mode: 1 (Cool), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 6 (UNKNOWN), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t result, prev;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &result, &prev));
@@ -1312,7 +1330,7 @@ TEST(TestHaierAC176Class, BuildKnownState) {
       "Power: On, Button: 4 (Fan), Mode: 4 (Heat), Temp: 24C, "
       "Fan: 1 (High), Turbo: Off, Quiet: Off, Swing(V): 0 (Off), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: On, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
   /* Disabled pending:
      https://github.com/crankyoldgit/IRremoteESP8266/issues/1480#issuecomment-885636790
@@ -1404,7 +1422,7 @@ TEST(TestHaierAC176Class, Timers) {
       "Power: Off, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 2 (On), On Timer: 00:30, Off Timer: Off",
+      "Timer Mode: 2 (On), On Timer: 00:30, Off Timer: Off, Lock: Off",
       ac.toString());
   ac.setRaw(timeroff);
   EXPECT_EQ(kHaierAcYrw02NoTimers, ac.getTimerMode());
@@ -1412,21 +1430,21 @@ TEST(TestHaierAC176Class, Timers) {
       "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
   ac.setRaw(timeroffthenon);
   EXPECT_EQ(
       "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 5 (Off-On), On Timer: 08:00, Off Timer: 00:30",
+      "Timer Mode: 5 (Off-On), On Timer: 08:00, Off Timer: 00:30, Lock: Off",
       ac.toString());
   ac.setTimerMode(kHaierAcYrw02OnThenOffTimer);
   EXPECT_EQ(
       "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 4 (On-Off), On Timer: 08:00, Off Timer: 00:30",
+      "Timer Mode: 4 (On-Off), On Timer: 08:00, Off Timer: 00:30, Lock: Off",
       ac.toString());
   ac.setTimerMode(kHaierAcYrw02OffTimer);
   EXPECT_EQ(0, ac.getOnTimer());
@@ -1435,7 +1453,7 @@ TEST(TestHaierAC176Class, Timers) {
       "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 1 (Off), On Timer: Off, Off Timer: 00:30",
+      "Timer Mode: 1 (Off), On Timer: Off, Off Timer: 00:30, Lock: Off",
       ac.toString());
   ac.setTimerMode(kHaierAcYrw02NoTimers);
   EXPECT_EQ(0, ac.getOnTimer());
@@ -1444,6 +1462,6 @@ TEST(TestHaierAC176Class, Timers) {
       "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
-      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
+      "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off, Lock: Off",
       ac.toString());
 }

--- a/test/ir_Haier_test.cpp
+++ b/test/ir_Haier_test.cpp
@@ -1401,7 +1401,7 @@ TEST(TestHaierAC176Class, Timers) {
   ac.setRaw(timer30m);
   EXPECT_EQ(kHaierAcYrw02OnTimer, ac.getTimerMode());
   EXPECT_EQ(
-      "Power: Off, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: Off, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 2 (On), On Timer: 00:30, Off Timer: Off",
@@ -1409,21 +1409,21 @@ TEST(TestHaierAC176Class, Timers) {
   ac.setRaw(timeroff);
   EXPECT_EQ(kHaierAcYrw02NoTimers, ac.getTimerMode());
   EXPECT_EQ(
-      "Power: On, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",
       ac.toString());
   ac.setRaw(timeroffthenon);
   EXPECT_EQ(
-      "Power: On, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 5 (Off-On), On Timer: 08:00, Off Timer: 00:30",
       ac.toString());
   ac.setTimerMode(kHaierAcYrw02OnThenOffTimer);
   EXPECT_EQ(
-      "Power: On, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 4 (On-Off), On Timer: 08:00, Off Timer: 00:30",
@@ -1432,7 +1432,7 @@ TEST(TestHaierAC176Class, Timers) {
   EXPECT_EQ(0, ac.getOnTimer());
   EXPECT_EQ(30, ac.getOffTimer());
   EXPECT_EQ(
-      "Power: On, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 1 (Off), On Timer: Off, Off Timer: 00:30",
@@ -1441,7 +1441,7 @@ TEST(TestHaierAC176Class, Timers) {
   EXPECT_EQ(0, ac.getOnTimer());
   EXPECT_EQ(0, ac.getOffTimer());
   EXPECT_EQ(
-      "Power: On, Button: 0 (Temp Up), Mode: 0 (Auto), Temp: 24C, "
+      "Power: On, Button: 16 (Timer), Mode: 0 (Auto), Temp: 24C, "
       "Fan: 5 (Auto), Turbo: Off, Quiet: Off, Swing(V): 2 (Middle), "
       "Swing(H): 0 (Middle), Sleep: Off, Health: Off, "
       "Timer Mode: 0 (N/A), On Timer: Off, Off Timer: Off",


### PR DESCRIPTION
`Lock` used to lock buttons on IR remote to prevent unintended operations.

* Add `getLock()` and `setLock()` methods
* Increase from 4 to 5 bits button's code in `HaierAc176Protocol`
* Add `Timer` and `Lock` button's codes
* Update tests
