### PR TITLE
[Bug] Fix the Coolix fan-only mode in IRac class.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -736,8 +736,10 @@ void IRac::coolix(IRCoolixAC *ac,
       ac->send();
       return;
   }
-  ac->setMode(ac->convertMode(mode));
   ac->setTemp(degrees);
+  // Mode needs to be set after temp as Fan-only uses a special temp.
+  ac->setMode(ac->convertMode(mode));
+  // Fan needs to be set after mode, as setMode can change the fan speed.
   ac->setFan(ac->convertFan(fan));
   // No Filter setting available.
   // No Beep setting available.

--- a/test/IRac_test.cpp
+++ b/test/IRac_test.cpp
@@ -247,6 +247,36 @@ TEST(TestIRac, Coolix) {
   ASSERT_EQ(stdAc::ac_command_t::kControlCommand, r.command);
 }
 
+TEST(TestIRac, Coolix_Issue2103) {
+  IRCoolixAC ac(kGpioUnused);
+  IRac irac(kGpioUnused);
+  IRrecv capture(kGpioUnused);
+  char expected[] =
+      "Power: On, Mode: 4 (Fan), Fan: 5 (Auto), Zone Follow: Off, "
+      "Sensor Temp: Off";
+
+  ac.begin();
+  irac.coolix(&ac,
+              true,                        // Power
+              stdAc::opmode_t::kFan,       // Mode
+              21,                          // Celsius
+              kNoTempValue,                // Sensor Temp
+              stdAc::fanspeed_t::kAuto,    // Fan speed
+              stdAc::swingv_t::kOff,       // Vertical swing
+              stdAc::swingh_t::kOff,       // Horizontal swing
+              false,                       // iFeel
+              false,                       // Turbo
+              false,                       // Light
+              false,                       // Clean
+              -1);                         // Sleep
+  ASSERT_EQ(expected, ac.toString());
+  ac._irsend.makeDecodeResult();
+  EXPECT_TRUE(capture.decode(&ac._irsend.capture));
+  ASSERT_EQ(COOLIX, ac._irsend.capture.decode_type);
+  ASSERT_EQ(kCoolixBits, ac._irsend.capture.bits);
+  ASSERT_EQ(expected, IRAcUtils::resultAcToString(&ac._irsend.capture));
+}
+
 TEST(TestIRac, Corona) {
   IRCoronaAc ac(kGpioUnused);
   IRac irac(kGpioUnused);


### PR DESCRIPTION
Mode was being incorrectly set in produced message as a "Dry" command. Adjusting order of when setMode() was called fixes the issue. Add a Unit test to confirm it is fixed and catch this in future.

Fixes #2103