### PR TITLE
Argo sendSensorTemp

### DIFF
--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -68,10 +68,10 @@ void IRArgoAC::send(const uint16_t repeat) {
 /// message (no acknowledgement from the device).
 /// @param[in] temp The temperature in degrees celsius.
 /// @param[in] repeat Nr. of times the message will be repeated.
-void IRArgoAC::sendTemperature(const uint8_t temp, const uint16_t repeat) {
-    unsigned char tempc = temp - kArgoTempDelta;
-    unsigned char check = 52 + tempc;
-    unsigned char end = 0b011;
+void IRArgoAC::sendSensorTemp(const uint8_t temp, const uint16_t repeat) {
+    uint8_t tempc = temp - kArgoTempDelta;
+    uint8_t check = 52 + tempc;
+    uint8_t end = 0b011;
 
     ArgoProtocol data;
     data.raw[0] = 0b10101100;

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -63,6 +63,27 @@ void IRArgoAC::begin(void) { _irsend.begin(); }
 void IRArgoAC::send(const uint16_t repeat) {
   _irsend.sendArgo(getRaw(), kArgoStateLength, repeat);
 }
+
+/// Send current room temperature for the iFeel feature as a silent IR message (no acknowledgement from the device).
+/// @param[in] temp The temperature in degrees celsius.
+/// @param[in] repeat Nr. of times the message will be repeated.
+void IRArgoAC::sendTemperature(const uint8_t temp, const uint16_t repeat) {
+    unsigned char tempc = temp - kArgoTempDelta;
+    unsigned char check = 52 + tempc;
+    unsigned char end = 0b011;
+
+    ArgoProtocol data;
+    data.raw[0] = 0b10101100;
+    data.raw[1] = 0b11110101;
+    data.raw[2] = (tempc << 3) | (check >> 5);
+    data.raw[3] = (check << 3) | end;
+    for (uint8_t i = 4; i < kArgoStateLength; i++) data.raw[i] = 0x0;
+    uint8_t sum = IRArgoAC::calcChecksum(data.raw, kArgoStateLength);
+    data.raw[10] = 0b00000010;
+    data.Sum = sum;
+
+    _irsend.sendArgo(data.raw, kArgoStateLength, repeat);
+}
 #endif  // SEND_ARGO
 
 /// Verify the checksum is valid for a given state.

--- a/src/ir_Argo.cpp
+++ b/src/ir_Argo.cpp
@@ -64,7 +64,8 @@ void IRArgoAC::send(const uint16_t repeat) {
   _irsend.sendArgo(getRaw(), kArgoStateLength, repeat);
 }
 
-/// Send current room temperature for the iFeel feature as a silent IR message (no acknowledgement from the device).
+/// Send current room temperature for the iFeel feature as a silent IR
+/// message (no acknowledgement from the device).
 /// @param[in] temp The temperature in degrees celsius.
 /// @param[in] repeat Nr. of times the message will be repeated.
 void IRArgoAC::sendTemperature(const uint8_t temp, const uint16_t repeat) {

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -131,6 +131,7 @@ class IRArgoAC {
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
+  void sendTemperature(const uint8_t temp, const uint16_t repeat = kArgoDefaultRepeat);
   /// Run the calibration to calculate uSec timing offsets for this platform.
   /// @return The uSec timing offset needed per modulation of the IR Led.
   /// @note This will produce a 65ms IR signal pulse at 38kHz.

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -131,8 +131,8 @@ class IRArgoAC {
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
-  void sendTemperature(const uint8_t temp,
-                       const uint16_t repeat = kArgoDefaultRepeat);
+  void sendSensorTemp(const uint8_t temp,
+                      const uint16_t repeat = kArgoDefaultRepeat);
   /// Run the calibration to calculate uSec timing offsets for this platform.
   /// @return The uSec timing offset needed per modulation of the IR Led.
   /// @note This will produce a 65ms IR signal pulse at 38kHz.

--- a/src/ir_Argo.h
+++ b/src/ir_Argo.h
@@ -131,7 +131,8 @@ class IRArgoAC {
 
 #if SEND_ARGO
   void send(const uint16_t repeat = kArgoDefaultRepeat);
-  void sendTemperature(const uint8_t temp, const uint16_t repeat = kArgoDefaultRepeat);
+  void sendTemperature(const uint8_t temp,
+                       const uint16_t repeat = kArgoDefaultRepeat);
   /// Run the calibration to calculate uSec timing offsets for this platform.
   /// @return The uSec timing offset needed per modulation of the IR Led.
   /// @note This will produce a 65ms IR signal pulse at 38kHz.


### PR DESCRIPTION
When using the iFeel functionality the remote regularly sends silent (i.e. no beep) messages to the Argo unit to update the current temperature. This function adds the ability to send such messages.

On a side note, to capture normal Argo IR messages using IRrecv::decodeArgo I had to reduce kArgoBits and disable the checksum, likely because the message wasn't fully recorded. To capture these temperature messages I had to use nbits = 32.