### PR TITLE
Fix compilation error when USB CDC on Boot is enabled

### DIFF
--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -130,6 +130,8 @@ decode_results results;  // Somewhere to store the results
 void setup() {
 #if defined(ESP8266)
   Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
+#elif ARDUINO_USB_CDC_ON_BOOT
+  Serial.begin(kBaudRate);
 #else  // ESP8266
   Serial.begin(kBaudRate, SERIAL_8N1);
 #endif  // ESP8266

--- a/examples/IRrecvDumpV3/IRrecvDumpV3.ino
+++ b/examples/IRrecvDumpV3/IRrecvDumpV3.ino
@@ -138,6 +138,8 @@ void setup() {
   OTAwifi();  // start default wifi (previously saved on the ESP) for OTA
 #if defined(ESP8266)
   Serial.begin(kBaudRate, SERIAL_8N1, SERIAL_TX_ONLY);
+#elif ARDUINO_USB_CDC_ON_BOOT
+  Serial.begin(kBaudRate);
 #else  // ESP8266
   Serial.begin(kBaudRate, SERIAL_8N1);
 #endif  // ESP8266


### PR DESCRIPTION
When USB CDC on Boot is enabled on ESP32-C3, an compilation error occurs, because `Serial.begin()` takes only one (or zero) parameter.

Check `ARDUINO_USB_CDC_ON_BOOT` and call it with the correct parameter.