### PR TITLE
Simplify code based on state_t being initialised by default.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -71,7 +71,6 @@ IRac::IRac(const uint16_t pin, const bool inverted, const bool use_modulation) {
   _pin = pin;
   _inverted = inverted;
   _modulation = use_modulation;
-  initState(&next);
   this->markAsSent();
 }
 
@@ -132,11 +131,8 @@ void IRac::initState(stdAc::state_t *state,
 /// @param[out] state A Ptr to where the settings will be stored.
 /// @note Sets all the parameters to reasonable base/automatic defaults.
 void IRac::initState(stdAc::state_t *state) {
-  initState(state, decode_type_t::UNKNOWN, -1, false, stdAc::opmode_t::kOff,
-            25, true,  // 25 degrees Celsius
-            stdAc::fanspeed_t::kAuto, stdAc::swingv_t::kOff,
-            stdAc::swingh_t::kOff, false, false, false, false, false, false,
-            false, -1, -1);
+  stdAc::state_t def;
+  *state = def;
 }
 
 /// Get the current internal A/C climate state.

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -95,24 +95,24 @@ enum class swingh_t {
 
 /// Structure to hold a common A/C state.
 struct state_t {
-  decode_type_t protocol;
-  int16_t model;
-  bool power;
-  stdAc::opmode_t mode;
-  float degrees;
-  bool celsius;
-  stdAc::fanspeed_t fanspeed;
-  stdAc::swingv_t swingv;
-  stdAc::swingh_t swingh;
-  bool quiet;
-  bool turbo;
-  bool econo;
-  bool light;
-  bool filter;
-  bool clean;
-  bool beep;
-  int16_t sleep;
-  int16_t clock;
+  decode_type_t protocol = decode_type_t::UNKNOWN;
+  int16_t model = -1;  // `-1` means unused.
+  bool power = false;
+  stdAc::opmode_t mode = stdAc::opmode_t::kOff;
+  float degrees = 25;
+  bool celsius = true;
+  stdAc::fanspeed_t fanspeed = stdAc::fanspeed_t::kAuto;
+  stdAc::swingv_t swingv = stdAc::swingv_t::kOff;
+  stdAc::swingh_t swingh = stdAc::swingh_t::kOff;
+  bool quiet = false;
+  bool turbo = false;
+  bool econo = false;
+  bool light = false;
+  bool filter = false;
+  bool clean = false;
+  bool beep = false;
+  int16_t sleep = -1;  // `-1` means off.
+  int16_t clock = -1;  // `-1` means not set.
 };
 };  // namespace stdAc
 

--- a/src/ir_Airton.cpp
+++ b/src/ir_Airton.cpp
@@ -317,7 +317,7 @@ bool IRAirtonAc::getHealth(void) const { return _.Health; }
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRAirtonAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::AIRTON;
   result.power = getPower();
   result.mode = toCommonMode(getMode());

--- a/src/ir_Airwell.cpp
+++ b/src/ir_Airwell.cpp
@@ -238,7 +238,7 @@ uint8_t IRAirwellAc::getTemp(void) const {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRAirwellAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Amcor.cpp
+++ b/src/ir_Amcor.cpp
@@ -314,7 +314,7 @@ stdAc::fanspeed_t IRAmcorAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRAmcorAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::AMCOR;
   result.power = getPower();
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -344,7 +344,7 @@ stdAc::fanspeed_t IRArgoAC::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRArgoAC::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::ARGO;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Carrier.cpp
+++ b/src/ir_Carrier.cpp
@@ -511,7 +511,7 @@ String IRCarrierAc64::toString(void) const {
 /// Convert the A/C state to it's common stdAc::state_t equivalent.
 /// @return A stdAc::state_t state.
 stdAc::state_t IRCarrierAc64::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::CARRIER_AC64;
   result.model = -1;  // No models used.
   result.power = _.Power;

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -496,7 +496,7 @@ stdAc::fanspeed_t IRCoolixAC::toCommonFanSpeed(const uint8_t speed) {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return A stdAc::state_t state.
 stdAc::state_t IRCoolixAC::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Corona.cpp
+++ b/src/ir_Corona.cpp
@@ -550,7 +550,7 @@ String IRCoronaAc::toString(void) const {
 /// Convert the A/C state to it's common stdAc::state_t equivalent.
 /// @return A stdAc::state_t state.
 stdAc::state_t IRCoronaAc::toCommon() const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::CORONA_AC;
   result.model = -1;  // No models used.
   result.power = _.Power;

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -529,7 +529,7 @@ stdAc::fanspeed_t IRDaikinESP::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikinESP::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -1199,7 +1199,7 @@ stdAc::swingh_t IRDaikin2::toCommonSwingH(const uint8_t setting) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin2::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN2;
   result.model = -1;  // No models used.
   result.power = getPower();
@@ -1621,7 +1621,7 @@ bool IRDaikin216::getPowerful(void) const { return _.Powerful; }
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin216::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN216;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -1971,7 +1971,7 @@ stdAc::swingv_t IRDaikin160::toCommonSwingV(const uint8_t setting) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin160::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN160;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -2362,7 +2362,7 @@ stdAc::fanspeed_t IRDaikin176::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin176::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN176;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -2883,7 +2883,7 @@ String IRDaikin128::toString(void) const {
 /// @param[in] prev Ptr to a previous state.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin128::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   if (prev != NULL) result = *prev;
   result.protocol = decode_type_t::DAIKIN128;
   result.model = -1;  // No models used.
@@ -3285,7 +3285,7 @@ bool IRDaikin152::getComfort(void) const { return _.Comfort; }
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin152::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DAIKIN152;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -3710,7 +3710,7 @@ String IRDaikin64::toString(void) const {
 /// @param[in] prev Ptr to a previous state.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDaikin64::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   if (prev != NULL) result = *prev;
   result.protocol = decode_type_t::DAIKIN64;
   result.model = -1;  // No models used.

--- a/src/ir_Delonghi.cpp
+++ b/src/ir_Delonghi.cpp
@@ -421,7 +421,7 @@ uint16_t IRDelonghiAc::getOffTimer(void) const {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRDelonghiAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::DELONGHI_AC;
   result.power = _.Power;
   // result.mode = toCommonMode(getMode());

--- a/src/ir_Ecoclim.cpp
+++ b/src/ir_Ecoclim.cpp
@@ -359,7 +359,7 @@ void IREcoclimAc::disableOffTimer(void) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IREcoclimAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::ECOCLIM;
   result.power = _.Power;
   result.mode = toCommonMode(getMode());

--- a/src/ir_Electra.cpp
+++ b/src/ir_Electra.cpp
@@ -359,7 +359,7 @@ uint8_t IRElectraAc::getSensorTemp(void) const {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRElectraAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::ELECTRA_AC;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -776,7 +776,7 @@ stdAc::fanspeed_t IRFujitsuAC::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRFujitsuAC::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::FUJITSU_AC;
   result.model = _model;
   result.power = getPower();

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -311,7 +311,7 @@ stdAc::fanspeed_t IRGoodweatherAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRGoodweatherAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::GOODWEATHER;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -575,7 +575,7 @@ stdAc::swingh_t IRGreeAC::toCommonSwingH(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRGreeAC::toCommon(void) {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::GREE;
   result.model = _model;
   result.power = _.Power;

--- a/src/ir_Haier.cpp
+++ b/src/ir_Haier.cpp
@@ -426,7 +426,7 @@ stdAc::swingv_t IRHaierAC::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRHaierAC::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::HAIER_AC;
   result.model = -1;  // No models used.
   result.power = true;
@@ -1127,7 +1127,7 @@ stdAc::swingh_t IRHaierAC176::toCommonSwingH(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRHaierAC176::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::HAIER_AC_YRW02;
   result.model = getModel();
   result.power = _.Power;

--- a/src/ir_Hitachi.cpp
+++ b/src/ir_Hitachi.cpp
@@ -381,7 +381,7 @@ stdAc::fanspeed_t IRHitachiAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRHitachiAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::HITACHI_AC;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -781,7 +781,7 @@ stdAc::fanspeed_t IRHitachiAc1::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRHitachiAc1::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::HITACHI_AC1;
   result.model = getModel();
   result.power = _.Power;
@@ -1261,7 +1261,7 @@ stdAc::fanspeed_t IRHitachiAc424::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRHitachiAc424::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::HITACHI_AC424;
   result.model = -1;  // No models used.
   result.power = getPower();

--- a/src/ir_Kelvinator.cpp
+++ b/src/ir_Kelvinator.cpp
@@ -401,7 +401,7 @@ stdAc::fanspeed_t IRKelvinatorAC::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the internal A/C object state to it's stdAc::state_t equivalent.
 /// @return A stdAc::state_t containing the current settings.
 stdAc::state_t IRKelvinatorAC::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::KELVINATOR;
   result.model = -1;  // Unused.
   result.power = _.Power;

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -740,7 +740,7 @@ uint8_t IRLgAc::convertVaneSwingV(const stdAc::swingv_t swingv) {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRLgAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Mirage.cpp
+++ b/src/ir_Mirage.cpp
@@ -733,7 +733,7 @@ stdAc::swingv_t IRMirageAc::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMirageAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MIRAGE;
   result.model = _model;
   result.power = getPower();

--- a/src/ir_Mitsubishi.cpp
+++ b/src/ir_Mitsubishi.cpp
@@ -781,7 +781,7 @@ stdAc::swingh_t IRMitsubishiAC::toCommonSwingH(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMitsubishiAC::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MITSUBISHI_AC;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -1195,7 +1195,7 @@ stdAc::swingv_t IRMitsubishi136::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMitsubishi136::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MITSUBISHI136;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -1660,7 +1660,7 @@ stdAc::swingh_t IRMitsubishi112::toCommonSwingH(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMitsubishi112::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MITSUBISHI112;
   result.model = -1;  // No models used.
   result.power = _.Power;

--- a/src/ir_MitsubishiHeavy.cpp
+++ b/src/ir_MitsubishiHeavy.cpp
@@ -454,7 +454,7 @@ stdAc::swingv_t IRMitsubishiHeavy152Ac::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMitsubishiHeavy152Ac::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MITSUBISHI_HEAVY_152;
   result.model = -1;  // No models used.
   result.power = _.Power;
@@ -899,7 +899,7 @@ stdAc::swingv_t IRMitsubishiHeavy88Ac::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRMitsubishiHeavy88Ac::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::MITSUBISHI_HEAVY_88;
   result.model = -1;  // No models used.
   result.power = _.Power;

--- a/src/ir_Neoclima.cpp
+++ b/src/ir_Neoclima.cpp
@@ -484,7 +484,7 @@ bool IRNeoclimaAc::getFollow(void) const {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRNeoclimaAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::NEOCLIMA;
   result.model = -1;  // No models used.
   result.power = _.Power;

--- a/src/ir_Panasonic.cpp
+++ b/src/ir_Panasonic.cpp
@@ -760,7 +760,7 @@ stdAc::swingv_t IRPanasonicAc::toCommonSwingV(const uint8_t pos) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRPanasonicAc::toCommon(void) {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::PANASONIC_AC;
   result.model = getModel();
   result.power = getPower();
@@ -1307,7 +1307,7 @@ String IRPanasonicAc32::toString(void) const {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRPanasonicAc32::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Rhoss.cpp
+++ b/src/ir_Rhoss.cpp
@@ -324,7 +324,7 @@ stdAc::fanspeed_t IRRhossAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRRhossAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::RHOSS;
   result.power = getPower();
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -866,7 +866,7 @@ stdAc::fanspeed_t IRSamsungAc::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRSamsungAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::SAMSUNG_AC;
   result.model = -1;  // Not supported.
   result.power = getPower();

--- a/src/ir_Sanyo.cpp
+++ b/src/ir_Sanyo.cpp
@@ -607,7 +607,7 @@ void IRSanyoAc::setOffTimer(const uint16_t mins) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRSanyoAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::SANYO_AC;
   result.model = -1;  // Not supported.
   result.power = getPower();
@@ -935,7 +935,7 @@ bool IRSanyoAc88::getSleep(void) const { return _.Sleep; }
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRSanyoAc88::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::SANYO_AC88;
   result.model = -1;  // Not supported.
   result.power = getPower();

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -837,7 +837,7 @@ stdAc::swingv_t IRSharpAc::toCommonSwingV(const uint8_t pos,
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRSharpAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) result = *prev;
   result.protocol = decode_type_t::SHARP_AC;

--- a/src/ir_Tcl.cpp
+++ b/src/ir_Tcl.cpp
@@ -444,7 +444,7 @@ stdAc::swingv_t IRTcl112Ac::toCommonSwingV(const uint8_t setting) {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTcl112Ac::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) result = *prev;
   result.protocol = decode_type_t::TCL112AC;

--- a/src/ir_Technibel.cpp
+++ b/src/ir_Technibel.cpp
@@ -363,7 +363,7 @@ uint16_t IRTechnibelAc::getTimer(void) const {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTechnibelAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::TECHNIBEL_AC;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Teco.cpp
+++ b/src/ir_Teco.cpp
@@ -294,7 +294,7 @@ stdAc::fanspeed_t IRTecoAc::toCommonFanSpeed(const uint8_t speed) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTecoAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::TECO;
   result.model = -1;  // Not supported.
   result.power = _.Power;

--- a/src/ir_Toshiba.cpp
+++ b/src/ir_Toshiba.cpp
@@ -409,7 +409,7 @@ stdAc::fanspeed_t IRToshibaAC::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRToshibaAC::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Transcold.cpp
+++ b/src/ir_Transcold.cpp
@@ -339,7 +339,7 @@ stdAc::fanspeed_t IRTranscoldAc::toCommonFanSpeed(const uint8_t speed) {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return A stdAc::state_t state.
 stdAc::state_t IRTranscoldAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Trotec.cpp
+++ b/src/ir_Trotec.cpp
@@ -266,7 +266,7 @@ stdAc::fanspeed_t IRTrotecESP::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTrotecESP::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::TROTEC;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);
@@ -601,7 +601,7 @@ stdAc::fanspeed_t IRTrotec3550::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTrotec3550::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::TROTEC_3550;
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);

--- a/src/ir_Truma.cpp
+++ b/src/ir_Truma.cpp
@@ -295,7 +295,7 @@ stdAc::fanspeed_t IRTrumaAc::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRTrumaAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
 
   result.protocol = decode_type_t::TRUMA;
   result.model = -1;  // Not supported.

--- a/src/ir_Vestel.cpp
+++ b/src/ir_Vestel.cpp
@@ -442,7 +442,7 @@ stdAc::fanspeed_t IRVestelAc::toCommonFanSpeed(const uint8_t spd) {
 /// Convert the current internal state into its stdAc::state_t equivalent.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRVestelAc::toCommon(void) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   result.protocol = decode_type_t::VESTEL_AC;
   result.model = -1;  // Not supported.
   result.power = _.Power;

--- a/src/ir_Voltas.cpp
+++ b/src/ir_Voltas.cpp
@@ -454,7 +454,7 @@ void IRVoltas::setOffTime(const uint16_t nr_of_mins) {
 /// @param[in] prev Ptr to the previous state if available.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRVoltas::toCommon(const stdAc::state_t *prev) {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/src/ir_Whirlpool.cpp
+++ b/src/ir_Whirlpool.cpp
@@ -493,7 +493,7 @@ stdAc::fanspeed_t IRWhirlpoolAc::toCommonFanSpeed(const uint8_t speed) {
 /// @param[in] prev Ptr to the previous state if required.
 /// @return The stdAc equivalent of the native settings.
 stdAc::state_t IRWhirlpoolAc::toCommon(const stdAc::state_t *prev) const {
-  stdAc::state_t result;
+  stdAc::state_t result{};
   // Start with the previous state if given it.
   if (prev != NULL) {
     result = *prev;

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -2965,7 +2965,6 @@ TEST(TestIRac, Issue1250) {
 TEST(TestIRac, Issue1339) {
   IRac irac(kGpioUnused);
   stdAc::state_t to_send;
-  IRac::initState(&to_send);
 
   to_send.protocol = decode_type_t::SAMSUNG_AC;
   ASSERT_TRUE(irac.sendAc(to_send, NULL));
@@ -3029,4 +3028,21 @@ TEST(TestIRac, Issue1424) {
   EXPECT_EQ(irac.next.swingv, stdAc::swingv_t::kOff);
   // Confirm the state really did change.
   ASSERT_TRUE(IRac::cmpStates(irac.next, copy_of_next_pre_receive));
+}
+
+// Confirm/check that the default initialisation of a state_t is as expected.
+TEST(TestIRac, initState) {
+  IRac irac(kGpioUnused);
+  stdAc::state_t builtin_init{};
+  stdAc::state_t custom_init;
+  stdAc::state_t no_init;
+  IRac::initState(&custom_init);
+
+  EXPECT_FALSE(IRac::cmpStates(builtin_init, custom_init));
+  builtin_init.protocol = decode_type_t::SAMSUNG_AC;
+  EXPECT_TRUE(IRac::cmpStates(builtin_init, custom_init));
+  EXPECT_FALSE(IRac::cmpStates(no_init, custom_init));
+  EXPECT_EQ(-1, builtin_init.model);
+  EXPECT_EQ(stdAc::swingv_t::kOff, builtin_init.swingv);
+  EXPECT_EQ(decode_type_t::UNKNOWN, no_init.protocol);
 }


### PR DESCRIPTION
* Ensure all `state_t` structs are initialised.
* Remove (now) redundant code.
* Add unit tests to confirm operation.

Ref #1699