### PR TITLE
Fixed the bug where the wind speed was always set to auto.

### DIFF
--- a/src/ir_Bosch.cpp
+++ b/src/ir_Bosch.cpp
@@ -176,7 +176,8 @@ uint8_t IRBosch144AC::getMode(void) const {
 /// @param[in] on true, the setting is on. false, the setting is off.
 void IRBosch144AC::setQuiet(const bool on) {
   _.Quiet = on;                 // save 1 bit in Section3
-  setFan(kBosch144FanAuto);     // set Fan -> Auto
+  if (on)  // if Quiet is on, set Fan to Auto
+    setFan(kBosch144FanAuto);     // set Fan -> Auto
 }
 
 /// Get the Quiet mode of the A/C.


### PR DESCRIPTION
https://github.com/crankyoldgit/IRremoteESP8266/issues/2236
Fixed a bug where the wind speed was always set to auto. The reason is that after setting the wind speed once, it would automatically change the wind speed back to auto due to setting quiet mode.