### PR TITLE
IRMQTTServer V1.6.1

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -285,7 +285,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.6.0"
+#define _MY_VERSION_ "v1.6.1"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds


### PR DESCRIPTION
- Fix the case when `MQTT_CLIMATE_HA_MODE` is enabled **and** Home Assistant is **_NOT_** being used, **and** `power` is turned _Off_ via the http interface, that it also sets the `mode` to _Off_, and vice-versa; i.e. Turning `mode` _"Off"_ also sets `power` _"Off"_.
- Move some literal strings to constants for consistency.
  - Helps with potential internationalisation.
- Bump version patch number.

Ref #1729
Fixes #1739