### PR TITLE
HITACHI_AC264: Add minimal detailed support.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -231,6 +231,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_HITACHI_AC1
     case decode_type_t::HITACHI_AC1:
 #endif
+#if SEND_HITACHI_AC264
+    case decode_type_t::HITACHI_AC264:
+#endif
 #if SEND_HITACHI_AC344
     case decode_type_t::HITACHI_AC344:
 #endif
@@ -1312,6 +1315,35 @@ void IRac::hitachi1(IRHitachiAc1 *ac, const hitachi_ac1_remote_model_t model,
   ac->send();
 }
 #endif  // SEND_HITACHI_AC1
+
+#if SEND_HITACHI_AC264
+/// Send a Hitachi 264-bit A/C message with the supplied settings.
+/// @param[in, out] ac A Ptr to an IRHitachiAc264 object to use.
+/// @param[in] on The power setting.
+/// @param[in] mode The operation mode setting.
+/// @param[in] degrees The temperature setting in degrees.
+/// @param[in] fan The speed setting for the fan.
+void IRac::hitachi264(IRHitachiAc264 *ac,
+                      const bool on, const stdAc::opmode_t mode,
+                      const float degrees, const stdAc::fanspeed_t fan) {
+  ac->begin();
+  ac->setMode(ac->convertMode(mode));
+  ac->setTemp(degrees);
+  ac->setFan(ac->convertFan(fan));
+  ac->setPower(on);
+  // No Swing(V) setting available.
+  // No Swing(H) setting available.
+  // No Quiet setting available.
+  // No Turbo setting available.
+  // No Light setting available.
+  // No Filter setting available.
+  // No Clean setting available.
+  // No Beep setting available.
+  // No Sleep setting available.
+  // No Clock setting available.
+  ac->send();
+}
+#endif  // SEND_HITACHI_AC264
 
 #if SEND_HITACHI_AC344
 /// Send a Hitachi 344-bit A/C message with the supplied settings.
@@ -2903,6 +2935,14 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       break;
     }
 #endif  // SEND_HITACHI_AC1
+#if SEND_HITACHI_AC264
+    case HITACHI_AC264:
+    {
+      IRHitachiAc264 ac(_pin, _inverted, _modulation);
+      hitachi264(&ac, send.power, send.mode, degC, send.fanspeed);
+      break;
+    }
+#endif  // SEND_HITACHI_AC264
 #if SEND_HITACHI_AC344
     case HITACHI_AC344:
     {
@@ -3756,6 +3796,13 @@ namespace IRAcUtils {
         return ac.toString();
       }
 #endif  // DECODE_HITACHI_AC1
+#if DECODE_HITACHI_AC264
+      case decode_type_t::HITACHI_AC264: {
+        IRHitachiAc264 ac(kGpioUnused);
+        ac.setRaw(result->state);
+        return ac.toString();
+      }
+#endif  // DECODE_HITACHI_AC264
 #if DECODE_HITACHI_AC344
       case decode_type_t::HITACHI_AC344: {
         IRHitachiAc344 ac(kGpioUnused);
@@ -4213,6 +4260,14 @@ namespace IRAcUtils {
         break;
       }
 #endif  // DECODE_HITACHI_AC1
+#if DECODE_HITACHI_AC264
+      case decode_type_t::HITACHI_AC264: {
+        IRHitachiAc264 ac(kGpioUnused);
+        ac.setRaw(decode->state);
+        *result = ac.toCommon();
+        break;
+      }
+#endif  // DECODE_HITACHI_AC264
 #if DECODE_HITACHI_AC344
       case decode_type_t::HITACHI_AC344: {
         IRHitachiAc344 ac(kGpioUnused);

--- a/src/IRac.h
+++ b/src/IRac.h
@@ -300,6 +300,11 @@ void electra(IRElectraAc *ac,
                 const stdAc::swingv_t swingv, const stdAc::swingh_t swingh,
                 const bool swing_toggle, const int16_t sleep = -1);
 #endif  // SEND_HITACHI_AC1
+#if SEND_HITACHI_AC264
+  void hitachi264(IRHitachiAc264 *ac,
+                  const bool on, const stdAc::opmode_t mode,
+                  const float degrees, const stdAc::fanspeed_t fan);
+#endif  // SEND_HITACHI_AC264
 #if SEND_HITACHI_AC344
   void hitachi344(IRHitachiAc344 *ac,
                   const bool on, const stdAc::opmode_t mode,

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -944,6 +944,35 @@ TEST(TestIRac, Hitachi1) {
   ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
 }
 
+TEST(TestIRac, Hitachi264) {
+  IRHitachiAc264 ac(kGpioUnused);
+  IRac irac(kGpioUnused);
+  IRrecv capture(kGpioUnused);
+  char expected_swingon[] =
+      "Power: On, Mode: 6 (Heat), Temp: 25C, Fan: 4 (High), "
+      "Button: 19 (Power/Mode)";
+
+  ac.begin();
+  irac.hitachi264(&ac,
+                  true,                         // Power
+                  stdAc::opmode_t::kHeat,       // Mode
+                  25,                           // Celsius
+                  stdAc::fanspeed_t::kMax);     // Fan speed
+
+  ASSERT_EQ(expected_swingon, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(HITACHI_AC264, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kHitachiAc264Bits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected_swingon, IRAcUtils::resultAcToString(&ac._irsend.capture));
+  stdAc::state_t r, p;
+  ASSERT_TRUE(IRAcUtils::decodeToState(&ac._irsend.capture, &r, &p));
+  EXPECT_EQ(decode_type_t::HITACHI_AC264, r.protocol);
+  EXPECT_TRUE(r.power);
+  EXPECT_EQ(stdAc::opmode_t::kHeat, r.mode);
+  EXPECT_EQ(25, r.degrees);
+}
+
 TEST(TestIRac, Hitachi344) {
   IRHitachiAc344 ac(kGpioUnused);
   IRac irac(kGpioUnused);

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -2197,4 +2197,16 @@ TEST(TestIRHitachiAc264Class, Issue1729_PowerOntoOff) {
   EXPECT_FALSE(off.power);
   EXPECT_EQ(stdAc::opmode_t::kHeat, off.mode);
   EXPECT_EQ(25, off.degrees);
+
+  // Verify that handleToggles() isn't screwing anything up.
+  IRac common(kGpioUnused);
+  stdAc::state_t toggle_state;
+  toggle_state = common.handleToggles(on, &prev);
+  EXPECT_FALSE(common.cmpStates(on, prev));  // They are the same.
+  EXPECT_FALSE(common.cmpStates(on, toggle_state));  // They are the same.
+  toggle_state = common.handleToggles(off, &on);
+  EXPECT_TRUE(common.cmpStates(off, on));  // They are different.
+  EXPECT_FALSE(common.cmpStates(off, toggle_state));  // They are the same.
+  EXPECT_EQ(off.protocol, decode_type_t::HITACHI_AC264);
+  // That confirms handleToggles() isn't causing any grief.
 }


### PR DESCRIPTION
* Supports Power, Temp, Mode, & Fanspeed. That's it.
  - Effectively a parent class of `IRHitachiAc424`.
* Add `IRac` integration.
* Update & add unit tests.

Fixes #1729