### PR TITLE
Fix undefined `std::round` compilation error

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -13,6 +13,11 @@
 #include <string>
 #endif
 #include <cmath>
+#if __cplusplus >= 201103L && defined(_GLIBCXX_USE_C99_MATH_TR1)
+    using std::roundf;
+#else
+    using ::roundf;
+#endif
 #include "IRsend.h"
 #include "IRremoteESP8266.h"
 #include "IRtext.h"
@@ -489,9 +494,9 @@ void IRac::argo(IRArgoAC *ac,
   ac->begin();
   ac->setPower(on);
   ac->setMode(ac->convertMode(mode));
-  ac->setTemp(static_cast<uint8_t>(std::round(degrees)));
+  ac->setTemp(static_cast<uint8_t>(roundf(degrees)));
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   }
   ac->setiFeel(iFeel);
   ac->setFan(ac->convertFan(fan));
@@ -537,7 +542,7 @@ void IRac::argoWrem3_ACCommand(IRArgoAC_WREM3 *ac, const bool on,
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   }
   ac->setiFeel(iFeel);
   ac->setFan(ac->convertFan(fan));
@@ -563,7 +568,7 @@ void IRac::argoWrem3_ACCommand(IRArgoAC_WREM3 *ac, const bool on,
 void IRac::argoWrem3_iFeelReport(IRArgoAC_WREM3 *ac, const float sensorTemp) {
   ac->begin();
   ac->setMessageType(argoIrMessageType_t::IFEEL_TEMP_REPORT);
-  ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+  ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   ac->send();
 }
 
@@ -738,7 +743,7 @@ void IRac::coolix(IRCoolixAC *ac,
   // No Econo setting available.
   // No Quiet setting available.
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   } else {
     ac->clearSensorTemp();
   }
@@ -1128,7 +1133,7 @@ void IRac::ecoclim(IREcoclimAc *ac,
   ac->setTemp(degrees);
   ac->setFan(ac->convertFan(fan));
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   } else {
     ac->setSensorTemp(degrees);  //< Set to the desired temp
                                  //  until we can disable.
@@ -1174,7 +1179,7 @@ void IRac::electra(IRElectraAc *ac,
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   }
   ac->setFan(ac->convertFan(fan));
   ac->setSwingV(swingv != stdAc::swingv_t::kOff);
@@ -2288,7 +2293,7 @@ void IRac::sanyo(IRSanyoAc *ac,
   ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
   if (sensorTemp != kNoTempValue) {
-    ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
+    ac->setSensorTemp(static_cast<uint8_t>(roundf(sensorTemp)));
   } else {
     ac->setSensorTemp(degrees);  // Set the sensor temp to the desired
                                  // (normal) temp.


### PR DESCRIPTION
In some implementations round is at the global scope as `::round` and some other implementations make it available as `std::round`.

The changes use the `float roundf(float)` flavor to make sure that we don't use `double round(double)` if this function isn't overloaded with the float type.

Here is the error that it fixes when compiling https://github.com/sharandac/My-TTGO-Watch/:

```log
Building in release mode
Compiling .pio/build/t-watch2020-v3/lib878/IRremoteESP8266/IRac.cpp.o
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::argo(IRArgoAC*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, stdAc::swingv_t, bool, bool, int16_t)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:492:36: error: 'round' is not a member of 'std'
   ac->setTemp(static_cast<uint8_t>(std::round(degrees)));
                                    ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:492:36: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:494:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:494:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::argoWrem3_ACCommand(IRArgoAC_WREM3*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, stdAc::swingv_t, bool, bool, bool, bool, bool, bool)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:540:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:540:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::argoWrem3_iFeelReport(IRArgoAC_WREM3*, float)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:566:42: error: 'round' is not a member of 'std'
   ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                          ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:566:42: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::coolix(IRCoolixAC*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, stdAc::swingv_t, stdAc::swingh_t, bool, bool, bool, bool, int16_t)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:741:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:741:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::ecoclim(IREcoclimAc*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, int16_t, int16_t)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:1131:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:1131:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::electra(IRElectraAc*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, stdAc::swingv_t, stdAc::swingh_t, bool, bool, bool, bool)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:1177:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:1177:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp: In member function 'void IRac::sanyo(IRSanyoAc*, bool, stdAc::opmode_t, float, float, stdAc::fanspeed_t, stdAc::swingv_t, bool, bool, int16_t)':
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:2291:44: error: 'round' is not a member of 'std'
     ac->setSensorTemp(static_cast<uint8_t>(std::round(sensorTemp)));
                                            ^
.pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:2291:44: note: suggested alternative:
In file included from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/esp32-hal.h:34:0,
                 from /Users/devnoname120/.platformio/packages/framework-arduinoespressif32/cores/esp32/Arduino.h:35,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.h:7,
                 from .pio/libdeps/t-watch2020-v3/IRremoteESP8266/src/IRac.cpp:7:
/Users/devnoname120/.platformio/packages/framework-arduinoespressif32/tools/sdk/include/newlib/math.h:278:15: note:   'round'
 extern double round _PARAMS((double));
               ^
*** [.pio/build/t-watch2020-v3/lib878/IRremoteESP8266/IRac.cpp.o] Error 1
```
