### PR TITLE
Partially working tests on macOS

### DIFF
--- a/src/IRutils.cpp
+++ b/src/IRutils.cpp
@@ -262,8 +262,8 @@ String resultToSourceCode(const decode_results * const results) {
   //   "uint32_t address = 0xDEADBEEF;\n"
   //   "uint32_t command = 0xDEADBEEF;\n"
   //   "uint64_t data = 0xDEADBEEFDEADBEEF;" = ~116 chars max.
-  output.reserve(55 + (length * 7) + hasState ? 25 + (results->bits / 8) * 6
-                                              : 116);
+  output.reserve(55 + (length * 7) + (hasState ? 25 + (results->bits / 8) * 6
+                                               : 116));
   // Start declaration
   output += F("uint16_t ");  // variable type
   output += F("rawData[");   // array name

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -112,8 +112,8 @@ void IRCoolixAC::send(const uint16_t repeat) {
   // Typically repeat is `kCoolixDefaultRepeat` which is `1`, so this allows
   // it to be 0 normally for this command, and allows additional repeats if
   // requested rather always 0 for that command.
-  _irsend.sendCOOLIX(getRaw(), kCoolixBits, repeat - (getSwingVStep() &&
-                                                          repeat > 0) ? 1 : 0);
+  _irsend.sendCOOLIX(getRaw(), kCoolixBits, repeat - ((getSwingVStep() &&
+                                                           repeat > 0) ? 1 : 0));
   // make sure to remove special state from the internal state
   // after command has being transmitted.
   recoverSavedState();

--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -240,6 +240,7 @@ void IRLgAc::stateReset(void) {
   _light = true;
   _swingv = kLgAcSwingVOff;
   _swingh = false;
+  _swingh_prev = false;
   for (uint8_t i = 0; i < kLgAcSwingVMaxVanes; i++)
     _vaneswingv[i] = 0;  // Reset to an unused value.
   updateSwingPrev();

--- a/test/ir_Argo_test.cpp
+++ b/test/ir_Argo_test.cpp
@@ -509,7 +509,7 @@ TEST_P(TestArgoConfigViaIRAc_Positive,
   EXPECT_EQ(state.command, r.command);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestIrAc,
   TestArgoConfigViaIRAc_Positive,
   ::testing::Values(
@@ -546,7 +546,7 @@ TEST_P(TestArgoConfigViaIRAc_Negative,
   ASSERT_EQ(nullptr, irac._lastDecodeResults);  // nothing got sent
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestIrAc,
   TestArgoConfigViaIRAc_Negative,
   ::testing::Values(
@@ -565,7 +565,7 @@ INSTANTIATE_TEST_CASE_P(
 
 using IRArgoACBase_typelist = ::testing::Types<ArgoProtocol, ArgoProtocolWREM3>;
 template<class> struct TestArgoACBaseClass : public testing::Test {};
-TYPED_TEST_CASE(TestArgoACBaseClass, IRArgoACBase_typelist);
+TYPED_TEST_SUITE(TestArgoACBaseClass, IRArgoACBase_typelist);
 
 
 TYPED_TEST(TestArgoACBaseClass, SetAndGetTemp) {
@@ -1520,7 +1520,7 @@ TEST_P(TestArgoE2E, RealExampleCommands) {
 }
 
 // Test cases
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestDecodeArgo,
   TestArgoE2E,
   ::testing::Values(

--- a/test/ir_Gorenje_test.cpp
+++ b/test/ir_Gorenje_test.cpp
@@ -84,7 +84,7 @@ TEST_P(TestDecodeGorenjeSyntheticSendTestFixture, SyntheticExample) {
   EXPECT_FALSE(irsend.capture.repeat);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestDecodeGorenje,
   TestDecodeGorenjeSyntheticSendTestFixture,
   ::testing::Values(0x2, 0x8, 0x4, 0x10, 0x20, 0x1));
@@ -112,7 +112,7 @@ TEST_P(TestDecodeGorenjeReceiveTestFixture, RealExample) {
   EXPECT_FALSE(irsend.capture.repeat);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   TestDecodeGorenje,
   TestDecodeGorenjeReceiveTestFixture,
   ::testing::Values(

--- a/test/ir_Hitachi_test.cpp
+++ b/test/ir_Hitachi_test.cpp
@@ -1831,7 +1831,7 @@ TEST(TestIRHitachiAc1Class, FanSpeedInDryMode) {
   ac.setPower(true);
   ac.setPowerToggle(true);
   ac.setMode(kHitachiAc1Dry);
-  ac.setTemp(22.5);
+  ac.setTemp(22);
   ac.setFan(kHitachiAc1FanLow);
   ac.setSwingV(false);
   ac.setSwingH(false);


### PR DESCRIPTION
Fixes four bugs and some warnings found when running the tests on macOS.
ir_Delonghi_test still fails sometimes for some unknown reason.
Also, the unused constants still makes make fail unless -Werror is removed.
It is also unknown if these issues are triggered by clang or macOS/Apple silicon.
This has only been verified to fail on macOS on Apple silicon.