### PR TITLE
Fix `IRHaierAC176::getTemp()` return value description

### DIFF
--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -702,7 +702,8 @@ void IRHaierAC176::setTemp(const uint8_t degree, const bool fahrenheit) {
 }
 
 /// Get the current temperature setting.
-/// @return The current setting for temp. in degrees celsius.
+/// The unit of temperature is specified by UseFahrenheit value.
+/// @return The current setting for temperature.
 uint8_t IRHaierAC176::getTemp(void) const {
   if (!_.UseFahrenheit) { return _.Temp + kHaierAcYrw02MinTempC; }
   uint8_t degree = _.Temp*2 + kHaierAcYrw02MinTempF + _.ExtraDegreeF;


### PR DESCRIPTION
In fact, `IRHaierAC176::getTemp()` return temperature in unit, dependent on `UseFahrenheit` value.