### PR TITLE
Add a d1_mini_noMDNS build option to IRMQTTServer.

### DIFF
--- a/examples/IRMQTTServer/platformio.ini
+++ b/examples/IRMQTTServer/platformio.ini
@@ -38,6 +38,14 @@ lib_deps = ${common_esp8266.lib_deps_external}
 board = d1_mini
 lib_deps = ${common_esp8266.lib_deps_external}
 
+[env:d1_mini_noMDNS]
+board = d1_mini
+build_flags =
+  ${env.build_flags}
+  -DMQTT_SERVER_AUTODETECT_ENABLE=false
+  -DMDNS_ENABLE=false
+lib_deps = ${common_esp8266.lib_deps_external}
+
 [env:d1_mini_no_mqtt]
 board = d1_mini
 build_flags =


### PR DESCRIPTION
Adding an option for those that don't want to use MDNS.