### PR TITLE
Ensure the `sleep` parameter is used for the `FUJITSU_AC` protocol.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3234,7 +3234,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       fujitsu(&ac, (fujitsu_ac_remote_model_t)send.model, send.power, send.mode,
               send.celsius, send.degrees, send.fanspeed,
               send.swingv, send.swingh, send.quiet,
-              send.turbo, send.econo, send.filter, send.clean);
+              send.turbo, send.econo, send.filter, send.clean, send.sleep);
       break;
     }
 #endif  // SEND_FUJITSU_AC

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -669,7 +669,8 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Turbo (Powerful)
                false,                       // Econo
                true,                        // Filter
-               true);                       // Clean
+               true,                        // Clean
+               -1);                         // Sleep
   ASSERT_EQ(ardb1_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -719,7 +720,8 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Turbo (Powerful)
                false,                       // Econo
                true,                        // Filter
-               true);                       // Clean
+               true,                        // Clean
+               -1);                         // Sleep
   ASSERT_EQ(arry4_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));
@@ -742,8 +744,9 @@ TEST(TestIRac, Fujitsu) {
                false,                       // Quiet
                false,                       // Turbo (Powerful)
                false,                       // Econo
-               false,                        // Filter
-               false);                       // Clean
+               false,                       // Filter
+               false,                       // Clean
+               -1);                         // Sleep
   ASSERT_EQ(arrew4e_expected, ac.toString());
   ac._irsend.makeDecodeResult();
   EXPECT_TRUE(capture.decode(&ac._irsend.capture));


### PR DESCRIPTION
It seems we were not passing it on in the `IRac` class.
Fixes #1991