### PR TITLE
Update IRsend sendHaierAC to include SEND_HAIER_AC160

### DIFF
--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -626,11 +626,12 @@ class IRsend {
                         uint16_t nbytes = kCarrierAc128StateLength,
                         uint16_t repeat = kCarrierAc128MinRepeat);
 #endif  // SEND_CARRIER_AC128
-#if (SEND_HAIER_AC || SEND_HAIER_AC_YRW02 || SEND_HAIER_AC176)
+#if (SEND_HAIER_AC || SEND_HAIER_AC_YRW02 || SEND_HAIER_AC160 || \
+    SEND_HAIER_AC176)
   void sendHaierAC(const unsigned char data[],
                    const uint16_t nbytes = kHaierACStateLength,
                    const uint16_t repeat = kHaierAcDefaultRepeat);
-#endif  // (SEND_HAIER_AC || SEND_HAIER_AC_YRW02 || SEND_HAIER_AC176)
+#endif  // (SEND_HAIER_AC || SEND_HAIER_AC_YRW02 || SEND_HAIER_AC160 || SEND_HAIER_AC176)
 #if SEND_HAIER_AC_YRW02
   void sendHaierACYRW02(const unsigned char data[],
                         const uint16_t nbytes = kHaierACYRW02StateLength,


### PR DESCRIPTION
`ir_Haier.cpp` defines it here https://github.com/crankyoldgit/IRremoteESP8266/blob/master/src/ir_Haier.cpp#L49

When using flags `-D_IR_ENABLE_DEFAULT_ = false`and `-DSEND_HAIER_AC160=true` it results in not compiling since it can't fine the method in the header file.