### PR TITLE
library.json specifies libCompatMode strict

### DIFF
--- a/library.json
+++ b/library.json
@@ -46,5 +46,6 @@
   ],
   "exclude": [".github", "extras", "docs", "assets"],
   "frameworks": "arduino",
+  "libCompatMode": "strict",
   "platforms": ["espressif8266", "espressif32"]
 }


### PR DESCRIPTION
This PR is based on platformio's documentation. I will test it next week.

This PR instructs platformio to pay attention to both the `frameworks` AND `platforms` specification before trying to compile IRremoteESP8266.

I would've thought that platformio would do this check by default, but apparently not. By default it only checks `frameworks`. Source: https://docs.platformio.org/en/latest/manifests/library-json/fields/platforms.html

The documentation for libCompatMode can be found here: https://docs.platformio.org/en/latest/manifests/library-json/fields/build/libcompatmode.html#manifest-library-json-build-libcompatmode