### PR TITLE
Moved specifics of Security Policy to github.io page.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 # Directories & files to ignore from release archives
 docs export-ignore
 assets export-ignore
-SECURITY.md export-ignore

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,3 @@
 # Security Policy
 
-## Supported Versions
-
-Only the `master` branch of the library will receive security updates.
-Security updates will **NOT** be applied to any previously published or released versions.
-
-A new release version of the library will be published, _if required_, to address any security updates.
-
-
-## Reporting a Vulnerability
-
-Please report any _sensitive_, _critical_, or _urgent_ vulnerablities directly to _David Conran (david@xyzzy.com.au)_ **and** <a href="https://github.com/crankyoldgit/IRremoteESP8266/issues/new/choose">create an issue</a> saying you need to communicate an important security issue. i.e. _Sensitive_ details in the email, _General_ details in the Issue. Two different notification paths to help make sure it's seen.
-
-After assessing the issue, we will work out how we will handle the matter and let you know how to proceed.
-
-If the vulnerablity is neither _sensitive_, _critical_, or _urgent_, please just create a <a href="https://github.com/crankyoldgit/IRremoteESP8266/issues/new/choose">new issue</a> as per normal.
-
-You _should_ receive an initial response with in **48** _(or so)_ hours typically.
-You _should_ get updates on a security vulnerability report with in a week, probably much sooner.
-This project is supported completely on a ad-hoc volounteer basis, and has only a handful of main contributers so there could be unforseen delays. e.g. Vacations etc.
-
-If you don't hear from anyone with in _two weeks_ & you think you should have, it's probably safe to assume we have missed you're messages. Please try again, or via another method or channel.
-
-We will endeavour to keep the issue reporter(s) in the loop as much as practical, and address the reported issue as soon as feasible.
+You can find this library's <a href="https://crankyoldgit.github.io/IRremoteESP8266/SECURITY">Security Policy</a> and contact procedure at https://crankyoldgit.github.io/IRremoteESP8266/SECURITY


### PR DESCRIPTION
Original `SECURITY.md` has been moved to the `gh-pages` branch so it shows up only on the web, not in the git branch itself.

Per #1618 & #1617 it was moved because only release packages may contain old details, and this way there is only one canonical location/copy etc.

Fixes #1617
Fixes #1618