### PR TITLE
[Build] Update build scripts to use non-deprecated actions tooling

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -25,7 +25,7 @@ jobs:
         JSONI=${JSONI//$'\n'}
         echo $JSONI
         # Set output
-        echo "::set-output name=matrix::[${JSONI}]"
+        echo "matrix=[${JSONI}]" >> $GITHUB_OUTPUT
   Build_Example:
     needs: Gen_Matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -36,19 +36,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/platformio.ini') }}
     - name: Cache PlatformIO build
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: .pio
         key: pio-${{ runner.os }}-${{ matrix.project }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Features:
- Fix build scripts to not use deprecated actions plugins
- Fix soon to be deprecated `set-output` command
- Update CodeQL from v2 to v3 as v2 will be deprecated soon