### PR TITLE
Use the correct string for Fan mode in Home Assistant.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3385,7 +3385,7 @@ String IRac::opmodeToString(const stdAc::opmode_t mode, const bool ha) {
     case stdAc::opmode_t::kCool: return kCoolStr;
     case stdAc::opmode_t::kHeat: return kHeatStr;
     case stdAc::opmode_t::kDry:  return kDryStr;
-    case stdAc::opmode_t::kFan:  return ha ? kFanOnlyStr : kFanStr;
+    case stdAc::opmode_t::kFan:  return ha ? kFan_OnlyStr : kFanStr;
     default:                     return kUnknownStr;
   }
 }

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -139,7 +139,7 @@ IRTEXT_CONST_STRING(kFanStr, D_STR_FAN);  ///< "Fan"
 // HomeAssistant & Google Home Climate integration. For compatibility only.
 // Ref: https://www.home-assistant.io/integrations/google_assistant/#climate-operation-modes
 IRTEXT_CONST_STRING(kFanOnlyStr, D_STR_FANONLY);  ///< "fan-only"
-IRTEXT_CONST_STRING(kFan_OnlyStr, D_STR_FAN_ONLY);  ///< "fan_only" (legacy)
+IRTEXT_CONST_STRING(kFan_OnlyStr, D_STR_FAN_ONLY);  ///< "fan_only" (HA/legacy)
 IRTEXT_CONST_STRING(kFanOnlyWithSpaceStr, D_STR_FANSPACEONLY);  ///< "Fan Only"
 IRTEXT_CONST_STRING(kFanOnlyNoSpaceStr, D_STR_FANONLYNOSPACE);  ///< "FanOnly"
 

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -2347,7 +2347,7 @@ TEST(TestIRac, opmodeToString) {
   EXPECT_EQ("UNKNOWN", IRac::opmodeToString((stdAc::opmode_t)500));
   // Home Assistant/Google Home differences.
   EXPECT_EQ("Fan", IRac::opmodeToString(stdAc::opmode_t::kFan, false));
-  EXPECT_EQ("fan-only", IRac::opmodeToString(stdAc::opmode_t::kFan, true));
+  EXPECT_EQ("fan_only", IRac::opmodeToString(stdAc::opmode_t::kFan, true));
   EXPECT_EQ("Fan", IRac::opmodeToString(stdAc::opmode_t::kFan));  // Default
 }
 


### PR DESCRIPTION
Home assistant needs the text for "Fan" mode to be "fan_only". i.e. the Underscore is important.
Problem was introduced in #1610 