### PR TITLE
Fix library version string calculation.

### DIFF
--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -63,7 +63,8 @@
 #define _IRREMOTEESP8266_VERSION_VAL(major, minor, patch) \
                                     ((major << 16) | (minor << 8) | (patch))
 // Macro to convert literal into a string
-#define MKSTR(x) #x
+#define MKSTR_HELPER(x) #x
+#define MKSTR(x) MKSTR_HELPER(x)
 // Integer version
 #define _IRREMOTEESP8266_VERSION _IRREMOTEESP8266_VERSION_VAL(\
     _IRREMOTEESP8266_VERSION_MAJOR, \

--- a/test/IRutils_test.cpp
+++ b/test/IRutils_test.cpp
@@ -780,3 +780,17 @@ TEST(TestUtils, InvertedBytePairs) {
 TEST(TestUtils, lowLevelSanityCheck) {
   ASSERT_EQ(0, irutils::lowLevelSanityCheck());
 }
+
+TEST(TestUtils, VersionDefines) {
+  // String
+  String version_str = uint64ToString(_IRREMOTEESP8266_VERSION_MAJOR) + '.' +
+      uint64ToString(_IRREMOTEESP8266_VERSION_MINOR) + '.' +
+      uint64ToString(_IRREMOTEESP8266_VERSION_PATCH);  // e.g. "2.8.1"
+  ASSERT_EQ(_IRREMOTEESP8266_VERSION_STR, version_str);
+  ASSERT_EQ(_IRREMOTEESP8266_VERSION_, version_str);
+  // Integer
+  uint64_t version_int = (_IRREMOTEESP8266_VERSION_MAJOR << 16) +
+                         (_IRREMOTEESP8266_VERSION_MINOR << 8) +
+                         _IRREMOTEESP8266_VERSION_PATCH;
+  ASSERT_EQ(_IRREMOTEESP8266_VERSION, version_int);
+}


### PR DESCRIPTION
 * Add unit tests to ensure calculation isn't broken in future.

Fixes #1725