### PR TITLE
Fix DAIKIN312 horizontal swing Off conversion

### DIFF
--- a/src/ir_Daikin.cpp
+++ b/src/ir_Daikin.cpp
@@ -4321,6 +4321,7 @@ uint8_t IRDaikin312::convertFan(const stdAc::fanspeed_t speed) {
 /// @return The native equivalent of the enum.
 uint8_t IRDaikin312::convertSwingH(const stdAc::swingh_t position) {
   switch (position) {
+    case stdAc::swingh_t::kOff:      return kDaikin312SwingHOff;
     case stdAc::swingh_t::kAuto:     return kDaikin312SwingHSwing;
     case stdAc::swingh_t::kLeftMax:  return kDaikin312SwingHLeftMax;
     case stdAc::swingh_t::kLeft:     return kDaikin312SwingHLeft;

--- a/test/ir_Daikin_test.cpp
+++ b/test/ir_Daikin_test.cpp
@@ -4224,6 +4224,26 @@ TEST(TestDaikin312Class, FanSpeed) {
   EXPECT_EQ(kDaikinFanQuiet, ac.getFan());
 }
 
+TEST(TestDaikin312Class, ConvertSwingH) {
+  EXPECT_EQ(
+      kDaikin312SwingHOff,
+      IRDaikin312::convertSwingH(stdAc::swingh_t::kOff));
+
+  EXPECT_EQ(
+      kDaikin312SwingHSwing,
+      IRDaikin312::convertSwingH(stdAc::swingh_t::kAuto));
+}
+
+TEST(TestDaikin312Class, ConvertSwingV) {
+  EXPECT_EQ(
+      kDaikin312SwingVOff,
+      IRDaikin312::convertSwingV(stdAc::swingv_t::kOff));
+
+  EXPECT_EQ(
+      kDaikin312SwingVSwing,
+      IRDaikin312::convertSwingV(stdAc::swingv_t::kAuto));
+}
+
 TEST(TestDaikin312Class, QuietAndPowerful) {
   IRDaikin312 ac(kGpioUnused);
   ac.begin();


### PR DESCRIPTION
## Summary

Fix the DAIKIN312 conversion of the common horizontal swing `Off`
setting.

`IRDaikin312::convertSwingH()` did not explicitly handle
`stdAc::swingh_t::kOff`. As a result, the value fell through to the
default case and was converted to `kDaikin312SwingHAuto`.

This change:

- maps `stdAc::swingh_t::kOff` to `kDaikin312SwingHOff`;
- adds regression tests for horizontal swing `Off` and `Auto`;
- adds equivalent vertical swing conversion tests for consistency.

## Real-world testing

Tested on an ESP8266 running Tasmota with DAIKIN312 support.

The transmitted frame was captured with a Flipper Zero and retransmitted
back to the Tasmota IR receiver.

Test command:

```text
IRHVAC {"Vendor":"DAIKIN312","Command":"Control","Mode":"Cool","Power":"Off","Celsius":"On","Temp":23,"FanSpeed":"Low","SwingV":"Off","SwingH":"Off"}