### PR TITLE
LG: Fix uninitialised and never-updated Swing(H) previous state

### DIFF
--- a/src/ir_LG.cpp
+++ b/src/ir_LG.cpp
@@ -591,6 +591,7 @@ void IRLgAc::setSwingV(const uint32_t position) {
 // Copy the previous swing settings from the current ones.
 void IRLgAc::updateSwingPrev(void) {
   _swingv_prev = _swingv;
+  _swingh_prev = _swingh;
   for (uint8_t i = 0; i < kLgAcSwingVMaxVanes; i++)
     _vaneswingv_prev[i] = _vaneswingv[i];
 }

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -1190,3 +1190,39 @@ TEST(TestIRLgAcClass, SwingVToggle) {
   EXPECT_EQ(ac._swingv, kLgAcSwingVToggle);
   EXPECT_NE(ac._swingv_prev, kLgAcSwingVToggle);
 }
+
+// Ensure the Swing(H) "previous" setting is initialised & kept up to date.
+// Without it, `_swingh_prev` is read uninitialised on the first send(), and
+// never tracks `_swingh` afterwards, so the "only send if it changed" check
+// either re-sends Swing(H) forever or never sends it at all.
+TEST(TestIRLgAcClass, SwingHPrevIsTracked) {
+  IRLgAc ac(kGpioUnused);
+  ac.begin();
+  ac.setModel(lg_ac_remote_model_t::AKB73757604);
+  ac.setPower(true);
+  ac.setMode(kLgAcCool);
+  ac.setTemp(25);
+  ac.setFan(kLgAcFanLow);
+  ac.setSwingH(true);
+
+  // Swing(H) has changed since the last send, so we expect the normal
+  // message plus a Swing(H) message.
+  ac._irsend.reset();
+  ac.send();
+  ac._irsend.makeDecodeResult();
+  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // i.e. Two messages.
+
+  // Nothing has changed, so the second send should be the normal message
+  // only, with no repeated Swing(H) message.
+  ac._irsend.reset();
+  ac.send();
+  ac._irsend.makeDecodeResult();
+  EXPECT_EQ(61, ac._irsend.capture.rawlen);  // i.e. One message.
+
+  // Changing it back should produce a Swing(H) message again.
+  ac.setSwingH(false);
+  ac._irsend.reset();
+  ac.send();
+  ac._irsend.makeDecodeResult();
+  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // i.e. Two messages.
+}

--- a/test/ir_LG_test.cpp
+++ b/test/ir_LG_test.cpp
@@ -1191,10 +1191,7 @@ TEST(TestIRLgAcClass, SwingVToggle) {
   EXPECT_NE(ac._swingv_prev, kLgAcSwingVToggle);
 }
 
-// Ensure the Swing(H) "previous" setting is initialised & kept up to date.
-// Without it, `_swingh_prev` is read uninitialised on the first send(), and
-// never tracks `_swingh` afterwards, so the "only send if it changed" check
-// either re-sends Swing(H) forever or never sends it at all.
+// Ensure Swing(H)'s previous state is initialised & kept up to date.
 TEST(TestIRLgAcClass, SwingHPrevIsTracked) {
   IRLgAc ac(kGpioUnused);
   ac.begin();
@@ -1205,24 +1202,19 @@ TEST(TestIRLgAcClass, SwingHPrevIsTracked) {
   ac.setFan(kLgAcFanLow);
   ac.setSwingH(true);
 
-  // Swing(H) has changed since the last send, so we expect the normal
-  // message plus a Swing(H) message.
   ac._irsend.reset();
   ac.send();
   ac._irsend.makeDecodeResult();
-  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // i.e. Two messages.
+  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // Normal + Swing(H) message.
 
-  // Nothing has changed, so the second send should be the normal message
-  // only, with no repeated Swing(H) message.
   ac._irsend.reset();
   ac.send();
   ac._irsend.makeDecodeResult();
-  EXPECT_EQ(61, ac._irsend.capture.rawlen);  // i.e. One message.
+  EXPECT_EQ(61, ac._irsend.capture.rawlen);  // Unchanged, so normal only.
 
-  // Changing it back should produce a Swing(H) message again.
   ac.setSwingH(false);
   ac._irsend.reset();
   ac.send();
   ac._irsend.makeDecodeResult();
-  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // i.e. Two messages.
+  EXPECT_EQ(121, ac._irsend.capture.rawlen);  // Changed again, so both.
 }


### PR DESCRIPTION
`IRLgAc::updateSwingPrev()` copies `_swingv` and `_vaneswingv[]` across to their
`_prev` counterparts, but never `_swingh`. Since `updateSwingPrev()` is also what
`stateReset()` uses to prime those values, `_swingh_prev` is never initialised at
all — and never updated after a send, either.

For the `AKB73757604` model (the only one that consults it in `send()`) that
means:

1. The first `send()` reads an uninitialised `bool`. UBSAN, on current master:

   ```
   ../src/ir_LG.cpp:280:24: runtime error: load of value 74, which is not a
   valid value for type 'bool'
   ```

2. The `if (_swingh != _swingh_prev)` "only send it if it changed" check never
   settles, so the Swing(H) message is either re-sent on *every* send or never
   sent at all, depending on whatever happened to be on the stack.

### This is the `TestIRac.LG2_AKB73757604` flake

That test asserts six messages are sent, and the sixth is exactly this Swing(H)
message, so it passes or fails on the garbage value. It's green on this machine
and was green in CI on 2026-08-02, but failed on the identical runner image in
an unrelated PR of mine today ([#2286][pr]), which is how I found it:

```
IRac_test.cpp:1490: Failure
Expected equality of these values:
  361
  ac._irsend.capture.rawlen
    Which is: 301
```

### The fix

One line — copy `_swingh` across in `updateSwingPrev()`, like its siblings.

Also adds `TestIRLgAcClass.SwingHPrevIsTracked`, which checks that a repeated
identical send doesn't re-send Swing(H). It fails on master *regardless* of what
the uninitialised value happens to be (either the first or the second assertion
trips, depending on the garbage), and passes with the fix.

### Testing

- Full `make run` suite passes; `cpplint` clean.
- Verified the new test fails on master and passes with the fix.
- Re-ran the LG tests under `-fsanitize=address,undefined`: the
  `ir_LG.cpp:280` runtime error is gone.
- Not tested against physical hardware — I don't own an LG unit. The change only
  affects whether an already-existing Swing(H) message is emitted when the
  setting hasn't changed, but a sanity check from someone with an AKB73757604
  would be worth having before this is trusted.

### Unrelated thing UBSAN also flagged

Not touched here, but while I had the sanitizer running:

```
../src/ir_LG.cpp:133:20: runtime error: left shift of 65535 by 20 places
cannot be represented in type 'int'
```

That's `encodeLG()`'s `address << 20` — `uint16_t` promotes to `int`, so a large
address overflows. Benign on the usual targets, but happy to send a follow-up
casting it to `uint32_t` if you'd like it silenced.

[pr]: https://github.com/crankyoldgit/IRremoteESP8266/pull/2286
