### PR TITLE
Add a structured library version number.

### DIFF
--- a/.github/workflows/MetaChecks.yml
+++ b/.github/workflows/MetaChecks.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check all the version numbers match.
       run: |
-        LIB_VERSION=$(egrep "^#define\s+_IRREMOTEESP8266_VERSION_\s+" src/IRremoteESP8266.h  | cut -d\" -f2)
+        LIB_VERSION=$(tools/extract_library_version.sh)
         test ${LIB_VERSION} == "$(jq -r .version library.json)"
         grep -q "^version=${LIB_VERSION}$" library.properties
   examples-have-platformio_ini:

--- a/.github/workflows/MetaChecks.yml
+++ b/.github/workflows/MetaChecks.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check all the version numbers match.
       run: |
-        LIB_VERSION=$(tools/extract_library_version.sh)
+        LIB_VERSION=$(tools/extract_lib_version.sh)
         test ${LIB_VERSION} == "$(jq -r .version library.json)"
         grep -q "^version=${LIB_VERSION}$" library.properties
   examples-have-platformio_ini:

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1249,7 +1249,7 @@ void handleInfo(void) {
     "Built: " __DATE__
       " " __TIME__ "<br>"
     "Period Offset: ") + String(offset) + F("us<br>"
-    "IR Lib Version: " _IRREMOTEESP8266_VERSION_ "<br>"
+    "IR Lib Version: " _IRREMOTEESP8266_VERSION_STR "<br>"
 #if defined(ESP8266)
     "ESP8266 Core Version: ") + ESP.getCoreVersion() + F("<br>"
     "Free Sketch Space: ") + String(maxSketchSpace() >> 10) + F("k<br>"

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -154,7 +154,7 @@ void loop() {
     if (results.overflow)
       Serial.printf(D_WARN_BUFFERFULL "\n", kCaptureBufferSize);
     // Display the library version the message was captured with.
-    Serial.println(D_STR_LIBRARY "   : v" _IRREMOTEESP8266_VERSION_ "\n");
+    Serial.println(D_STR_LIBRARY "   : v" _IRREMOTEESP8266_VERSION_STR "\n");
     // Display the tolerance percentage if it has been change from the default.
     if (kTolerancePercentage != kTolerance)
       Serial.printf(D_STR_TOLERANCE " : %d%%\n", kTolerancePercentage);

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -163,7 +163,7 @@ void loop() {
     if (results.overflow)
       Serial.printf(D_WARN_BUFFERFULL "\n", kCaptureBufferSize);
     // Display the library version the message was captured with.
-    Serial.println(D_STR_LIBRARY "   : v" _IRREMOTEESP8266_VERSION_ "\n");
+    Serial.println(D_STR_LIBRARY "   : v" _IRREMOTEESP8266_VERSION_STR "\n");
     // Display the tolerance percentage if it has been change from the default.
     if (kTolerancePercentage != kTolerance)
       Serial.printf(D_STR_TOLERANCE " : %d%%\n", kTolerancePercentage);

--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -52,8 +52,29 @@
 #include <string>
 #endif  // UNIT_TEST
 
-// Library Version
-#define _IRREMOTEESP8266_VERSION_ "2.8.0"
+// Library Version Information
+// Major version number (X.x.x)
+#define _IRREMOTEESP8266_VERSION_MAJOR 2
+// Minor version number (x.X.x)
+#define _IRREMOTEESP8266_VERSION_MINOR 8
+// Patch version number (x.x.X)
+#define _IRREMOTEESP8266_VERSION_PATCH 0
+// Macro to convert version info into an integer
+#define _IRREMOTEESP8266_VERSION_VAL(major, minor, patch) \
+                                    ((major << 16) | (minor << 8) | (patch))
+// Macro to convert literal into a string
+#define MKSTR(x) #x
+// Integer version
+#define _IRREMOTEESP8266_VERSION _IRREMOTEESP8266_VERSION_VAL(\
+    _IRREMOTEESP8266_VERSION_MAJOR, \
+    _IRREMOTEESP8266_VERSION_MINOR, \
+    _IRREMOTEESP8266_VERSION_PATCH)
+// String version
+#define _IRREMOTEESP8266_VERSION_STR MKSTR(_IRREMOTEESP8266_VERSION_MAJOR) "." \
+                                     MKSTR(_IRREMOTEESP8266_VERSION_MINOR) "." \
+                                     MKSTR(_IRREMOTEESP8266_VERSION_PATCH)
+// String version (DEPRECATED)
+#define _IRREMOTEESP8266_VERSION_ _IRREMOTEESP8266_VERSION_STR
 
 // Set the language & locale for the library. See the `locale` dir for options.
 #ifndef _IR_LOCALE_

--- a/tools/extract_lib_version.sh
+++ b/tools/extract_lib_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+# Copyright 2021 crankyoldgit
+# Extract and constuct the string version of the IRremoteESP8266 Library Version
+function getVerNum()
+{
+  echo $(egrep "^#define\s+_IRREMOTEESP8266_VERSION_$1\s+" \
+             src/IRremoteESP8266.h | awk '{print $3;}')
+}
+
+MAJOR=$(getVerNum "MAJOR")
+MINOR=$(getVerNum "MINOR")
+PATCH=$(getVerNum "PATCH")
+LIB_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo $LIB_VERSION


### PR DESCRIPTION
Allow a structured integer library version numbering system so that programs can make pre-compiler descissions if needed.

Reconstruct library version numbering consistency checks to use new scheme.

Make sure there is only one canonical location for the version number in C++ land. i.e. _IRREMOTEESP8266_VERSION_ & _IRREMOTEESP8266_VERSION_STR are synthetically constructed from MAJOR, MINOR, & PATCH numbers.

Use `_IRREMOTEESP8266_VERSION_STR` instead of `_IRREMOTEESP8266_VERSION_` in our examples.