### PR TITLE
FUJITSU: Improve handling of short (command only) messages.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -4252,7 +4252,7 @@ namespace IRAcUtils {
       case decode_type_t::FUJITSU_AC: {
         IRFujitsuAC ac(kGpioUnused);
         ac.setRaw(decode->state, decode->bits / 8);
-        *result = ac.toCommon();
+        *result = ac.toCommon(prev);
         break;
       }
 #endif  // DECODE_FUJITSU_AC

--- a/src/ir_Fujitsu.cpp
+++ b/src/ir_Fujitsu.cpp
@@ -250,8 +250,7 @@ bool IRFujitsuAC::isLongCode(void) const {
 /// @return PTR to a code for this protocol based on the current internal state.
 uint8_t* IRFujitsuAC::getRaw(void) {
   checkSum();
-  if (isLongCode()) return _.longcode;
-  return _.shortcode;
+  return isLongCode() ? _.longcode : _.shortcode;
 }
 
 /// Build the internal state/config from the current (raw) A/C message.

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -1,5 +1,5 @@
 // Copyright 2017 Jonny Graham
-// Copyright 2018-2021 David Conran
+// Copyright 2018-2022 David Conran
 // Copyright 2021 siriuslzx
 
 /// @file
@@ -206,6 +206,7 @@ class IRFujitsuAC {
   bool setRaw(const uint8_t newState[], const uint16_t length);
   uint8_t getStateLength(void);
   static bool validChecksum(uint8_t* state, const uint16_t length);
+  bool isLongCode(void) const;
   void setPower(const bool on);
   void off(void);
   void on(void);
@@ -233,7 +234,7 @@ class IRFujitsuAC {
   static uint8_t convertFan(stdAc::fanspeed_t speed);
   static stdAc::opmode_t toCommonMode(const uint8_t mode);
   static stdAc::fanspeed_t toCommonFanSpeed(const uint8_t speed);
-  stdAc::state_t toCommon(void) const;
+  stdAc::state_t toCommon(const stdAc::state_t *prev = NULL);
   String toString(void) const;
 #ifndef UNIT_TEST
 

--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -250,6 +250,7 @@ class IRFujitsuAC {
   fujitsu_ac_remote_model_t _model;
   uint8_t _state_length;
   uint8_t _state_length_short;
+  bool _rawstatemodified;
   void checkSum(void);
   bool updateUseLongOrShort(void);
   void buildFromState(const uint16_t length);

--- a/test/ir_Fujitsu_test.cpp
+++ b/test/ir_Fujitsu_test.cpp
@@ -318,9 +318,7 @@ TEST(TestDecodeFujitsuAC, SyntheticShortMessages) {
   uint8_t expected_arrah2e[7] = {0x14, 0x63, 0x0, 0x10, 0x10, 0x02, 0xFD};
   EXPECT_STATE_EQ(expected_arrah2e, irsend.capture.state, irsend.capture.bits);
   EXPECT_EQ(
-      "Model: 1 (ARRAH2E), Id: 0, Power: Off, Mode: 0 (Auto), Temp: 16C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
-      "Timer: Off",
+      "Model: 1 (ARRAH2E), Id: 0, Power: Off, Command: N/A",
       IRAcUtils::resultAcToString(&irsend.capture));
   stdAc::state_t r, p;
   ASSERT_TRUE(IRAcUtils::decodeToState(&irsend.capture, &r, &p));
@@ -617,9 +615,7 @@ TEST(TestIRFujitsuACClass, toCommon) {
 
   // Now test it.
   EXPECT_EQ(    // Off mode technically has no temp, mode, fan, etc.
-      "Model: 1 (ARRAH2E), Id: 0, Power: Off, Mode: 0 (Auto), Temp: 16C, "
-      "Fan: 0 (Auto), Clean: Off, Filter: Off, Swing: 0 (Off), Command: N/A, "
-      "Timer: Off",
+      "Model: 1 (ARRAH2E), Id: 0, Power: Off, Command: N/A",
       ac.toString());
   ASSERT_EQ(decode_type_t::FUJITSU_AC, ac.toCommon().protocol);
   ASSERT_EQ(fujitsu_ac_remote_model_t::ARRAH2E, ac.toCommon().model);


### PR DESCRIPTION
* Add previous state support to `toCommon()`.
  - Try to better keep the settings if we can when using the `IRac` class interface, if supplied a previous state. This better handles the short commands that don't have most of the settings in them.
  - Add unit tests to ensure it works as expected.
* If we only have info from a _real_ short (command only) message, don't report other settings.
  - This makes text for single messages more accurate.
  - If the Class's state has been modified synthetically, report all the settings.

For #1780
