### PR TITLE
Fix python build on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ lib/googletest/
 # Python compiled files
 **/*.pyc
 
+/python/*.so
+/python/*.o
+/python/*.cxx
+/python/irhvac.py
+
 # Unit Test builds
 test/*.o
 test/*.a

--- a/python/Makefile
+++ b/python/Makefile
@@ -17,6 +17,14 @@ else
 SWIGTYPE = global
 endif
 
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+  # macOS: extensions are bundles with dynamic_lookup; don't link libpython
+  SHARED_FLAGS = -bundle -undefined dynamic_lookup
+else
+  SHARED_FLAGS = -shared -Wl,-soname,lib_irhvac.so
+endif
+
 # Where to find user code.
 SRC_DIR = ../src
 
@@ -40,7 +48,7 @@ objects = $(patsubst %.cpp,%,$(wildcard *.cpp))
 all : _irhvac.so
 
 library : $(objects)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -shared -Wl,-soname,lib_irhvac.so -o _irhvac.so $(COMMON_OBJ)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SHARED_FLAGS) -o _irhvac.so $(COMMON_OBJ)
 
 swig :	libirhvac_wrap.cxx
 ifneq (,$(wildcard /.dockerenv))
@@ -101,7 +109,7 @@ libirhvac_wrap.cxx :
 	swig $(INCLUDES) $(DEFFLAGS) -c++ -python libirhvac.i
 
 _irhvac.so : $(COMMON_OBJ)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -shared -Wl,-soname,lib_irhvac.so -o _irhvac.so $(COMMON_OBJ)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SHARED_FLAGS) -o _irhvac.so $(COMMON_OBJ)
 
 swig-4.2.0/swig :
 	curl -s -L -o - http://downloads.sourceforge.net/project/swig/swig/swig-4.2.0/swig-4.2.0.tar.gz | tar xfz -


### PR DESCRIPTION
This PR fixes build issue for the python bindings added in #2067. On my MacBook Pro M1 running Tahoe 26.3.1 I got the following error when running `make`.

```
c++ -D_IR_LOCALE_=en-AU -fPIC -DUNIT_TEST -DSWIGLIB -g -Wall -Wextra -pthread -std=gnu++11 -shared -Wl,-soname,lib_irhvac.so -o _irhvac.so libirhvac_wrap.o IRutils.o IRtimer.o IRsend.o IRrecv.o IRtext.o IRac.o ir_Airton.o ir_Airwell.o ir_Aiwa.o ir_Amcor.o ir_Argo.o ir_Arris.o ir_BluestarHeavy.o ir_Bosch.o ir_Bose.o ir_Carrier.o ir_ClimaButler.o ir_Coolix.o ir_Corona.o ir_Daikin.o ir_Delonghi.o ir_Denon.o ir_Dish.o ir_Doshisha.o ir_Ecoclim.o ir_Electra.o ir_EliteScreens.o ir_Epson.o ir_Eurom.o ir_Fujitsu.o ir_GICable.o ir_GlobalCache.o ir_Goodweather.o ir_Gorenje.o ir_Gree.o ir_Haier.o ir_Hitachi.o ir_Inax.o ir_JVC.o ir_Kelon.o ir_Kelvinator.o ir_Lasertag.o ir_Lego.o ir_LG.o ir_Lutron.o ir_Magiquest.o ir_Metz.o ir_Midea.o ir_MilesTag2.o ir_Mirage.o ir_Mitsubishi.o ir_MitsubishiHeavy.o ir_Multibrackets.o ir_MWM.o ir_NEC.o ir_Neoclima.o ir_Nikai.o ir_Panasonic.o ir_Pioneer.o ir_Pronto.o ir_RC5_RC6.o ir_RCMM.o ir_Rhoss.o ir_Samsung.o ir_Sanyo.o ir_Sharp.o ir_Sherwood.o ir_Sony.o ir_Symphony.o ir_Tcl.o ir_Technibel.o ir_Teco.o ir_Teknopoint.o ir_Toshiba.o ir_Toto.o ir_Transcold.o ir_Trotec.o ir_Truma.o ir_Vestel.o ir_Voltas.o ir_Whirlpool.o ir_Whynter.o ir_Wowwee.o ir_Xmp.o ir_York.o ir_Zepeal.o
ld: unknown options: -soname
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [_irhvac.so] Error 1
```

Note: `export CPLUS_INCLUDE_PATH="$( xcrun --show-sdk-path )/usr/include/c++/v1"` is required before build.

I have tested that the build, as well as `make testdocker` succeeds.