### PR TITLE
Add Toshiba remote and A/C models to ir_Toshiba.h

### DIFF
--- a/src/ir_Toshiba.h
+++ b/src/ir_Toshiba.h
@@ -21,6 +21,8 @@
 //   Brand: Toshiba,  Model: RAS-2558V A/C
 //   Brand: Toshiba,  Model: WH-TA01JE remote
 //   Brand: Toshiba,  Model: RAS-25SKVP2-ND A/C
+//   Brand: Toshiba,  Model: WH-TG01NE 50224A remote
+//   Brand: Toshiba,  Model: RAS-B13B2KVG-E3 A/C
 //   Brand: Carrier,  Model: 42NQV060M2 / 38NYV060M2 A/C
 //   Brand: Carrier,  Model: 42NQV050M2 / 38NYV050M2 A/C
 //   Brand: Carrier,  Model: 42NQV035M2 / 38NYV035M2 A/C


### PR DESCRIPTION
Note support for additional Toshiba remote and A/C models.

Fixes #2276