### PR TITLE
Daikin: Support setting temperature in 0.5 C unit

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -225,12 +225,12 @@ bool IRDaikinESP::getPower(void) const {
 void IRDaikinESP::setTemp(const float temp) {
   float degrees = std::max(temp, static_cast<float>(kDaikinMinTemp));
   degrees = std::min(degrees, static_cast<float>(kDaikinMaxTemp));
-  _.Temp2 = degrees * 2.0f;
+  _.Temp = degrees * 2.0f;
 }
 
 /// Get the current temperature setting.
 /// @return The current setting for temp. in degrees celsius.
-float IRDaikinESP::getTemp(void) const { return _.Temp2 / 2.0f; }
+float IRDaikinESP::getTemp(void) const { return _.Temp / 2.0f; }
 
 /// Set the speed of the fan.
 /// @param[in] fan The desired setting.
@@ -537,7 +537,7 @@ stdAc::state_t IRDaikinESP::toCommon(void) const {
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);
   result.celsius = true;
-  result.degrees = _.Temp2 / 2.0f;
+  result.degrees = getTemp();
   result.fanspeed = toCommonFanSpeed(getFan());
   result.swingv = _.SwingV ? stdAc::swingv_t::kAuto :
                                              stdAc::swingv_t::kOff;
@@ -564,7 +564,7 @@ String IRDaikinESP::toString(void) const {
   result += addBoolToString(_.Power, kPowerStr, false);
   result += addModeToString(_.Mode, kDaikinAuto, kDaikinCool, kDaikinHeat,
                             kDaikinDry, kDaikinFan);
-  result += addTempFloatToString(_.Temp2 / 2.0f);
+  result += addTempFloatToString(getTemp());
   result += addFanToString(getFan(), kDaikinFanMax, kDaikinFanMin,
                            kDaikinFanAuto, kDaikinFanQuiet, kDaikinFanMed);
   result += addBoolToString(_.Powerful, kPowerfulStr);

--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -46,6 +46,7 @@ using irutils::addModeToString;
 using irutils::addSwingHToString;
 using irutils::addSwingVToString;
 using irutils::addTempToString;
+using irutils::addTempFloatToString;
 using irutils::addFanToString;
 using irutils::bcdToUint8;
 using irutils::minsToString;
@@ -221,15 +222,15 @@ bool IRDaikinESP::getPower(void) const {
 
 /// Set the temperature.
 /// @param[in] temp The temperature in degrees celsius.
-void IRDaikinESP::setTemp(const uint8_t temp) {
-  uint8_t degrees = std::max(temp, kDaikinMinTemp);
-  degrees = std::min(degrees, kDaikinMaxTemp);
-  _.Temp = degrees;
+void IRDaikinESP::setTemp(const float temp) {
+  float degrees = std::max(temp, static_cast<float>(kDaikinMinTemp));
+  degrees = std::min(degrees, static_cast<float>(kDaikinMaxTemp));
+  _.Temp2 = degrees * 2.0f;
 }
 
 /// Get the current temperature setting.
 /// @return The current setting for temp. in degrees celsius.
-uint8_t IRDaikinESP::getTemp(void) const { return _.Temp; }
+float IRDaikinESP::getTemp(void) const { return _.Temp2 / 2.0f; }
 
 /// Set the speed of the fan.
 /// @param[in] fan The desired setting.
@@ -536,7 +537,7 @@ stdAc::state_t IRDaikinESP::toCommon(void) const {
   result.power = _.Power;
   result.mode = toCommonMode(_.Mode);
   result.celsius = true;
-  result.degrees = _.Temp;
+  result.degrees = _.Temp2 / 2.0f;
   result.fanspeed = toCommonFanSpeed(getFan());
   result.swingv = _.SwingV ? stdAc::swingv_t::kAuto :
                                              stdAc::swingv_t::kOff;
@@ -563,7 +564,7 @@ String IRDaikinESP::toString(void) const {
   result += addBoolToString(_.Power, kPowerStr, false);
   result += addModeToString(_.Mode, kDaikinAuto, kDaikinCool, kDaikinHeat,
                             kDaikinDry, kDaikinFan);
-  result += addTempToString(_.Temp);
+  result += addTempFloatToString(_.Temp2 / 2.0f);
   result += addFanToString(getFan(), kDaikinFanMax, kDaikinFanMin,
                            kDaikinFanAuto, kDaikinFanQuiet, kDaikinFanMed);
   result += addBoolToString(_.Powerful, kPowerfulStr);

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -99,7 +99,7 @@ union DaikinESPProtocol{
     uint64_t Mode     :3;
     uint64_t          :1;
     // Byte 22
-    uint64_t Temp2    :8;  // Temp2 should be between 20 - 64 (10 C - 32 C)
+    uint64_t Temp     :8;  // Temp should be between 20 - 64 (10 C - 32 C)
     // Byte 23
     uint64_t          :8;
 

--- a/src/ir_Daikin.h
+++ b/src/ir_Daikin.h
@@ -99,8 +99,7 @@ union DaikinESPProtocol{
     uint64_t Mode     :3;
     uint64_t          :1;
     // Byte 22
-    uint64_t          :1;
-    uint64_t Temp     :7;  // Temp should be between 10 - 32
+    uint64_t Temp2    :8;  // Temp2 should be between 20 - 64 (10 C - 32 C)
     // Byte 23
     uint64_t          :8;
 
@@ -738,8 +737,8 @@ class IRDaikinESP {
   void off(void);
   void setPower(const bool on);
   bool getPower(void) const;
-  void setTemp(const uint8_t temp);
-  uint8_t getTemp(void) const;
+  void setTemp(const float temp);
+  float getTemp(void) const;
   void setFan(const uint8_t fan);
   uint8_t getFan(void) const;
   void setMode(const uint8_t mode);


### PR DESCRIPTION
Daikin 280-bit A/C protocol can set the temperature in 0.5 C unit. However, IRDaikinESP didn't support it.
This PR allows to set and get the temperature in 0.5 C unit.

It looks like some other Daikin protocols also support setting the temperature in 0.5 C unit:
* Daikin2
* Daikin216
* Daikin160
* Daikin176
* Daikin152

However, they are not implemented in this PR, because I cannot test them.