### PR TITLE
Allow the BlynkIRRemote.ino code to compile again.

### DIFF
--- a/examples/BlynkIrRemote/BlynkIrRemote.ino
+++ b/examples/BlynkIrRemote/BlynkIrRemote.ino
@@ -104,6 +104,8 @@
 
 /* Comment this out to disable prints and save space */
 #define BLYNK_PRINT Serial
+#define BLYNK_TEMPLATE_ID      "TMPL••••••••"  // Made up values. Please Change.
+#define BLYNK_TEMPLATE_NAME    "My First Device"  // Please Change.
 
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>


### PR DESCRIPTION
Seems something with Blynk has changed. It needs `BLYNK_TEMPLATE_ID` & `BLYNK_TEMPLATE_NAME` defined to compile.
e.g.
https://github.com/crankyoldgit/IRremoteESP8266/actions/runs/5665306257/job/15349934790?pr=2015#step:8:148

```
Compiling .pio/build/esp32dev/libbf0/BlynkNcpDriver/BlynkRpcClientWeakImpl.c.o
In file included from .pio/libdeps/esp32dev/Blynk/src/BlynkApiArduino.h:14,
                 from .pio/libdeps/esp32dev/Blynk/src/BlynkSimpleEsp32.h:20,
                 from /home/runner/work/IRremoteESP8266/IRremoteESP8266/examples/BlynkIrRemote/BlynkIrRemote.ino:115:
.pio/libdeps/esp32dev/Blynk/src/Blynk/BlynkApi.h:39:6: error: #error "Please specify your BLYNK_TEMPLATE_ID and BLYNK_TEMPLATE_NAME"
     #error "Please specify your BLYNK_TEMPLATE_ID and BLYNK_TEMPLATE_NAME"
      ^~~~~
```