### PR TITLE
Fix `intelhex` failures in the build tests

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -56,7 +56,9 @@ jobs:
           pio-${{ runner.os }}-
           pio-
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade intelhex
         pip install --upgrade platformio
     - name: Build example
       env:


### PR DESCRIPTION
This fixes the automated CI tests for ESP32 builds