### PR TITLE
IR MQTT Server: HA multi output discovery

### DIFF
--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -290,7 +290,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.7.1"
+#define _MY_VERSION_ "v1.7.2"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -299,7 +299,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.8.0"
+#define _MY_VERSION_ "v1.8.1"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.h
+++ b/examples/IRMQTTServer/IRMQTTServer.h
@@ -290,7 +290,7 @@ const uint16_t kJsonAcStateMaxSize = 1024;  // Bytes
 // ----------------- End of User Configuration Section -------------------------
 
 // Constants
-#define _MY_VERSION_ "v1.7.2"
+#define _MY_VERSION_ "v1.8.0"
 
 const uint8_t kRebootTime = 15;  // Seconds
 const uint8_t kQuickDisplayTime = 2;  // Seconds

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2148,7 +2148,7 @@ void init_vars(void) {
   MqttClimateCmnd = MqttClimate + '/' + MQTT_CLIMATE_CMND + '/';
   // Sub-topic for the climate stat topics.
 #if MQTT_DISCOVERY_ENABLE
-  MqttDiscovery = "homeassistant/climate/" + String(Hostname) + "/config";
+  MqttDiscovery = "homeassistant/climate/" + String(Hostname);
   MqttUniqueId = WiFi.macAddress();
   MqttUniqueId.replace(":", "");
 #endif  // MQTT_DISCOVERY_ENABLE
@@ -2467,7 +2467,11 @@ void handleSendMqttDiscovery(void) {
       " is sent.</p>") +
       addJsReloadUrl(kUrlRoot, kRebootTime, true) +
       htmlEnd());
-  sendMQTTDiscovery(MqttDiscovery.c_str());
+  for (uint16_t i = 0; i < kNrOfIrTxGpios; i++) {
+    String channel_id = "";
+    if (i > 0) channel_id = "_" + String(i);
+    sendMQTTDiscovery(MqttDiscovery.c_str(), channel_id);
+  }
 }
 #endif  // MQTT_DISCOVERY_ENABLE
 
@@ -2640,12 +2644,13 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 }
 
 #if MQTT_DISCOVERY_ENABLE
-void sendMQTTDiscovery(const char *topic) {
+void sendMQTTDiscovery(const char *topic, String &channel_id) {
+  String pub_topic = String(topic) + channel_id + F("/config");
   if (mqtt_client.publish(
-      topic, String(
+      pub_topic.c_str(), String(
       F("{"
-      "\"~\":\"") + MqttClimate + F("\","
-      "\"name\":\"") + MqttHAName + F("\","
+      "\"~\":\"") + MqttClimate + channel_id + F("\","
+      "\"name\":\"") + MqttHAName + channel_id + F("\","
 #if (!MQTT_CLIMATE_HA_MODE)
       // Typically we don't need or use the power command topic if we are using
       // our Home Assistant Climate compatiblity mode. It causes odd behaviour
@@ -2671,9 +2676,9 @@ void sendMQTTDiscovery(const char *topic) {
       "\"swing_modes\":[\"" D_STR_OFF "\",\"" D_STR_AUTO "\",\"" D_STR_HIGHEST
                         "\",\"" D_STR_HIGH "\",\"" D_STR_MIDDLE "\",\""
                         D_STR_LOW "\",\"" D_STR_LOWEST "\"],"
-      "\"uniq_id\":\"") + MqttUniqueId + F("\","
+      "\"uniq_id\":\"") + MqttUniqueId + channel_id + F("\","
       "\"device\":{"
-        "\"identifiers\":[\"") + MqttUniqueId + F("\"],"
+        "\"identifiers\":[\"") + MqttUniqueId + channel_id + F("\"],"
         "\"connections\":[[\"mac\",\"") + WiFi.macAddress() + F("\"]],"
         "\"manufacturer\":\"IRremoteESP8266\","
         "\"model\":\"IRMQTTServer\","

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -2702,7 +2702,7 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 }
 
 #if MQTT_DISCOVERY_ENABLE
-void sendMQTTDiscovery(const char *topic, String &channel_id) {
+void sendMQTTDiscovery(const char *topic, String channel_id) {
   String pub_topic = String(topic) + channel_id + F("/config");
   if (mqtt_client.publish(
       pub_topic.c_str(), String(

--- a/examples/IRMQTTServer/IRMQTTServer.ino
+++ b/examples/IRMQTTServer/IRMQTTServer.ino
@@ -3081,7 +3081,11 @@ void updateClimate(stdAc::state_t *state, const String str,
     state->mode = IRac::strToOpmode(payload.c_str());
 #if MQTT_CLIMATE_HA_MODE
     // When in Home Assistant mode, a Mode of Off, means turn the Power off too.
-    if (state->mode == stdAc::opmode_t::kOff) state->power = false;
+    if (state->mode == stdAc::opmode_t::kOff) {
+      state->power = false;
+    } else {
+      state->power = true;
+    }
 #endif  // MQTT_CLIMATE_HA_MODE
   } else if (str.equals(prefix + F(KEY_TEMP))) {
     state->degrees = payload.toFloat();


### PR DESCRIPTION
When using the server to control more than one AC with Home Assistant, this will send a discovery message for each configured output. The naming and ID matching uses the same as the MQTT implementation (ie: `0` has no extension, `1` has `_1` etc).