### PR TITLE
pylint fix raw_to_pronto_code.py

### DIFF
--- a/tools/raw_to_pronto_code.py
+++ b/tools/raw_to_pronto_code.py
@@ -8,7 +8,7 @@ from auto_analyse_raw_data import convert_rawdata, add_rawdata_args, get_rawdata
 
 
 # pylint: disable=too-many-arguments
-def parse_and_report(rawdata_str, hertz=38000, end_usecs=100000,
+def parse_and_report(rawdata_str, hertz=38000, *, end_usecs=100000,
                      use_initial=False, generate_code=False, verbose=False,
                      output=sys.stdout):
   """Analyse the rawdata c++ definition of a IR message."""
@@ -94,9 +94,11 @@ def main():
       default=False)
   add_rawdata_args(arg_parser)
   arg_options = arg_parser.parse_args()
-  parse_and_report(get_rawdata(arg_options), arg_options.hertz,
-                   arg_options.usecs, arg_options.use_initial,
-                   arg_options.generate_code, arg_options.verbose)
+  parse_and_report(get_rawdata(arg_options), hertz=arg_options.hertz,
+                   end_usecs=arg_options.usecs,
+                   use_initial=arg_options.use_initial,
+                   generate_code=arg_options.generate_code,
+                   verbose=arg_options.verbose)
 
 
 if __name__ == '__main__':

--- a/tools/raw_to_pronto_code_test.py
+++ b/tools/raw_to_pronto_code_test.py
@@ -14,8 +14,9 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 100000, True, False, False,
-                            output)
+    pronto.parse_and_report(input_str, hertz=38000, end_usecs=100000,
+                            use_initial=True, generate_code=False,
+                            verbose=False, output=output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -28,8 +29,9 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 36000, 100000, True, False, False,
-                            output)
+    pronto.parse_and_report(input_str, hertz=36000, end_usecs=100000,
+                            use_initial=True, generate_code=False,
+                            verbose=False, output=output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -42,8 +44,9 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
       uint16_t rawData[7] = {
           20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 57600, 100000, True, False, False,
-                            output)
+    pronto.parse_and_report(input_str, hertz=57600, end_usecs=100000,
+                            use_initial=True, generate_code=False,
+                            verbose=False, output=output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -56,8 +59,9 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 30000, False, False, False,
-                            output)
+    pronto.parse_and_report(input_str, hertz=38000, end_usecs=30000,
+                            use_initial=False, generate_code=False,
+                            verbose=False, output=output)
     self.assertEqual(
         output.getvalue(),
         "Pronto code = "
@@ -70,7 +74,9 @@ class TestRawToPronto(unittest.TestCase):
     input_str = """
         uint16_t rawData[7] = {
             20100, 20472, 15092, 30704, 20102, 20472, 15086};"""
-    pronto.parse_and_report(input_str, 38000, 30000, True, True, False, output)
+    pronto.parse_and_report(input_str, 38000, end_usecs=30000,
+                            use_initial=True, generate_code=True,
+                            verbose=False, output=output)
     self.assertEqual(
         output.getvalue(),
         "uint16_t pronto[12] = {0x0000, 0x006D, 0x0004, 0x0000, 0x02fb, "


### PR DESCRIPTION
Force named parameters to make pylint happy
option to new to disable reliably

tools/raw_to_pronto_code.py:11:0: R0917: Too many positional arguments (7/5) (too-many-positional-arguments) https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html