### PR TITLE
Fix old Sony CD-Player Remote (12 Bit)

### DIFF
--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -120,7 +120,7 @@ uint32_t IRsend::encodeSony(const uint16_t nbits, const uint16_t command,
 ///   bits long.
 bool IRrecv::decodeSony(decode_results *results, uint16_t offset,
                         const uint16_t nbits, const bool strict) {
-  if (results->rawlen <= 2 * nbits + kHeader - 1 + offset)
+  if (results->rawlen < 2 * nbits + kHeader - 1 + offset)
     return false;  // Message is smaller than we expected.
 
   // Compliance


### PR DESCRIPTION
Uses 12 bits, 12*2 + 2 - 1 + 1 = 26, so the first length check fails (returns false with exactly 26)
This PR changes this test from <=26 to < 26, and the remote starts working.