### PR TITLE
Reduce time for workflow/Build

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -46,12 +46,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.platformio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: ${{ runner.os }}-${{ hashFiles('**/platformio.ini') }}
     - name: Cache PlatformIO build
       uses: actions/cache@v2
       with:
         path: .pio
-        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+        key: ${{ runner.os }}-${{ matrix.project }}
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install PlatformIO

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,9 +7,31 @@ on:
     branches: [ master ]
 
 jobs:
-  Build_Examples:
-
+  Gen_Matrix:
+    outputs:
+      matrix: ${{ steps.files.outputs.matrix }}
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: set the list
+      id: files
+      run: |
+        JSONI=$(find . -name platformio.ini -type f | sed 's,/platformio.ini$,,' | xargs -n 1 -I {} echo -e '"{}",')
+
+        # Remove last "," and add closing brackets
+        if [[ $JSONI == *, ]]; then
+        JSONI="${JSONI%?}"
+        fi
+        JSONI=${JSONI//$'\n'}
+        echo $JSONI
+        # Set output
+        echo "::set-output name=matrix::[${JSONI}]"
+  Build_Examples:
+    needs: Gen_Matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: ${{fromJson(needs.Gen_Matrix.outputs.matrix)}}
 
     steps:
     - uses: actions/checkout@v2
@@ -39,4 +61,4 @@ jobs:
     - name: Build all the examples
       env:
         PLATFORMIO_BUILD_CACHE_DIR: "../../.pio/buildcache"
-      run: find . -name platformio.ini -type f | sed 's,/platformio.ini$,,' | xargs --verbose -n 1 pio run --jobs 2 --project-dir
+      run: pio run --jobs 2 --project-dir ${{ matrix.project }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -62,3 +62,10 @@ jobs:
       env:
         PLATFORMIO_BUILD_CACHE_DIR: "../../.pio/buildcache"
       run: pio run --jobs 2 --project-dir ${{ matrix.project }}
+
+  Build_Examples:
+    needs: Build_Example
+    runs-on: ubuntu-latest
+    steps:
+    - name: done
+      run: echo ok

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set the list
+    - name: Generate Matrix of all examples
       id: files
       run: |
         JSONI=$(find . -name platformio.ini -type f | sed 's,/platformio.ini$,,' | xargs -n 1 -I {} echo -e '"{}",')
@@ -26,7 +26,7 @@ jobs:
         echo $JSONI
         # Set output
         echo "::set-output name=matrix::[${JSONI}]"
-  Build_Examples:
+  Build_Example:
     needs: Gen_Matrix
     runs-on: ubuntu-latest
     strategy:
@@ -58,7 +58,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
-    - name: Build all the examples
+    - name: Build example
       env:
         PLATFORMIO_BUILD_CACHE_DIR: "../../.pio/buildcache"
       run: pio run --jobs 2 --project-dir ${{ matrix.project }}

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -51,7 +51,10 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .pio
-        key: ${{ runner.os }}-${{ matrix.project }}
+        key: pio-${{ runner.os }}-${{ matrix.project }}
+        restore-keys: |
+          pio-${{ runner.os }}-
+          pio-
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install PlatformIO

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Cache PlatformIO build
+      uses: actions/cache@v2
+      with:
+        path: .pio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Install PlatformIO

--- a/library.json
+++ b/library.json
@@ -46,11 +46,5 @@
   ],
   "exclude": [".github", "extras", "docs", "assets"],
   "frameworks": "arduino",
-  "platforms": ["espressif8266", "espressif32"],
-  "build": {
-    "flags": [
-      "-Lsrc",
-      "-lsrc"
-    ]
-  }
+  "platforms": ["espressif8266", "espressif32"]
 }

--- a/library.json
+++ b/library.json
@@ -46,5 +46,11 @@
   ],
   "exclude": [".github", "extras", "docs", "assets"],
   "frameworks": "arduino",
-  "platforms": ["espressif8266", "espressif32"]
+  "platforms": ["espressif8266", "espressif32"],
+  "build": {
+    "flags": [
+      "-Lsrc",
+      "-lsrc"
+    ]
+  }
 }


### PR DESCRIPTION
* Use cache for `.pio` path, this keeps buildtime down when unchanged.
* Use dynamic matrix to run jobs in parallel
  - These jobs are generated from location of `platformio.ini` files
  - All jobs runs on their own, some duplication of setup
  - Status is reported for each job
  - One final job that requires all other jobs to succeed