### PR TITLE
[SamsungAc] Add support for On, Off, & Sleep Timers

### DIFF
--- a/src/IRac.h
+++ b/src/IRac.h
@@ -409,8 +409,9 @@ void electra(IRElectraAc *ac,
                const stdAc::fanspeed_t fan, const stdAc::swingv_t swingv,
                const bool quiet, const bool turbo, const bool light,
                const bool filter, const bool clean,
-               const bool beep, const bool prevpower = true,
-               const bool forcepower = true);
+               const bool beep, const int16_t sleep = -1,
+               const bool prevpower = true, const int16_t prevsleep = -1,
+               const bool forceextended = true);
 #endif  // SEND_SAMSUNG_AC
 #if SEND_SANYO_AC
   void sanyo(IRSanyoAc *ac,

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -18,10 +18,11 @@
 //   Brand: Samsung,  Model: AH59-02692E Soundbar remote (SAMSUNG36)
 //   Brand: Samsung,  Model: HW-J551 Soundbar (SAMSUNG36)
 //   Brand: Samsung,  Model: AR09FSSDAWKNFA A/C (SAMSUNG_AC)
+//   Brand: Samsung,  Model: AR09HSFSBWKN A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: AR12KSFPEWQNET A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: AR12HSSDBWKNEU A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: AR12NXCXAWKXEU A/C (SAMSUNG_AC)
-//   Brand: Samsung,  Model: AR09HSFSBWKN A/C (SAMSUNG_AC)
+//   Brand: Samsung,  Model: AR12TXEAAWKNEU A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: DB93-14195A remote (SAMSUNG_AC)
 
 #ifndef IR_SAMSUNG_H_
@@ -186,7 +187,7 @@ class IRSamsungAc {
  public:
   explicit IRSamsungAc(const uint16_t pin, const bool inverted = false,
                        const bool use_modulation = true);
-  void stateReset(const bool forcepower = true, const bool initialPower = true);
+  void stateReset(const bool extended = true, const bool initialPower = true);
 #if SEND_SAMSUNG_AC
   void send(const uint16_t repeat = kSamsungAcDefaultRepeat);
   void sendExtended(const uint16_t repeat = kSamsungAcDefaultRepeat);
@@ -229,6 +230,8 @@ class IRSamsungAc {
   void setOnTimer(const uint16_t nr_of_mins);
   uint16_t getOffTimer(void) const;
   void setOffTimer(const uint16_t nr_of_mins);
+  uint16_t getSleepTimer(void) const;
+  void setSleepTimer(const uint16_t nr_of_mins);
   uint8_t* getRaw(void);
   void setRaw(const uint8_t new_code[],
               const uint16_t length = kSamsungAcStateLength);
@@ -252,10 +255,12 @@ class IRSamsungAc {
   /// @endcond
 #endif  // UNIT_TEST
   SamsungProtocol _;
-  bool _forcepower;  ///< Hack to know when we need to send a special power mesg
+  bool _forceextended;  ///< Flag to know when we need to send an extended mesg.
   bool _lastsentpowerstate;
   bool _OnTimerEnable;
   bool _OffTimerEnable;
+  bool _Sleep;
+  bool _lastSleep;
   uint16_t _OnTimer;
   uint16_t _OffTimer;
   uint16_t _lastOnTimer;
@@ -265,6 +270,7 @@ class IRSamsungAc {
   uint16_t _getOffTimer(void) const;
   void _setOnTimer(void);
   void _setOffTimer(void);
+  void _setSleepTimer(void);
 };
 
 #endif  // IR_SAMSUNG_H_

--- a/src/ir_Samsung.h
+++ b/src/ir_Samsung.h
@@ -7,6 +7,7 @@
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1062
 /// @see http://elektrolab.wz.cz/katalog/samsung_protocol.pdf
 /// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1538 (Checksum)
+/// @see https://github.com/crankyoldgit/IRremoteESP8266/issues/1277 (Timers)
 
 // Supports:
 //   Brand: Samsung,  Model: UA55H6300 TV (SAMSUNG)
@@ -24,6 +25,7 @@
 //   Brand: Samsung,  Model: AR12NXCXAWKXEU A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: AR12TXEAAWKNEU A/C (SAMSUNG_AC)
 //   Brand: Samsung,  Model: DB93-14195A remote (SAMSUNG_AC)
+//   Brand: Samsung,  Model: DB96-24901C remote (SAMSUNG_AC)
 
 #ifndef IR_SAMSUNG_H_
 #define IR_SAMSUNG_H_


### PR DESCRIPTION
* Merge Powerful & Breeze bit settings.
* Add basics for setting and decoding On, Off, & Sleep timers in extended messages.
* Unit testing for timer functions.
* Remove optional checksum calcs from `send()` & `sendExtended()` since checksums now work fine.
* Improve logic for when an Extended Message needs to be sent.
* Add `sleep` support for SamsungAc to `IRac`.
* Change some parameters/variable names to better suiting names.
* Update supported devices.

Fixes #1277