### PR TITLE
Update haier160 & HaierYRWO2 to use quiet in the common class.

### DIFF
--- a/src/IRac.cpp
+++ b/src/IRac.cpp
@@ -3279,8 +3279,8 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     {
       IRHaierAC160 ac(_pin, _inverted, _modulation);
       haier160(&ac, send.power, send.mode, send.celsius, send.degrees,
-               send.fanspeed, send.swingv, send.turbo, send.filter, send.clean,
-               send.light, prev_light, send.sleep);
+               send.fanspeed, send.swingv, send.turbo, send.quiet,
+               send.filter, send.clean, send.light, prev_light, send.sleep);
       break;
     }
 #endif  // SEND_HAIER_AC160
@@ -3301,7 +3301,7 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
       IRHaierACYRW02 ac(_pin, _inverted, _modulation);
       haierYrwo2(&ac, send.power, send.mode, send.celsius, send.degrees,
                  send.fanspeed, send.swingv, send.swingh, send.turbo,
-                 send.filter, send.sleep);
+                 send.quiet, send.filter, send.sleep);
       break;
     }
 #endif  // SEND_HAIER_AC_YRW02


### PR DESCRIPTION
Quiet mode operation was missing in the function calls of `haierYrwo2()` and `haier160()` thus passing the wrong arguments to the function. Add the `quiet` parameter in fixes this.

For #2101 