### PR TITLE
ESP32-C3: Work around for some C3 specific compiler issues again.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -1166,8 +1166,8 @@ bool IRrecv::matchAtLeast(uint32_t measured, uint32_t desired,
   DPRINT(". Matching: ");
   DPRINT(measured);
   DPRINT(" >= ");
-  DPRINT(ticksLow(std::min(desired, MS_TO_USEC(params.timeout)), tolerance,
-                  delta));
+  DPRINT(ticksLow(std::min(desired, (uint32_t)MS_TO_USEC(params.timeout)),
+                  tolerance, delta));
   DPRINT(" [min(");
   DPRINT(ticksLow(desired, tolerance, delta));
   DPRINT(", ");


### PR DESCRIPTION
This is a sibling of 3f871e4b7989789fa0093548b4d7b7eb240f7908.

Fixes #1695