### PR TITLE
Disabled interrupts for timing critical code section

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -15,7 +15,7 @@
 #endif
 #include "IRtimer.h"
 
-#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+#if defined(ESP32) && !defined(UNIT_TEST)
 static portMUX_TYPE timingMux = portMUX_INITIALIZER_UNLOCKED;
 #endif
 
@@ -54,13 +54,13 @@ void IRsend::begin() {
 }
 
 void IRsend::beginCritical() {
-#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+#if defined(ESP32) && !defined(UNIT_TEST)
   portENTER_CRITICAL(&timingMux);
 #endif
 }
-  
+
 void IRsend::endCritical() {
-#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+#if defined(ESP32) && !defined(UNIT_TEST)
   portEXIT_CRITICAL(&timingMux);
   vTaskDelay(1);  // Yield to the OS.
 #endif

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -15,6 +15,10 @@
 #endif
 #include "IRtimer.h"
 
+#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+static portMUX_TYPE timingMux = portMUX_INITIALIZER_UNLOCKED;
+#endif
+
 /// Constructor for an IRsend object.
 /// @param[in] IRsendPin Which GPIO pin to use when sending an IR command.
 /// @param[in] inverted Optional flag to invert the output. (default = false)
@@ -47,6 +51,19 @@ void IRsend::begin() {
   pinMode(IRpin, OUTPUT);
 #endif
   ledOff();  // Ensure the LED is in a known safe state when we start.
+}
+
+void IRsend::beginCritical() {
+#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+  portENTER_CRITICAL(&timingMux);
+#endif
+}
+  
+void IRsend::endCritical() {
+#if (defined(ESP32) || defined(ESP8266)) && !defined(UNIT_TEST)
+  portEXIT_CRITICAL(&timingMux);
+  vTaskDelay(1);  // Yield to the OS.
+#endif
 }
 
 /// Turn off the IR LED.
@@ -362,6 +379,7 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
 
   // We always send a message, even for repeat=0, hence '<= repeat'.
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     usecs.reset();
 
     // Header
@@ -379,6 +397,8 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
       space(gap);
     else
       space(std::max(gap, mesgtime - elapsed));
+
+    endCritical();
   }
 }
 
@@ -419,6 +439,7 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   enableIROut(frequency, dutycycle);
   // We always send a message, even for repeat=0, hence '<= repeat'.
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     if (headermark) mark(headermark);
     if (headerspace) space(headerspace);
@@ -431,6 +452,7 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
     // Footer
     if (footermark) mark(footermark);
     space(gap);
+    endCritical();
   }
 }
 
@@ -518,6 +540,7 @@ void IRsend::sendManchester(const uint16_t headermark,
 
   // We always send a message, even for repeat=0, hence '<= repeat'.
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     if (headermark) mark(headermark);
     if (headerspace) space(headerspace);
@@ -526,6 +549,7 @@ void IRsend::sendManchester(const uint16_t headermark,
     // Footer
     if (footermark) mark(footermark);
     if (gap) space(gap);
+    endCritical();
   }
 }
 
@@ -542,6 +566,7 @@ void IRsend::sendRaw(const uint16_t buf[], const uint16_t len,
                      const uint16_t hz) {
   // Set IR carrier frequency
   enableIROut(hz);
+  beginCritical();
   for (uint16_t i = 0; i < len; i++) {
     if (i & 1) {  // Odd bit.
       space(buf[i]);
@@ -550,6 +575,7 @@ void IRsend::sendRaw(const uint16_t buf[], const uint16_t len,
     }
   }
   ledOff();  // We potentially have ended with a mark(), so turn of the LED.
+  endCritical();
 }
 #endif  // SEND_RAW
 

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -28,13 +28,9 @@ const int8_t kPeriodOffset = -2;
 // Calculated on an ESP8266 NodeMCU v2 board using:
 // v2.6.0 with v2.5.2 ESP core @ 160MHz
 const int8_t kPeriodOffset = -2;
-#include <FreeRTOS.h>
-#include <task.h>
 #else  // (defined(ESP8266) && F_CPU == 160000000L)
 // Calculated on ESP8266 Wemos D1 mini using v2.4.1 with v2.4.0 ESP core @ 40MHz
 const int8_t kPeriodOffset = -5;
-#include <FreeRTOS.h>
-#include <task.h>
 #endif  // (defined(ESP8266) && F_CPU == 160000000L)
 const uint8_t kDutyDefault = 50;  // Percentage
 const uint8_t kDutyMax = 100;     // Percentage
@@ -297,7 +293,7 @@ class IRsend {
                    const uint8_t *dataptr, const uint16_t nbytes,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
-  void beginCritical(); 
+  void beginCritical();
   void endCritical();
   static uint16_t minRepeats(const decode_type_t protocol);
   static uint16_t defaultBits(const decode_type_t protocol);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -293,6 +293,8 @@ class IRsend {
                    const uint8_t *dataptr, const uint16_t nbytes,
                    const uint16_t frequency, const bool MSBfirst,
                    const uint16_t repeat, const uint8_t dutycycle);
+  void beginCritical(); 
+  void endCritical();
   static uint16_t minRepeats(const decode_type_t protocol);
   static uint16_t defaultBits(const decode_type_t protocol);
   bool send(const decode_type_t type, const uint64_t data,

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -28,9 +28,13 @@ const int8_t kPeriodOffset = -2;
 // Calculated on an ESP8266 NodeMCU v2 board using:
 // v2.6.0 with v2.5.2 ESP core @ 160MHz
 const int8_t kPeriodOffset = -2;
+#include <FreeRTOS.h>
+#include <task.h>
 #else  // (defined(ESP8266) && F_CPU == 160000000L)
 // Calculated on ESP8266 Wemos D1 mini using v2.4.1 with v2.4.0 ESP core @ 40MHz
 const int8_t kPeriodOffset = -5;
+#include <FreeRTOS.h>
+#include <task.h>
 #endif  // (defined(ESP8266) && F_CPU == 160000000L)
 const uint8_t kDutyDefault = 50;  // Percentage
 const uint8_t kDutyMax = 100;     // Percentage

--- a/src/ir_Coolix.cpp
+++ b/src/ir_Coolix.cpp
@@ -54,6 +54,7 @@ void IRsend::sendCOOLIX(uint64_t data, uint16_t nbits, uint16_t repeat) {
   enableIROut(38);
 
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     mark(kCoolixHdrMark);
     space(kCoolixHdrSpace);
@@ -75,6 +76,7 @@ void IRsend::sendCOOLIX(uint64_t data, uint16_t nbits, uint16_t repeat) {
     // Footer
     mark(kCoolixBitMark);
     space(kCoolixMinGap);  // Pause before repeating
+    endCritical();
   }
   space(kDefaultMessageGap);
 }

--- a/src/ir_Goodweather.cpp
+++ b/src/ir_Goodweather.cpp
@@ -37,6 +37,7 @@ void IRsend::sendGoodweather(const uint64_t data, const uint16_t nbits,
   enableIROut(38);
 
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     mark(kGoodweatherHdrMark);
     space(kGoodweatherHdrSpace);
@@ -54,6 +55,7 @@ void IRsend::sendGoodweather(const uint64_t data, const uint16_t nbits,
     space(kGoodweatherHdrSpace);
     mark(kGoodweatherBitMark);
     space(kDefaultMessageGap);
+    endCritical();
   }
 }
 #endif  // SEND_GOODWEATHER

--- a/src/ir_Gree.cpp
+++ b/src/ir_Gree.cpp
@@ -81,6 +81,7 @@ void IRsend::sendGree(const uint64_t data, const uint16_t nbits,
   enableIROut(38);
 
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     mark(kGreeHdrMark);
     space(kGreeHdrSpace);
@@ -100,6 +101,7 @@ void IRsend::sendGree(const uint64_t data, const uint16_t nbits,
     // Footer
     mark(kGreeBitMark);
     space(kGreeMsgSpace);
+    endCritical();
   }
 }
 #endif  // SEND_GREE

--- a/src/ir_Midea.cpp
+++ b/src/ir_Midea.cpp
@@ -58,6 +58,7 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
   enableIROut(38);
 
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // The protocol sends the message, then follows up with an entirely
     // inverted payload.
     for (size_t inner_loop = 0; inner_loop < 2; inner_loop++) {
@@ -83,6 +84,7 @@ void IRsend::sendMidea(uint64_t data, uint16_t nbits, uint16_t repeat) {
       data = ~data;
     }
     space(kDefaultMessageGap);
+    endCritical();
   }
 }
 #endif  // SEND_MIDEA

--- a/src/ir_Transcold.cpp
+++ b/src/ir_Transcold.cpp
@@ -43,6 +43,7 @@ void IRsend::sendTranscold(uint64_t data, uint16_t nbits, uint16_t repeat) {
   // Set IR carrier frequency
   enableIROut(38);
   for (uint16_t r = 0; r <= repeat; r++) {
+    beginCritical();
     // Header
     mark(kTranscoldHdrMark);
     space(kTranscoldHdrSpace);
@@ -63,6 +64,7 @@ void IRsend::sendTranscold(uint64_t data, uint16_t nbits, uint16_t repeat) {
     space(kTranscoldHdrSpace);
     mark(kTranscoldBitMark);
     space(kDefaultMessageGap);
+    endCritical();
   }
 }
 #endif  // SEND_TRANSCOLD


### PR DESCRIPTION
## Add Critical Sections for Timing-Critical IR Transmission

### Problem
IR protocols require precise microsecond-level timing. On ESP32, interrupts from WiFi, 
Bluetooth, or other tasks can disrupt bit-banging operations, causing timing jitter that results 
in unreliable IR transmissions or receiver decode failures.

### Solution
Implemented `beginCritical()` and `endCritical()` methods using FreeRTOS critical sections with 
a shared mutex (`portMUX_TYPE`). Device-specific send methods now wrap their entire transmission 
sequence (header + data + footer) in a single atomic critical section, ensuring uninterrupted 
timing throughout the IR pulse train.

### Implementation Details
- Added static `timingMux` for cross-platform (ESP32) critical section protection
- `beginCritical()`: Disables interrupts via `portENTER_CRITICAL(&timingMux)`
- `endCritical()`: Re-enables interrupts and yields with `vTaskDelay(1)` to prevent watchdog timeouts
- Device classes manage critical sections around their complete send sequences
- Critical section code is conditionally compiled only for ESP32 platform and excluded 
  from unit tests (`#if defined(ESP32)  && !defined(UNIT_TEST)`), ensuring 
  no impact on other platforms or test environments

This approach ensures reliable IR transmission even with WiFi/Bluetooth active, without requiring 
RMT hardware peripheral support.