### PR TITLE
IRMQTTServer: add MQTT_SERVER_AUTODETECT_ENABLE

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -169,6 +169,11 @@ const uint32_t kMqttReconnectTime = 5000;  // Delay(ms) between reconnect tries.
 // In theory, you shouldn't need this as you can always clean up by hand, hence
 // it is disabled by default. Note: `false` saves ~1.2k.
 #define MQTT_CLEAR_ENABLE false
+
+#ifndef MQTT_SERVER_AUTODETECT_ENABLE
+// Whether or not MQTT Server IP is detected through mDNS
+#define MQTT_SERVER_AUTODETECT_ENABLE true
+#endif  // MQTT_SERVER_AUTODETECT_ENABLE
 #endif  // MQTT_ENABLE
 
 // ------------------------ IR Capture Settings --------------------------------
@@ -285,7 +290,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.6.1"
+#define _MY_VERSION_ "v1.7.0"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2345,8 +2345,8 @@ bool reconnect(void) {
   while (!mqtt_client.connected() && tries <= 3) {
     int connected = false;
 #if MQTT_SERVER_AUTODETECT_ENABLE
-  mqtt_detect_server();
-  mqtt_client.setServer(MqttServer, atoi(MqttPort));
+    mqtt_detect_server();
+    mqtt_client.setServer(MqttServer, atoi(MqttPort));
 #endif  // MQTT_SERVER_AUTODETECT_ENABLE
     // Attempt to connect
     debug(("Attempting MQTT connection to " + String(MqttServer) + ":" +

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -24,6 +24,10 @@
  * ## Before First Boot (i.e. Compile time)
  * - Disable MQTT if desired. (see '#define MQTT_ENABLE' in IRMQTTServer.h).
  *
+ * - The MQTT server IP is detected automatically through mDNS (aka avahi,
+ *   bonjour, zeroconf) if the server advertises _mqtt._tcp. Disable this if
+ *   desired (see '#define MQTT_SERVER_AUTODETECT_ENABLE' in IRMQTTServer.h).
+ *
  * - Site specific settings:
  *   o Search for 'CHANGE_ME' in IRMQTTServer.h for the things you probably
  *     need to change for your particular situation.
@@ -1973,6 +1977,29 @@ void handleNotFound(void) {
   server.send(404, "text/plain", message);
 }
 
+#if (MQTT_ENABLE && MQTT_SERVER_AUTODETECT_ENABLE)
+void mqtt_detect_server(void) {
+  debug("Looking for the MQTT server...");
+  int nrOfServices = MDNS.queryService("mqtt", "tcp");
+  if (nrOfServices == 0) {
+    debug("MQTT server not found");
+    return;
+  }
+
+  debug(("Number of MQTT servers found: " + String(nrOfServices)).c_str());
+  for (int i = 0; i < nrOfServices; i=i+1) {
+    debug(("Hostname: " + MDNS.hostname(i)).c_str());
+    debug(("IP address: " + MDNS.IP(i).toString()).c_str());
+    debug(("Port: " + String(MDNS.port(i))).c_str());
+  }
+  strncpy(MqttServer, MDNS.IP(0).toString().c_str(), kHostnameLength);
+  strncpy(MqttPort, String(MDNS.port(0)).c_str(), kPortLength);
+
+  debug(("First one selected: " + String(MqttServer) + ":" +
+         String(MqttPort)).c_str());
+}
+#endif  // (MQTT_ENABLE && MQTT_SERVER_AUTODETECT_ENABLE))
+
 void setup_wifi(void) {
   delay(10);
   loadConfigFile();
@@ -2000,6 +2027,12 @@ void setup_wifi(void) {
   WiFiManagerParameter custom_mqtt_text(
       "<br><br><center>MQTT Broker details</center>");
   wifiManager.addParameter(&custom_mqtt_text);
+#if MQTT_SERVER_AUTODETECT_ENABLE
+  WiFiManagerParameter custom_mqtt_server_text(
+      "<br><left>NOTE: if _mqtt._tcp mDNS service is found, it will be "
+      "used instead of the mqtt server:port below</left><br><br>");
+  wifiManager.addParameter(&custom_mqtt_server_text);
+#endif  // MQTT_SERVER_AUTODETECT_ENABLE
   WiFiManagerParameter custom_mqtt_server(
       kMqttServerKey, "mqtt server", MqttServer, kHostnameLength);
   wifiManager.addParameter(&custom_mqtt_server);
@@ -2196,6 +2229,9 @@ void setup(void) {
   // Finish setup of the mqtt clent object.
   if (!mqtt_client.setBufferSize(kMqttBufferSize))
     debug("Can't fully allocate MQTT buffer! Try a smaller value.");
+#if MQTT_SERVER_AUTODETECT_ENABLE
+  mqtt_detect_server();
+#endif  // MQTT_SERVER_AUTODETECT_ENABLE
   mqtt_client.setServer(MqttServer, atoi(MqttPort));
   mqtt_client.setCallback(mqttCallback);
   // Set various variables
@@ -2308,6 +2344,10 @@ bool reconnect(void) {
   uint16_t tries = 1;
   while (!mqtt_client.connected() && tries <= 3) {
     int connected = false;
+#if MQTT_SERVER_AUTODETECT_ENABLE
+  mqtt_detect_server();
+  mqtt_client.setServer(MqttServer, atoi(MqttPort));
+#endif  // MQTT_SERVER_AUTODETECT_ENABLE
     // Attempt to connect
     debug(("Attempting MQTT connection to " + String(MqttServer) + ":" +
            String(MqttPort) + "... ").c_str());


### PR DESCRIPTION
The MQTT broker can change address if its IP is not static.

Add MQTT_SERVER_AUTODETECT_ENABLE option which detects the broker that
advertises the service _mqtt._tcp

If the broker changes address it won't be a problem. If the broker
doesn't advertise the service, then use the pre-configured IP as before.

Example testing on Debian:

```
$ apt install mosquitto avahi-daemon

$ cat <<EOT >> /etc/mosquitto/conf.d/my_broker.conf
listener 1883 0.0.0.0
allow_anonymous true
EOT

$ cat <<EOT >> /etc/avahi/services/mqtt.service
<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
<service-group>
  <name replace-wildcards="yes">%h</name>
  <service protocol="ipv4">
    <type>_mqtt._tcp</type>
    <port>1883</port>
  </service>
</service-group>
EOT

$ systemctl start mosquitto
$ systemctl start avahi-daemon
```