### PR TITLE
Better fix for #1699

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -94,7 +94,7 @@ namespace stdAc {
   };
 
   /// Structure to hold a common A/C state.
-  typedef struct {
+  struct state_t {
     decode_type_t protocol;
     int16_t model;
     bool power;
@@ -113,7 +113,7 @@ namespace stdAc {
     bool beep;
     int16_t sleep;
     int16_t clock;
-  } state_t;
+  };
 };  // namespace stdAc
 
 /// Fujitsu A/C model numbers

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -42,78 +42,78 @@ const uint32_t kDefaultMessageGap = 100000;
 
 /// Enumerators and Structures for the Common A/C API.
 namespace stdAc {
-  /// Common A/C settings for A/C operating modes.
-  enum class opmode_t {
-    kOff  = -1,
-    kAuto =  0,
-    kCool =  1,
-    kHeat =  2,
-    kDry  =  3,
-    kFan  =  4,
-    // Add new entries before this one, and update it to point to the last entry
-    kLastOpmodeEnum = kFan,
-  };
+/// Common A/C settings for A/C operating modes.
+enum class opmode_t {
+  kOff  = -1,
+  kAuto =  0,
+  kCool =  1,
+  kHeat =  2,
+  kDry  =  3,
+  kFan  =  4,
+  // Add new entries before this one, and update it to point to the last entry
+  kLastOpmodeEnum = kFan,
+};
 
-  /// Common A/C settings for Fan Speeds.
-  enum class fanspeed_t {
-    kAuto =   0,
-    kMin =    1,
-    kLow =    2,
-    kMedium = 3,
-    kHigh =   4,
-    kMax =    5,
-    // Add new entries before this one, and update it to point to the last entry
-    kLastFanspeedEnum = kMax,
-  };
+/// Common A/C settings for Fan Speeds.
+enum class fanspeed_t {
+  kAuto =   0,
+  kMin =    1,
+  kLow =    2,
+  kMedium = 3,
+  kHigh =   4,
+  kMax =    5,
+  // Add new entries before this one, and update it to point to the last entry
+  kLastFanspeedEnum = kMax,
+};
 
-  /// Common A/C settings for Vertical Swing.
-  enum class swingv_t {
-    kOff =    -1,
-    kAuto =    0,
-    kHighest = 1,
-    kHigh =    2,
-    kMiddle =  3,
-    kLow =     4,
-    kLowest =  5,
-    // Add new entries before this one, and update it to point to the last entry
-    kLastSwingvEnum = kLowest,
-  };
+/// Common A/C settings for Vertical Swing.
+enum class swingv_t {
+  kOff =    -1,
+  kAuto =    0,
+  kHighest = 1,
+  kHigh =    2,
+  kMiddle =  3,
+  kLow =     4,
+  kLowest =  5,
+  // Add new entries before this one, and update it to point to the last entry
+  kLastSwingvEnum = kLowest,
+};
 
-  /// Common A/C settings for Horizontal Swing.
-  enum class swingh_t {
-    kOff =     -1,
-    kAuto =     0,  // a.k.a. On.
-    kLeftMax =  1,
-    kLeft =     2,
-    kMiddle =   3,
-    kRight =    4,
-    kRightMax = 5,
-    kWide =     6,  // a.k.a. left & right at the same time.
-    // Add new entries before this one, and update it to point to the last entry
-    kLastSwinghEnum = kWide,
-  };
+/// Common A/C settings for Horizontal Swing.
+enum class swingh_t {
+  kOff =     -1,
+  kAuto =     0,  // a.k.a. On.
+  kLeftMax =  1,
+  kLeft =     2,
+  kMiddle =   3,
+  kRight =    4,
+  kRightMax = 5,
+  kWide =     6,  // a.k.a. left & right at the same time.
+  // Add new entries before this one, and update it to point to the last entry
+  kLastSwinghEnum = kWide,
+};
 
-  /// Structure to hold a common A/C state.
-  struct state_t {
-    decode_type_t protocol;
-    int16_t model;
-    bool power;
-    stdAc::opmode_t mode;
-    float degrees;
-    bool celsius;
-    stdAc::fanspeed_t fanspeed;
-    stdAc::swingv_t swingv;
-    stdAc::swingh_t swingh;
-    bool quiet;
-    bool turbo;
-    bool econo;
-    bool light;
-    bool filter;
-    bool clean;
-    bool beep;
-    int16_t sleep;
-    int16_t clock;
-  };
+/// Structure to hold a common A/C state.
+struct state_t {
+  decode_type_t protocol;
+  int16_t model;
+  bool power;
+  stdAc::opmode_t mode;
+  float degrees;
+  bool celsius;
+  stdAc::fanspeed_t fanspeed;
+  stdAc::swingv_t swingv;
+  stdAc::swingh_t swingh;
+  bool quiet;
+  bool turbo;
+  bool econo;
+  bool light;
+  bool filter;
+  bool clean;
+  bool beep;
+  int16_t sleep;
+  int16_t clock;
+};
 };  // namespace stdAc
 
 /// Fujitsu A/C model numbers

--- a/src/ir_Kelon.cpp
+++ b/src/ir_Kelon.cpp
@@ -440,7 +440,10 @@ stdAc::fanspeed_t IRKelonAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the internal A/C object state to it's stdAc::state_t equivalent.
 /// @return A stdAc::state_t containing the current settings.
 stdAc::state_t IRKelonAc::toCommon(const stdAc::state_t *prev) const {
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
   stdAc::state_t result{};
+  #pragma GCC diagnostic pop
   result.protocol = decode_type_t::KELON;
   result.model = -1;  // Unused.
   result.mode = toCommonMode(getMode());

--- a/src/ir_Kelon.cpp
+++ b/src/ir_Kelon.cpp
@@ -440,10 +440,7 @@ stdAc::fanspeed_t IRKelonAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the internal A/C object state to it's stdAc::state_t equivalent.
 /// @return A stdAc::state_t containing the current settings.
 stdAc::state_t IRKelonAc::toCommon(const stdAc::state_t *prev) const {
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
   stdAc::state_t result{};
-  #pragma GCC diagnostic pop
   result.protocol = decode_type_t::KELON;
   result.model = -1;  // Unused.
   result.mode = toCommonMode(getMode());

--- a/src/ir_Kelon.cpp
+++ b/src/ir_Kelon.cpp
@@ -440,7 +440,7 @@ stdAc::fanspeed_t IRKelonAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the internal A/C object state to it's stdAc::state_t equivalent.
 /// @return A stdAc::state_t containing the current settings.
 stdAc::state_t IRKelonAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::KELON;
   result.model = -1;  // Unused.
   result.mode = toCommonMode(getMode());


### PR DESCRIPTION
In PR #1700, I removed the curly braces, because GCC (ESP8266) warned about uninitialized fields (see #1699).  After digging deeper, the warnings that GCC emitted were incorrect.  Special shout out to @mcspr for questioning this, and making me dig deeper!

PR #1700 resulted in the removal of explicitly zero-initialization of the structure.   While the function then initialized each field, there are likely unused packing bytes (e.g., between final `beep` and `sleep`) that would not be initialized to zero.

I admit that I'm not sure how GCC handles returning a local `struct` ... (does it use the copy constructor?), but regardless of whether this actually exposes uninitialized bytes, it's still bad practice(*) to not properly initialized structures.

@crankyoldgit ... please accept my apologies.  I didn't dig deeply enough, and made a mistake.


