### PR TITLE
Fix compilation dependency of LG on Samsung send protocol

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -310,11 +310,12 @@ class IRsend {
   void sendSherwood(uint64_t data, uint16_t nbits = kSherwoodBits,
                     uint16_t repeat = kSherwoodMinRepeat);
 #endif
-#if SEND_SAMSUNG
+  // `sendSAMSUNG()` is required by `sendLG()`
+#if (SEND_SAMSUNG || SEND_LG)
   void sendSAMSUNG(const uint64_t data, const uint16_t nbits = kSamsungBits,
                    const uint16_t repeat = kNoRepeat);
   uint32_t encodeSAMSUNG(const uint8_t customer, const uint8_t command);
-#endif
+#endif  // (SEND_SAMSUNG || SEND_LG)
 #if SEND_SAMSUNG36
   void sendSamsung36(const uint64_t data, const uint16_t nbits = kSamsung36Bits,
                      const uint16_t repeat = kNoRepeat);

--- a/src/ir_Samsung.cpp
+++ b/src/ir_Samsung.cpp
@@ -82,7 +82,8 @@ using irutils::addTempToString;
 using irutils::addToggleToString;
 using irutils::minsToString;
 
-#if SEND_SAMSUNG
+// This sending protocol is used by some other protocols. e.g. LG.
+#if (SEND_SAMSUNG || SEND_LG)
 /// Send a 32-bit Samsung formatted message.
 /// Status: STABLE / Should be working.
 /// @param[in] data The message to be sent.
@@ -112,7 +113,7 @@ uint32_t IRsend::encodeSAMSUNG(const uint8_t customer, const uint8_t command) {
   return ((revcommand ^ 0xFF) | (revcommand << 8) | (revcustomer << 16) |
           (revcustomer << 24));
 }
-#endif
+#endif  // (SEND_SAMSUNG || SEND_LG)
 
 #if DECODE_SAMSUNG
 /// Decode the supplied Samsung 32-bit message.


### PR DESCRIPTION
`sendSAMSUNG()` is needed by `sendLG()`, so fix the `#ifdef`s appropriately.

i.e. Compilation shouldn't break if `SEND_LG == TRUE` and `SEND_SAMSUNG == FALSE`

Fixes #2010