### PR TITLE
[Build] Prepare for newer build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 # vi/vim
 **/*.swp
 
-# vscode
+# vscode and plugins
 .vscode
+# LLVM clangd support file
+compile_commands.json
 
 ## Build environments
 # Platformio
@@ -23,6 +25,7 @@ examples/**/.travis.yml
 examples/**/.gitignore
 lib/readme.txt
 lib/googletest/
+.platformio/
 
 # GCC pre-compiled headers.
 **/*.gch

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,4 +1,5 @@
 [platformio]
+core_dir        = .platformio
 # Default to building IRrecvDumpV2 if not in a specific example directory.
 src_dir = examples/IRrecvDumpV2
 
@@ -23,5 +24,5 @@ board = esp32dev
 
 # Experimental IDF 5.x support
 [env:esp32devIDF5x]
-platform = https://github.com/tasmota/platform-espressif32/releases/download/2025.12.30/platform-espressif32.zip
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2026.03.50/platform-espressif32.zip
 board    = esp32dev


### PR DESCRIPTION
Features:

- Move build tools in project-local `.platformio` folder
- Update to newer IDF 5.x platform
- Support `pioarduino` instead of `PlatformIO` plugin so newer IDF releases and `clangd` C++ tooling can be used
- Add stuff to `gitignore` to support above features