### PR TITLE
Fix #if for DECODE_COOLIX48

### DIFF
--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -719,7 +719,7 @@ void IRsend::sendCoolix48(const uint64_t data, const uint16_t nbits,
 }
 #endif  // SEND_COOLIX48
 
-#if DECODE_COOLIX
+#if DECODE_COOLIX48
 /// Decode the supplied Coolix 48-bit A/C message.
 /// Status: BETA / Probably Working.
 /// @param[in,out] results Ptr to the data to decode & where to store the decode


### PR DESCRIPTION
I believe there is a typo in the `#if` condition, it should be `DECODE_COOLIX48` and not `DECODE_COOLIX`