### PR TITLE
Update IRac.cpp to also control left vane of Mitsubishi AC when command sent from generic IRac

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -1642,6 +1642,7 @@ void IRac::mitsubishi(IRMitsubishiAC *ac,
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
   ac->setVane(ac->convertSwingV(swingv));
+  ac->setVaneLeft(ac->convertSwingV(swingv));
   ac->setWideVane(ac->convertSwingH(swingh));
   if (quiet) ac->setFan(kMitsubishiAcFanSilent);
   ac->setISave10C(false);


### PR DESCRIPTION
Mitsubishi AC, when sent from generic IRac only controls the right vane. Make the left vane use the same setting.