### PR TITLE
Make KELON (48 bit) protocol decoding stricter.

### DIFF
--- a/test/ir_Kelon_test.cpp
+++ b/test/ir_Kelon_test.cpp
@@ -105,6 +105,7 @@ TEST(TestDecodeKelon, Timer12HSmartMode) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x1679030683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 25C, Mode: 1 (Auto), Fan: 3 (High), Sleep: Off, Dry: 0, "
       "Timer: 12:00, Turbo: Off",
@@ -124,6 +125,7 @@ TEST(TestDecodeKelon, Timer5_5hSuperCoolMode) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x100B0A010683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 18C, Mode: 2 (Cool), Fan: 1 (Low), Sleep: Off, Dry: 0, "
       "Timer: 05:30, Turbo: On",
@@ -143,6 +145,7 @@ TEST(TestDecodeKelon, ChangeSettingsWithTimerSetHeatMode) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x58000683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 23C, Mode: 0 (Heat), Fan: 0 (Auto), Sleep: Off, Dry: 0, "
       "Timer: On, Turbo: Off",
@@ -162,6 +165,7 @@ TEST(TestDecodeKelon, TestPowerToggleDryMode) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x83040683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 26C, Mode: 3 (Dry), Fan: 0 (Auto), Sleep: Off, Dry: 0, Timer:"
       " Off, Turbo: Off, Power Toggle: On",
@@ -181,6 +185,7 @@ TEST(TestDecodeKelon, TestSwingToggleDryMode) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x83800683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 26C, Mode: 3 (Dry), Fan: 0 (Auto), Sleep: Off, Dry: 0, Timer:"
       " Off, Turbo: Off, Swing(V) Toggle: On",
@@ -200,6 +205,7 @@ TEST(TestDecodeKelon, TestDryGradeNegativeValue) {
   EXPECT_TRUE(irrecv.decode(&irsend.capture));
   EXPECT_EQ(KELON, irsend.capture.decode_type);
   EXPECT_EQ(kKelonBits, irsend.capture.bits);
+  EXPECT_EQ(0x83600683, irsend.capture.value);
   EXPECT_EQ(
       "Temp: 26C, Mode: 3 (Dry), Fan: 0 (Auto), Sleep: Off, Dry: -2,"
       " Timer: Off, Turbo: Off",
@@ -425,4 +431,69 @@ TEST(TestUtils, Housekeeping) {
   ASSERT_TRUE(IRac::isProtocolSupported(decode_type_t::KELON));
   ASSERT_EQ(kKelonBits, IRsend::defaultBits(decode_type_t::KELON));
   ASSERT_EQ(kNoRepeat, IRsend::minRepeats(decode_type_t::KELON));
+}
+
+TEST(TestDecodeKelon, Discussion1744) {
+  IRsendTest irsend(kGpioUnused);
+  IRrecv irrecv(kGpioUnused);
+  // Ref: https://github.com/crankyoldgit/IRremoteESP8266/discussions/1744#discussioncomment-2061968
+  // Note: This message is NOT at 48-bit Kelon protocol message.
+  //       It is actually 48 + 64 + 56 = 168 bit (21 byte) message.
+  //       i.e. A different protocol all together.
+  const uint16_t rawData[343] = {
+      8922, 4494,  // Header
+      548, 1714, 524, 1718, 524, 572, 524, 550,  // Byte 0
+      550, 556, 550, 560, 548, 586, 524, 1724,
+      526, 564, 524, 1692, 550, 1696, 550, 552,  // Byte 1
+      550, 554, 550, 560, 548, 586, 524, 550,
+      548, 1688, 550, 1694, 548, 548, 550, 552,  // Byte 2
+      548, 556, 548, 582, 524, 586, 524, 576,
+      524, 540, 548, 568, 526, 572, 526, 548,    // Byte 3
+      550, 1702, 550, 1706, 550, 1734, 526, 574,
+      526, 564, 526, 544, 550, 548, 548, 550,    // Byte 4
+      550, 554, 550, 582, 526, 586, 524, 550,
+      548, 540, 550, 544, 550, 570, 526, 550,    // Byte 5
+      550, 558, 546, 582, 524, 586, 524, 562,
+      524, 7978,  // Section Footer
+      548, 1690, 548, 568, 524, 1696, 548, 1700,  // Byte 6
+      548, 554, 550, 560, 548, 560, 550, 1722,
+      526, 1686, 550, 1692, 548, 1696, 550, 576,  // Byte 7
+      524, 1704, 548, 558, 550, 562, 548, 550,
+      550, 564, 524, 570, 524, 548, 548, 576,     // Byte 8
+      524, 578, 526, 558, 550, 586, 524, 574,
+      524, 566, 524, 568, 526, 548, 548, 576,     // Byte 9
+      526, 556, 548, 558, 550, 560, 550, 550,
+      550, 564, 526, 544, 548, 548, 548, 552,     // Byte 10
+      548, 556, 548, 582, 526, 564, 548, 550,
+      550, 540, 548, 568, 526, 546, 550, 550,     // Byte 11
+      550, 580, 524, 558, 550, 560, 550, 1698,
+      550, 542, 548, 542, 550, 546, 550, 1722,    // Byte 12
+      524, 1706, 548, 582, 526, 586, 524, 574,
+      526, 1690, 548, 544, 550, 546, 550, 552,    // Byte 13
+      548, 1726, 526, 1730, 524, 1734, 526, 562,
+      524, 7976,  // Section footer
+      550, 566, 524, 544, 550, 570, 526, 550,     // Byte 14
+      548, 554, 550, 1706, 550, 562, 548, 574,
+      526, 542, 548, 544, 550, 572, 526, 548,     // Byte 15
+      552, 554, 550, 582, 526, 584, 526, 574,
+      524, 542, 548, 544, 548, 572, 524, 552,     // Byte 16
+      548, 578, 524, 560, 548, 562, 548, 550,
+      550, 540, 550, 546, 548, 572, 524, 576,     // Byte 17
+      526, 556, 548, 560, 546, 564, 548, 574,
+      526, 540, 550, 546, 546, 546, 550, 1698,    // Byte 18
+      550, 1728, 524, 1706, 548, 564, 548, 574,
+      524, 544, 548, 568, 526, 548, 548, 574,     // Byte 19
+      524, 554, 550, 558, 550, 562, 548, 550,
+      550, 566, 524, 544, 548, 546, 552, 1698,    // Byte 20
+      548, 1702, 550, 560, 546, 586, 524, 538,
+      546  // Footer
+  };  // KELON 178D000070030683
+
+  irsend.begin();
+  irsend.reset();
+  irsend.sendRaw(rawData, 343, 38000);
+  irsend.makeDecodeResult();
+  EXPECT_TRUE(irrecv.decode(&irsend.capture));
+  EXPECT_NE(KELON, irsend.capture.decode_type);  // Not a KELON message
+  EXPECT_NE(kKelonBits, irsend.capture.bits);    // Not a 48 bit message.
 }


### PR DESCRIPTION
* Ensure checking of inter-message gap is being done.
  - Fixes a false positive detection.
* Code style cleanup.
* Ensure result address & commands are cleared.
* Add unit tests based on Discussion #1744
* Improve older unit tests by confirming capture code is correct.

Ref #1744