### PR TITLE
Fix links in docs/README*.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,15 +43,15 @@ cd ~/Arduino/libraries/IRremoteESP8266 && git pull
 ```
 
 ## Contributing
-If you want to [contribute](.github/CONTRIBUTING.md#how-can-i-contribute) to this project, consider:
-- [Reporting](.github/CONTRIBUTING.md#reporting-bugs) bugs and errors
+If you want to [contribute](../.github/CONTRIBUTING.md#how-can-i-contribute) to this project, consider:
+- [Reporting](../.github/CONTRIBUTING.md#reporting-bugs) bugs and errors
 - Ask for enhancements
 - Improve our documentation
-- [Creating issues](.github/CONTRIBUTING.md#reporting-bugs) and [pull requests](.github/CONTRIBUTING.md#pull-requests)
+- [Creating issues](../.github/CONTRIBUTING.md#reporting-bugs) and [pull requests](../.github/CONTRIBUTING.md#pull-requests)
 - Tell other people about this library
 
 ## Contributors
-Available [here](.github/Contributors.md)
+Available [here](../.github/Contributors.md)
 
 ## Library History
 This library was originally based on Ken Shirriff's work (https://github.com/shirriff/Arduino-IRremote/)

--- a/docs/README_de.md
+++ b/docs/README_de.md
@@ -41,15 +41,15 @@ cd ~/Arduino/libraries/IRremoteESP8266 && git pull
 ```
 
 ## Mithelfen
-Anregungen für die [Mithilfe](.github/CONTRIBUTING.md#how-can-i-contribute) am Projekt:
-- Das [Melden](.github/CONTRIBUTING.md#reporting-bugs) von Bugs und Fehlern
+Anregungen für die [Mithilfe](../.github/CONTRIBUTING.md#how-can-i-contribute) am Projekt:
+- Das [Melden](../.github/CONTRIBUTING.md#reporting-bugs) von Bugs und Fehlern
 - Das Einreichen von Verbesserungs- und Erweiterungsvorschlägen
 - Das Erstellen und Verbessern der Dokumentation
-- Das [Melden von Problemen](.github/CONTRIBUTING.md#reporting-bugs) und Einreichen von [Pull-Requests](.github/CONTRIBUTING.md#pull-requests)
+- Das [Melden von Problemen](../.github/CONTRIBUTING.md#reporting-bugs) und Einreichen von [Pull-Requests](../.github/CONTRIBUTING.md#pull-requests)
 - Anderen Leuten von dieser Bibliothek erzählen
 
 ## Beitragende
-Die Beitragenden sind [hier](.github/Contributors.md) aufgelistet.
+Die Beitragenden sind [hier](../.github/Contributors.md) aufgelistet.
 
 ## Historie der Bibliothek
 Diese Bibliothek basiert auf Ken Shirriff's Vorarbeit (https://github.com/shirriff/Arduino-IRremote/).

--- a/docs/README_fr.md
+++ b/docs/README_fr.md
@@ -46,15 +46,15 @@ cd ~/Arduino/libraries/IRremoteESP8266 && git pull
 ```
 
 ## Contribution
-Si vous voulez  [contribuer](.github/CONTRIBUTING.md#how-can-i-contribute) au projet, pour les erreurs:
-- [Reporting](.github/CONTRIBUTING.md#reporting-bugs) bug et erreurs
+Si vous voulez  [contribuer](../.github/CONTRIBUTING.md#how-can-i-contribute) au projet, pour les erreurs:
+- [Reporting](../.github/CONTRIBUTING.md#reporting-bugs) bug et erreurs
 - Demander des améliorations
 - Améliorer notre documentation
-- [Création d'issues](.github/CONTRIBUTING.md#reporting-bugs) et [pull requests](.github/CONTRIBUTING.md#pull-requests)
+- [Création d'issues](../.github/CONTRIBUTING.md#reporting-bugs) et [pull requests](../.github/CONTRIBUTING.md#pull-requests)
 - Parlez de cettre librairie à d'autres personnes
 
 ## Contributeurs
-disponible [ici](.github/Contributors.md)
+disponible [ici](../.github/Contributors.md)
 
 ## Historique de la bibliothèque
 Elle est basée sur le travail de Shirriff (https://github.com/shirriff/Arduino-IRremote/)


### PR DESCRIPTION
The README files in `docs/` had some broken links. This fixes them.

Signed-off-by: Tristan Andrus <tristan@tristanandrus.com>