### PR TITLE
IRac::isProtocolSupported() — do not list WHIRLPOOL_AC unconditionally as supported protocol

### DIFF
--- a/examples/IRrecvDumpV2/platformio.ini
+++ b/examples/IRrecvDumpV2/platformio.ini
@@ -64,4 +64,9 @@ build_flags = -D_IR_LOCALE_=zh-CN  ;  Chinese (Simplified)
 ; Build the library with all protocols disabled to flush out #if/#ifdef issues &
 ; any compiler warnings, by turning them into errors.
 [env:shakedown_no_protocols]
-build_flags = -D_IR_ENABLE_DEFAULT_=false -Werror -Wno-error=switch
+build_flags =
+  ${env.build_flags}
+  -Werror
+  -Wno-error=switch
+  -Wno-error=switch-unreachable
+  -D_IR_ENABLE_DEFAULT_=false

--- a/examples/SmartIRRepeater/platformio.ini
+++ b/examples/SmartIRRepeater/platformio.ini
@@ -34,4 +34,5 @@ build_flags =
   ${env.build_flags}
   -Werror
   -Wno-error=switch
+  -Wno-error=switch-unreachable
   -D_IR_ENABLE_DEFAULT_=false

--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -371,7 +371,9 @@ bool IRac::isProtocolSupported(const decode_type_t protocol) {
 #if SEND_YORK
     case decode_type_t::YORK:
 #endif
+#if SEND_WHIRLPOOL_AC
     case decode_type_t::WHIRLPOOL_AC:
+#endif
       return true;
     default:
       return false;


### PR DESCRIPTION
It is reported as such when in Tasmota the command IRHVAC {"Vendor":"ABC"} is sent.

I know this replaces one problem (I have) with another problem (which I do not have).