### PR TITLE
Remove unused constant `kRcmmExcess`

### DIFF
--- a/src/ir_RCMM.cpp
+++ b/src/ir_RCMM.cpp
@@ -35,7 +35,6 @@ const uint16_t kRcmmMinGapTicks = 120;
 const uint32_t kRcmmMinGap = 3360;
 // Use a tolerance of +/-10% when matching some data spaces.
 const uint8_t kRcmmTolerance = 10;
-const uint16_t kRcmmExcess = 50;
 
 #if SEND_RCMM
 /// Send a Philips RC-MM packet.


### PR DESCRIPTION
Per https://github.com/crankyoldgit/IRremoteESP8266/issues/2031#issuecomment-1702159536