### PR TITLE
Give IRmacros.h smaller scope to avoid impacting projects using IRremoteESP8266

### DIFF
--- a/src/IRremoteESP8266.h
+++ b/src/IRremoteESP8266.h
@@ -52,8 +52,6 @@
 #include <string>
 #endif  // UNIT_TEST
 
-#include "IRmacros.h"
-
 // Library Version Information
 // Major version number (X.x.x)
 #define _IRREMOTEESP8266_VERSION_MAJOR 2

--- a/src/IRtext.cpp
+++ b/src/IRtext.cpp
@@ -11,6 +11,8 @@
 #include "IRremoteESP8266.h"
 #include "i18n.h"
 
+#include "IRmacros.h"
+
 #ifndef PROGMEM
 #define PROGMEM  // Pretend we have the PROGMEM macro even if we really don't.
 #endif


### PR DESCRIPTION
Most projects use IRremoteESP8266 by including the `IRremoteESP8266.h` file.
To avoid unexpectedly impacting these projects it is safer to move the include to *only* where it is to be used.