### PR TITLE
KELVINATOR: Add Gree YAP2F remote & GSE-50CI A/C as supported models

### DIFF
--- a/src/ir_Kelvinator.h
+++ b/src/ir_Kelvinator.h
@@ -15,6 +15,8 @@
 //   Brand: Kelvinator,  Model: KSV80HRC A/C
 //   Brand: Gree,  Model: YAPOF3 remote
 //   Brand: Gree,  Model: YAP0F8 remote
+//   Brand: Gree,  Model: YAP2F remote
+//   Brand: Gree,  Model: GSE-50CI A/C
 //   Brand: Sharp,  Model: YB1FA remote
 //   Brand: Sharp,  Model: A5VEY A/C
 


### PR DESCRIPTION
Adds the Gree YAP2F remote and the Gree GSE-50CI split A/C (2.5 kW, 220 V, 2021) to the Kelvinator supported models list.

Verified on real hardware:
- Frames captured from the YAP2F remote decode as the Kelvinator 128-bit format (two 4+4 byte blocks with the 0b010 marker bits and constant 0x50 in byte 3).
- Frames generated by IRKelvinatorAC control the GSE-50CI correctly: power on/off, mode, target temperature, and fan speed all confirmed against the unit.
- The unit does not respond to the short 64-bit GREE protocol frames; only the Kelvinator format works.