### PR TITLE
Add light pause to ESP32

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -405,6 +405,17 @@ void IRrecv::disableIRIn(void) {
 #endif  // UNIT_TEST
 }
 
+/// Pause collection of received IR data.
+/// @see IRrecv class constructor
+void IRrecv::pause(void) {
+  params.rcvstate = kStopState;
+  params.rawlen = 0;
+  params.overflow = false;
+#if defined(ESP32)
+  gpio_intr_disable((gpio_num_t)params.recvpin);
+#endif  // ESP32
+}
+
 /// Resume collection of received IR data.
 /// @note This is required if `decode()` is successful and `save_buffer` was
 ///   not set when the class was instanciated.
@@ -415,6 +426,7 @@ void IRrecv::resume(void) {
   params.overflow = false;
 #if defined(ESP32)
   timerAlarmDisable(timer);
+  gpio_intr_enable((gpio_num_t)params.recvpin);
 #endif  // ESP32
 }
 

--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -137,6 +137,7 @@ class IRrecv {
               uint8_t max_skip = 0, uint16_t noise_floor = 0);
   void enableIRIn(const bool pullup = false);
   void disableIRIn(void);
+  void pause(void);
   void resume(void);
   uint16_t getBufSize(void);
 #if DECODE_HASH


### PR DESCRIPTION
In Tasmota, we generally turn off IR receive while sending IR, to avoid triggering the decoder and potentially polluting timing. However repeatedly calling `disableIRIn()` and `enableIRIn()` cause a crash on ESP32 for unresolved reasons.

However we only need to pause reception, not deconfigure it completely. I propose to add `pause()` to `IRrecv` as a lightweight option to suspend receiving IR.

It has already been tested on Tasmota and proved to work fine.