### PR TITLE
[SAMSUNG_AC] Highest fan speed is available without Powerful setting.

### DIFF
--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -644,9 +644,6 @@ void IRSamsungAc::setPowerful(const bool on) {
     // Powerful mode sets fan speed to Turbo.
     setFan(kSamsungAcFanTurbo);
     setQuiet(false);  // Powerful 'on' is mutually exclusive to Quiet.
-  } else {
-    // Turning off Powerful mode sets fan speed to Auto if we were in Turbo mode
-    if (_.Fan == kSamsungAcFanTurbo) setFan(kSamsungAcFanAuto);
   }
 }
 

--- a/test/ir_Samsung_test.cpp
+++ b/test/ir_Samsung_test.cpp
@@ -597,7 +597,6 @@ TEST(TestIRSamsungAcClass, SetAndGetPowerful) {
   EXPECT_EQ(kSamsungAcFanTurbo, ac.getFan());
   ac.setPowerful(false);
   EXPECT_FALSE(ac.getPowerful());
-  EXPECT_EQ(kSamsungAcFanAuto, ac.getFan());
 
   // Breeze, Econo, and Powerful/Turbo are mutually exclusive.
   ac.setPowerful(true);


### PR DESCRIPTION
Per user feedback, it seems the highest fan speed is just a normal fan speed, not locked behind `setPowerful(true)` as previous thought.

Already confirmed working.

Fixes #1675