### PR TITLE
[Bugfix] Handle gcc unsupported __VA_OPT___ macro (#1880)

### DIFF
--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -34,7 +34,7 @@
 #if !VA_OPT_SUPPORTED
 // #pragma message("Compiler without __VA_OPT__ support")
 #define COND(cond, a, b) a
-#else
+#else  // !VA_OPT_SUPPORTED
 #define NOTHING
 #define EXPAND(...) __VA_ARGS__
 #define STUFF_P(a, ...) __VA_OPT__(a)
@@ -44,7 +44,7 @@
 #define NEGATE(a) VA_TEST(a, a)
 #define COND_P(cond, a, b) STUFF(a, cond)STUFF(b, NEGATE(cond))
 #define COND(cond, a, b) EXPAND(COND_P(cond, a, b))
-#endif
+#endif  // !VA_OPT_SUPPORTED
 /// @endcond
 /**
  * end of COND() set of macros

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -6,29 +6,16 @@
 /// @file IRmacros.h
 
 /**
- * PP_NARG() macro get number of arguments provided
- * Source:
- * http://jonjagger.blogspot.com/2010/11/c-macro-magic-ppnarg.html
- * ('base' version)
+ * VA_OPT_SUPPORTED macro to check if __VA_OPT__ is supported
+ * Source: https://stackoverflow.com/questions/48045470/
+ * portably-detect-va-opt-support
+ * (answer by cpplearner)
  */
-/// @cond TEST
-#ifndef __VA_OPT__
-#define __VA_OPT__(...)
-#endif
-#define PP_NARG(...) \
-    PP_NARG_(__VA_ARGS__, PP_RSEQ_N())
-
-#define PP_NARG_(...) \
-    PP_ARG_N(__VA_ARGS__)
-
-#define PP_ARG_N( \
-    _1, _2, _3, _4, _5, _6, N, ...)   (N)
-
-#define PP_RSEQ_N() \
-    6, 5, 4, 3, 2, 1, 0
-/// @endcond
+#define PP_THIRD_ARG(a, b, c, ...) c
+#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(, ), true, false, )
+#define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 /**
- * PP_NARG() end
+ * VA_OPT_SUPPORTED end
  */
 
 /**
@@ -43,7 +30,8 @@
  * NB: If __VA_OPT__ macro not supported, the <true_result> will be expanded!
  */
 /// @cond TEST
-#if PP_NARG(__VA_OPT__(, )) != 2
+#if !VA_OPT_SUPPORTED
+// #pragma message("Compiler without __VA_OPT__ support")
 #define COND(cond, a, b) a
 #else
 #define NOTHING

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -6,6 +6,29 @@
 /// @file IRmacros.h
 
 /**
+ * PP_NARG() macro get number of arguments provided
+ * Source:
+ * http://jonjagger.blogspot.com/2010/11/c-macro-magic-ppnarg.html
+ * ('base' version)
+ */
+/// @cond TEST
+#define PP_NARG(...) \
+    PP_NARG_(__VA_ARGS__, PP_RSEQ_N())
+
+#define PP_NARG_(...) \
+    PP_ARG_N(__VA_ARGS__)
+
+#define PP_ARG_N( \
+    _1, _2, _3, _4, _5, _6, N, ...)   (N)
+
+#define PP_RSEQ_N() \
+    6,5,4,3,2,1,0
+/// @endcond
+/**
+ * PP_NARG() end
+ */
+
+/**
  * COND() Set of macros to facilitate single-line conditional compilation
  * argument checking.
  * Found here: https://www.reddit.com/r/C_Programming/comments/ud3xrv/
@@ -13,8 +36,13 @@
  * 
  * Usage:
  * COND(<define_to_test>[||/&&<more_define>...], <true_result>, <false_result>)
+ * 
+ * NB: If __VA_OPT__ macro not supported, the <true_result> will be expanded!
  */
 /// @cond TEST
+#if PP_NARG(__VA_OPT__(,)) != 2
+#define COND(cond, a, b) a
+#else
 #define NOTHING
 #define EXPAND(...) __VA_ARGS__
 #define STUFF_P(a, ...) __VA_OPT__(a)
@@ -24,6 +52,7 @@
 #define NEGATE(a) VA_TEST(a, a)
 #define COND_P(cond, a, b) STUFF(a, cond)STUFF(b, NEGATE(cond))
 #define COND(cond, a, b) EXPAND(COND_P(cond, a, b))
+#endif
 /// @endcond
 /**
  * end of COND() set of macros

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -11,9 +11,11 @@
  * portably-detect-va-opt-support
  * (answer by cpplearner)
  */
+/// @cond TEST
 #define PP_THIRD_ARG(a, b, c, ...) c
 #define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(, ), true, false, )
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
+/// @endcond
 /**
  * VA_OPT_SUPPORTED end
  */

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -12,6 +12,9 @@
  * ('base' version)
  */
 /// @cond TEST
+#ifndef __VA_OPT__
+#define __VA_OPT__(...)
+#endif
 #define PP_NARG(...) \
     PP_NARG_(__VA_ARGS__, PP_RSEQ_N())
 
@@ -22,7 +25,7 @@
     _1, _2, _3, _4, _5, _6, N, ...)   (N)
 
 #define PP_RSEQ_N() \
-    6,5,4,3,2,1,0
+    6, 5, 4, 3, 2, 1, 0
 /// @endcond
 /**
  * PP_NARG() end
@@ -40,7 +43,7 @@
  * NB: If __VA_OPT__ macro not supported, the <true_result> will be expanded!
  */
 /// @cond TEST
-#if PP_NARG(__VA_OPT__(,)) != 2
+#if PP_NARG(__VA_OPT__(, )) != 2
 #define COND(cond, a, b) a
 #else
 #define NOTHING

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -13,7 +13,7 @@
  */
 /// @cond TEST
 #define PP_THIRD_ARG(a, b, c, ...) c
-#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(, ), true, false, )
+#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,), true, false,)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 /// @endcond
 /**

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -14,7 +14,7 @@
 /// @cond TEST
 #define PP_THIRD_ARG(a, b, c, ...) c
 #define VA_OPT_SUPPORTED_I(...) \
-            PP_THIRD_ARG(__VA_OPT__(, ), true, false, false)
+            PP_THIRD_ARG(__VA_OPT__(, false), true, false, false)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 /// @endcond
 /**

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -13,7 +13,8 @@
  */
 /// @cond TEST
 #define PP_THIRD_ARG(a, b, c, ...) c
-#define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,), true, false,)
+#define VA_OPT_SUPPORTED_I(...) \
+            PP_THIRD_ARG(__VA_OPT__(, ), true, false, false)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
 /// @endcond
 /**

--- a/src/IRmacros.h
+++ b/src/IRmacros.h
@@ -7,9 +7,7 @@
 
 /**
  * VA_OPT_SUPPORTED macro to check if __VA_OPT__ is supported
- * Source: https://stackoverflow.com/questions/48045470/
- * portably-detect-va-opt-support
- * (answer by cpplearner)
+ * Source: https://stackoverflow.com/a/48045656
  */
 /// @cond TEST
 #define PP_THIRD_ARG(a, b, c, ...) c


### PR DESCRIPTION
Resolves #1880 

Add check to see if `__VA_OPT__` macro is supported, if not, applies `<true_result>` value for `COND()` macro by default.

This has the side-effect/limitation that all protocol names are included in the build, even if the protocol is not available in the code, but _only_ for compilers dat do _not_ support the `__VA_OPT__` macro, notably gcc 4.8.2 (and older).