### PR TITLE
Implement Blomberg AC protocol

### DIFF
--- a/src/ir_Blomberg.cpp
+++ b/src/ir_Blomberg.cpp
@@ -1,0 +1,132 @@
+#include "ir_Blomberg.h"
+#include "IRutils.h"
+
+IRBlombergAc::IRBlombergAc(const uint16_t pin, const bool inverted,
+                           const bool use_modulation)
+    : _irsend(pin, inverted, use_modulation) {
+  stateReset();
+}
+
+void IRBlombergAc::stateReset() {
+  const uint8_t default_state[kBlombergStateLength] = {
+      86, 111, 0, 0, 33, 196, 0, 0, 0, 0, 0, 0, 0, 0, 0}; 
+  std::memcpy(remote_state, default_state, kBlombergStateLength);
+  checksum();
+}
+
+void IRBlombergAc::begin() { 
+  _irsend.begin(); 
+}
+
+void IRBlombergAc::send(const uint16_t repeat) {
+  checksum();
+  _irsend.sendMirage(remote_state, kBlombergStateLength, repeat);
+}
+
+uint8_t* IRBlombergAc::getRaw() {
+  checksum();
+  return remote_state;
+}
+
+void IRBlombergAc::setRaw(const uint8_t state[]) {
+  std::memcpy(remote_state, state, kBlombergStateLength);
+}
+
+uint8_t IRBlombergAc::calcChecksum(const uint8_t state[], const uint16_t length) {
+  uint8_t sum = 0;
+  for (uint16_t i = 0; i < length - 1; i++) {
+    sum += (state[i] >> 4) & 0x0F;
+    sum += state[i] & 0x0F;
+  }
+  return sum;
+}
+
+bool IRBlombergAc::validChecksum(const uint8_t state[], const uint16_t length) {
+  return state[length - 1] == calcChecksum(state, length);
+}
+
+void IRBlombergAc::checksum() {
+  remote_state[kBlombergStateLength - 1] = calcChecksum(remote_state);
+}
+
+void IRBlombergAc::setPower(const bool on) {
+  if (on) {
+    remote_state[5] &= ~0x80;
+  } else {
+    remote_state[5] |= 0x80;
+  }
+}
+
+bool IRBlombergAc::getPower() const {
+  return !(remote_state[5] & 0x80);
+}
+
+void IRBlombergAc::setMode(const uint8_t mode) {
+  // Preserve the lower nibble (Fan) and update the upper nibble (Mode)
+  remote_state[4] = (mode & 0xF0) | (remote_state[4] & 0x0F);
+
+  // Set the specific Heat/Auto flag on Byte 6
+  if (mode == kBlombergModeHeat || mode == kBlombergModeAuto) {
+    remote_state[6] = 0x40; // 64
+  } else {
+    remote_state[6] = 0x00; // 0
+  }
+}
+
+uint8_t IRBlombergAc::getMode() const {
+  return remote_state[4] & 0xF0;
+}
+
+void IRBlombergAc::setTemp(const uint8_t temp) {
+  uint8_t t = std::max(kBlombergMinTemp, std::min(temp, kBlombergMaxTemp));
+  remote_state[1] = t + 92;
+}
+
+uint8_t IRBlombergAc::getTemp() const {
+  return remote_state[1] - 92;
+}
+
+void IRBlombergAc::setFan(const uint8_t fan) {
+  // Preserve the upper nibble (Mode) and update the lower nibble (Fan)
+  remote_state[4] = (remote_state[4] & 0xF0) | (fan & 0x0F);
+}
+
+uint8_t IRBlombergAc::getFan() const {
+  return remote_state[4] & 0x0F;
+}
+
+void IRBlombergAc::setSwing(const bool on) {
+  if (on) {
+    remote_state[5] |= 0x02;
+  } else {
+    remote_state[5] &= ~0x02;
+  }
+}
+
+bool IRBlombergAc::getSwing() const {
+  return remote_state[5] & 0x02;
+}
+
+void IRBlombergAc::setLed(const bool on) {
+  if (on) {
+    remote_state[5] &= ~0x04; 
+  } else {
+    remote_state[5] |= 0x04; 
+  }
+}
+
+bool IRBlombergAc::getLed() const {
+  return !(remote_state[5] & 0x04);
+}
+
+void IRBlombergAc::setTurbo(const bool on) {
+  if (on) {
+    remote_state[8] |= 0x80;
+  } else {
+    remote_state[8] &= ~0x80;
+  }
+}
+
+bool IRBlombergAc::getTurbo() const {
+  return remote_state[8] & 0x80;
+}

--- a/src/ir_Blomberg.h
+++ b/src/ir_Blomberg.h
@@ -1,0 +1,71 @@
+#ifndef IR_BLOMBERG_H_
+#define IR_BLOMBERG_H_
+
+#ifndef UNIT_TEST
+#include <Arduino.h>
+#endif
+#include "IRremoteESP8266.h"
+#include "IRsend.h"
+#include "IRrecv.h"
+
+// Constants
+const uint16_t kBlombergStateLength = 15;
+const uint8_t kBlombergMinTemp = 19;
+const uint8_t kBlombergMaxTemp = 30;
+
+// Operation Modes (Upper nibble of Byte 4)
+const uint8_t kBlombergModeHeat = 0x10; // 16
+const uint8_t kBlombergModeCool = 0x20; // 32
+const uint8_t kBlombergModeDry  = 0x30; // 48
+const uint8_t kBlombergModeAuto = 0x40; // 64
+const uint8_t kBlombergModeFan  = 0x50; // 80
+
+// Fan Speeds (Lower nibble of Byte 4)
+const uint8_t kBlombergFanAuto = 0x00; // 0
+const uint8_t kBlombergFanHigh = 0x01; // 1
+const uint8_t kBlombergFanLow  = 0x02; // 2
+const uint8_t kBlombergFanMed  = 0x03; // 3
+
+class IRBlombergAc {
+ public:
+  explicit IRBlombergAc(const uint16_t pin, const bool inverted = false,
+                        const bool use_modulation = true);
+  void stateReset();
+  void begin();
+  void send(const uint16_t repeat = 0);
+
+  uint8_t* getRaw();
+  void setRaw(const uint8_t state[]);
+  static uint8_t calcChecksum(const uint8_t state[], 
+                              const uint16_t length = kBlombergStateLength);
+  static bool validChecksum(const uint8_t state[], 
+                            const uint16_t length = kBlombergStateLength);
+  void checksum();
+
+  void setPower(const bool on);
+  bool getPower() const;
+
+  void setMode(const uint8_t mode);
+  uint8_t getMode() const;
+
+  void setTemp(const uint8_t temp);
+  uint8_t getTemp() const;
+
+  void setFan(const uint8_t fan);
+  uint8_t getFan() const;
+
+  void setSwing(const bool on);
+  bool getSwing() const;
+
+  void setLed(const bool on);
+  bool getLed() const;
+
+  void setTurbo(const bool on);
+  bool getTurbo() const;
+
+ private:
+  IRsend _irsend;
+  uint8_t remote_state[kBlombergStateLength];
+};
+
+#endif  // IR_BLOMBERG_H_


### PR DESCRIPTION
This pull request introduces support for Blomberg air conditioner IR remote control by adding a new `IRBlombergAc` class. The implementation provides methods to manipulate and transmit IR commands specific to Blomberg AC units, including state management, encoding/decoding, and device feature controls.

**New Blomberg AC IR Protocol Support:**

* Added `IRBlombergAc` class in `ir_Blomberg.h` and `ir_Blomberg.cpp` to encapsulate all logic for Blomberg AC IR communication, including state management and IR transmission. [[1]](diffhunk://#diff-3e47c8b2210eb0ba6ddaae89cd8664135d6eb52143de6b58b5f0f00b33943b1eR1-R71) [[2]](diffhunk://#diff-7467b640777cbf217d38b1e15f6e2a3df519163734ca9152121a300c156ac65bR1-R132)

**Device Control Methods:**

* Implemented methods in `IRBlombergAc` for setting and getting AC features such as power, mode, temperature, fan speed, swing, LED, and turbo, allowing granular control over device state.

**Protocol Constants and State Handling:**

* Defined protocol-specific constants (e.g., state length, temperature limits, mode/fan codes) and provided methods to reset, set, and retrieve the internal state buffer representing the IR command. [[1]](diffhunk://#diff-3e47c8b2210eb0ba6ddaae89cd8664135d6eb52143de6b58b5f0f00b33943b1eR1-R71) [[2]](diffhunk://#diff-7467b640777cbf217d38b1e15f6e2a3df519163734ca9152121a300c156ac65bR1-R132)

**Checksum and Validation:**

* Implemented checksum calculation and validation methods to ensure data integrity of the IR command payload before transmission.

**IR Transmission Integration:**

* Integrated with the existing IR sending infrastructure, allowing commands to be sent via the `send` method and supporting repeated transmissions as needed.