### PR TITLE
Add basic support for YX1F8F remote

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -157,6 +157,7 @@ enum gree_ac_remote_model_t {
   YBOFB,      // (2) Green, YBOFB2, YAPOF3
   YX1FSF,     // (3) Soleus Air window unit (Similar to YAW1F, but with an
               //     Operation mode of Energy Saver (Econo))
+  YX1F8F,     // Similiar to YX1FSF
 };
 
 /// HAIER_AC176 A/C model numbers

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -218,7 +218,8 @@ void IRGreeAC::off(void) { setPower(false); }
 void IRGreeAC::setPower(const bool on) {
   _.Power = on;
   // May not be needed. See #814
-  _.ModelA = (on && (_model == gree_ac_remote_model_t::YAW1F || _model == gree_ac_remote_model_t::YX1F8F));
+  _.ModelA = (on && (_model == gree_ac_remote_model_t::YAW1F
+                  || _model == gree_ac_remote_model_t::YX1F8F));
 }
 
 /// Get the value of the current power setting.

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -218,7 +218,7 @@ void IRGreeAC::off(void) { setPower(false); }
 void IRGreeAC::setPower(const bool on) {
   _.Power = on;
   // May not be needed. See #814
-  _.ModelA = (on && _model == gree_ac_remote_model_t::YAW1F);
+  _.ModelA = (on && (_model == gree_ac_remote_model_t::YAW1F || _model == gree_ac_remote_model_t::YX1F8F));
 }
 
 /// Get the value of the current power setting.

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -122,8 +122,16 @@ void IRGreeAC::stateReset(void) {
   std::memset(_.remote_state, 0, sizeof _.remote_state);
   _.Temp = 9;  // _.remote_state[1] = 0x09;
   _.Light = true;  // _.remote_state[2] = 0x20;
-  _.unknown1 = 5;  // _.remote_state[3] = 0x50;
-  _.unknown2 = 4;  // _.remote_state[5] = 0x20;
+
+  if (_model == gree_ac_remote_model_t::YX1F8F) {
+      _.unknown1 = 10;  // _.remote_state[3] = 0x0A;
+      _.unknown2 = 0;   // _.remote_state[5] = 0x01;
+      _.unknown3 = 1;   // _.remote_state[5] = 0x01;
+  } else {
+    _.unknown1 = 5;  // _.remote_state[3] = 0x50;
+    _.unknown2 = 4;  // _.remote_state[5] = 0x20;
+    _.unknown3 = 0;  // _.remote_state[5] = 0x20;
+  }
 }
 
 /// Fix up the internal state so it is correct.
@@ -188,7 +196,8 @@ void IRGreeAC::setModel(const gree_ac_remote_model_t model) {
   switch (model) {
     case gree_ac_remote_model_t::YAW1F:
     case gree_ac_remote_model_t::YBOFB:
-    case gree_ac_remote_model_t::YX1FSF: _model = model; break;
+    case gree_ac_remote_model_t::YX1FSF:
+    case gree_ac_remote_model_t::YX1F8F: _model = model; break;
     default: _model = gree_ac_remote_model_t::YAW1F;
   }
 }

--- a/src/ir_Gree.h
+++ b/src/ir_Gree.h
@@ -26,6 +26,7 @@
 //   Brand: Vailland,  Model: YACIFB remote
 //   Brand: Vailland,  Model: VAI5-035WNI A/C
 //   Brand: Soleus Air,  Model: window A/C (YX1FSF)
+//   Brand: Frigidaire, Model: YX1F8F remote
 
 #ifndef IR_GREE_H_
 #define IR_GREE_H_
@@ -76,7 +77,7 @@ union GreeProtocol{
     uint8_t IFeel       :1;
     uint8_t unknown2    :3;  // value = 0b100
     uint8_t WiFi        :1;
-    uint8_t             :1;
+    uint8_t unknown3    :1;  // value = 0b0
     // Byte 6
     uint8_t             :8;
     // Byte 7


### PR DESCRIPTION
This merge request adds basic support for the YX1F8F remote. This includes support for setting temperature, fan, and mode (including a new eco mode).

It does not currently include support for using the timer functionality. That requires sending 3 packets, of which the middle packet seems to contain an internal timer countdown reference that is tracked by the remote. I have mapped that packet out, but need to see if the timer value actually affects the internal timer on the AC unit or not.