### PR TITLE
Fix a bug where we never detached the timer interrupt on ESP32s.

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -399,8 +399,8 @@ void IRrecv::disableIRIn(void) {
 #endif  // ESP8266
 #if defined(ESP32)
   timerAlarmDisable(timer);
-  timerEnd(timer);
   timerDetachInterrupt(timer);
+  timerEnd(timer);
 #endif  // ESP32
   detachInterrupt(params.recvpin);
 #endif  // UNIT_TEST

--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -400,6 +400,7 @@ void IRrecv::disableIRIn(void) {
 #if defined(ESP32)
   timerAlarmDisable(timer);
   timerEnd(timer);
+  timerDetachInterrupt(timer);
 #endif  // ESP32
   detachInterrupt(params.recvpin);
 #endif  // UNIT_TEST


### PR DESCRIPTION
Kudos to @homy-newfs8 for finding, isolating, and providing a suggested fix for the bug.

Fixes #1983