### PR TITLE
Fix `decodeYork()` parameter names & defaults.

### DIFF
--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -879,8 +879,8 @@ class IRrecv {
 #endif  // DECODE_WOWWEE
 #if DECODE_YORK
   bool decodeYork(decode_results *results,
-                  uint16_t kStartOffset,
-                  const uint16_t kYorkBits,
+                  uint16_t offset = kStartOffset,
+                  const uint16_t nbits = kYorkBits,
                   const bool strict = true);
 #endif  // DECODE_YORK
 };


### PR DESCRIPTION
Clean up some code ugliness.
Not even sure it should have compiled before. \o/