### PR TITLE
pin python v3.13

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -56,7 +56,9 @@ jobs:
           pio-${{ runner.os }}-
           pio-
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
     - name: Install PlatformIO
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
since Platformio does not yet officially support python v3.14

@crankyoldgit 