### PR TITLE
Fujitsu General: update supported devices

### DIFF
--- a/src/ir_Fujitsu.h
+++ b/src/ir_Fujitsu.h
@@ -40,6 +40,7 @@
 //   Brand: Fujitsu,  Model: AR-REW1E remote (ARREW4E)
 //   Brand: Fujitsu,  Model: AR-REG1U remote (ARRAH2E)
 //   Brand: OGeneral,  Model: AR-RCL1E remote (ARRAH2E)
+//   Brand: Fujitsu General,  Model: AR-JW17 remote (ARDB1)
 
 #ifndef IR_FUJITSU_H_
 #define IR_FUJITSU_H_


### PR DESCRIPTION
Add the Fujitsu General "AR-JW17" remote as a supported device (tested with Tasmota IR and IRrecvDumpV3), it's basically the same remote as the "AR-JW2" except for the horizontal swing.

![fujitsu_ar-jw17](https://user-images.githubusercontent.com/29929941/169891405-6b1bb3be-cf0b-4d1d-8699-c8744ff95b42.jpg)

