### PR TITLE
Guard rawbuf bounds in decode() when rawlen == bufsize (#2198)

### DIFF
--- a/src/IRrecv.cpp
+++ b/src/IRrecv.cpp
@@ -602,7 +602,12 @@ bool IRrecv::decode(decode_results *results, irparams_t *save,
   // resume() but that is a much more expensive operation compare to this.
   // However, don't do this if rawbuf is already full as we stomp over the heap.
   // See: https://github.com/crankyoldgit/IRremoteESP8266/issues/1516
-  if (!params.overflow) params.rawbuf[params.rawlen] = 0;
+  // Also guard against rawlen == bufsize (with overflow still false), which
+  // occurs because the ISR increments rawlen *after* writing the last entry.
+  // Writing rawbuf[bufsize] would be an off-by-one heap overflow.
+  // See: https://github.com/crankyoldgit/IRremoteESP8266/issues/2198
+  if (!params.overflow && params.rawlen < params.bufsize)
+    params.rawbuf[params.rawlen] = 0;
 
   bool resumed = false;  // Flag indicating if we have resumed.
 

--- a/test/IRrecv_test.cpp
+++ b/test/IRrecv_test.cpp
@@ -85,6 +85,55 @@ TEST(TestIRrecv, DecodeHeapOverflow) {
   EXPECT_EQ(99, params_ptr->rawbuf[params_ptr->rawlen + 1]);
 }
 
+// Test for the edge case in issue #2198:
+// rawlen == bufsize but overflow is still false.
+// This happens because the ISR writes rawbuf[rawlen] first, then increments
+// rawlen to bufsize. On the *next* ISR call it sees rawlen >= bufsize and sets
+// overflow = true. But if decode() runs before that next call, overflow is
+// still false while rawlen already equals bufsize, so the old guard
+// `if (!params.overflow)` was insufficient and wrote rawbuf[bufsize] —
+// one element past the end of the heap allocation.
+TEST(TestIRrecv, DecodeHeapOverflowNoOverflowFlag) {
+  // Ref: https://github.com/crankyoldgit/IRremoteESP8266/issues/2198
+  IRrecv irrecv(1);
+  irrecv.enableIRIn();
+  ASSERT_EQ(kRawBuf, irrecv.getBufSize());
+  atomic_irparams_t *params_ptr = irrecv._getParamsPtr();
+  // Replace the buffer with a slightly bigger one so we can plant canaries
+  // past the official end and detect any out-of-bounds write.
+  params_ptr->rawbuf = new uint16_t[kRawBuf + 10];
+  ASSERT_EQ(kRawBuf, irrecv.getBufSize());  // Should not change.
+  // Fill the entire extended buffer: 100 inside the valid range, 99 beyond it.
+  for (uint16_t i = 0; i < irrecv.getBufSize() + 10; i++) {
+    params_ptr->rawbuf[i] = 100;
+    if (i >= irrecv.getBufSize()) params_ptr->rawbuf[i]--;
+  }
+  ASSERT_EQ(100, params_ptr->rawbuf[kRawBuf - 1]);  // Last valid slot.
+  EXPECT_EQ(99, params_ptr->rawbuf[kRawBuf]);        // Canary — must stay 99.
+  EXPECT_EQ(99, params_ptr->rawbuf[kRawBuf + 1]);    // Canary — must stay 99.
+  ASSERT_EQ(kRawBuf, params_ptr->bufsize);
+  decode_results results;
+  // Key difference from DecodeHeapOverflow: overflow is FALSE here.
+  // rawlen == bufsize means the ISR filled the last slot and incremented
+  // rawlen, but hadn't yet looped back to set overflow = true.
+  params_ptr->rawlen = kRawBuf;   // rawlen exactly equals bufsize
+  params_ptr->overflow = false;   // overflow NOT set — the triggering condition
+  params_ptr->rcvstate = kStopState;
+  // Wire up results to point at the same buffer.
+  results.rawbuf = params_ptr->rawbuf;
+  results.rawlen = params_ptr->rawlen;
+  results.overflow = params_ptr->overflow;
+
+  // Do the decode — this must NOT write rawbuf[kRawBuf].
+  irrecv.decode(&results);
+  // Verify the canaries are untouched — a write would change rawbuf[kRawBuf]
+  // from 99 to 0 (the sentinel value the old code would have written).
+  EXPECT_EQ(99, params_ptr->rawbuf[kRawBuf])
+      << "Heap overflow detected: rawbuf[bufsize] was written out-of-bounds!";
+  EXPECT_EQ(99, params_ptr->rawbuf[kRawBuf + 1])
+      << "Heap overflow detected: rawbuf[bufsize+1] was corrupted!";
+}
+
 // Tests for copyIrParams()
 
 TEST(TestCopyIrParams, CopyEmpty) {


### PR DESCRIPTION
# PR Template for Issue #2198

---

## Branch Name

```

fix/decode-rawbuf-off-by-one-overflow

```

## PR Title

```

fix(IRrecv): prevent off-by-one heap write in decode() when rawlen == bufsize (#2198)

```

---

## PR Body

Hi folks 👋

I've done some digging into #2198 (calling decode() randomly corrupts unrelated variables like

ServerIP[])

and found the source of the problem. Turns out, it's a legit off-by-one in

decode()

itself, not some esoteric interaction between the user code and the library, as I initially thought.

### tl;dr

decode()

has this lovely piece of code to zero out the "pending" slot in the buffer before decoding:

if (!params.overflow) params.rawbuf[params.rawlen] = 0;

but

params.rawbuf is of size bufsize, i.e. indices 0..bufsize-1 are valid. The ISR, however, does

params.rawbuf[rawlen] = ;

params.rawlen = params.rawlen + 1;

i.e. it writes to the current index, then increments the index. So, when the buffer is filled to the brim, this is what happens:

What happens rawlen overflow

ISR fires, writes rawbuf[bufsize-1], increments rawlen -> bufsize false

Timeout expires, capture ends bufsize false

decode() is called bufsize false

if (!overflow) ... bufsize false

params.rawbuf[params.rawlen] = 0; -> writes to rawbuf[bufsize], which is beyond the buffer! bufsize -

Next ISR would set overflow to true, but it never fires bufsize true

so decode() is called with rawlen == bufsize, overflow == false. The existing !overflow guard (added in #1516) is not sufficient to prevent the off-by-one, it only guards against the case when the overflow flag is manually set. This is a different scenario, but equally dangerous: the overflow flag is not set yet, but rawlen is already equal to bufsize. The next ISR would have set overflow to true and increased rawlen to bufsize + 1, but it did not happen yet. From the perspective of decode(), it is as good as rawlen == bufsize - 1, overflow == false. So it tries to write to rawbuf[bufsize] in the hopes of it being the "pending" slot. However, that slot is not allocated, and it's whatever happens to be on the heap after the rawbuf array. In the user's case, that happened to be the ServerIP array.

### The fix

is simple: add another condition to the existing check, so that the rawlen is within the buffer:

params.rawbuf[params.rawlen] = 0;

becomes

if (!params.overflow && params.rawlen < params.bufsize)

params.rawbuf[params.rawlen] = 0;

there's no public API change, so existing users should not see any difference in runtime unless they somehow managed to have rawlen == bufsize, which is now guarded against.

### Testing

I've added a new test IRrecv_test.cpp:TestIRrecv.DecodeHeapOverflowNoOverflowFlag that checks this scenario. It's basically the same code as the existing DecodeHeapOverflow test from #1516, but with a couple of changes:

1. It sets up canary values (99) in the slots past the end of the buffer (bufsize)

2. It simulates the scenario where rawlen == bufsize, overflow == false

and verifies that decode() does not overwrite the canary values.

Without the fix, the test would crash with a bus error (writing to an invalid address), or, if the canary values were placed right after the buffer in the heap, it would overwrite them, causing some random memory corruption later.

With the fix, the canary values should remain untouched.

### Wontfix

I can see why you put the wontfix label on this issue: it did look like some weird memory layout problem that only happens on the user's code, but it's actually not. It's a pretty straightforward off-by-one that is similar to the one fixed in #1516 but under different circumstances. I think the reason why it took so long to fix is that the overflow flag is set too late relative to rawlen increment in the ISR. In the test scenario, I don't even need to use real hardware to reproduce the issue: a unit test with a mocked IRrecv object is enough.

The help wanted label caught my eye, so I thought I'd take a crack at it!