### PR TITLE
Sync the on state to power from mode for HA

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -290,7 +290,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.7.1"
+#define _MY_VERSION_ "v1.7.2"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3081,7 +3081,11 @@ void updateClimate(stdAc::state_t *state, const String str,
     state->mode = IRac::strToOpmode(payload.c_str());
 #if MQTT_CLIMATE_HA_MODE
     // When in Home Assistant mode, a Mode of Off, means turn the Power off too.
-    if (state->mode == stdAc::opmode_t::kOff) state->power = false;
+    if (state->mode == stdAc::opmode_t::kOff) {
+      state->power = false;
+    } else {
+      state->power = true;
+    }
 #endif  // MQTT_CLIMATE_HA_MODE
   } else if (str.equals(prefix + F(KEY_TEMP))) {
     state->degrees = payload.toFloat();


### PR DESCRIPTION
I'm setting up the IRMQTTserver to link with HA (first time I've done it with an AC), and running with 2 outputs. I've found that the On state was doing weird things and this is the solution that worked for me (forcing the sync of the power state to On as well).

Please let me know if I missed something - it's been a while since I've had a chance to work on such things :) 

I'm using the `FUJITSU_AC` protocol (not sure it matters, but this one has a completely different "Off" format vs On).