### PR TITLE
[BUG] ESP32-C3: Fix reboot/crashes on ESP32-C3s when receiving.

### DIFF
--- a/examples/DumbIRRepeater/DumbIRRepeater.ino
+++ b/examples/DumbIRRepeater/DumbIRRepeater.ino
@@ -57,7 +57,12 @@
 
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+// Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
+#ifndef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 14;
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#endif  // ARDUINO_ESP32C3_DEV
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).
 const uint16_t kIrLedPin = 4;

--- a/examples/DumbIRRepeater/DumbIRRepeater.ino
+++ b/examples/DumbIRRepeater/DumbIRRepeater.ino
@@ -58,10 +58,10 @@
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 // Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
-#ifndef ARDUINO_ESP32C3_DEV
-const uint16_t kRecvPin = 14;
-#else  // ARDUINO_ESP32C3_DEV
+#ifdef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 14;
 #endif  // ARDUINO_ESP32C3_DEV
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -24,7 +24,12 @@
 // An IR detector/demodulator is connected to GPIO pin 14(D5 on a NodeMCU
 // board).
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+// Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
+#ifndef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 14;
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#endif  // ARDUINO_ESP32C3_DEV
 
 IRrecv irrecv(kRecvPin);
 

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -25,10 +25,10 @@
 // board).
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 // Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
-#ifndef ARDUINO_ESP32C3_DEV
-const uint16_t kRecvPin = 14;
-#else  // ARDUINO_ESP32C3_DEV
+#ifdef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 14;
 #endif  // ARDUINO_ESP32C3_DEV
 
 IRrecv irrecv(kRecvPin);

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -39,10 +39,10 @@
 // e.g. D5 on a NodeMCU board.
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 // Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
-#ifndef ARDUINO_ESP32C3_DEV
-const uint16_t kRecvPin = 14;
-#else  // ARDUINO_ESP32C3_DEV
+#ifdef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 14;
 #endif  // ARDUINO_ESP32C3_DEV
 
 // The Serial connection baud rate.

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -38,7 +38,12 @@
 // An IR detector/demodulator is connected to GPIO pin 14
 // e.g. D5 on a NodeMCU board.
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+// Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
+#ifndef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 14;
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#endif  // ARDUINO_ESP32C3_DEV
 
 // The Serial connection baud rate.
 // i.e. Status message will be sent to the PC at this baud rate.

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -46,10 +46,10 @@
 // e.g. D5 on a NodeMCU board.
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 // Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
-#ifndef ARDUINO_ESP32C3_DEV
-const uint16_t kRecvPin = 14;
-#else  // ARDUINO_ESP32C3_DEV
+#ifdef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 14;
 #endif  // ARDUINO_ESP32C3_DEV
 
 // The Serial connection baud rate.

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -45,7 +45,12 @@
 // An IR detector/demodulator is connected to GPIO pin 14
 // e.g. D5 on a NodeMCU board.
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+// Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
+#ifndef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 14;
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#endif  // ARDUINO_ESP32C3_DEV
 
 // The Serial connection baud rate.
 // i.e. Status message will be sent to the PC at this baud rate.

--- a/examples/SmartIRRepeater/SmartIRRepeater.ino
+++ b/examples/SmartIRRepeater/SmartIRRepeater.ino
@@ -60,7 +60,12 @@
 
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
+// Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
+#ifndef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 14;
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#endif  // ARDUINO_ESP32C3_DEV
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).
 const uint16_t kIrLedPin = 4;

--- a/examples/SmartIRRepeater/SmartIRRepeater.ino
+++ b/examples/SmartIRRepeater/SmartIRRepeater.ino
@@ -61,10 +61,10 @@
 // The GPIO an IR detector/demodulator is connected to. Recommended: 14 (D5)
 // Note: GPIO 16 won't work on the ESP8266 as it does not have interrupts.
 // Note: GPIO 14 won't work on the ESP32-C3 as it causes the board to reboot.
-#ifndef ARDUINO_ESP32C3_DEV
-const uint16_t kRecvPin = 14;
-#else  // ARDUINO_ESP32C3_DEV
+#ifdef ARDUINO_ESP32C3_DEV
 const uint16_t kRecvPin = 10;  // 14 on a ESP32-C3 causes a boot loop.
+#else  // ARDUINO_ESP32C3_DEV
+const uint16_t kRecvPin = 14;
 #endif  // ARDUINO_ESP32C3_DEV
 
 // GPIO to use to control the IR LED circuit. Recommended: 4 (D2).

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -268,7 +268,14 @@ IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
                const uint8_t timeout, const bool save_buffer,
                const uint8_t timer_num) {
   // Ensure we use a valid timer number.
-  _timer_num = std::min(timer_num, (uint8_t)(SOC_TIMER_GROUP_TOTAL_TIMERS - 1));
+  _timer_num = std::min(timer_num,
+                        (uint8_t)(
+#ifdef SOC_TIMER_GROUP_TOTAL_TIMERS
+                                  SOC_TIMER_GROUP_TOTAL_TIMERS - 1
+#else  // SOC_TIMER_GROUP_TOTAL_TIMERS
+                                  3
+#endif  // SOC_TIMER_GROUP_TOTAL_TIMERS
+                                 ));
 #else  // ESP32
 /// @cond IGNORE
 /// Class constructor

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -271,11 +271,10 @@ IRrecv::IRrecv(const uint16_t recvpin, const uint16_t bufsize,
   _timer_num = std::min(timer_num,
                         (uint8_t)(
 #ifdef SOC_TIMER_GROUP_TOTAL_TIMERS
-                                  SOC_TIMER_GROUP_TOTAL_TIMERS - 1
+                                  SOC_TIMER_GROUP_TOTAL_TIMERS - 1));
 #else  // SOC_TIMER_GROUP_TOTAL_TIMERS
-                                  3
+                                  3));
 #endif  // SOC_TIMER_GROUP_TOTAL_TIMERS
-                                 ));
 #else  // ESP32
 /// @cond IGNORE
 /// Class constructor

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -52,8 +52,11 @@ const uint16_t kMaxTimeoutMs = kRawTick * (UINT16_MAX / MS_TO_USEC(1));
 const uint32_t kFnvPrime32 = 16777619UL;
 const uint32_t kFnvBasis32 = 2166136261UL;
 
-// Which of the ESP32 timers to use by default. (0-3)
-const uint8_t kDefaultESP32Timer = 3;
+#ifdef ESP32
+// Which of the ESP32 timers to use by default.
+// (3 for most ESP32s, 1 for ESP32-C3s)
+const uint8_t kDefaultESP32Timer = SOC_TIMER_GROUP_TOTAL_TIMERS - 1;
+#endif  // ESP32
 
 #if DECODE_AC
 // Hitachi AC is the current largest state size.

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -55,7 +55,11 @@ const uint32_t kFnvBasis32 = 2166136261UL;
 #ifdef ESP32
 // Which of the ESP32 timers to use by default.
 // (3 for most ESP32s, 1 for ESP32-C3s)
+#ifdef SOC_TIMER_GROUP_TOTAL_TIMERS
 const uint8_t kDefaultESP32Timer = SOC_TIMER_GROUP_TOTAL_TIMERS - 1;
+#else  // SOC_TIMER_GROUP_TOTAL_TIMERS
+const uint8_t kDefaultESP32Timer = 3;
+#endif  // SOC_TIMER_GROUP_TOTAL_TIMERS
 #endif  // ESP32
 
 #if DECODE_AC


### PR DESCRIPTION
- Seems an irrecv gpio of `14` was a poor default for the ESP-C3. Using it causes a reboot.
  - Using `10` for the input GPIO avoids the reboot.
- Ensure when we allocate/use a system timer, that it actually succeeds.
  - ESP32-C3 only has two system timers (0 & 1). Try to automatically cater for that scenario.
  - Add extra debug messages
  - Add a run-time assert to check it succeeded.

Fixes #1751