### PR TITLE
IRMQTTServer example: Fix compiling error for ESP32

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -1249,8 +1249,8 @@ void handleInfo(void) {
     "Built: " __DATE__
       " " __TIME__ "<br>"
     "Period Offset: ") + String(offset) + F("us<br>"
-    "IR Lib Version: " _IRREMOTEESP8266_VERSION_STR "<br>"
 #if defined(ESP8266)
+    "IR Lib Version: " _IRREMOTEESP8266_VERSION_STR "<br>"
     "ESP8266 Core Version: ") + ESP.getCoreVersion() + F("<br>"
     "Free Sketch Space: ") + String(maxSketchSpace() >> 10) + F("k<br>"
 #endif  // ESP8266


### PR DESCRIPTION
_IRREMOTEESP8266_VERSION_STR is not defined for ESP32, so move it inside
the #if defined(ESP8266) block, otherwise it won't compile for ESP32
with the following error:

IRremoteESP8266/examples/IRMQTTServer/IRMQTTServer.ino: In function
'void handleInfo()':
IRMQTTServer:1252:24: error: expected ';' before
'_IRREMOTEESP8266_VERSION_STR'
     "IR Lib Version: " _IRREMOTEESP8266_VERSION_STR "<br>"
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~