### PR TITLE
Remove extra const qualifier for char pointer

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -57,7 +57,7 @@
 #ifndef STRCASECMP
 #if defined(ESP8266)
 #define STRCASECMP(LHS, RHS) \
-    strcasecmp_P(LHS, reinterpret_cast<const char* const>(RHS))
+    strcasecmp_P(LHS, reinterpret_cast<const char*>(RHS))
 #else  // ESP8266
 #define STRCASECMP(LHS, RHS) strcasecmp(LHS, RHS)
 #endif  // ESP8266


### PR DESCRIPTION
Just like IRtext.cpp macro for flash strings, this does not make sense in the context
Can be seen with `build_flags = ... -Wextra`

Fixing warnings similar to this
```
.pio/libdeps/d1_mini/IRremoteESP8266/src/IRac.cpp:3272:13: note: in expansion of macro 'STRCASECMP'
 3272 |            !STRCASECMP(str, kUpStr))
      |             ^~~~~~~~~~
.pio/libdeps/d1_mini/IRremoteESP8266/src/IRac.cpp: In static member function 'static stdAc::swingh_t IRac::strToSwingH(const char*, stdAc::swingh_t)':
.pio/libdeps/d1_mini/IRremoteESP8266/src/IRac.cpp:59:23: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   59 |     strcasecmp_P(LHS, reinterpret_cast<const char* const>(RHS))
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```